### PR TITLE
Fixed missing type, consistent capitalization

### DIFF
--- a/includes_resources/includes_resource_launchd_syntax.rst
+++ b/includes_resources/includes_resource_launchd_syntax.rst
@@ -8,7 +8,7 @@ A |resource launchd| resource manages system-wide services (daemons) and per-use
 
    launchd 'call.mom.weekly' do
      program '/Library/scripts/call_mom.sh'
-     start_calendar_interval 'Weekday' => 7, 'Hourly' => 10
+     start_calendar_interval 'weekday' => 7, 'hourly' => 10
      time_out 300
    end
 
@@ -66,6 +66,7 @@ The full syntax for all of the properties that are available to the |resource la
      subscribes                 # see description
      throttle_interval          Integer
      time_out                   Integer
+     type                       String
      umask                      Integer
      username                   String
      wait_for_debugger          TrueClass, FalseClass
@@ -79,4 +80,4 @@ where
 * ``launchd`` is the resource
 * ``name`` is the name of the resource block
 * ``:action`` identifies the steps the |chef client| will take to bring the node into the desired state
-* ``abandon_process_group``, ``backup``, ``cookbook``, ``debug``, ``disabled``, ``enable_globbing``, ``enable_transactions``, ``environment_variables``, ``exit_timeout``, ``group``, ``hard_resource_limits``, ``hash``, ``inetd_compatibility``, ``init_groups``, ``keep_alive``, ``label``, ``launch_only_once``, ``limit_load_from_hosts``, ``limit_load_to_hosts``, ``limit_load_to_session_type``, ``low_priority_io``, ``mach_services``, ``mode``, ``nice``, ``on_demand``, ``owner``, ``path``, ``process_type``, ``program``, ``program_arguments``, ``queue_directories``, ``retries``, ``retry_delay``, ``root_directory``, ``run_at_load``, ``sockets``, ``soft_resource_limits``, ``standard_error_path``, ``standard_in_path``, ``standard_out_path``, ``start_calendar_interval``, ``start_interval``, ``start_on_mount``, ``throttle_interval``, ``time_out``, ``umask``, ``username``, ``wait_for_debugger``, ``watch_paths``, and ``working_directory`` are properties of this resource, with the |ruby| type shown. |see attributes|
+* ``abandon_process_group``, ``backup``, ``cookbook``, ``debug``, ``disabled``, ``enable_globbing``, ``enable_transactions``, ``environment_variables``, ``exit_timeout``, ``group``, ``hard_resource_limits``, ``hash``, ``inetd_compatibility``, ``init_groups``, ``keep_alive``, ``label``, ``launch_only_once``, ``limit_load_from_hosts``, ``limit_load_to_hosts``, ``limit_load_to_session_type``, ``low_priority_io``, ``mach_services``, ``mode``, ``nice``, ``on_demand``, ``owner``, ``path``, ``process_type``, ``program``, ``program_arguments``, ``queue_directories``, ``retries``, ``retry_delay``, ``root_directory``, ``run_at_load``, ``sockets``, ``soft_resource_limits``, ``standard_error_path``, ``standard_in_path``, ``standard_out_path``, ``start_calendar_interval``, ``start_interval``, ``start_on_mount``, ``throttle_interval``, ``time_out``, ``type``, ``umask``, ``username``, ``wait_for_debugger``, ``watch_paths``, and ``working_directory`` are properties of this resource, with the |ruby| type shown. |see attributes|

--- a/step_resource/step_resource_launchd_create_using_keys.rst
+++ b/step_resource/step_resource_launchd_create_using_keys.rst
@@ -7,6 +7,6 @@
 
    launchd 'call.mom.weekly' do
      program '/Library/scripts/call_mom.sh'
-     start_calendar_interval 'Weekday' => 7, 'Hourly' => 10
+     start_calendar_interval 'weekday' => 7, 'hourly' => 10
      time_out 300
    end


### PR DESCRIPTION
In the launchd docs, there's inconsistent capitalization for start_calendar_interval. In some examples, the keys are "Hourly", "Weekday", etc., and in later examples, they're lower case.  To be consistent with Chef styling, this PR makes them all lower case.

Additionally, the syntax section is missing the 'type' property, which is defined later on in the list of properties but not mentioned anywhere else (and is important for anyone distinguishing launch daemons from launch agents!).
