### PR TITLE
Remove references to providers

### DIFF
--- a/chef_master/source/cookbooks.rst
+++ b/chef_master/source/cookbooks.rst
@@ -41,8 +41,8 @@ In addition to attributes and recipes, the following items are also part of cook
      - A custom resource is an abstract approach for defining a set of actions and (for each action) a set of properties and validation parameters.
    * - :doc:`Metadata </cookbook_repo>`
      - A metadata file is used to ensure that each cookbook is correctly deployed to each node.\
-   * - :doc:`Resources and Providers </resource>`
-     - A resource is a package, a service, a group of users, and so on. A resource tells the |chef client| which provider to use during a |chef client| run for various tasks like installing packages, running |ruby| code, or accessing directories and file systems. The resource is generic: "install program A" while the provider knows what to do with that process on |debian| and |ubuntu| and |windows|. A provider defines the steps that are required to bring that piece of the system into the desired state. The |chef client| includes default providers that cover all of the most common scenarios. For the full list of resources that are built-in to the |chef client|, see https://docs.chef.io/resources.html.
+   * - :doc:`Resources </resource>`
+     - A resource instructs the |chef client| to complete various tasks like installing packages, running |ruby| code, or accessing directories and file systems. The |chef client| includes built-in resources that cover many common scenarios. For the full list of resources that are built-in to the |chef client|, see https://docs.chef.io/resources.html.
    * - :doc:`Templates </templates>`
      - A template is a file written in markup language that uses |ruby| statements to solve complex configuration scenarios.
    * - :doc:`Cookbook Versions </cookbook_versions>`


### PR DESCRIPTION
We shouldn't be distinguishing between providers and resources. Let's keep this area simple since this is a pretty high level overview

Signed-off-by: Tim Smith tsmith@chef.io
