### PR TITLE
Fix typo describing node.normal vs. node.default

### DIFF
--- a/chef_master/source/ruby.rst
+++ b/chef_master/source/ruby.rst
@@ -905,7 +905,7 @@ node.set
 -----------------------------------------------------
 Use ``node.default`` (or maybe ``node.override``) instead of ``node.set`` because ``node.set`` is an alias for ``node.normal``. Normal data is persisted on the node object. Therefore, using ``node.set`` will persist data in the node object. If the code that uses ``node.set`` is later removed, if that data has already been set on the node, it will remain.
 
-Normal and override attributes are cleared at the start of the chef-client run, and are then rebuilt as part of the run based on the code in the cookbooks and recipes at that time.
+Default and override attributes are cleared at the start of the chef-client run, and are then rebuilt as part of the run based on the code in the cookbooks and recipes at that time.
 
 ``node.set`` (and ``node.normal``) should only be used to do something like generate a password for a database on the first chef-client run, after which it's remembered (instead of persisted). Even this case should be avoided, as using a data bag is the recommended way to store this type of data.
 


### PR DESCRIPTION
This sentence seemed to conflict with the paragraph above it.
I think this change is what was intended, though I'm not personally familiar with the difference between `node.normal` and `node.default`.

Signed-off-by: Greg Mefford greg@gregmefford.com
