### PR TITLE
Make Windows omnitruck examples consistent.

### DIFF
--- a/includes_packages/includes_packages_install_script_run_windows.rst
+++ b/includes_packages/includes_packages_install_script_run_windows.rst
@@ -1,7 +1,6 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
 .. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics. 
 
-
 On |windows| systems the |omnitruck| install script is invoked using |windows powershell|:
 
 .. code-block:: powershell


### PR DESCRIPTION
The Windows command line examples differed on the same rendered page in the way they were presented. This unifies the examples and makes them very clear as to what actually needs to be typed.
