### PR TITLE
Warn about issues with non-alphanumeric cookbook/resource names

### DIFF
--- a/chef_master/source/ruby.rst
+++ b/chef_master/source/ruby.rst
@@ -123,6 +123,8 @@ This section covers best practices for cookbook and recipe authoring.
 -----------------------------------------------------
 .. include:: ../../includes_ruby/includes_ruby_style_patterns_git_etiquette.rst
 
+.. _ruby_style_patterns_cookbook_naming:
+
 Cookbook Naming
 -----------------------------------------------------
 .. include:: ../../includes_ruby/includes_ruby_style_patterns_cookbook_naming.rst

--- a/includes_ctl_chef/includes_ctl_chef_generate_app.rst
+++ b/includes_ctl_chef/includes_ctl_chef_generate_app.rst
@@ -10,3 +10,4 @@ Use the ``chef generate app`` subcommand to generate a cookbook structure that:
 * Supports a top-level instance of |kitchen| that can be used to test each cookbook in the appication
 * Supports a single |policyfile rb|, which is an upcoming feature of the |chef dk| that defines a workflow around a set of cookbooks and related policy (such as roles, environments, and so on); for more information about |policyfile rb|, see the chef.lists discussions (search for "policyfile")
 
+.. note:: Avoid using hyphens or other non-alphanumeric characters in cookbook names. Doing so can cause unexpected errors when trying to use those names in recipes. See :ref:`ruby_style_patterns_cookbook_naming` for more information.

--- a/includes_ctl_chef/includes_ctl_chef_generate_cookbook.rst
+++ b/includes_ctl_chef/includes_ctl_chef_generate_cookbook.rst
@@ -3,3 +3,5 @@
 
 
 Use the ``chef generate cookbook`` subcommand to generate a cookbook.
+
+.. note:: Avoid using hyphens or other non-alphanumeric characters in cookbook names. Doing so can cause unexpected errors when trying to use those names in recipes. See :ref:`ruby_style_patterns_cookbook_naming` for more information.

--- a/includes_ctl_chef/includes_ctl_chef_generate_lwrp.rst
+++ b/includes_ctl_chef/includes_ctl_chef_generate_lwrp.rst
@@ -3,3 +3,5 @@
 
 
 Use the ``chef generate lwrp`` subcommand to generate a lightweight resource and provider in the ``/resources`` and ``/providers`` directory.
+
+.. note:: Avoid using hyphens or other non-alphanumeric characters in resource and provider names. Doing so can cause unexpected errors when trying to use those names in recipes.

--- a/includes_custom_resources/includes_custom_resources_syntax_example.rst
+++ b/includes_custom_resources/includes_custom_resources_syntax_example.rst
@@ -56,3 +56,5 @@ and to delete the exampleco website, do the following:
    exampleco_site 'httpd' do
      action :delete
    end
+
+.. note:: Non-alphanumeric characters in cookbook names and resource file names are replaced by underscores (``_``) in recipes. For example, if the ``exampleco`` cookbook was instead named ``exampleco-beta``, the resource name ``exampleco_beta_site`` would be used in the recipe.

--- a/includes_definition/includes_definition_example_as_resource.rst
+++ b/includes_definition/includes_definition_example_as_resource.rst
@@ -36,3 +36,5 @@ or:
    host_porter 'www1' do
      port 4001
    end
+
+.. note:: Non-alphanumeric characters in cookbook names and resource file names are replaced by underscores (``_``) in recipes. For example, if the ``exampleco`` cookbook was instead named ``exampleco-beta``, the resource name ``exampleco_beta_site`` would be used in the recipe.

--- a/includes_dsl_custom_resource/includes_dsl_custom_resource_method_resource_name.rst
+++ b/includes_dsl_custom_resource/includes_dsl_custom_resource_method_resource_name.rst
@@ -1,14 +1,10 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
 .. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
-
-
-By default, the custom resource name is inferred from the name of the cookbook and the name of the resource file, separated by an underscore(``_``). For example, a cookbook named ``website`` and a custom resource file named ``httpd`` is used in a recipe with ``website_httpd``.
-
-Use the ``resource_name`` method at the top of a custom resource to declare a custom name for that resource. For example:
+By default, the custom resource name is inferred from the name of the cookbook and the name of the resource file, separated by an underscore (``_``), and with non-alphanumeric characters replaced with underscores. To give it a different name, use the ``resource_name`` method at the top of the file. For example:
 
 .. code-block:: ruby
 
-   resource_name :name
+   resource_name :custom_name
 
-where ``:name`` declares the resource name as it may be used in a recipe.
+where ``:custom_name`` is the resource name as it may be used in a recipe.

--- a/includes_knife/includes_knife_cookbook_create.rst
+++ b/includes_knife/includes_knife_cookbook_create.rst
@@ -1,7 +1,6 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
 .. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
-
 Use the ``create`` argument to create a new cookbook directory on the local machine, including the following directories and files:
 
   * cookbook/attributes
@@ -18,3 +17,4 @@ Use the ``create`` argument to create a new cookbook directory on the local mach
 
 After the cookbook is created, it can be uploaded to the |chef server| using the ``knife upload`` argument.
 
+.. note:: Avoid using hyphens or other non-alphanumeric characters in cookbook names. Doing so can cause unexpected errors when trying to use those names in recipes. See :ref:`ruby_style_patterns_cookbook_naming` for more information.

--- a/includes_ruby/includes_ruby_style_patterns_cookbook_naming.rst
+++ b/includes_ruby/includes_ruby_style_patterns_cookbook_naming.rst
@@ -1,5 +1,5 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
 .. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
-* Avoid dashes in cookbook names. This is because many custom resources use the cookbook name as part of the resource name, so the method names themselves can become awkward, but also ``-`` cannot be part of a symbol in |ruby| and the presence of dashes in cookbook names may trigger undesired errors later on in the process
-* All organization application cookbooks should be prefixed with a short organizational prefix, such as 'sm' for 'SecondMarket' (e.g. 'smpostgresql')
+* Avoid hyphens and other non-alphanumeric characters in cookbook names.  :doc:`Custom resource </custom_resources>` names are generated from the cookbook name and the resource file name, with any non-alphanumeric characters replaced by underscores (``_``). As a result, those resources' names may be different from what you expect, making them especially error-prone.
+* All organization application cookbooks should be prefixed with a short organizational prefix, such as ``sm`` for "SecondMarket" (e.g.  ``smpostgresql``).


### PR DESCRIPTION
Clarify behavior and provide guidance on cookbook and resource names with hyphens and other non-alphanumeric characters. Users are regularly tripped up by this, e.g. chef/chef#4723.
