### PR TITLE
Correct paths in "chef generate app" example output

### DIFF
--- a/step_ctl_chef/step_ctl_chef_generate_application.rst
+++ b/step_ctl_chef/step_ctl_chef_generate_application.rst
@@ -25,23 +25,23 @@ will return something similar to:
      * directory[/Users/grantmc/chef-repo/cookbooks] action create
        - create new directory /Users/grantmc/chef-repo/cookbooks
    
-     * directory[/Users/grantmc/chef-repo/cookbooks/grantmc] action create
-       - create new directory /Users/grantmc/chef-repo/cookbooks/grantmc
+     * directory[/Users/grantmc/chef-repo/cookbooks/chef-repo] action create
+       - create new directory /Users/grantmc/chef-repo/cookbooks/chef-repo
    
-     * template[/Users/grantmc/chef-repo/cookbooks/grantmc/metadata.rb] action create
-       - create new file /Users/grantmc/chef-repo/cookbooks/grantmc/metadata.rb
+     * template[/Users/grantmc/chef-repo/cookbooks/chef-repo/metadata.rb] action create
+       - create new file /Users/grantmc/chef-repo/cookbooks/chef-repo/metadata.rb
    
-     * cookbook_file[/Users/grantmc/chef-repo/cookbooks/grantmc/chefignore] action create
-       - create new file /Users/grantmc/chef-repo/cookbooks/grantmc/chefignore
+     * cookbook_file[/Users/grantmc/chef-repo/cookbooks/chef-repo/chefignore] action create
+       - create new file /Users/grantmc/chef-repo/cookbooks/chef-repo/chefignore
 
-     * cookbook_file[/Users/grantmc/chef-repo/cookbooks/grantmc/Berksfile] action create
-       - create new file /Users/grantmc/chef-repo/cookbooks/grantmc/Berksfile
+     * cookbook_file[/Users/grantmc/chef-repo/cookbooks/chef-repo/Berksfile] action create
+       - create new file /Users/grantmc/chef-repo/cookbooks/chef-repo/Berksfile
 
-     * directory[/Users/grantmc/chef-repo/cookbooks/grantmc/recipes] action create
-       - create new directory /Users/grantmc/chef-repo/cookbooks/grantmc/recipes
+     * directory[/Users/grantmc/chef-repo/cookbooks/chef-repo/recipes] action create
+       - create new directory /Users/grantmc/chef-repo/cookbooks/chef-repo/recipes
 
-     * template[/Users/grantmc/chef-repo/cookbooks/grantmc/recipes/default.rb] action create
-       - create new file /Users/grantmc/chef-repo/cookbooks/grantmc/recipes/default.rb
+     * template[/Users/grantmc/chef-repo/cookbooks/chef-repo/recipes/default.rb] action create
+       - create new file /Users/grantmc/chef-repo/cookbooks/chef-repo/recipes/default.rb
    
      * execute[initialize-git] action run
        - execute git init .


### PR DESCRIPTION
Quick fix for some example output that didn't match reality. Looks like the author used the output from `chef generate app grantmc` for the example command output, but the given example command and the tree block that follows were pulled from the output of `chef generate app chef-repo`
