### PR TITLE
Fixed typo with 'BUILD_NODE_FDQN' that should be 'BUILD_NODE_FQDN'. R…

### DIFF
--- a/chef_master/source/install_chef_automate.rst
+++ b/chef_master/source/install_chef_automate.rst
@@ -337,7 +337,7 @@ The following steps are performed on the Chef Automate server:
                                    --ssh-identity-file $SSH_IDENTITY_FILE \
                                    --port $SSH_PORT
 
-   You can view the logs at ``/var/log/delivery-ctl/build-node-install_$BUILD_NODE_FDQN.log``.
+   You can view the logs at ``/var/log/delivery-ctl/build-node-install_$BUILD_NODE_FQDN.log``.
 
    You maybe be asked about overwriting your build node's registration in Chef Server.  This will remove any previous run lists or Chef Server configuration on this node.  This is done in case this hostname was previously being used for something else.  Setting the ``--[no]-overwrite-registration`` flag will allow you to avoid that prompt.
 


### PR DESCRIPTION
Reported by customer Stanford University on Zendesk ticket #11543:

URL: 
https://docs.chef.io/install_chef_automate.html 
HAS: 
You can view the logs at /var/log/delivery-ctl/build-node-install_$BUILD_NODE_FDQN.log.

The variable named $BUILD_NODE_FDQN should be named $BUILD_NODE_FQDN. The ;DQ' should be 'QD'
