### PR TITLE
Ruby 2.1.0 deprecated File.exists?

### DIFF
--- a/chef_master/source/ctl_ohai.rst
+++ b/chef_master/source/ctl_ohai.rst
@@ -76,13 +76,13 @@ An Ohai plugin can be run independently of a chef-client run. First, ensure that
      collect_data(:default) do
        sl Mash.new
 
-       if ::File.exists?("/usr/games/sl")
+       if ::File.exist?("/usr/games/sl")
          sl[:installed] = true
        else
          sl[:installed] = false
        end
 
-       # sl[:installed] = ::File.exists?("/usr/games/sl")
+       # sl[:installed] = ::File.exist?("/usr/games/sl")
 
      end
    end

--- a/chef_master/source/dsl_recipe.rst
+++ b/chef_master/source/dsl_recipe.rst
@@ -1683,7 +1683,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/chef_master/source/handlers.rst
+++ b/chef_master/source/handlers.rst
@@ -671,7 +671,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/chef_master/source/resource_bash.rst
+++ b/chef_master/source/resource_bash.rst
@@ -24,7 +24,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -400,7 +400,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -472,7 +472,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -482,7 +482,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/chef_master/source/resource_chef_handler.rst
+++ b/chef_master/source/resource_chef_handler.rst
@@ -432,7 +432,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/chef_master/source/resource_common.rst
+++ b/chef_master/source/resource_common.rst
@@ -248,7 +248,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 **Ensure a node can resolve a host**
@@ -336,14 +336,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/chef_master/source/resource_examples.rst
+++ b/chef_master/source/resource_examples.rst
@@ -191,7 +191,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -713,7 +713,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -785,7 +785,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -795,7 +795,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -2711,7 +2711,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:
@@ -5308,7 +5308,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -5352,7 +5352,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -5362,7 +5362,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -5392,7 +5392,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:
@@ -5809,7 +5809,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -5881,7 +5881,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -5891,7 +5891,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/chef_master/source/resource_execute.rst
+++ b/chef_master/source/resource_execute.rst
@@ -628,7 +628,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/chef_master/source/resource_perl.rst
+++ b/chef_master/source/resource_perl.rst
@@ -24,7 +24,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/chef_master/source/resource_remote_file.rst
+++ b/chef_master/source/resource_remote_file.rst
@@ -679,7 +679,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -723,7 +723,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -733,7 +733,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -763,7 +763,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/chef_master/source/resource_ruby.rst
+++ b/chef_master/source/resource_ruby.rst
@@ -24,7 +24,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/chef_master/source/resource_ruby_block.rst
+++ b/chef_master/source/resource_ruby_block.rst
@@ -351,7 +351,7 @@ The following example shows how the ``platform?`` method and an if statement can
            jdk_home = Dir.glob("#{java_home_parent}/java*#{version}*openjdk{,[-\.]#{arch}}")[0]
            Chef::Log.debug("jdk_home is #{jdk_home}")
 
-           if File.exists? java_home
+           if File.exist? java_home
              FileUtils.rm_f java_home
            end
            FileUtils.ln_sf jdk_home, java_home

--- a/chef_master/source/resource_script.rst
+++ b/chef_master/source/resource_script.rst
@@ -34,7 +34,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -56,7 +56,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -592,7 +592,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -664,7 +664,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -674,7 +674,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/chef_master/source/resources.rst
+++ b/chef_master/source/resources.rst
@@ -379,7 +379,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -119,7 +119,7 @@ The following example shows how the Chef server sets up and configures SSL certi
    ssl_crtfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.crt")
    ssl_signing_conf = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}-ssl.conf")
 
-   unless File.exists?(ssl_keyfile) && File.exists?(ssl_crtfile) && File.exists?(ssl_signing_conf)
+   unless File.exist?(ssl_keyfile) && File.exist?(ssl_crtfile) && File.exist?(ssl_signing_conf)
      file ssl_keyfile do
        owner 'root'
        group 'root'

