### PR TITLE
fix the configuration key used by kitchen for where to store things

### DIFF
--- a/includes_test_kitchen/includes_test_kitchen_yml_provisioner.rst
+++ b/includes_test_kitchen/includes_test_kitchen_yml_provisioner.rst
@@ -56,7 +56,7 @@
      - |https_proxy|
    * - ``json_attributes``
      - |chef client| provisioner only. 
-   * - ``kitchen_root``
+   * - ``root_path``
      - The directory in which |kitchen| will stage all content on the target node. This directory should be large enough to store all the content and must be writable. (Typically, this value does not need to be modified from the default value.) Default value: ``/tmp/kitchen``.
    * - ``log_file``
      - 


### PR DESCRIPTION
On my system running ChefDK 0.12.0 I found the current documentation to be in accurate. `kitchen_root` (as viewed via `kitchen diag`) is actually a value on the local host with its value set to the location on disk where the cookbook source is stored (ie the directory you are working on it in). Changing its value has no effect on the remote host. However, setting `root_path` instead does the trick. Additionally `root_path` as viewed via `kitchen diag` has a default of `/tmp/kitchen`
