### PR TITLE
Cj/server rb

### DIFF
--- a/includes_server_tuning/includes_server_tuning_general.rst
+++ b/includes_server_tuning/includes_server_tuning_general.rst
@@ -1,7 +1,7 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
 .. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
-The following settings are typically added to the server configuration file:
+The following settings are typically added to the server configuration file (please note that there is no equal sign necessary to set the value):
 
 ``api_fqdn``
    The |fqdn| for the |chef server|. This setting is not in the server configuration file by default. When added, its value should be equal to the |fqdn| for the service URI used by the |chef server|. For example: ``api_fqdn "chef.example.com"``.

--- a/includes_server_tuning/includes_server_tuning_general.rst
+++ b/includes_server_tuning/includes_server_tuning_general.rst
@@ -1,7 +1,7 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
 .. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
-The following settings are typically added to the server configuration file (please note that there is no equal sign neccessary to set the value):
+The following settings are typically added to the server configuration file (please note that there is no equal sign necessary to set the value):
 
 ``api_fqdn``
    The |fqdn| for the |chef server|. This setting is not in the server configuration file by default. When added, its value should be equal to the |fqdn| for the service URI used by the |chef server|. For example: ``api_fqdn "chef.example.com"``.

--- a/includes_server_tuning/includes_server_tuning_general.rst
+++ b/includes_server_tuning/includes_server_tuning_general.rst
@@ -1,7 +1,7 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
 .. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
-The following settings are typically added to the server configuration file (please note that there is no equal sign necessary to set the value):
+The following settings are typically added to the server configuration file (please note that there is no equal sign neccessary to set the value):
 
 ``api_fqdn``
    The |fqdn| for the |chef server|. This setting is not in the server configuration file by default. When added, its value should be equal to the |fqdn| for the service URI used by the |chef server|. For example: ``api_fqdn "chef.example.com"``.


### PR DESCRIPTION
As customers struggle to set the value right (api_fqdn) this has to be added. If there´s an equal sign the setting will be ignored and causes confusion, especially as ruby allow to set a value using an equal sign and we don´t do a syntax check which will be a better solution in the future.

Cheers
Christian
