### PR TITLE
Remove end of life platforms from push-jobs

### DIFF
--- a/includes_adopted_platforms/includes_adopted_platforms_push_jobs.rst
+++ b/includes_adopted_platforms/includes_adopted_platforms_push_jobs.rst
@@ -1,33 +1,33 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
-.. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics. 
+.. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
 The following table lists the Foundational platforms for the |push jobs|:
 
 .. list-table::
    :widths: 280 100 120
    :header-rows: 1
- 
+
    * - Platform
      - Architecture
      - Version
    * - |centos|
      - ``i386``
      - ``5``, ``6``
-   * - 
+   * -
      - ``x86_64``
      - ``5``, ``6``, ``7``
    * - |debian|
      - ``i386``, ``x86_64``
-     - ``6``, ``7``
+     - `7``
    * - |redhat enterprise linux|
      - ``i386``
      - ``5``, ``6``
-   * - 
+   * -
      - ``x86_64``
      - ``5``, ``6``, ``7``
    * - |ubuntu|
      - ``x86``, ``x86_64``
-     - ``10.04``, ``12.04``, ``14.04``
+     - ``12.04``, ``14.04``
    * - |windows|
      - ``x86``, ``x86_64``
      - ``2008r2``, ``2012``, ``2012r2``, ``7``, ``8``, ``8.1``, ``10``


### PR DESCRIPTION
We don't support EoL platforms so we don't support these

Signed-off-by: Tim Smith tsmith@chef.io
