### PR TITLE
Update step_resource_template_inline_method.rst

### DIFF
--- a/step_resource/step_resource_template_inline_method.rst
+++ b/step_resource/step_resource_template_inline_method.rst
@@ -23,7 +23,7 @@ An inline helper method can also take arguments:
 .. code-block:: ruby
 
    template '/path' do
-     helper(:app_conf) { |setting| node['app']['setting'] }
+     helper(:app_conf) { |setting| node['app'][setting] }
    end
 
 Once declared, a template can then use the helper methods to build a file. For example:


### PR DESCRIPTION
fix example of inline method arguments. i'm pretty sure the variable not string was intended there.
