### PR TITLE
Fix list of subcommands for knife-push

### DIFF
--- a/chef_master/source/install_push_jobs.rst
+++ b/chef_master/source/install_push_jobs.rst
@@ -50,7 +50,7 @@ To set up the Chef push jobs workstation, install the ``knife push jobs`` plugin
 
    chef gem install knife-push
 
-Once installed, the following subcommands will be available: ``knife job status``, ``knife job list``, ``knife job start``, and ``knife job status``.
+Once installed, the following subcommands will be available: ``knife job list``, ``knife job start``, ``knife job output``, ``knife job status``, and ``knife node status``.
 
 **push-jobs** Cookbook
 -----------------------------------------------------


### PR DESCRIPTION
"knife job status" was listed twice, and two subcommands were not listed.
Ref: [the knife-push README as at 24th Oct 2016](https://github.com/chef/knife-push/blob/f9d6b6897cc59d429dfb2d8299fe9a64b50e3270/README.md#configuration)
