### PR TITLE
Update ChefDK platforms to match the downloads page

### DIFF
--- a/includes_adopted_platforms/includes_adopted_platforms_chefdk.rst
+++ b/includes_adopted_platforms/includes_adopted_platforms_chefdk.rst
@@ -1,27 +1,27 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
-.. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics. 
+.. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
 The following table lists the Foundational platforms for the |chef dk_title|:
 
 .. list-table::
    :widths: 280 100 120
    :header-rows: 1
- 
+
    * - Platform
      - Architecture
      - Version
-   * - |fedora|
-     - 
-     - current non-EOL releases
+   * - |debian|
+     -
+     - ``7.x``, ``8.x``
    * - |mac os x|
-     - 
-     - ``10.8``, ``10.9``, ``10.10``
+     -
+     - ``10.9``, ``10.10``, ``10.11``
    * - |redhat enterprise linux|
-     - 
+     -
      - ``6.x``, ``7.x``
    * - |ubuntu|
-     - 
+     -
      - ``12.04``, ``14.04``
    * - |windows|
-     - 
-     - ``7``, ``8``, ``8.1``
+     -
+     - ``7``, ``8``, ``8.1``, ``2008 R2``, ``2012``, ``2012 R2``


### PR DESCRIPTION
We don't support Fedora
We do support Debian 7/8
We do support OS X 10.11
We don't support OS X 10.8
We do support Windows Server

Signed-off-by: Tim Smith tsmith@chef.io
