### PR TITLE
Remove incorrect parameters from API /cookbooks/NAME

### DIFF
--- a/includes_api_chef_server/includes_api_chef_server_endpoint_cookbook_name_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_cookbook_name_get.rst
@@ -3,17 +3,6 @@
 
 The ``GET`` method is used to return a hash that contains a key-value pair that corresponds to the specified cookbook, with a URL for the cookbook and for each version of the cookbook.
 
-This method has the following parameters:
-
-.. list-table::
-   :widths: 200 300
-   :header-rows: 1
-
-   * - Parameter
-     - Description
-   * - ``num_versions=n``
-     - |num_versions|
-
 **Request**
 
 .. code-block:: none


### PR DESCRIPTION
The `num_versions` parameters does nothing, so it should not be documented. Validated on older Server versions (e.g. 12.4.1) and the latest (12.9.1). Here's the output from latest:

```
$ knife exec -E "puts JSON.pretty_generate(api.get('/cookbooks/apt?num_versions=2'))"
{
  "apt": {
    "url": "https://my_server/organizations/test/cookbooks/apt",
    "versions": [
      {
        "version": "1.0.0",
        "url": "https://my_server/organizations/test/cookbooks/apt/1.0.0"
      },
      {
        "version": "0.3.0",
        "url": "https://my_server/organizations/test/cookbooks/apt/0.3.0"
      },
      {
        "version": "0.2.0",
        "url": "https://my_server/organizations/test/cookbooks/apt/0.2.0"
      },
      {
        "version": "0.1.0",
        "url": "https://my_server/organizations/test/cookbooks/apt/0.1.0"
      }
    ]
  }
}
```

(note that that's the same output as when you leave off the num_versions parameter)

I think this functionality _should_ be implemented, but we can add it in again later if/when that happens.
