### PR TITLE
Adding Cisco IOS XR and NX-OS to Tier 1 platforms

### DIFF
--- a/includes_supported_platforms/includes_supported_platforms_client_tier1.rst
+++ b/includes_supported_platforms/includes_supported_platforms_client_tier1.rst
@@ -1,12 +1,12 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
-.. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics. 
+.. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
 The following table lists the Tier 1 supported platforms for the |chef client|:
 
 .. list-table::
    :widths: 280 100 120
    :header-rows: 1
- 
+
    * - Platform
      - Architecture
      - Version
@@ -37,3 +37,9 @@ The following table lists the Tier 1 supported platforms for the |chef client|:
    * - |windows|
      - ``x86``, ``x86_64``
      - ``2008``, ``2008r2``, ``2012``, ``2012r2``, ``7``, ``8``, ``8.1``
+   * - |cisco-nxos|
+     - ``x86_64``
+     - ``7``
+   * - |cisco-iosxr|
+     - ``x86_64``
+     - ``6``

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -369,7 +369,7 @@
 .. |amazon elb| replace:: Amazon Elastic Load Balancing (ELB)
 .. |amazon iam| replace:: Identity and Access Management (IAM)
 .. |amazon linux| replace:: Amazon Linux
-.. |amazon rds| replace:: Amazon Relational Database Service (RDS) 
+.. |amazon rds| replace:: Amazon Relational Database Service (RDS)
 .. |amazon s3| replace:: Amazon Simple Storage Service (S3)
 .. |amazon sns| replace:: Amazon Simple Notification Service (SNS)
 .. |amazon sqs| replace:: Amazon Simple Queue Service (SQS)
@@ -438,6 +438,8 @@
 .. |cisco| replace:: Cisco
 .. |cisco asa| replace:: Cisco ASA
 .. |cisco ucs| replace:: Cisco UCS
+.. |cisco-iosxr| replace:: Cisco IOS XR
+.. |cisco-nxos| replace:: Cisco NX-OS
 .. |clojure| replace:: Clojure
 .. |cloudkick| replace:: Cloudkick
 .. |cloudstack| replace:: CloudStack
@@ -902,4 +904,3 @@
 ..
 
 .. |default bootstrap| replace:: Ubuntu 10.04 with RubyGems
-


### PR DESCRIPTION
This is just housekeeping as we are wrapping up our contract with Cisco. The builds are already available on the website.
