### PR TITLE
Update supported distros for chef-client to match downloads page

### DIFF
--- a/includes_adopted_platforms/includes_adopted_platforms_client_other.rst
+++ b/includes_adopted_platforms/includes_adopted_platforms_client_other.rst
@@ -1,49 +1,52 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
-.. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics. 
+.. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
 The following platforms are not tested by Chef Software:
 
 .. list-table::
    :widths: 280 100 120
    :header-rows: 1
- 
+
    * - Platform
      - Architecture
      - Version
    * - |ibm aix|
-     - 
+     -
      - ``5.1L``
    * - |centos|
-     - 
+     -
      - ``4.x`` (or older)
    * - |freebsd|
-     - 
+     -
      - ``8``
    * - |hpux|
-     - 
-     - 
+     -
+     -
    * - |mac os x|
-     - 
-     - ``10.7`` (and older), anything PPC-based
+     -
+     - ``10.8`` (and older), anything PPC-based
    * - |netbsd|
-     - 
-     - 
-   * - |open bsd|
-     - 
-     - 
+     -
+     -
+   * - |openbsd|
+     -
+     -
    * - |oracle linux|
-     - 
+     -
      - ``4.x`` (or older)
    * - |redhat enterprise linux|
      - ``ppc64``, ``System/z``
-     - 
+     -
 
    * - |suse els|
      - ``ppc64``, ``System/z``
-     - 
+     -
    * - |solaris|
-     - 
+     -
      - ``8``, ``9``
+   * - |ubuntu|
+     -
+     - ``10.04`` (or older)
    * - |windows|
-     - 
-     - ``2000``, ``2003``
+     -
+     - ``2000``, ``2003``, ``2003 R2``, ``2008``

--- a/includes_adopted_platforms/includes_adopted_platforms_client_tier1.rst
+++ b/includes_adopted_platforms/includes_adopted_platforms_client_tier1.rst
@@ -21,7 +21,7 @@ The following table lists the Foundational platforms for the |chef client|:
      - ``9``, ``10``
    * - |mac os x|
      - ``x86_64``
-     - ``10.8``, ``10.9``, ``10.10``, ``10.11``
+     - ``10.9``, ``10.10``, ``10.11``
    * - |oracle linux|
      - ``i386``, ``x86_64``
      - ``5``, ``6``, ``7``
@@ -33,15 +33,13 @@ The following table lists the Foundational platforms for the |chef client|:
      - ``10``, ``11``
    * - |ubuntu|
      - ``x86``, ``x86_64``
-     - ``12.04``, ``14.04``, ``16.04``\*
+     - ``12.04``, ``14.04``, ``16.04``
    * - |windows|
      - ``x86``, ``x86_64``
-     - ``2008``, ``2008r2``, ``2012``, ``2012r2``, ``7``, ``8``, ``8.1``
+     - `2008r2``, ``2012``, ``2012r2``, ``7``, ``8``, ``8.1``, ``10``
    * - |cisco-nxos|
      - ``x86_64``
      - ``7``
    * - |cisco-iosxr|
      - ``x86_64``
      - ``6``
-
-\*This platform version has packages and support available, but has not been fully tested yet.

--- a/includes_adopted_platforms/includes_adopted_platforms_client_tier2.rst
+++ b/includes_adopted_platforms/includes_adopted_platforms_client_tier2.rst
@@ -1,39 +1,36 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
-.. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics. 
+.. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
 The following table lists the Secondary platforms for the |chef client|:
 
 .. list-table::
    :widths: 280 100 120
    :header-rows: 1
- 
+
    * - Platform
      - Architecture
      - Version
    * - |archlinux|
-     - 
+     -
      - current version
    * - |debian|
      - ``i686``, ``x86_64``
-     - ``6``, ``7``
+     - ``6``, ``7``, ``8``
    * - |fedora|
-     - 
+     -
      - current non-EOL releases
-   * - |freebsd|
-     - ``amd64``
-     - ``9``
    * - |gentoo|
-     - 
+     -
      - current version
    * - |omnios|
-     - 
+     -
      - stable and LTS releases
    * - |opensuse|
-     - 
-     - ``13.1``
+     -
+     - ``13``
    * - |scientific linux|
      - ``i386``, ``x86-64``
-     - ``5.x``, ``6.x``, ``7.x``
+     - ``5``, ``6``, ``7``
    * - |suse els|
-     - 
+     -
      - ``10``, ``11``


### PR DESCRIPTION
Add Debian 8 to Tier 2
Remove FreeBSD 9 from Tier 2 since it's in Tier 1
Remove support for Windows 2008
Remove support for OS X 10.8
Remove the warning on Ubuntu 16.04
openbsd is 1 word

Signed-off-by: Tim Smith tsmith@chef.io
