### PR TITLE
Add "--json-attribute-file FILE" option

### DIFF
--- a/chef_master/source/knife_bootstrap.rst
+++ b/chef_master/source/knife_bootstrap.rst
@@ -138,6 +138,9 @@ This subcommand has the following options:
 ``-j JSON_ATTRIBS``, ``--json-attributes JSON_ATTRIBS``
    A JSON string that is added to the first run of a chef-client.
 
+``--json-attribute-file FILE``
+   A JSON file to be added to the first run of chef-client.
+
 ``-N NAME``, ``--node-name NAME``
    The name of the node.
 

--- a/chef_master/source/knife_bootstrap.rst
+++ b/chef_master/source/knife_bootstrap.rst
@@ -141,6 +141,8 @@ This subcommand has the following options:
 ``--json-attribute-file FILE``
    A JSON file to be added to the first run of chef-client.
 
+   New in Chef client 12.6.
+
 ``-N NAME``, ``--node-name NAME``
    The name of the node.
 

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -908,6 +908,11 @@ This subcommand has the following options:
 ``-j JSON_ATTRIBS``, ``--json-attributes JSON_ATTRIBS``
    A JSON string that is added to the first run of a chef-client.
 
+``--json-attribute-file FILE``
+   A JSON file to be added to the first run of chef-client.
+
+   New in Chef client 12.6.
+
 ``-N NAME``, ``--node-name NAME``
    The name of the node.
 


### PR DESCRIPTION
The "--json-attribute-file FILE" option has been available since Chef Client 12.6.0.

https://github.com/chef/chef/blob/12.6.0/CHANGELOG.md