### PR TITLE
Update reporting requirements

### DIFF
--- a/includes_system_requirements/includes_system_requirements_reporting.rst
+++ b/includes_system_requirements/includes_system_requirements_reporting.rst
@@ -9,8 +9,12 @@
 * |chef server oec| 11.1.7 (and earlier) should use |reporting| 1.1.2 (or earlier); |chef server oec| 11.1.8 should use |reporting| 1.1.5 (and later)
 * |chef client| version 11.6.0 (or later), with the exception of |chef client| version 11.8.0
 
+|reporting| can make use of an external database, but to do so |reporting| 1.5.5 or later is needed along with |chef server| 12.2.0 or later or |chef server oec| 11.3.2 or later.
+
 The |reporting| client is built into the |chef client| and can run on all platforms that |chef client| is supported on.
 
 .. warning:: |reporting| does not work on |chef client| version 11.8.0; upgrade to |chef client| version 11.8.2 (or later) if |reporting| is being run in your organization.
 
 .. warning:: |reporting| requires version 1.0.1 (or later) when the |chef server oec| is run in a high availability configuration.
+
+.. warning:: |reporting| versions 1.5.2, 1.5.3, and 1.5.4 were removed from availability due to incompatibilities with |chef server| 12.2.0. |reporting| 1.5.5 replaced these versions.


### PR DESCRIPTION
Explains what happened to reporting versions 1.5.2, 1.5.3, and 1.5.4
Also makes clear the versions needed to run an external database with
reporting
