### PR TITLE
Update tutorial links

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -113,27 +113,27 @@
           {
             "title": "Learn the Basics",
             "hasSubItems": false,
-            "url": "https://learn.chef.io/learn-the-basics"
+            "url": "https://learn.chef.io/tutorials/learn-the-basics/"
           },
           {
             "title": "Manage a Node",
             "hasSubItems": false,
-            "url": "https://learn.chef.io/manage-a-node"
+            "url": "https://learn.chef.io/tutorials/manage-a-node/"
           },
           {
-            "title": "Local Development",
+            "title": "Develop Locally",
             "hasSubItems": false,
-            "url": "https://learn.chef.io/local-development"
+            "url": "https://learn.chef.io/tutorials/local-development/"
           },
           {
             "title": "Manage a Web App",
             "hasSubItems": false,
-            "url": "https://learn.chef.io/manage-a-web-app"
+            "url": "https://learn.chef.io/manage-a-web-app/"
           },
           {
-            "title": "Test Your Infrastructure",
+            "title": "Test Locally",
             "hasSubItems": false,
-            "url": "https://learn.chef.io/test-your-infrastructure-code"
+            "url": "https://learn.chef.io/tutorials/test-your-infrastructure-code/"
           }
         ]
       },

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -59,12 +59,11 @@ Getting Started
 Tutorials
 -----------------------------------------------------
 
- `Learn the Basics <https://learn.chef.io/tutorials/#learn-the-basics>`_ |
- `Manage a Node <https://learn.chef.io/tutorials/#manage-a-node>`_ |
- `Local Development <https://learn.chef.io/tutorials/#local-development>`_ |
- `Manage a Web App <https://learn.chef.io/tutorials/#manage-a-web-app>`_ |
- `Test Your Infrastructure <https://learn.chef.io/tutorials/#test-your-infrastructure-code>`_ |
- `Install Chef Server <https://learn.chef.io/tutorials/#install-and-manage-your-own-chef-server>`_
+ `Learn the Basics <https://learn.chef.io/tutorials/learn-the-basics/>`_ |
+ `Manage a Node <https://learn.chef.io/tutorials/manage-a-node/>`_ |
+ `Develop Locally <https://learn.chef.io/tutorials/local-development/>`_ |
+ `Manage a Web App <https://learn.chef.io/manage-a-web-app/>`_ |
+ `Test Locally <https://learn.chef.io/tutorials/test-your-infrastructure-code/>`_ |
 
 Concepts
 -----------------------------------------------------


### PR DESCRIPTION
☠️ Do not merge. This PR depends on a change to Learn Chef to finish first ☠️ 

- Update to new path names (/tutorials/)
- Tweak a few titles, ensure each link ends with /.
- Remove “Install Chef Server” link, as it is now retired.