### PR TITLE
Remove the workflow diagram from the client release page

### DIFF
--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -3,17 +3,7 @@ Release Notes: chef-client 12.0 - 12.16
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/release_notes.rst>`__
 
-.. tag chef
-
-Chef is a powerful automation platform that transforms infrastructure into code. Whether you’re operating in the cloud, on-premises, or in a hybrid environment, Chef automates how infrastructure is configured, deployed, and managed across your network, no matter its size.
-
-This diagram shows how you develop, test, and deploy your Chef code.
-
-.. image:: ../../images/start_chef.svg
-   :width: 700px
-   :align: center
-
-.. end_tag
+Chef Client is released on a monthly schedule with new releases the first Wednesday of every month. Below are the major changes for each release. For a detailed list of changes see the `[Chef CHANGELOG.md] <https://github.com/chef/chef/blob/master/CHANGELOG.md>`__
 
 What's New in 12.16
 =====================================================

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -3,7 +3,7 @@ Release Notes: chef-client 12.0 - 12.16
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/release_notes.rst>`__
 
-Chef Client is released on a monthly schedule with new releases the first Wednesday of every month. Below are the major changes for each release. For a detailed list of changes see the `[Chef CHANGELOG.md] <https://github.com/chef/chef/blob/master/CHANGELOG.md>`__
+Chef client is released on a monthly schedule with new releases the first Wednesday of every month. Below are the major changes for each release. For a detailed list of changes see the `[Chef CHANGELOG.md] <https://github.com/chef/chef/blob/master/CHANGELOG.md>`__
 
 What's New in 12.16
 =====================================================


### PR DESCRIPTION
This came in with an include, but doesn't make sense now

Signed-off-by: Tim Smith <tsmith@chef.io>