### PR TITLE
Remove hyperlinks to external doc sets

### DIFF
--- a/chef_master/source/attributes.rst
+++ b/chef_master/source/attributes.rst
@@ -94,11 +94,7 @@ Attributes are provided to the chef-client from the following locations:
 * Environments
 * Roles
 
-If we go back to the `overview of Chef <https://docs.chef.io/release/11-18/chef_overview.html>`_, but then focus only on where attributes are located, it looks something like this:
-
-.. image:: ../../images/overview_chef_11x_attributes.png
-
-where
+Notes:
 
 * Many attributes are maintained in the chef-repo for environments, roles, and cookbooks (attribute files and recipes)
 * Many attributes are collected by Ohai on each individual node at the start of every chef-client run

--- a/chef_master/source/ohai.rst
+++ b/chef_master/source/ohai.rst
@@ -318,7 +318,7 @@ A custom Ohai plugin describes a set of attributes to be collected by Ohai, and 
 
 .. note:: See https://github.com/rackerlabs/ohai-plugins/tree/master/plugins for some great examples of custom Ohai plugins.
 
-.. warning:: The syntax for custom plugins changes significantly between Ohai 6 and newer versions of Ohai. This page is about newer plugins and `this page is about Ohai 6 plugins <https://docs.chef.io/release/ohai-6/>`_). While Chef has worked to ensure backwards compatibility for all Ohai 6 plugins, a plan should be put in place to update the syntax for all Ohai 6 plugins so they are usable with the new pattern. Once updated, please test and verify those plugins before running them in a production environment.
+.. warning:: The syntax for custom plugins changed significantly between Ohai 6 and later versions. This page is about plugins after Ohai 6. While Chef has worked to ensure backwards compatibility for all Ohai 6 plugins, a plan should be put in place to update the syntax for all Ohai 6 plugins so they are usable with the new pattern. Once updated, please test and verify those plugins before running them in a production environment.
 
 Syntax
 -----------------------------------------------------

--- a/chef_master/source/platform_overview.rst
+++ b/chef_master/source/platform_overview.rst
@@ -134,7 +134,7 @@ Chef Automate creates customizable reports that identify compliance issues, secu
 * :doc:`Set up the Chef Compliance server </install_compliance>`
 * :doc:`Allow nodes to download compliance profiles </integrate_compliance_chef_server>` from the Chef server
 * Send the results of compliance scans to the Chef Compliance server via the Chef server
-* Use the Chef Automate workflow feature to `build remediation into your software deployment pipeline <https://docs.chef.io/release/delivery/>`__
+* Use the Chef Automate workflow feature to :doc:`build remediation into your software deployment pipeline <workflow>`
 
 High availability
 -----------------------------------------------------


### PR DESCRIPTION
Remove obsolete hyperlink references that cross doc set boundaries.

Signed-off-by: Colin Campbell colin@chef.io
