### PR TITLE
Make oc_id application examples safer

### DIFF
--- a/chef_master/source/supermarket.rst
+++ b/chef_master/source/supermarket.rst
@@ -38,10 +38,9 @@ To set up |chef identity|, do the following:
 
    .. code-block:: ruby
 
-      oc_id['applications'] = {
-        'supermarket' => {
-          'redirect_uri' => 'https://supermarket.mycompany.com/auth/chef_oauth2/callback'
-        }
+      oc_id['applications'] = {} unless oc_id['applications']
+      oc_id['applications']['supermarket'] = {
+        'redirect_uri' => 'https://supermarket.mycompany.com/auth/chef_oauth2/callback'
       }
 
 #. Run the following command:

--- a/chef_master/source/supermarket.rst
+++ b/chef_master/source/supermarket.rst
@@ -38,7 +38,7 @@ To set up |chef identity|, do the following:
 
    .. code-block:: ruby
 
-      oc_id['applications'] = {} unless oc_id['applications']
+      oc_id['applications'] ||= {}
       oc_id['applications']['supermarket'] = {
         'redirect_uri' => 'https://supermarket.mycompany.com/auth/chef_oauth2/callback'
       }

--- a/includes_install/includes_install_analytics_standalone_11.rst
+++ b/includes_install/includes_install_analytics_standalone_11.rst
@@ -27,7 +27,7 @@ Configure the |chef server|. On each server in the |chef server| configuration, 
 
    .. code-block:: bash
 
-      oc_id['applications'] = {} unless oc_id['applications']
+      oc_id['applications'] ||= {}
       oc_id['applications']['analytics'] = {
         'redirect_uri' => 'https://<analytics_fqdn>/'
       }

--- a/includes_install/includes_install_analytics_standalone_11.rst
+++ b/includes_install/includes_install_analytics_standalone_11.rst
@@ -10,13 +10,13 @@ Install |chef analytics|:
 #. Download the package from http://downloads.chef.io/analytics/ to the dedicated standalone server that will be used for |chef analytics|. For |redhat| and |centos| 6:
 
    .. code-block:: bash
-      
+
       $ rpm -Uvh /tmp/opscode-analytics-<version>.rpm
 
    For |ubuntu|:
 
    .. code-block:: bash
-      
+
       $ dpkg -i /tmp/opscode-analytics-<version>.deb
 
    After a few minutes, |chef analytics| will be installed.
@@ -27,18 +27,17 @@ Configure the |chef server|. On each server in the |chef server| configuration, 
 
    .. code-block:: bash
 
-	  oc_id['applications'] = { 
-	    'analytics' => { 
-	      'redirect_uri' => 'https://<analytics_fqdn>/' 
-	    } 
-	  }
+      oc_id['applications'] = {} unless oc_id['applications']
+      oc_id['applications']['analytics'] = {
+        'redirect_uri' => 'https://<analytics_fqdn>/'
+      }
 
 #. Stop the |chef server|:
 
    .. code-block:: bash
 
       $ chef-server-ctl stop
-	  
+
 #. Enable remote access to |rabbitmq| on the |chef server| backend by adding the following settings to ``/etc/opscode/chef-server.rb``:
 
    .. code-block:: ruby
@@ -48,7 +47,7 @@ Configure the |chef server|. On each server in the |chef server| configuration, 
 
    where ``BACKEND_VIP`` is the external IP address for the backend |chef server|. ``node_ip_address`` MUST be set to ``0.0.0.0``.
 
-   .. note:: |analytics rabbitmq_settings| 
+   .. note:: |analytics rabbitmq_settings|
 
 #. Reconfigure the |chef server|:
 
@@ -59,7 +58,7 @@ Configure the |chef server|. On each server in the |chef server| configuration, 
    This updates the |chef server| and creates the ``actions-source.json`` file, which is required by |chef analytics|, and adds it to the ``/etc/opscode-analytics`` directory on the |chef server|.
 
 #. Restart the |chef server|:
-   
+
    .. code-block:: bash
 
       $ chef-server-ctl restart

--- a/includes_install/includes_install_analytics_tiered.rst
+++ b/includes_install/includes_install_analytics_tiered.rst
@@ -33,7 +33,7 @@ Configure the |chef server|. On each machine in the |chef server| configuration,
 
    .. code-block:: bash
 
-      oc_id['applications'] = {} unless oc_id['applications']
+      oc_id['applications'] ||= {}
       oc_id['applications']['analytics'] = {
         'redirect_uri' => 'https://<analytics_fe_fqdn>/'
       }

--- a/includes_install/includes_install_analytics_tiered.rst
+++ b/includes_install/includes_install_analytics_tiered.rst
@@ -1,9 +1,9 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
 .. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
-In a tiered configuration, the |chef analytics| deployment is on different servers from the |chef server|, with a single backend and multiple load-balanced frontends. In a tiered configuration, an existing |chef server| deployment should already running. 
+In a tiered configuration, the |chef analytics| deployment is on different servers from the |chef server|, with a single backend and multiple load-balanced frontends. In a tiered configuration, an existing |chef server| deployment should already running.
 
-|chef analytics| is installed in the following steps: 
+|chef analytics| is installed in the following steps:
 
 * Configuring the |chef server| for |chef analytics|
 * Installing |chef analytics| on the backend
@@ -16,13 +16,13 @@ Install |chef analytics| on the backend machine:
 #. Download the package from http://downloads.chef.io/analytics/ to the machines that will be used for the |chef analytics| deployment. For |redhat| and |centos| 6:
 
    .. code-block:: bash
-      
+
       $ rpm -Uvh /tmp/opscode-analytics-<version>.rpm
 
    For |ubuntu|:
 
    .. code-block:: bash
-      
+
       $ dpkg -i /tmp/opscode-analytics-<version>.deb
 
    After a few minutes, |chef analytics| will be installed.
@@ -33,18 +33,17 @@ Configure the |chef server|. On each machine in the |chef server| configuration,
 
    .. code-block:: bash
 
-	  oc_id['applications'] = { 
-	    'analytics' => { 
-	      'redirect_uri' => 'https://<analytics_fe_fqdn>/' 
-	    } 
-	  }
+      oc_id['applications'] = {} unless oc_id['applications']
+      oc_id['applications']['analytics'] = {
+        'redirect_uri' => 'https://<analytics_fe_fqdn>/'
+      }
 
 #. On the |chef server| backend, stop the |chef server|:
 
    .. code-block:: bash
 
       $ chef-server-ctl stop
-	  
+
 #. On the |chef server| backend, enable remote access to |rabbitmq| on the |chef server| backend machine by adding the following settings to ``/etc/opscode/chef-server.rb``:
 
    .. code-block:: ruby
@@ -54,7 +53,7 @@ Configure the |chef server|. On each machine in the |chef server| configuration,
 
    where ``BACKEND_VIP`` is the external IP address for the backend |chef server|. ``node_ip_address`` MUST be set to ``0.0.0.0``.
 
-   .. note:: |analytics rabbitmq_settings| 
+   .. note:: |analytics rabbitmq_settings|
 
 #. Reconfigure the |chef server|:
 
@@ -65,7 +64,7 @@ Configure the |chef server|. On each machine in the |chef server| configuration,
    This updates the |chef server| and creates the ``actions-source.json`` file, which is required by |chef analytics|, and adds it to the ``/etc/opscode-analytics`` directory on the |chef server|.
 
 #. Restart the |chef server| backend:
-   
+
    .. code-block:: bash
 
       $ chef-server-ctl restart
@@ -153,6 +152,5 @@ Install |chef analytics| on frontend servers:
 #. Reconfigure the |chef server|:
 
    .. code-block:: bash
-      
-      $ sudo chef-server-ctl reconfigure
 
+      $ sudo chef-server-ctl reconfigure

--- a/step_config/step_config_ocid_application_hash.rst
+++ b/step_config/step_config_ocid_application_hash.rst
@@ -6,11 +6,10 @@ To define |oauth| 2 information for both |chef analytics| and |supermarket|, cre
 
    .. code-block:: ruby
 
-      oc_id['applications'] = {
-        'analytics' => {
-          'redirect_uri' => 'https://analytics.rhel.aws'
-        },
-        'supermarket' => {
-          'redirect_uri' => 'https://vagrantup.com/auth'
-        }
+      oc_id['applications'] = {} unless oc_id['applications']
+      oc_id['applications']['analytics'] = {
+        'redirect_uri' => 'https://analytics.rhel.aws'
+      }
+      oc_id['applications']['supermarket'] = {
+        'redirect_uri' => 'https://vagrantup.com/auth'
       }

--- a/step_config/step_config_ocid_application_hash.rst
+++ b/step_config/step_config_ocid_application_hash.rst
@@ -6,7 +6,7 @@ To define |oauth| 2 information for both |chef analytics| and |supermarket|, cre
 
    .. code-block:: ruby
 
-      oc_id['applications'] = {} unless oc_id['applications']
+      oc_id['applications'] ||= {}
       oc_id['applications']['analytics'] = {
         'redirect_uri' => 'https://analytics.rhel.aws'
       }


### PR DESCRIPTION
https://github.com/chef/chef-compliance/issues/739#issuecomment-206233353 describes why this docs change is needed.

It will prevent multiple oc_id['application'] blocks in chef-server.rb from stepping on each other.
