### PR TITLE
add kitchen.yml documentation related to kitchen transports

### DIFF
--- a/chef_master/source/config_yml_kitchen.rst
+++ b/chef_master/source/config_yml_kitchen.rst
@@ -18,6 +18,10 @@ Provisioner Settings
 
 .. note:: There are two community provisioners for |kitchen|: `kitchen-dsc <https://github.com/smurawski/kitchen-dsc>`__ and `kitchen-pester <https://github.com/smurawski/kitchen-pester>`__.
 
+Transport Settings
+==========================================================================
+.. include:: ../../includes_test_kitchen/includes_test_kitchen_yml_transport.rst
+
 Work with Proxies
 --------------------------------------------------------------------------
 .. include:: ../../includes_test_kitchen/includes_test_kitchen_yml_syntax_proxy.rst

--- a/includes_test_kitchen/includes_test_kitchen_yml_example_windows_platform.rst
+++ b/includes_test_kitchen/includes_test_kitchen_yml_example_windows_platform.rst
@@ -11,8 +11,8 @@ The following example shows platform settings for the |windows| platform:
    platforms:
      - name: eval-win2012r2-standard
        os_type: windows
-       shell_type: powershell
        transport:
          name: winrm
+         elevated: true
 
-where ``os_type``, ``shell_type``, and the transport ``name`` are all required.
+If ``name`` begins with ``win`` then the ``os_type`` defaults to ``windows``. The ``winrm`` transport is the default on Windows operating systems. Here ``elevated`` is true which runs windows commands via a scheduled task to imitate a local user.

--- a/includes_test_kitchen/includes_test_kitchen_yml_syntax.rst
+++ b/includes_test_kitchen/includes_test_kitchen_yml_syntax.rst
@@ -15,6 +15,9 @@ The basic structure of a |kitchen yml| file is as follows:
    verifier:
      name: verifier_name
    
+   transport:
+     name: transport_name
+
    platforms:
      - name: platform-version
        driver:
@@ -42,6 +45,7 @@ where:
 * ``driver_name`` is the name of a driver that will be used to create platform instances used during cookbook testing. This is the default driver used for all platforms and suites **unless** a platform or suite specifies a ``driver`` to override the default driver for that platform or suite; a driver specified for a suite will override a driver set for a platform
 * ``provisioner_name`` specifies how the |chef client| will be simulated during testing. ``chef_zero``  and ``chef_solo`` are the most common provisioners used for testing cookbooks
 * ``verifier_name`` specifies which application to use when running tests, such as ``inspec``
+* ``transport_name`` specifies which transport to use when executing commands remotely on the test instance. ``winrm`` is the default transport on Windows. The ``ssh`` transport is the default on all other operating systems.
 * ``platform-version`` is a the name of a platform on which |kitchen| will perform cookbook testing, for example, ``ubuntu-12.04`` or ``centos-6.4``; depending on the platform, additional driver details---for example, instance names and URLs used with cloud platforms like |openstack| or |amazon ec2|---may be required
 * ``platforms`` may define |chef server| attributes that are common to the collection of test suites
 * ``suites`` is a collection of test suites, with each ``suite_name`` grouping defining an aspect of a cookbook to be tested. Each ``suite_name`` must specify a run-list, for example: 

--- a/includes_test_kitchen/includes_test_kitchen_yml_transport.rst
+++ b/includes_test_kitchen/includes_test_kitchen_yml_transport.rst
@@ -1,0 +1,66 @@
+.. The contents of this file may be included in multiple topics (using the includes directive).
+.. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
+
+
+|kitchen| can configure a transport with the following settings for either ``ssh`` or ``winrm`` transports:
+
+.. list-table::
+   :widths: 200 300
+   :header-rows: 1
+
+   * - Setting
+     - Description
+   * - ``connection_retries``
+     - Maximum number of times to retry after a failed attempt to open a connection. The default is 5.
+   * - ``connection_retry_sleep``
+     - Number of seconds to wait until attempting to make another connection after a failure.
+   * - ``max_wait_until_ready``
+     - Maximum number of attempts to determine if the test instance is ready to accept commands. This defaults to 600.
+   * - ``password``
+     - The password used for authenticating to the test instance.
+   * - ``port``
+     - The port used to connect to the test instance. This defaults to ``22`` for the ``ssh`` transport and ``5985`` or ``5986`` for ``winrm`` using ``http`` or ``https`` respectively.
+   * - ``username``
+     - The username used for authenticating to the test instance. This defaults to ``administrator`` for the ``winrm`` transport and ``root`` for the ``ssh`` transport. Some drivers may change this default.
+
+These settings may be added to the ``transport`` section of the |kitchen yml| file when the transport is |ssh|:
+
+.. list-table::
+   :widths: 200 300
+   :header-rows: 1
+
+   * - Setting
+     - Description
+   * - ``compression``
+     - Wether or not to use compression. The default is ``false``.
+   * - ``compression_level``
+     - The default is 6 if ``compression`` is ``true``.
+   * - ``connection_timeout``
+     - Defaults to 15.
+   * - ``keepalive``
+     - Defaults to ``true``.
+   * - ``keepalive_interval``
+     - Defaults to 60.
+   * - ``max_ssh_sessions``
+     - Maximum number of parallel ssh sessions.
+   * - ``ssh_key``
+     - Path to an ssh key identity file.
+
+These settings may be added to the ``transport`` section of the |kitchen yml| file when the transport is |winrm|:
+
+.. list-table::
+   :widths: 200 300
+   :header-rows: 1
+
+   * - Setting
+     - Description
+   * - ``elevated``
+     - When ``true``, all commands are executed via a scheduled task. This may eliminate access denied errors related to double hop authentication, interacting with windows updates and installing some MSIs such as sql server and .net runtimes. Defaults to ``false``.
+   * - ``elevated_password``
+     - The password used by the identity running the scheduled task. This may be ``null`` in the case of service accounts. Defaults to ``password``.
+   * - ``elevated_username``
+     - The identity that the task runs under. This may also be set to service accounts such as ``System``. This defaults to ``username``.
+   * - ``rdp_port``
+     - Port used making ``rdp`` connections for ``kitchen login`` commands. Defaults to 3389.
+   * - ``winrm_transport``
+     - The transport type used by winrm as explained `here <https://github.com/WinRb/WinRM`__. The default is ``negotiate``. ``ssl`` and ``plaintext`` are also acceptable values.


### PR DESCRIPTION
I have gotten several comments from customers that the transport is woefully under documented. This does not fix the entire documentation story but puts it somewhere that is googlable.
