### PR TITLE
Remove extra `'` from InSpec `registry_key` syntax

### DIFF
--- a/includes_inspec_resources/includes_inspec_resource_registry_key_syntax.rst
+++ b/includes_inspec_resources/includes_inspec_resource_registry_key_syntax.rst
@@ -26,7 +26,7 @@ Or use a |ruby hash|:
    describe registry_key({
      name: 'Task Scheduler',
      hive: 'HKEY_LOCAL_MACHINE',
-     key: ''\SYSTEM\CurrentControlSet\services\Schedule'
+     key: '\SYSTEM\CurrentControlSet\services\Schedule'
    }) do
      its('Start') { should eq 2 }
    end


### PR DESCRIPTION
In `https://docs.chef.io/inspec_registry_key.html`: 

```
describe registry_key({
  name: 'Task Scheduler',
  hive: 'HKEY_LOCAL_MACHINE',
  key: ''\SYSTEM\CurrentControlSet\services\Schedule'
}) do
  its('Start') { should eq 2 }
end
```

becomes

```
describe registry_key({
  name: 'Task Scheduler',
  hive: 'HKEY_LOCAL_MACHINE',
  key: '\SYSTEM\CurrentControlSet\services\Schedule'
}) do
  its('Start') { should eq 2 }
end
```
