### PR TITLE
Make Recipe DSL reachable in the nav.

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -41,26 +41,26 @@
         "title": "Packages &amp; Platforms",
         "hasSubItems": true,
         "subItems": [
-           {
-             "title": "Packages",
-             "hasSubItems": false,
-             "url": "/packages.html"
-           },
-           {
-             "title": "Platforms",
-             "hasSubItems": false,
-             "url": "/platforms.html"
-           },
-           {
-             "title": "Omnitruck API",
-             "hasSubItems": false,
-             "url": "/api_omnitruck.html"
-           },
-           {
-             "title": "Licensing",
-             "hasSubItems": false,
-             "url": "/chef_license.html"
-           }
+          {
+            "title": "Packages",
+            "hasSubItems": false,
+            "url": "/packages.html"
+          },
+          {
+            "title": "Platforms",
+            "hasSubItems": false,
+            "url": "/platforms.html"
+          },
+          {
+            "title": "Omnitruck API",
+            "hasSubItems": false,
+            "url": "/api_omnitruck.html"
+          },
+          {
+            "title": "Licensing",
+            "hasSubItems": false,
+            "url": "/chef_license.html"
+          }
         ]
       }
     ]
@@ -103,7 +103,7 @@
                 "url": "/release_notes_server.html"
               }
             ]
-          },
+          }
         ]
       },
       {
@@ -250,7 +250,7 @@
                 "title": "FIPS-mode",
                 "hasSubItems": false,
                 "url": "/ctl_chef_client.html#run-in-fips-mode"
-              },
+              }
             ]
           },
           {
@@ -292,9 +292,9 @@
                 "title": "Glossary",
                 "hasSubItems": false,
                 "url": "/glossary.html"
-              },
+              }
             ]
-          },
+          }
         ]
       },
       {
@@ -449,7 +449,7 @@
             "title": "Uninstall",
             "hasSubItems": false,
             "url": "/uninstall.html"
-          },
+          }
         ]
       },
       {
@@ -494,147 +494,147 @@
                 "title": "Debug Recipes, Client Runs",
                 "hasSubItems": false,
                 "url": "/debug.html"
+              }
+            ]
+          },
+          {
+            "title": "Recipe DSL",
+            "hasSubItems": true,
+            "subItems": [
+              {
+                "title": "attribute?",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#attribute"
               },
               {
-                "title": "Recipe DSL",
-                "hasSubItems": true,
-                "subItems": [
-                  {
-                    "title": "attribute?",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#attribute"
-                  },
-                  {
-                    "title": "control",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#control"
-                  },
-                  {
-                    "title": "control_group",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#control-group"
-                  },
-                  {
-                    "title": "cookbook_name",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#cookbook-name"
-                  },
-                  {
-                    "title": "data_bag",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#data-bag"
-                  },
-                  {
-                    "title": "data_bag_item",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#data-bag-item"
-                  },
-                  {
-                    "title": "platform?",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#platform"
-                  },
-                  {
-                    "title": "platform_family?",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#platform-family"
-                  },
-                  {
-                    "title": "reboot_pending?",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#reboot-pending"
-                  },
-                  {
-                    "title": "recipe_name",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#recipe-name"
-                  },
-                  {
-                    "title": "registry_data_exists?",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#registry-data-exists"
-                  },
-                  {
-                    "title": "registry_get_subkeys",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#registry-get-subkeys"
-                  },
-                  {
-                    "title": "registry_get_values",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#registry-get-values"
-                  },
-                  {
-                    "title": "registry_has_subkeys?",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#registry-has-subkeys"
-                  },
-                  {
-                    "title": "registry_key_exists?",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#registry-key-exists"
-                  },
-                  {
-                    "title": "registry_value_exists?",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#registry-value-exists"
-                  },
-                  {
-                    "title": "resources",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#resources"
-                  },
-                  {
-                    "title": "search",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#search"
-                  },
-                  {
-                    "title": "shell_out",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#shell-out"
-                  },
-                  {
-                    "title": "shell_out!",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#shell-out-bang"
-                  },
-                  {
-                    "title": "shell_out_with_systems_locale",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#shell-out-with-systems-locale"
-                  },
-                  {
-                    "title": "tag",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#tag-tagged-untag"
-                  },
-                  {
-                    "title": "tagged?",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#tag-tagged-untag"
-                  },
-                  {
-                    "title": "untag",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#tag-tagged-untag"
-                  },
-                  {
-                    "title": "value_for_platform",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#value-for-platform"
-                  },
-                  {
-                    "title": "value_for_platform_family",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#value-for-platform-family"
-                  },
-                  {
-                    "title": "Windows Platform Helpers",
-                    "hasSubItems": false,
-                    "url": "/dsl_recipe.html#helpers"
-                  }
-                ]
+                "title": "control",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#control"
+              },
+              {
+                "title": "control_group",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#control-group"
+              },
+              {
+                "title": "cookbook_name",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#cookbook-name"
+              },
+              {
+                "title": "data_bag",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#data-bag"
+              },
+              {
+                "title": "data_bag_item",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#data-bag-item"
+              },
+              {
+                "title": "platform?",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#platform"
+              },
+              {
+                "title": "platform_family?",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#platform-family"
+              },
+              {
+                "title": "reboot_pending?",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#reboot-pending"
+              },
+              {
+                "title": "recipe_name",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#recipe-name"
+              },
+              {
+                "title": "registry_data_exists?",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#registry-data-exists"
+              },
+              {
+                "title": "registry_get_subkeys",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#registry-get-subkeys"
+              },
+              {
+                "title": "registry_get_values",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#registry-get-values"
+              },
+              {
+                "title": "registry_has_subkeys?",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#registry-has-subkeys"
+              },
+              {
+                "title": "registry_key_exists?",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#registry-key-exists"
+              },
+              {
+                "title": "registry_value_exists?",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#registry-value-exists"
+              },
+              {
+                "title": "resources",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#resources"
+              },
+              {
+                "title": "search",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#search"
+              },
+              {
+                "title": "shell_out",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#shell-out"
+              },
+              {
+                "title": "shell_out!",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#shell-out-bang"
+              },
+              {
+                "title": "shell_out_with_systems_locale",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#shell-out-with-systems-locale"
+              },
+              {
+                "title": "tag",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#tag-tagged-untag"
+              },
+              {
+                "title": "tagged?",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#tag-tagged-untag"
+              },
+              {
+                "title": "untag",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#tag-tagged-untag"
+              },
+              {
+                "title": "value_for_platform",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#value-for-platform"
+              },
+              {
+                "title": "value_for_platform_family",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#value-for-platform-family"
+              },
+              {
+                "title": "Windows Platform Helpers",
+                "hasSubItems": false,
+                "url": "/dsl_recipe.html#helpers"
               }
             ]
           },
