### PR TITLE
Be more explicit about :upgrade action w/ version

### DIFF
--- a/includes_resources/includes_resource_package_yum_actions.rst
+++ b/includes_resources/includes_resource_package_yum_actions.rst
@@ -16,4 +16,4 @@ This resource has the following actions:
    Remove a package.
 
 ``:upgrade``
-   Install a package and/or ensure that a package is the latest version.
+   Install a package and/or ensure that a package is the latest version. Ignores any ``version`` attribute for the resource.


### PR DESCRIPTION
They yum_package resource ignores the provided version when called with `action :upgrade`. My team and I misinterpreted the docs, and thought that calling `:upgrade` with a version attribute would upgrade the package to the specified version. We understand that's really an `install` action now, but this could be clearer. Maybe package should bomb out if you specify a version and :upgrade action?
## Example recipe

``` ruby
yum_package 'ruby' do
  action :upgrade
  version '2.1.3-1.el6'
end
```
## chef-shell output

```
chef (12.6.0)> recipe_mode
chef:recipe (12.6.0)> yum_package 'ruby' do
chef:recipe > action :upgrade
chef:recipe ?> version '2.1.3-1.el6'
chef:recipe ?> end
 => <yum_package[ruby] @name: "ruby" @noop: nil @before: nil @params: {} @provider: nil @allowed_actions: [:nothing, :install, :upgrade, :remove, :purge, :reconfig] @action: [:upgrade] @updated: false @updated_by_last_action: false @supports: {} @ignore_failure: false @retries: 0 @retry_delay: 2 @source_line: "(irb#1):1:in `irb_binding'" @guard_interpreter: nil @default_guard_interpreter: :default @elapsed_time: 0 @sensitive: false @options: nil @package_name: "ruby" @response_file: nil @response_file_variables: {} @source: nil @version: "2.1.3-1.el6" @timeout: nil @flush_cache: {:before=>false, :after=>false} @allow_downgrade: false @yum_binary: nil @declared_type: :yum_package @cookbook_name: nil @recipe_name: nil>
chef:recipe (12.6.0)> exit
 => :recipe
chef (12.6.0)> run_chef
DEBUG: yum_package[ruby] checking yum info for ruby-2.1.3-1.el6
DEBUG: yum_package[ruby] installed version: [nil] candidate version: 2.2.0-1.el6
DEBUG: yum_package[ruby] ruby is out of date, will upgrade to 2.2.0-1.el6
INFO: yum_package[ruby] installing ruby-2.2.0-1.el6 from foo-staging repository
DEBUG: yum_package[ruby]: yum command: "yum -d0 -e0 -y install ruby-2.2.0-1.el6"
INFO: yum_package[ruby] upgraded ruby to 2.2.0-1.el6
```