--- a/snapshots/release_12-x_master/custom_resources.rst
+++ b/snapshots/release_12-x_master/custom_resources.rst
@@ -980,7 +980,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")
@@ -1474,7 +1474,7 @@ The ``ssh_known_hosts_entry`` custom provider (found in the `ssh_known_hosts <ht
        backup        false
        content       
        only_if do
-         !::File.exists?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
+         !::File.exist?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
        end
      end
 
@@ -1765,7 +1765,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")

--- a/snapshots/release_chef_11-0/source/custom_resources.rst
+++ b/snapshots/release_chef_11-0/source/custom_resources.rst
@@ -985,7 +985,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")
@@ -1479,7 +1479,7 @@ The ``ssh_known_hosts_entry`` custom provider (found in the `ssh_known_hosts <ht
        backup        false
        content       
        only_if do
-         !::File.exists?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
+         !::File.exist?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
        end
      end
 
@@ -1770,7 +1770,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")

--- a/snapshots/release_chef_11-0/source/definitions.rst
+++ b/snapshots/release_chef_11-0/source/definitions.rst
@@ -124,7 +124,7 @@ A definition file can be used to create an object that the chef-client can then 
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/#{params[:name]}') or
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/000-#{params[:name]}')
          end
-         only_if do ::File.exists?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
+         only_if do ::File.exist?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
        end
      else
        execute 'a2dissite #{params[:name]}' do

--- a/snapshots/release_chef_11-0/source/dsl_recipe.rst
+++ b/snapshots/release_chef_11-0/source/dsl_recipe.rst
@@ -555,7 +555,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-0/source/handlers.rst
+++ b/snapshots/release_chef_11-0/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-0/source/resource_bash.rst
+++ b/snapshots/release_chef_11-0/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-0/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_11-0/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-0/source/resource_common.rst
+++ b/snapshots/release_chef_11-0/source/resource_common.rst
@@ -246,7 +246,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -358,14 +358,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_11-0/source/resource_execute.rst
+++ b/snapshots/release_chef_11-0/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-0/source/resource_perl.rst
+++ b/snapshots/release_chef_11-0/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-0/source/resource_remote_file.rst
+++ b/snapshots/release_chef_11-0/source/resource_remote_file.rst
@@ -486,7 +486,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -530,7 +530,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -540,7 +540,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -570,7 +570,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-0/source/resource_ruby.rst
+++ b/snapshots/release_chef_11-0/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-0/source/resource_script.rst
+++ b/snapshots/release_chef_11-0/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -496,7 +496,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -568,7 +568,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -578,7 +578,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-10/source/custom_resources.rst
+++ b/snapshots/release_chef_11-10/source/custom_resources.rst
@@ -986,7 +986,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")
@@ -1480,7 +1480,7 @@ The ``ssh_known_hosts_entry`` custom provider (found in the `ssh_known_hosts <ht
        backup        false
        content       
        only_if do
-         !::File.exists?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
+         !::File.exist?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
        end
      end
 
@@ -1771,7 +1771,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")

--- a/snapshots/release_chef_11-10/source/definitions.rst
+++ b/snapshots/release_chef_11-10/source/definitions.rst
@@ -195,7 +195,7 @@ A definition file can be used to create an object that the chef-client can then 
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/#{params[:name]}') or
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/000-#{params[:name]}')
          end
-         only_if do ::File.exists?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
+         only_if do ::File.exist?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
        end
      else
        execute 'a2dissite #{params[:name]}' do

--- a/snapshots/release_chef_11-10/source/dsl_recipe.rst
+++ b/snapshots/release_chef_11-10/source/dsl_recipe.rst
@@ -553,7 +553,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-10/source/handlers.rst
+++ b/snapshots/release_chef_11-10/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-10/source/resource_bash.rst
+++ b/snapshots/release_chef_11-10/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-10/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_11-10/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-10/source/resource_common.rst
+++ b/snapshots/release_chef_11-10/source/resource_common.rst
@@ -246,7 +246,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -358,14 +358,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_11-10/source/resource_execute.rst
+++ b/snapshots/release_chef_11-10/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-10/source/resource_perl.rst
+++ b/snapshots/release_chef_11-10/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-10/source/resource_remote_file.rst
+++ b/snapshots/release_chef_11-10/source/resource_remote_file.rst
@@ -607,7 +607,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -651,7 +651,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -661,7 +661,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -691,7 +691,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-10/source/resource_ruby.rst
+++ b/snapshots/release_chef_11-10/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-10/source/resource_script.rst
+++ b/snapshots/release_chef_11-10/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -496,7 +496,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -568,7 +568,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -578,7 +578,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-12/source/custom_resources.rst
+++ b/snapshots/release_chef_11-12/source/custom_resources.rst
@@ -986,7 +986,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")
@@ -1480,7 +1480,7 @@ The ``ssh_known_hosts_entry`` custom provider (found in the `ssh_known_hosts <ht
        backup        false
        content       
        only_if do
-         !::File.exists?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
+         !::File.exist?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
        end
      end
 
@@ -1771,7 +1771,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")

--- a/snapshots/release_chef_11-12/source/definitions.rst
+++ b/snapshots/release_chef_11-12/source/definitions.rst
@@ -195,7 +195,7 @@ A definition file can be used to create an object that the chef-client can then 
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/#{params[:name]}') or
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/000-#{params[:name]}')
          end
-         only_if do ::File.exists?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
+         only_if do ::File.exist?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
        end
      else
        execute 'a2dissite #{params[:name]}' do

--- a/snapshots/release_chef_11-12/source/dsl_recipe.rst
+++ b/snapshots/release_chef_11-12/source/dsl_recipe.rst
@@ -555,7 +555,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-12/source/handlers.rst
+++ b/snapshots/release_chef_11-12/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-12/source/resource_bash.rst
+++ b/snapshots/release_chef_11-12/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-12/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_11-12/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-12/source/resource_common.rst
+++ b/snapshots/release_chef_11-12/source/resource_common.rst
@@ -247,7 +247,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -359,14 +359,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_11-12/source/resource_execute.rst
+++ b/snapshots/release_chef_11-12/source/resource_execute.rst
@@ -655,7 +655,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-12/source/resource_perl.rst
+++ b/snapshots/release_chef_11-12/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-12/source/resource_remote_file.rst
+++ b/snapshots/release_chef_11-12/source/resource_remote_file.rst
@@ -603,7 +603,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -647,7 +647,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -657,7 +657,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -687,7 +687,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-12/source/resource_ruby.rst
+++ b/snapshots/release_chef_11-12/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-12/source/resource_script.rst
+++ b/snapshots/release_chef_11-12/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -602,7 +602,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -674,7 +674,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -684,7 +684,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-14/source/custom_resources.rst
+++ b/snapshots/release_chef_11-14/source/custom_resources.rst
@@ -986,7 +986,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")
@@ -1480,7 +1480,7 @@ The ``ssh_known_hosts_entry`` custom provider (found in the `ssh_known_hosts <ht
        backup        false
        content       
        only_if do
-         !::File.exists?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
+         !::File.exist?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
        end
      end
 
@@ -1771,7 +1771,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")

--- a/snapshots/release_chef_11-14/source/definitions.rst
+++ b/snapshots/release_chef_11-14/source/definitions.rst
@@ -195,7 +195,7 @@ A definition file can be used to create an object that the chef-client can then 
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/#{params[:name]}') or
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/000-#{params[:name]}')
          end
-         only_if do ::File.exists?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
+         only_if do ::File.exist?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
        end
      else
        execute 'a2dissite #{params[:name]}' do

--- a/snapshots/release_chef_11-14/source/dsl_recipe.rst
+++ b/snapshots/release_chef_11-14/source/dsl_recipe.rst
@@ -555,7 +555,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-14/source/handlers.rst
+++ b/snapshots/release_chef_11-14/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-14/source/resource_bash.rst
+++ b/snapshots/release_chef_11-14/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-14/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_11-14/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-14/source/resource_common.rst
+++ b/snapshots/release_chef_11-14/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_11-14/source/resource_execute.rst
+++ b/snapshots/release_chef_11-14/source/resource_execute.rst
@@ -653,7 +653,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-14/source/resource_perl.rst
+++ b/snapshots/release_chef_11-14/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-14/source/resource_remote_file.rst
+++ b/snapshots/release_chef_11-14/source/resource_remote_file.rst
@@ -603,7 +603,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -647,7 +647,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -657,7 +657,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -687,7 +687,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-14/source/resource_ruby.rst
+++ b/snapshots/release_chef_11-14/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-14/source/resource_script.rst
+++ b/snapshots/release_chef_11-14/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -602,7 +602,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -674,7 +674,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -684,7 +684,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-16/source/custom_resources.rst
+++ b/snapshots/release_chef_11-16/source/custom_resources.rst
@@ -986,7 +986,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")
@@ -1480,7 +1480,7 @@ The ``ssh_known_hosts_entry`` custom provider (found in the `ssh_known_hosts <ht
        backup        false
        content       
        only_if do
-         !::File.exists?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
+         !::File.exist?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
        end
      end
 
@@ -1771,7 +1771,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")

--- a/snapshots/release_chef_11-16/source/definitions.rst
+++ b/snapshots/release_chef_11-16/source/definitions.rst
@@ -195,7 +195,7 @@ A definition file can be used to create an object that the chef-client can then 
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/#{params[:name]}') or
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/000-#{params[:name]}')
          end
-         only_if do ::File.exists?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
+         only_if do ::File.exist?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
        end
      else
        execute 'a2dissite #{params[:name]}' do

--- a/snapshots/release_chef_11-16/source/dsl_recipe.rst
+++ b/snapshots/release_chef_11-16/source/dsl_recipe.rst
@@ -555,7 +555,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-16/source/handlers.rst
+++ b/snapshots/release_chef_11-16/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-16/source/resource_bash.rst
+++ b/snapshots/release_chef_11-16/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-16/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_11-16/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-16/source/resource_common.rst
+++ b/snapshots/release_chef_11-16/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_11-16/source/resource_execute.rst
+++ b/snapshots/release_chef_11-16/source/resource_execute.rst
@@ -665,7 +665,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-16/source/resource_perl.rst
+++ b/snapshots/release_chef_11-16/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-16/source/resource_remote_file.rst
+++ b/snapshots/release_chef_11-16/source/resource_remote_file.rst
@@ -607,7 +607,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -651,7 +651,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -661,7 +661,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -691,7 +691,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-16/source/resource_ruby.rst
+++ b/snapshots/release_chef_11-16/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-16/source/resource_script.rst
+++ b/snapshots/release_chef_11-16/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -602,7 +602,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -674,7 +674,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -684,7 +684,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-18/source/custom_resources.rst
+++ b/snapshots/release_chef_11-18/source/custom_resources.rst
@@ -986,7 +986,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")
@@ -1480,7 +1480,7 @@ The ``ssh_known_hosts_entry`` custom provider (found in the `ssh_known_hosts <ht
        backup        false
        content       
        only_if do
-         !::File.exists?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
+         !::File.exist?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
        end
      end
 
@@ -1771,7 +1771,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")

--- a/snapshots/release_chef_11-18/source/definitions.rst
+++ b/snapshots/release_chef_11-18/source/definitions.rst
@@ -195,7 +195,7 @@ A definition file can be used to create an object that the chef-client can then 
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/#{params[:name]}') or
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/000-#{params[:name]}')
          end
-         only_if do ::File.exists?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
+         only_if do ::File.exist?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
        end
      else
        execute 'a2dissite #{params[:name]}' do

--- a/snapshots/release_chef_11-18/source/dsl_recipe.rst
+++ b/snapshots/release_chef_11-18/source/dsl_recipe.rst
@@ -555,7 +555,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-18/source/handlers.rst
+++ b/snapshots/release_chef_11-18/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-18/source/resource_bash.rst
+++ b/snapshots/release_chef_11-18/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-18/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_11-18/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-18/source/resource_common.rst
+++ b/snapshots/release_chef_11-18/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_11-18/source/resource_execute.rst
+++ b/snapshots/release_chef_11-18/source/resource_execute.rst
@@ -665,7 +665,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-18/source/resource_perl.rst
+++ b/snapshots/release_chef_11-18/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-18/source/resource_remote_file.rst
+++ b/snapshots/release_chef_11-18/source/resource_remote_file.rst
@@ -607,7 +607,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -651,7 +651,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -661,7 +661,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -691,7 +691,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-18/source/resource_ruby.rst
+++ b/snapshots/release_chef_11-18/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-18/source/resource_script.rst
+++ b/snapshots/release_chef_11-18/source/resource_script.rst
@@ -42,7 +42,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -64,7 +64,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -608,7 +608,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -680,7 +680,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -690,7 +690,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-2/source/custom_resources.rst
+++ b/snapshots/release_chef_11-2/source/custom_resources.rst
@@ -986,7 +986,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")
@@ -1480,7 +1480,7 @@ The ``ssh_known_hosts_entry`` custom provider (found in the `ssh_known_hosts <ht
        backup        false
        content       
        only_if do
-         !::File.exists?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
+         !::File.exist?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
        end
      end
 
@@ -1771,7 +1771,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")

--- a/snapshots/release_chef_11-2/source/definitions.rst
+++ b/snapshots/release_chef_11-2/source/definitions.rst
@@ -124,7 +124,7 @@ A definition file can be used to create an object that the chef-client can then 
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/#{params[:name]}') or
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/000-#{params[:name]}')
          end
-         only_if do ::File.exists?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
+         only_if do ::File.exist?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
        end
      else
        execute 'a2dissite #{params[:name]}' do

--- a/snapshots/release_chef_11-2/source/dsl_recipe.rst
+++ b/snapshots/release_chef_11-2/source/dsl_recipe.rst
@@ -555,7 +555,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-2/source/handlers.rst
+++ b/snapshots/release_chef_11-2/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-2/source/resource_bash.rst
+++ b/snapshots/release_chef_11-2/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-2/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_11-2/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-2/source/resource_common.rst
+++ b/snapshots/release_chef_11-2/source/resource_common.rst
@@ -246,7 +246,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -358,14 +358,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_11-2/source/resource_execute.rst
+++ b/snapshots/release_chef_11-2/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-2/source/resource_perl.rst
+++ b/snapshots/release_chef_11-2/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-2/source/resource_remote_file.rst
+++ b/snapshots/release_chef_11-2/source/resource_remote_file.rst
@@ -486,7 +486,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -530,7 +530,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -540,7 +540,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -570,7 +570,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-2/source/resource_ruby.rst
+++ b/snapshots/release_chef_11-2/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-2/source/resource_script.rst
+++ b/snapshots/release_chef_11-2/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -496,7 +496,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -568,7 +568,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -578,7 +578,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-4/source/custom_resources.rst
+++ b/snapshots/release_chef_11-4/source/custom_resources.rst
@@ -986,7 +986,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")
@@ -1480,7 +1480,7 @@ The ``ssh_known_hosts_entry`` custom provider (found in the `ssh_known_hosts <ht
        backup        false
        content       
        only_if do
-         !::File.exists?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
+         !::File.exist?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
        end
      end
 
@@ -1771,7 +1771,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")

--- a/snapshots/release_chef_11-4/source/definitions.rst
+++ b/snapshots/release_chef_11-4/source/definitions.rst
@@ -124,7 +124,7 @@ A definition file can be used to create an object that the chef-client can then 
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/#{params[:name]}') or
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/000-#{params[:name]}')
          end
-         only_if do ::File.exists?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
+         only_if do ::File.exist?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
        end
      else
        execute 'a2dissite #{params[:name]}' do

--- a/snapshots/release_chef_11-4/source/dsl_recipe.rst
+++ b/snapshots/release_chef_11-4/source/dsl_recipe.rst
@@ -555,7 +555,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-4/source/handlers.rst
+++ b/snapshots/release_chef_11-4/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-4/source/resource_bash.rst
+++ b/snapshots/release_chef_11-4/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-4/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_11-4/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-4/source/resource_common.rst
+++ b/snapshots/release_chef_11-4/source/resource_common.rst
@@ -246,7 +246,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -358,14 +358,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_11-4/source/resource_execute.rst
+++ b/snapshots/release_chef_11-4/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-4/source/resource_perl.rst
+++ b/snapshots/release_chef_11-4/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-4/source/resource_remote_file.rst
+++ b/snapshots/release_chef_11-4/source/resource_remote_file.rst
@@ -486,7 +486,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -530,7 +530,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -540,7 +540,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -570,7 +570,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-4/source/resource_ruby.rst
+++ b/snapshots/release_chef_11-4/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-4/source/resource_script.rst
+++ b/snapshots/release_chef_11-4/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -496,7 +496,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -568,7 +568,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -578,7 +578,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-6/source/custom_resources.rst
+++ b/snapshots/release_chef_11-6/source/custom_resources.rst
@@ -986,7 +986,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")
@@ -1480,7 +1480,7 @@ The ``ssh_known_hosts_entry`` custom provider (found in the `ssh_known_hosts <ht
        backup        false
        content       
        only_if do
-         !::File.exists?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
+         !::File.exist?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
        end
      end
 
@@ -1771,7 +1771,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")

--- a/snapshots/release_chef_11-6/source/definitions.rst
+++ b/snapshots/release_chef_11-6/source/definitions.rst
@@ -195,7 +195,7 @@ A definition file can be used to create an object that the chef-client can then 
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/#{params[:name]}') or
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/000-#{params[:name]}')
          end
-         only_if do ::File.exists?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
+         only_if do ::File.exist?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
        end
      else
        execute 'a2dissite #{params[:name]}' do

--- a/snapshots/release_chef_11-6/source/dsl_recipe.rst
+++ b/snapshots/release_chef_11-6/source/dsl_recipe.rst
@@ -555,7 +555,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-6/source/handlers.rst
+++ b/snapshots/release_chef_11-6/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-6/source/resource_bash.rst
+++ b/snapshots/release_chef_11-6/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-6/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_11-6/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-6/source/resource_common.rst
+++ b/snapshots/release_chef_11-6/source/resource_common.rst
@@ -246,7 +246,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -358,14 +358,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_11-6/source/resource_execute.rst
+++ b/snapshots/release_chef_11-6/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-6/source/resource_perl.rst
+++ b/snapshots/release_chef_11-6/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-6/source/resource_remote_file.rst
+++ b/snapshots/release_chef_11-6/source/resource_remote_file.rst
@@ -607,7 +607,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -651,7 +651,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -661,7 +661,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -691,7 +691,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-6/source/resource_ruby.rst
+++ b/snapshots/release_chef_11-6/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-6/source/resource_script.rst
+++ b/snapshots/release_chef_11-6/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -496,7 +496,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -568,7 +568,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -578,7 +578,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-8/source/custom_resources.rst
+++ b/snapshots/release_chef_11-8/source/custom_resources.rst
@@ -986,7 +986,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")
@@ -1480,7 +1480,7 @@ The ``ssh_known_hosts_entry`` custom provider (found in the `ssh_known_hosts <ht
        backup        false
        content       
        only_if do
-         !::File.exists?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
+         !::File.exist?(node['ssh_known_hosts']['file']) || ::File.new(node['ssh_known_hosts']['file']).readlines.length == 0
        end
      end
 
@@ -1771,7 +1771,7 @@ For example:
 .. code-block:: ruby
 
    action :delete do
-     if ::File.exists?(new_resource.path)
+     if ::File.exist?(new_resource.path)
        converge_by("deleting #{new_resource.path}) do
          if ::File.writable?(new_resource.path)
            Chef::Log.info("Deleting #{new_resource} at #{new_resource.path}")

--- a/snapshots/release_chef_11-8/source/definitions.rst
+++ b/snapshots/release_chef_11-8/source/definitions.rst
@@ -195,7 +195,7 @@ A definition file can be used to create an object that the chef-client can then 
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/#{params[:name]}') or
            ::File.symlink?('#{node[:apache][:dir]}/sites-enabled/000-#{params[:name]}')
          end
-         only_if do ::File.exists?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
+         only_if do ::File.exist?('#{node[:apache][:dir]}/sites-available/#{params[:name]}') end
        end
      else
        execute 'a2dissite #{params[:name]}' do

--- a/snapshots/release_chef_11-8/source/dsl_recipe.rst
+++ b/snapshots/release_chef_11-8/source/dsl_recipe.rst
@@ -555,7 +555,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-8/source/handlers.rst
+++ b/snapshots/release_chef_11-8/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-8/source/resource_bash.rst
+++ b/snapshots/release_chef_11-8/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_11-8/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_11-8/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_11-8/source/resource_common.rst
+++ b/snapshots/release_chef_11-8/source/resource_common.rst
@@ -246,7 +246,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -358,14 +358,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_11-8/source/resource_execute.rst
+++ b/snapshots/release_chef_11-8/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-8/source/resource_perl.rst
+++ b/snapshots/release_chef_11-8/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-8/source/resource_remote_file.rst
+++ b/snapshots/release_chef_11-8/source/resource_remote_file.rst
@@ -607,7 +607,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -651,7 +651,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -661,7 +661,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -691,7 +691,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_11-8/source/resource_ruby.rst
+++ b/snapshots/release_chef_11-8/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_11-8/source/resource_script.rst
+++ b/snapshots/release_chef_11-8/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -496,7 +496,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -568,7 +568,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -578,7 +578,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-0/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-0/source/dsl_recipe.rst
@@ -550,7 +550,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-0/source/handlers.rst
+++ b/snapshots/release_chef_12-0/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-0/source/resource_bash.rst
+++ b/snapshots/release_chef_12-0/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-0/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-0/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-0/source/resource_common.rst
+++ b/snapshots/release_chef_12-0/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-0/source/resource_execute.rst
+++ b/snapshots/release_chef_12-0/source/resource_execute.rst
@@ -647,7 +647,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-0/source/resource_perl.rst
+++ b/snapshots/release_chef_12-0/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-0/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-0/source/resource_remote_file.rst
@@ -607,7 +607,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -651,7 +651,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -661,7 +661,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -691,7 +691,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-0/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-0/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-0/source/resource_script.rst
+++ b/snapshots/release_chef_12-0/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -602,7 +602,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -674,7 +674,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -684,7 +684,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-1/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-1/source/dsl_recipe.rst
@@ -1540,7 +1540,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-1/source/handlers.rst
+++ b/snapshots/release_chef_12-1/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-1/source/resource_bash.rst
+++ b/snapshots/release_chef_12-1/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-1/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-1/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-1/source/resource_common.rst
+++ b/snapshots/release_chef_12-1/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-1/source/resource_execute.rst
+++ b/snapshots/release_chef_12-1/source/resource_execute.rst
@@ -647,7 +647,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-1/source/resource_perl.rst
+++ b/snapshots/release_chef_12-1/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-1/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-1/source/resource_remote_file.rst
@@ -669,7 +669,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -713,7 +713,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -723,7 +723,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -753,7 +753,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-1/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-1/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-1/source/resource_script.rst
+++ b/snapshots/release_chef_12-1/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -602,7 +602,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -674,7 +674,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -684,7 +684,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-10/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-10/source/dsl_recipe.rst
@@ -1759,7 +1759,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-10/source/handlers.rst
+++ b/snapshots/release_chef_12-10/source/handlers.rst
@@ -688,7 +688,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-10/source/resource_bash.rst
+++ b/snapshots/release_chef_12-10/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -417,7 +417,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -489,7 +489,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -499,7 +499,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-10/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-10/source/resource_chef_handler.rst
@@ -445,7 +445,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-10/source/resource_common.rst
+++ b/snapshots/release_chef_12-10/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-10/source/resource_execute.rst
+++ b/snapshots/release_chef_12-10/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-10/source/resource_perl.rst
+++ b/snapshots/release_chef_12-10/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-10/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-10/source/resource_remote_file.rst
@@ -685,7 +685,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -729,7 +729,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -739,7 +739,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -769,7 +769,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-10/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-10/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-10/source/resource_script.rst
+++ b/snapshots/release_chef_12-10/source/resource_script.rst
@@ -37,7 +37,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -59,7 +59,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -609,7 +609,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -681,7 +681,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -691,7 +691,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-11/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-11/source/dsl_recipe.rst
@@ -1759,7 +1759,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-11/source/handlers.rst
+++ b/snapshots/release_chef_12-11/source/handlers.rst
@@ -688,7 +688,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-11/source/resource_bash.rst
+++ b/snapshots/release_chef_12-11/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -417,7 +417,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -489,7 +489,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -499,7 +499,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-11/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-11/source/resource_chef_handler.rst
@@ -445,7 +445,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-11/source/resource_common.rst
+++ b/snapshots/release_chef_12-11/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-11/source/resource_execute.rst
+++ b/snapshots/release_chef_12-11/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-11/source/resource_perl.rst
+++ b/snapshots/release_chef_12-11/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-11/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-11/source/resource_remote_file.rst
@@ -685,7 +685,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -729,7 +729,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -739,7 +739,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -769,7 +769,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-11/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-11/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-11/source/resource_script.rst
+++ b/snapshots/release_chef_12-11/source/resource_script.rst
@@ -37,7 +37,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -59,7 +59,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -609,7 +609,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -681,7 +681,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -691,7 +691,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-12/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-12/source/dsl_recipe.rst
@@ -1759,7 +1759,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-12/source/handlers.rst
+++ b/snapshots/release_chef_12-12/source/handlers.rst
@@ -688,7 +688,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-12/source/resource_bash.rst
+++ b/snapshots/release_chef_12-12/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -417,7 +417,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -489,7 +489,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -499,7 +499,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-12/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-12/source/resource_chef_handler.rst
@@ -445,7 +445,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-12/source/resource_common.rst
+++ b/snapshots/release_chef_12-12/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-12/source/resource_execute.rst
+++ b/snapshots/release_chef_12-12/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-12/source/resource_perl.rst
+++ b/snapshots/release_chef_12-12/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-12/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-12/source/resource_remote_file.rst
@@ -685,7 +685,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -729,7 +729,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -739,7 +739,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -769,7 +769,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-12/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-12/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-12/source/resource_script.rst
+++ b/snapshots/release_chef_12-12/source/resource_script.rst
@@ -37,7 +37,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -59,7 +59,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -609,7 +609,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -681,7 +681,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -691,7 +691,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-13/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-13/source/dsl_recipe.rst
@@ -1759,7 +1759,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-13/source/handlers.rst
+++ b/snapshots/release_chef_12-13/source/handlers.rst
@@ -688,7 +688,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-13/source/resource_bash.rst
+++ b/snapshots/release_chef_12-13/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -417,7 +417,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -489,7 +489,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -499,7 +499,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-13/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-13/source/resource_chef_handler.rst
@@ -445,7 +445,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-13/source/resource_common.rst
+++ b/snapshots/release_chef_12-13/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-13/source/resource_execute.rst
+++ b/snapshots/release_chef_12-13/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-13/source/resource_perl.rst
+++ b/snapshots/release_chef_12-13/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-13/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-13/source/resource_remote_file.rst
@@ -685,7 +685,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -729,7 +729,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -739,7 +739,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -769,7 +769,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-13/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-13/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-13/source/resource_script.rst
+++ b/snapshots/release_chef_12-13/source/resource_script.rst
@@ -37,7 +37,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -59,7 +59,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -609,7 +609,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -681,7 +681,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -691,7 +691,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-2/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-2/source/dsl_recipe.rst
@@ -1540,7 +1540,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-2/source/handlers.rst
+++ b/snapshots/release_chef_12-2/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-2/source/resource_bash.rst
+++ b/snapshots/release_chef_12-2/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-2/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-2/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-2/source/resource_common.rst
+++ b/snapshots/release_chef_12-2/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-2/source/resource_execute.rst
+++ b/snapshots/release_chef_12-2/source/resource_execute.rst
@@ -647,7 +647,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-2/source/resource_perl.rst
+++ b/snapshots/release_chef_12-2/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-2/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-2/source/resource_remote_file.rst
@@ -669,7 +669,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -713,7 +713,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -723,7 +723,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -753,7 +753,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-2/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-2/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-2/source/resource_script.rst
+++ b/snapshots/release_chef_12-2/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -602,7 +602,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -674,7 +674,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -684,7 +684,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-3/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-3/source/dsl_recipe.rst
@@ -1540,7 +1540,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-3/source/handlers.rst
+++ b/snapshots/release_chef_12-3/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-3/source/resource_bash.rst
+++ b/snapshots/release_chef_12-3/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-3/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-3/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-3/source/resource_common.rst
+++ b/snapshots/release_chef_12-3/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-3/source/resource_execute.rst
+++ b/snapshots/release_chef_12-3/source/resource_execute.rst
@@ -647,7 +647,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-3/source/resource_perl.rst
+++ b/snapshots/release_chef_12-3/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-3/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-3/source/resource_remote_file.rst
@@ -673,7 +673,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -717,7 +717,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -727,7 +727,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -757,7 +757,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-3/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-3/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-3/source/resource_script.rst
+++ b/snapshots/release_chef_12-3/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -602,7 +602,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -674,7 +674,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -684,7 +684,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-4/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-4/source/dsl_recipe.rst
@@ -1540,7 +1540,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-4/source/handlers.rst
+++ b/snapshots/release_chef_12-4/source/handlers.rst
@@ -343,7 +343,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-4/source/resource_bash.rst
+++ b/snapshots/release_chef_12-4/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-4/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-4/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-4/source/resource_common.rst
+++ b/snapshots/release_chef_12-4/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-4/source/resource_execute.rst
+++ b/snapshots/release_chef_12-4/source/resource_execute.rst
@@ -647,7 +647,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-4/source/resource_perl.rst
+++ b/snapshots/release_chef_12-4/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-4/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-4/source/resource_remote_file.rst
@@ -679,7 +679,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -723,7 +723,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -733,7 +733,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -763,7 +763,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-4/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-4/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-4/source/resource_script.rst
+++ b/snapshots/release_chef_12-4/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -602,7 +602,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -674,7 +674,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -684,7 +684,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-5/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-5/source/dsl_recipe.rst
@@ -1540,7 +1540,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-5/source/handlers.rst
+++ b/snapshots/release_chef_12-5/source/handlers.rst
@@ -688,7 +688,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-5/source/resource_bash.rst
+++ b/snapshots/release_chef_12-5/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -411,7 +411,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -483,7 +483,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -493,7 +493,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-5/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-5/source/resource_chef_handler.rst
@@ -439,7 +439,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-5/source/resource_common.rst
+++ b/snapshots/release_chef_12-5/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-5/source/resource_execute.rst
+++ b/snapshots/release_chef_12-5/source/resource_execute.rst
@@ -647,7 +647,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-5/source/resource_perl.rst
+++ b/snapshots/release_chef_12-5/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-5/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-5/source/resource_remote_file.rst
@@ -679,7 +679,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -723,7 +723,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -733,7 +733,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -763,7 +763,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-5/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-5/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-5/source/resource_script.rst
+++ b/snapshots/release_chef_12-5/source/resource_script.rst
@@ -36,7 +36,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -58,7 +58,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -602,7 +602,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -674,7 +674,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -684,7 +684,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-6/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-6/source/dsl_recipe.rst
@@ -1540,7 +1540,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-6/source/handlers.rst
+++ b/snapshots/release_chef_12-6/source/handlers.rst
@@ -688,7 +688,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-6/source/resource_bash.rst
+++ b/snapshots/release_chef_12-6/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -417,7 +417,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -489,7 +489,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -499,7 +499,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-6/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-6/source/resource_chef_handler.rst
@@ -445,7 +445,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-6/source/resource_common.rst
+++ b/snapshots/release_chef_12-6/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-6/source/resource_execute.rst
+++ b/snapshots/release_chef_12-6/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-6/source/resource_perl.rst
+++ b/snapshots/release_chef_12-6/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-6/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-6/source/resource_remote_file.rst
@@ -685,7 +685,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -729,7 +729,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -739,7 +739,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -769,7 +769,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-6/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-6/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-6/source/resource_script.rst
+++ b/snapshots/release_chef_12-6/source/resource_script.rst
@@ -37,7 +37,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -59,7 +59,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -609,7 +609,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -681,7 +681,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -691,7 +691,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-7/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-7/source/dsl_recipe.rst
@@ -1540,7 +1540,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-7/source/handlers.rst
+++ b/snapshots/release_chef_12-7/source/handlers.rst
@@ -688,7 +688,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-7/source/resource_bash.rst
+++ b/snapshots/release_chef_12-7/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -417,7 +417,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -489,7 +489,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -499,7 +499,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-7/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-7/source/resource_chef_handler.rst
@@ -445,7 +445,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-7/source/resource_common.rst
+++ b/snapshots/release_chef_12-7/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-7/source/resource_execute.rst
+++ b/snapshots/release_chef_12-7/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-7/source/resource_perl.rst
+++ b/snapshots/release_chef_12-7/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-7/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-7/source/resource_remote_file.rst
@@ -685,7 +685,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -729,7 +729,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -739,7 +739,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -769,7 +769,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-7/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-7/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-7/source/resource_script.rst
+++ b/snapshots/release_chef_12-7/source/resource_script.rst
@@ -37,7 +37,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -59,7 +59,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -609,7 +609,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -681,7 +681,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -691,7 +691,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-8/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-8/source/dsl_recipe.rst
@@ -1540,7 +1540,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-8/source/handlers.rst
+++ b/snapshots/release_chef_12-8/source/handlers.rst
@@ -688,7 +688,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-8/source/resource_bash.rst
+++ b/snapshots/release_chef_12-8/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -417,7 +417,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -489,7 +489,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -499,7 +499,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-8/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-8/source/resource_chef_handler.rst
@@ -445,7 +445,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-8/source/resource_common.rst
+++ b/snapshots/release_chef_12-8/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-8/source/resource_execute.rst
+++ b/snapshots/release_chef_12-8/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-8/source/resource_perl.rst
+++ b/snapshots/release_chef_12-8/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-8/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-8/source/resource_remote_file.rst
@@ -685,7 +685,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -729,7 +729,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -739,7 +739,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -769,7 +769,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-8/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-8/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-8/source/resource_script.rst
+++ b/snapshots/release_chef_12-8/source/resource_script.rst
@@ -37,7 +37,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -59,7 +59,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -609,7 +609,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -681,7 +681,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -691,7 +691,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-9/source/dsl_recipe.rst
+++ b/snapshots/release_chef_12-9/source/dsl_recipe.rst
@@ -1540,7 +1540,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-9/source/handlers.rst
+++ b/snapshots/release_chef_12-9/source/handlers.rst
@@ -688,7 +688,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-9/source/resource_bash.rst
+++ b/snapshots/release_chef_12-9/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -417,7 +417,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -489,7 +489,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -499,7 +499,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_chef_12-9/source/resource_chef_handler.rst
+++ b/snapshots/release_chef_12-9/source/resource_chef_handler.rst
@@ -445,7 +445,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_chef_12-9/source/resource_common.rst
+++ b/snapshots/release_chef_12-9/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_chef_12-9/source/resource_execute.rst
+++ b/snapshots/release_chef_12-9/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-9/source/resource_perl.rst
+++ b/snapshots/release_chef_12-9/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-9/source/resource_remote_file.rst
+++ b/snapshots/release_chef_12-9/source/resource_remote_file.rst
@@ -685,7 +685,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -729,7 +729,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -739,7 +739,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -769,7 +769,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_chef_12-9/source/resource_ruby.rst
+++ b/snapshots/release_chef_12-9/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_chef_12-9/source/resource_script.rst
+++ b/snapshots/release_chef_12-9/source/resource_script.rst
@@ -37,7 +37,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -59,7 +59,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -609,7 +609,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -681,7 +681,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -691,7 +691,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_devkit/source/dsl_recipe.rst
+++ b/snapshots/release_devkit/source/dsl_recipe.rst
@@ -1743,7 +1743,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_devkit/source/handlers.rst
+++ b/snapshots/release_devkit/source/handlers.rst
@@ -688,7 +688,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_devkit/source/resource_bash.rst
+++ b/snapshots/release_devkit/source/resource_bash.rst
@@ -27,7 +27,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -417,7 +417,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -489,7 +489,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -499,7 +499,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_devkit/source/resource_chef_handler.rst
+++ b/snapshots/release_devkit/source/resource_chef_handler.rst
@@ -445,7 +445,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end

--- a/snapshots/release_devkit/source/resource_common.rst
+++ b/snapshots/release_devkit/source/resource_common.rst
@@ -251,7 +251,7 @@ The following example shows how to use ``not_if`` to guard against running the `
    execute "apt-get-update" do
      command "apt-get update"
      ignore_failure true
-     not_if do ::File.exists?('/var/lib/apt/periodic/update-success-stamp') end
+     not_if do ::File.exist?('/var/lib/apt/periodic/update-success-stamp') end
    end
 
 .. end_tag
@@ -363,14 +363,14 @@ The following example shows how to use ``only_if`` to ensure that the chef-clien
    aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4' do
      command "#{aspnet_regiis} -i"
-     only_if { File.exists?(aspnet_regiis) }
+     only_if { File.exist?(aspnet_regiis) }
      action :nothing
    end
 
    aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
    execute 'Register ASP.NET v4 (x64)' do
      command "#{aspnet_regiis64} -i"
-     only_if { File.exists?(aspnet_regiis64) }
+     only_if { File.exist?(aspnet_regiis64) }
      action :nothing
    end
 

--- a/snapshots/release_devkit/source/resource_execute.rst
+++ b/snapshots/release_devkit/source/resource_execute.rst
@@ -659,7 +659,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_devkit/source/resource_perl.rst
+++ b/snapshots/release_devkit/source/resource_perl.rst
@@ -27,7 +27,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_devkit/source/resource_remote_file.rst
+++ b/snapshots/release_devkit/source/resource_remote_file.rst
@@ -712,7 +712,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -756,7 +756,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -766,7 +766,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -796,7 +796,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:

--- a/snapshots/release_devkit/source/resource_ruby.rst
+++ b/snapshots/release_devkit/source/resource_ruby.rst
@@ -27,7 +27,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where

--- a/snapshots/release_devkit/source/resource_ruby_block.rst
+++ b/snapshots/release_devkit/source/resource_ruby_block.rst
@@ -376,7 +376,7 @@ The following example shows how the ``platform?`` method and an if statement can
            jdk_home = Dir.glob("#{java_home_parent}/java*#{version}*openjdk{,[-\.]#{arch}}")[0]
            Chef::Log.debug("jdk_home is #{jdk_home}")
 
-           if File.exists? java_home
+           if File.exist? java_home
              FileUtils.rm_f java_home
            end
            FileUtils.ln_sf jdk_home, java_home

--- a/snapshots/release_devkit/source/resource_script.rst
+++ b/snapshots/release_devkit/source/resource_script.rst
@@ -37,7 +37,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -59,7 +59,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -609,7 +609,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -681,7 +681,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -691,7 +691,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_devkit/source/resources.rst
+++ b/snapshots/release_devkit/source/resources.rst
@@ -379,7 +379,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -1975,7 +1975,7 @@ A **bash** resource block executes scripts using Bash:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -2276,7 +2276,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -2348,7 +2348,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -2358,7 +2358,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -3953,7 +3953,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
            end
          end
          def build_report_dir
-           unless File.exists?(config[:path])
+           unless File.exist?(config[:path])
              FileUtils.mkdir_p(config[:path])
              File.chmod(00700, config[:path])
            end
@@ -9298,7 +9298,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:
@@ -16058,7 +16058,7 @@ A **perl** resource block executes scripts Perl:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -18779,7 +18779,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -18823,7 +18823,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -18833,7 +18833,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag
@@ -18863,7 +18863,7 @@ The following is an example of using the ``platform_family?`` method in the Reci
      command <<-EOF
        # command for installing Python goes here
        EOF
-     not_if { File.exists?(pip_binary) }
+     not_if { File.exist?(pip_binary) }
    end
 
 where a command for installing Python might look something like:
@@ -19372,7 +19372,7 @@ A **ruby** resource block executes scripts using Ruby:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -19979,7 +19979,7 @@ The following example shows how the ``platform?`` method and an if statement can
            jdk_home = Dir.glob("#{java_home_parent}/java*#{version}*openjdk{,[-\.]#{arch}}")[0]
            Chef::Log.debug("jdk_home is #{jdk_home}")
 
-           if File.exists? java_home
+           if File.exist? java_home
              FileUtils.rm_f java_home
            end
            FileUtils.ln_sf jdk_home, java_home
@@ -20061,7 +20061,7 @@ A **script** resource block typically executes scripts using a specified interpr
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 where
@@ -20083,7 +20083,7 @@ The same command as above, but run using the **bash** resource:
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 The full syntax for all of the properties that are available to the **script** resource is:
@@ -20438,7 +20438,7 @@ The following is an example of how to install the ``foo123`` module for Nginx. T
        tar xzf #{src_filename} -C #{extract_path}
        mv #{extract_path}/*/* #{extract_path}/
        EOH
-     not_if { ::File.exists?(extract_path) }
+     not_if { ::File.exist?(extract_path) }
    end
 
 .. end_tag
@@ -20510,7 +20510,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
      source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
      checksum node['python']['checksum']
      mode '0755'
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
    bash 'build-and-install-python' do
@@ -20520,7 +20520,7 @@ and then the methods in the recipe may refer to these values. A recipe that is u
        (cd Python-#{version} && ./configure #{configure_options})
        (cd Python-#{version} && make && make install)
      EOF
-     not_if { ::File.exists?(install_path) }
+     not_if { ::File.exist?(install_path) }
    end
 
 .. end_tag

--- a/snapshots/release_ohai_6/source/index.rst
+++ b/snapshots/release_ohai_6/source/index.rst
@@ -673,7 +673,7 @@ An Ohai plugin can be run independently of a chef-client run. First, ensure that
 
    provides "sl"
 
-   if ::File.exists?("/usr/games/sl")
+   if ::File.exist?("/usr/games/sl")
      sl Mash.new
      sl[:installed] = true
    end

--- a/snapshots/release_server_12-0/source/server_security.rst
+++ b/snapshots/release_server_12-0/source/server_security.rst
@@ -126,7 +126,7 @@ The following example shows how the Chef server sets up and configures SSL certi
    ssl_crtfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.crt")
    ssl_signing_conf = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}-ssl.conf")
 
-   unless File.exists?(ssl_keyfile) && File.exists?(ssl_crtfile) && File.exists?(ssl_signing_conf)
+   unless File.exist?(ssl_keyfile) && File.exist?(ssl_crtfile) && File.exist?(ssl_signing_conf)
      file ssl_keyfile do
        owner 'root'
        group 'root'

--- a/snapshots/release_server_12-1/source/server_security.rst
+++ b/snapshots/release_server_12-1/source/server_security.rst
@@ -126,7 +126,7 @@ The following example shows how the Chef server sets up and configures SSL certi
    ssl_crtfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.crt")
    ssl_signing_conf = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}-ssl.conf")
 
-   unless File.exists?(ssl_keyfile) && File.exists?(ssl_crtfile) && File.exists?(ssl_signing_conf)
+   unless File.exist?(ssl_keyfile) && File.exist?(ssl_crtfile) && File.exist?(ssl_signing_conf)
      file ssl_keyfile do
        owner 'root'
        group 'root'

--- a/snapshots/release_server_12-2/source/server_security.rst
+++ b/snapshots/release_server_12-2/source/server_security.rst
@@ -126,7 +126,7 @@ The following example shows how the Chef server sets up and configures SSL certi
    ssl_crtfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.crt")
    ssl_signing_conf = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}-ssl.conf")
 
-   unless File.exists?(ssl_keyfile) && File.exists?(ssl_crtfile) && File.exists?(ssl_signing_conf)
+   unless File.exist?(ssl_keyfile) && File.exist?(ssl_crtfile) && File.exist?(ssl_signing_conf)
      file ssl_keyfile do
        owner 'root'
        group 'root'

--- a/snapshots/release_server_12-3/source/server_security.rst
+++ b/snapshots/release_server_12-3/source/server_security.rst
@@ -126,7 +126,7 @@ The following example shows how the Chef server sets up and configures SSL certi
    ssl_crtfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.crt")
    ssl_signing_conf = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}-ssl.conf")
 
-   unless File.exists?(ssl_keyfile) && File.exists?(ssl_crtfile) && File.exists?(ssl_signing_conf)
+   unless File.exist?(ssl_keyfile) && File.exist?(ssl_crtfile) && File.exist?(ssl_signing_conf)
      file ssl_keyfile do
        owner 'root'
        group 'root'

--- a/snapshots/release_server_12-4/source/server_security.rst
+++ b/snapshots/release_server_12-4/source/server_security.rst
@@ -126,7 +126,7 @@ The following example shows how the Chef server sets up and configures SSL certi
    ssl_crtfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.crt")
    ssl_signing_conf = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}-ssl.conf")
 
-   unless File.exists?(ssl_keyfile) && File.exists?(ssl_crtfile) && File.exists?(ssl_signing_conf)
+   unless File.exist?(ssl_keyfile) && File.exist?(ssl_crtfile) && File.exist?(ssl_signing_conf)
      file ssl_keyfile do
        owner 'root'
        group 'root'

--- a/snapshots/release_server_12-5/source/server_security.rst
+++ b/snapshots/release_server_12-5/source/server_security.rst
@@ -126,7 +126,7 @@ The following example shows how the Chef server sets up and configures SSL certi
    ssl_crtfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.crt")
    ssl_signing_conf = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}-ssl.conf")
 
-   unless File.exists?(ssl_keyfile) && File.exists?(ssl_crtfile) && File.exists?(ssl_signing_conf)
+   unless File.exist?(ssl_keyfile) && File.exist?(ssl_crtfile) && File.exist?(ssl_signing_conf)
      file ssl_keyfile do
        owner 'root'
        group 'root'

--- a/snapshots/release_server_12-6/source/server_security.rst
+++ b/snapshots/release_server_12-6/source/server_security.rst
@@ -126,7 +126,7 @@ The following example shows how the Chef server sets up and configures SSL certi
    ssl_crtfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.crt")
    ssl_signing_conf = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}-ssl.conf")
 
-   unless File.exists?(ssl_keyfile) && File.exists?(ssl_crtfile) && File.exists?(ssl_signing_conf)
+   unless File.exist?(ssl_keyfile) && File.exist?(ssl_crtfile) && File.exist?(ssl_signing_conf)
      file ssl_keyfile do
        owner 'root'
        group 'root'

--- a/snapshots/release_server_12-7/source/server_security.rst
+++ b/snapshots/release_server_12-7/source/server_security.rst
@@ -126,7 +126,7 @@ The following example shows how the Chef server sets up and configures SSL certi
    ssl_crtfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.crt")
    ssl_signing_conf = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}-ssl.conf")
 
-   unless File.exists?(ssl_keyfile) && File.exists?(ssl_crtfile) && File.exists?(ssl_signing_conf)
+   unless File.exist?(ssl_keyfile) && File.exist?(ssl_crtfile) && File.exist?(ssl_signing_conf)
      file ssl_keyfile do
        owner 'root'
        group 'root'

--- a/snapshots/release_server_12-8/source/server_security.rst
+++ b/snapshots/release_server_12-8/source/server_security.rst
@@ -126,7 +126,7 @@ The following example shows how the Chef server sets up and configures SSL certi
    ssl_crtfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.crt")
    ssl_signing_conf = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}-ssl.conf")
 
-   unless File.exists?(ssl_keyfile) && File.exists?(ssl_crtfile) && File.exists?(ssl_signing_conf)
+   unless File.exist?(ssl_keyfile) && File.exist?(ssl_crtfile) && File.exist?(ssl_signing_conf)
      file ssl_keyfile do
        owner 'root'
        group 'root'


### PR DESCRIPTION
Signed-off-by: Sander van Zoest sander@vanzoest.com

Replaced File#exists? with File#exist? mentioned in Resource guards