@@ -1081,7 +1081,7 @@
                 "title": "Examples (by Resource)",
                 "hasSubItems": false,
                 "url": "/resource_examples.html"
-              },
+              }
             ]
           },
           {
@@ -1644,49 +1644,49 @@
                 "url": "/provisioning.html"
               },
               {
-                 "title": "load_balancer resource",
-                 "hasSubItems": false,
-                 "url": "/resource_load_balancer.html"
+                "title": "load_balancer resource",
+                "hasSubItems": false,
+                "url": "/resource_load_balancer.html"
               },
               {
-                 "title": "machine resource",
-                 "hasSubItems": false,
-                 "url": "/resource_machine.html"
+                "title": "machine resource",
+                "hasSubItems": false,
+                "url": "/resource_machine.html"
               },
               {
-                 "title": "machine_batch resource",
-                 "hasSubItems": false,
-                 "url": "/resource_machine_batch.html"
+                "title": "machine_batch resource",
+                "hasSubItems": false,
+                "url": "/resource_machine_batch.html"
               },
               {
-                 "title": "machine_execute resource",
-                 "hasSubItems": false,
-                 "url": "/resource_machine_execute.html"
+                "title": "machine_execute resource",
+                "hasSubItems": false,
+                "url": "/resource_machine_execute.html"
               },
               {
-                 "title": "machine_file resource",
-                 "hasSubItems": false,
-                 "url": "/resource_machine_file.html"
+                "title": "machine_file resource",
+                "hasSubItems": false,
+                "url": "/resource_machine_file.html"
               },
               {
-                 "title": "machine_image resource",
-                 "hasSubItems": false,
-                 "url": "/resource_machine_image.html"
+                "title": "machine_image resource",
+                "hasSubItems": false,
+                "url": "/resource_machine_image.html"
               },
               {
-                 "title": "AWS Driver Resources",
-                 "hasSubItems": false,
-                 "url": "/provisioning_aws.html"
+                "title": "AWS Driver Resources",
+                "hasSubItems": false,
+                "url": "/provisioning_aws.html"
               },
               {
-                 "title": "Fog Driver Resources",
-                 "hasSubItems": false,
-                 "url": "/provisioning_fog.html"
+                "title": "Fog Driver Resources",
+                "hasSubItems": false,
+                "url": "/provisioning_fog.html"
               },
               {
-                 "title": "Vagrant Driver Resources",
-                 "hasSubItems": false,
-                 "url": "/provisioning_vagrant.html"
+                "title": "Vagrant Driver Resources",
+                "hasSubItems": false,
+                "url": "/provisioning_vagrant.html"
               }
             ]
           },
