### PR TITLE
Remove legacy cookbook link

### DIFF
--- a/includes_community/includes_community_contribute.rst
+++ b/includes_community/includes_community_contribute.rst
@@ -5,7 +5,6 @@
 
 * `Chef on GitHub <https://github.com/chef>`_
 * `Chef-managed cookbooks <https://github.com/chef-cookbooks>`_
-* `Community cookbooks <http://supermarket.chef.io>`_
+* `Community cookbooks <https://supermarket.chef.io>`_
 * `Documentation <https://github.com/chef/chef-docs>`_
-* `Legacy Chef-managed cookbooks <https://github.com/chef-cookbooks>`_
 * `Share your Chef product ideas <https://feedback.chef.io>`_


### PR DESCRIPTION
This would sort of make sense if it was opscode-cookbooks. It makes no sense right now.

Signed-off-by: Tim Smith tsmith@chef.io
