### PR TITLE
Update configuration sample in install_dk.rst

### DIFF
--- a/chef_master/source/install_dk.rst
+++ b/chef_master/source/install_dk.rst
@@ -386,7 +386,7 @@ The knife.rb file must be created in the .chef folder. It should look similar to
    log_location             STDOUT
    node_name                'node_name'
    client_key               "#{current_dir}/USER.pem"
-   validation_client_name   'chef-validator'
+   validation_client_name   'ORG_NAME-validator'
    validation_key           "#{current_dir}/ORGANIZATION-validator.pem"
    chef_server_url          'https://api.chef.io/organizations/ORG_NAME'
    cache_type               'BasicFile'


### PR DESCRIPTION
The value of *validation_client_name* setting to "ORG_NAME-validator" instead of a fixed string to match the style of the other lines in this sample config.