### PR TITLE
Ignore the virtualenvwrapper settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,6 @@ build/
 
 /.delivery/cli.toml
 
+/.venv
+
 *.*~


### PR DESCRIPTION
its described in README this way, but the .venv is not in the gitignore
