### PR TITLE
Change `MintTTY` to `MinTTY`

### DIFF
--- a/chef_master/source/ctl_delivery.rst
+++ b/chef_master/source/ctl_delivery.rst
@@ -738,7 +738,7 @@ delivery token
 =====================================================
 Use the ``token`` subcommand to manage a Chef Automate API token.
 
-.. note:: If you're running this command on Windows in Git Bash with MintTTY you must include ``winpty`` before ``delivery token`` to avoid errors.
+.. note:: If you're running this command on Windows in Git Bash with MinTTY you must include ``winpty`` before ``delivery token`` to avoid errors.
 
 Syntax
 -----------------------------------------------------


### PR DESCRIPTION
Product is called [MinTTY](https://mintty.github.io/)