### PR TITLE
Fix typo in FIPS mode instructions

### DIFF
--- a/includes_chef_client/includes_chef_client_fips_mode.rst
+++ b/includes_chef_client/includes_chef_client_fips_mode.rst
@@ -9,5 +9,5 @@
 Notes about |fips|:
 
 * May be enabled for nodes running on |windows| and |enterprise_linux| platforms
-* Should should only be enabled for environments that require |fips_current| compliance
+* Should only be enabled for environments that require |fips_current| compliance
 * May not be enabled for any version of the |chef client| earlier than 12.8


### PR DESCRIPTION
This removes the extra `should` from [this](https://docs.chef.io/knife_bootstrap.html#fips-mode) document:

```
Should should only be enabled for environments that require FIPS 140-2 compliance
```

becomes

```
Should only be enabled for environments that require FIPS 140-2 compliance
```
