### PR TITLE
Fix typo in unsharing a cookbook version command.

### DIFF
--- a/step_knife/step_knife_site_cookbook_unshare_version.rst
+++ b/step_knife/step_knife_site_cookbook_unshare_version.rst
@@ -6,4 +6,4 @@ To unshare cookbook version ``0.10.0`` for the ``getting-started`` cookbook, ent
 
 .. code-block:: bash
 
-   $ knife cookbook site unshare "getting-started/version/0.10.0"
+   $ knife cookbook site unshare "getting-started/versions/0.10.0"


### PR DESCRIPTION
`versions` must be plural to match the route to unshare
a single version of a cookbook.
