### PR TITLE
Specify location of delivery.rb file

### DIFF
--- a/chef_master/source/config_rb_delivery.rst
+++ b/chef_master/source/config_rb_delivery.rst
@@ -14,7 +14,7 @@ delivery.rb Settings
 
 .. end_tag
 
-The ``delivery.rb`` file contains all of the non-default configuration settings used by the Chef Automate. (The default settings are built-in to the Chef Automate configuration and should only be added to the ``delivery.rb`` file to apply non-default values.) These configuration settings are processed when the ``delivery-server-ctl reconfigure`` command is run, such as immediately after setting up Chef Automate or after making a change to the underlying configuration settings after the server has been deployed. The ``delivery.rb`` file is a Ruby file, which means that conditional statements can be used in the configuration file.
+The ``delivery.rb`` file, located at ``/etc/delivery/delivery.rb``, contains all of the non-default configuration settings used by the Chef Automate. (The default settings are built-in to the Chef Automate configuration and should only be added to the ``delivery.rb`` file to apply non-default values.) These configuration settings are processed when the ``delivery-server-ctl reconfigure`` command is run, such as immediately after setting up Chef Automate or after making a change to the underlying configuration settings after the server has been deployed. The ``delivery.rb`` file is a Ruby file, which means that conditional statements can be used in the configuration file.
 
 Recommended Settings
 =====================================================


### PR DESCRIPTION
The doc page that describes the configuration options for a file should probably include the location of that file (if it's not obvious). It wasn't obvious to me, so hopefully this helps others.