### PR TITLE
Fix attribute for start handlers

### DIFF
--- a/includes_handler/includes_handler_type_start_run_from_recipe.rst
+++ b/includes_handler/includes_handler_type_start_run_from_recipe.rst
@@ -11,7 +11,7 @@ The |cookbook chef_client| cookbook can be configured to automatically install a
      :action => :install
    }
    
-   node.set['chef_client']['start_handlers'] = [
+   node.set['chef_client']['config']['start_handlers'] = [
      {
        :class => 'Chef::Reporting::StartHandler',
        :arguments => []


### PR DESCRIPTION
The chef-client cookbook offers an attribute `node['chef_client']['config']['start_handlers']` to add start handlers.

The documentation, however, has an example that mentions `node['chef_client']['start_handlers']`. Correct this.
