### PR TITLE
chef_gem is only a package in the loosest sense

### DIFF
--- a/chef_master/source/resource_chef_gem.rst
+++ b/chef_master/source/resource_chef_gem.rst
@@ -20,12 +20,6 @@ The **chef_gem** resource works with all of the same properties and options as t
 
 .. end_tag
 
-.. note:: .. tag notes_resource_based_on_package
-
-          In many cases, it is better to use the **package** resource instead of this one. This is because when the **package** resource is used in a recipe, the chef-client will use details that are collected by Ohai at the start of the chef-client run to determine the correct package application. Using the **package** resource allows a recipe to be authored in a way that allows it to be used across many platforms.
-
-          .. end_tag
-
 Syntax
 =====================================================
 A **chef_gem** resource block manages a package on a node, typically by installing it. The simplest use of the **chef_gem** resource is:


### PR DESCRIPTION
The normal "use the package resource" note makes very little sense for `chef_gem`