### PR TITLE
Minor grammatical fixes and URL fix

### DIFF
--- a/_themes/chefv2/nav-docs.html
+++ b/_themes/chefv2/nav-docs.html
@@ -212,7 +212,7 @@
     {%- endfor %} <!-- /for item in navItems -->
     {% endblock %}
     <li class="main-item dark-item">
-      <a href="https://github.com/chef/chef-docs" title="Available on Github">
+      <a href="https://github.com/chef/chef-web-docs" title="Available on Github">
         <i class="fa fa-github icon-left"></i>
         Available on Github
       </a>

--- a/includes_resources_common/includes_resources_common_provider_attributes.rst
+++ b/includes_resources_common/includes_resources_common_provider_attributes.rst
@@ -3,7 +3,7 @@
 
 The |chef client| will determine the correct provider based on configuration data collected by |ohai| at the start of the |chef client| run. This configuration data is then mapped to a platform and an associated list of providers.
 
-Generally, it's best to let the |chef client| choose the provider and this is (by far) the most common approach. However, in some cases specifying a provider may be desirable. There are two approaches:
+Generally, it's best to let the |chef client| choose the provider, and this is (by far) the most common approach. However, in some cases, specifying a provider may be desirable. There are two approaches:
 
 * Use a more specific short name---``yum_package "foo" do`` instead of ``package "foo" do``, ``script "foo" do`` instead of ``bash "foo" do``, and so on---when available
-* Use the ``provider`` property within the resource block to specify the long name of the provider as an property of a resource. For example: ``provider Chef::Provider::Long::Name``
+* Use the ``provider`` property within the resource block to specify the long name of the provider as a property of a resource. For example: ``provider Chef::Provider::Long::Name``


### PR DESCRIPTION
Just some minor grammatical issues I came across while referencing the documentation.  Also, I think it makes sense to update the URL of the navbar link to GitHub so it points to the correct, current repo.
