### PR TITLE
Readme update to reflect the current state of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,16 +34,6 @@ BUILD_COMMAND_AND_ARGS = $(BUILD_COMMAND) $(PARALLEL_BUILD)
 # all analytics delivery client devkit server
 #
 
-#
-# Parallel Building:
-# Supported by Sphinx 1.2.x and above
-#
-# Specify PARALLEL_BUILD="-j X" on the make cmdline
-# If you have an 8 cpu machine, 6 might be a good number
-#
-# make master PARALLEL_BUILD="-j 6"
-#
-
 clean:
 	@rm -rf $(BUILDDIR)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 BUILDDIR = build
-S3BUCKET = chef-docs
-S3OPTIONS = --acl-public --exclude='.doctrees/*' --exclude='chef/.doctrees/*' --config ~/.s3cfg-chef-docs  --add-header "Cache-Control: max-age=900"
 BUILD_COMMAND = sphinx-build -a -W
 PARALLEL_BUILD:=
 BUILD_COMMAND_AND_ARGS = $(BUILD_COMMAND) $(PARALLEL_BUILD)
@@ -239,10 +237,6 @@ server_12-0:
 supermarket:
 	mkdir -p $(BUILDDIR)/release/supermarket/
 	$(BUILD_COMMAND_AND_ARGS) release_supermarket/source $(BUILDDIR)/release/supermarket/
-
-
-upload:	release
-	s3cmd sync $(S3OPTIONS) $(BUILDDIR)/ s3://$(S3BUCKET)/
 
 #
 # OLD BUILDS DO NOT BUILD

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ There's a `Makefile` in the root of the repo, that should have the majority of t
 
 Run:
 
-    make release
+    make master
 
-This will build *all* the documentation into HTML, and place it inside `./build/chef/`.
-Open `./build/chef/index.html` to view the rendered files locally.
+This will build *all* the documentation into HTML, and place it inside `./build/`.
+Open `./build/index.html` to view the rendered files locally.
 
 IMPORTANT: Depending on what has changed since the last time a build was run, the build process can take anywhere from a few minutes to a few hours. The make file gets changed a lot because Chef uses this file to manage how the docs get published to our website. For your local builds, you may want to edit the make file prior to building to only use the chef_master build, which is the build to use for the current version of Chef.
 
@@ -81,7 +81,11 @@ The first time you run the build, it will take longer (45-75 mins), as it has to
 
 This will also apply when you've run the `make clean` command, which effectively resets your working environment or if files located in the `/swaps` folder are changed.
 
-Subsequent runs of `make release` should be relatively fast (2-5 mins), and you can use subsets. For example: `master` for the main docs build, `server` for the Chef server, `client` for the chef-client, and so on. The full list is available at the top of the `makefile`.
+Subsequent runs of `make master` should be relatively fast (2-5 mins), and you can use subsets. For example: `master` for the main docs build, `server` for the Chef server, `client` for the chef-client, and so on. The full list is available in the `Makefile`.
+
+You can use parallel building with Sphinx > 1.2.x. Specify `PARALLEL_BUILD="-j X"` on the make cmdline. If you have an 8 cpu machine, 6 might be a good number:
+
+    make master PARALLEL_BUILD="-j 6"
 
 ## License
 


### PR DESCRIPTION
- `make master` instead of `make release`
- removal of dead upload target
