### PR TITLE
Corrected command for Compliance configuration

### DIFF
--- a/includes_cloud/includes_cloud_azure_portal_compliance_marketplace.rst
+++ b/includes_cloud/includes_cloud_azure_portal_compliance_marketplace.rst
@@ -40,7 +40,7 @@
    .. code-block:: bash
 
       $ sudo chef-marketplace-ctl hostname <fqdn>
-      $ sudo chef-compliance-ctl restart
+      $ sudo chef-compliance-ctl reconfigure
 
 #. Now proceed to the web based setup wizard ``https://<fqdn>/#/setup``
 


### PR DESCRIPTION
Working with a partner they had issues configuring the compliance server.

This is because the Compliance server was set to `restart` rather than `reconfigure`.  This PR is for that change.

Once we did this on the compliance server it started to work properly and we did not get a redirect to the internal DNS address for the Dashboard in Azure.