@@ -1710,7 +1710,8 @@
             "title": "Runbook (Single Page)",
             "hasSubItems": false,
             "url": "/runbook.html"
-          },{
+          },
+          {
             "title": "Backup &amp; Restore",
             "hasSubItems": false,
             "url": "/server_backup_restore.html"
@@ -1838,7 +1839,7 @@
                 "title": "Server Sent Events",
                 "hasSubItems": false,
                 "url": "/server_sent_events.html"
-              },
+              }
             ]
           },
           {
@@ -1908,9 +1909,9 @@
             "hasSubItems": true,
             "subItems": [
               {
-               "title": "Configure SAML",
-               "hasSubItems": false,
-               "url": "/server_configure_saml.html"
+                "title": "Configure SAML",
+                "hasSubItems": false,
+                "url": "/server_configure_saml.html"
               },
               {
                 "title": "Clients",
@@ -1969,7 +1970,7 @@
     "subItems": [
       {
         "title": "Habitat Overview",
-         "url": "/habitat.html"
+        "url": "/habitat.html"
       },
       {
         "title": "Tutorials",
@@ -2005,7 +2006,7 @@
         "subItems": [
           {
             "title": "Chef Automate Overview",
-            "url": "/chef_automate.html",
+            "url": "/chef_automate.html"
           },
           {
             "title": "Installation Guide",
@@ -2068,7 +2069,7 @@
         "title": "Concepts",
         "hasSubItems": true,
         "subItems": [
-           {
+          {
             "title": "Workflow",
             "hasSubItems": true,
             "subItems": [
@@ -2082,9 +2083,8 @@
                 "hasSubItems": false,
                 "url": "/delivery_manage_dependencies.html"
               }
-           ]
+            ]
           },
-
           {
             "title": "Visibility Overview",
             "hasSubItems": false,
@@ -2196,7 +2196,7 @@
                 "title": "Restore Backups",
                 "hasSubItems": false,
                 "url": "/delivery_server_backup.html#restore-backups"
-              },
+              }
             ]
           },
           {
@@ -2361,9 +2361,9 @@
             "url": "/manage_indices_chef_automate.html"
           },
           {
-           "title": "Node Search Reference",
-           "hasSubItems": false,
-           "url": "/search_query_chef_automate.html"
+            "title": "Node Search Reference",
+            "hasSubItems": false,
+            "url": "/search_query_chef_automate.html"
           },
           {
             "title": "Secrets",
@@ -2371,9 +2371,9 @@
             "url": "/delivery_manage_secrets.html"
           },
           {
-           "title": "Stream Data",
-           "hasSubItems": false,
-           "url": "/stream_data_chef_automate.html"
+            "title": "Stream Data",
+            "hasSubItems": false,
+            "url": "/stream_data_chef_automate.html"
           },
           {
             "title": "Tuning",
@@ -2467,7 +2467,7 @@
             "title": "Community Handlers",
             "hasSubItems": false,
             "url": "/plugin_community.html#handlers"
-          },
+          }
         ]
       },
       {
@@ -2488,7 +2488,7 @@
             "title": "Community Plugins",
             "hasSubItems": false,
             "url": "/plugin_community.html#knife"
-          },
+          }
         ]
       },
       {
@@ -2504,7 +2504,7 @@
             "title": "Community Plugins",
             "hasSubItems": false,
             "url": "/plugin_community.html#ohai"
-          },
+          }
         ]
       },
       {


### PR DESCRIPTION
This solution makes Recipe DSL a sibling of Recipe rather than a child.
The heirarchy is altered, but the fine grain links are retained. This
appears to have been davidwrede's intent according to
https://github.com/chef/chef-web-docs/pull/143

NOTE: To make such a significant heirarchy change I had to lint the
JSON. This resulted in a lot of minor whitespace and comma corrections.
I wasn't trying to be pedantic.