### PR TITLE
Update knife node show docs for nested attributes

### DIFF
--- a/step_knife/step_knife_node_show_attribute.rst
+++ b/step_knife/step_knife_node_show_attribute.rst
@@ -8,4 +8,12 @@ To list a single node attribute:
 
    knife node show NODE_NAME -a ATTRIBUTE_NAME
 
-where ``ATTRIBUTE_NAME`` is something like ``kernel`` or ``platform``. This doesn't work for nested attributes like ``node[kernel][machine]`` because ``knife node show`` doesn't understand nested attributes.
+where ``ATTRIBUTE_NAME`` is something like ``kernel`` or ``platform``.
+
+To list a nested attribute:
+
+.. code-block:: bash
+
+   knife node show NODE_NAME -a ATTRIBUTE_NAME.NESTED_ATTRIBUTE_NAME
+
+where ``ATTRIBUTE_NAME`` is something like ``kernel`` and ``NESTED_ATTRIBUTE_NAME`` is something like ``machine``.


### PR DESCRIPTION
The docs previously indicated that nested attributes were not understood
by knife however on my v12.11.18 install a construct like ''knife node
show NODE_NAME -a kernel.machine'' does work.

I presume that this functionality was added to knife at some point, though
I don't know specifically when.
