### PR TITLE
Add action_class block documentation

### DIFF
--- a/chef_master/source/custom_resources.rst
+++ b/chef_master/source/custom_resources.rst
@@ -514,9 +514,9 @@ action_class
 -----------------------------------------------------
 .. tag dsl_custom_resource_block_action_class
 
-Use the action_class block to make methods available to the actions in the custom resource.  Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the action_class block.  Code in the action_class block has access to the new_resource properties.
+Use the ``action_class`` block to make methods available to the actions in the custom resource.  Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the ``action_class`` block.  Code in the ``action_class`` block has access to the new_resource properties.
 
-Assume a helper module has been created in the cookbook libraries/helper.rb file.
+Assume a helper module has been created in the cookbook ``libraries/helper.rb`` file.
 
 .. code-block:: ruby
 
@@ -528,7 +528,7 @@ Assume a helper module has been created in the cookbook libraries/helper.rb file
      end
    end
    
-Methods may be made available to the custom resource actions by using an action_class block.
+Methods may be made available to the custom resource actions by using an ``action_class`` block.
 
 .. code-block:: ruby
    

--- a/chef_master/source/custom_resources.rst
+++ b/chef_master/source/custom_resources.rst
@@ -489,7 +489,7 @@ When finished adding the templates and building the custom resource, the cookboo
 
 Recipe
 -----------------------------------------------------
-The custom resource name is inferred from the name of the cookbook (``website``), the name of the recipe (``httpd``), and is separated by an underscore(``_``): ``website_httpd``.
+The custom resource name is inferred from the name of the cookbook (``website``), the name of the resource file (``httpd``), and is separated by an underscore(``_``): ``website_httpd``.  The custom resource may be used in a recipe.
 
 .. code-block:: ruby
 
@@ -509,6 +509,53 @@ which does the following:
 Custom Resource DSL
 =====================================================
 The following sections describe additional Custom Resource DSL methods that were not used in the preceding scenario:
+
+action_class
+-----------------------------------------------------
+.. tag dsl_custom_resource_block_action_class
+
+Use the action_class block to make methods available to the actions in the custom resource.  Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the action_class block.  Code in the action_class block has access to the new_resource properties.
+
+Assume a helper module has been created in the cookbook libraries/helper.rb file.
+
+.. code-block:: ruby
+
+   module Sample
+     module Helper
+       def helper_method
+         # code
+       end
+     end
+   end
+   
+Methods may be made available to the custom resource actions by using an action_class block.
+
+.. code-block:: ruby
+   
+   property file, String
+
+   action_class do
+
+     def file_exist
+       ::File.exist?(file)
+     end
+
+     def file_ex
+       ::File.exist?(new_resource.file)
+     end
+
+     require 'fileutils'
+    
+     include Sample::Helper
+
+   end
+
+   action :delete do
+     helper_method
+     FileUtils.rm(file) if file_ex
+   end 
+
+.. end_tag
 
 converge_if_changed
 -----------------------------------------------------
@@ -536,7 +583,7 @@ For example, a custom resource defines two properties (``content`` and ``path``)
    property :path, String, name_property: true
 
    load_current_value do
-     if File.exist?(path)
+     if ::File.exist?(path)
        content IO.read(path)
      end
    end
@@ -571,9 +618,9 @@ The ``converge_if_changed`` method may be used multiple times. The following exa
    property :mode, String
 
    load_current_value do
-     if File.exist?(path)
+     if ::File.exist?(path)
        content IO.read(path)
-       mode File.stat(path).mode
+       mode ::File.stat(path).mode
      end
    end
 
@@ -582,7 +629,7 @@ The ``converge_if_changed`` method may be used multiple times. The following exa
        IO.write(path, content)
      end
      converge_if_changed :mode do
-       File.chmod(mode, path)
+       ::File.chmod(mode, path)
      end
    end
 
@@ -649,10 +696,10 @@ Use the ``load_current_value`` method to guard against property values being rep
    action :some_action do
 
      load_current_value do
-       if File.exist?('/var/www/html/index.html')
+       if ::File.exist?('/var/www/html/index.html')
          homepage IO.read('/var/www/html/index.html')
        end
-       if File.exist?('/var/www/html/404.html')
+       if ::File.exist?('/var/www/html/404.html')
          page_not_found IO.read('/var/www/html/404.html')
        end
      end

--- a/chef_master/source/dsl_custom_resource.rst
+++ b/chef_master/source/dsl_custom_resource.rst
@@ -19,9 +19,9 @@ action_class
 =====================================================
 .. tag dsl_custom_resource_block_action_class
 
-Use the action_class block to make methods available to the actions in the custom resource.  Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the action_class block.  Code in the action_class block has access to the new_resource properties.
+Use the ``action_class`` block to make methods available to the actions in the custom resource.  Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the ``action_class`` block.  Code in the ``action_class`` block has access to the new_resource properties.
 
-Assume a helper module has been created in the cookbook libraries/helper.rb file.
+Assume a helper module has been created in the cookbook ``libraries/helper.rb`` file.
 
 .. code-block:: ruby
 
@@ -33,7 +33,7 @@ Assume a helper module has been created in the cookbook libraries/helper.rb file
      end
    end
 
-Methods may be made available to the custom resource actions by using an action_class block.
+Methods may be made available to the custom resource actions by using an ``action_class`` block.
 
 .. code-block:: ruby
 

--- a/chef_master/source/dsl_custom_resource.rst
+++ b/chef_master/source/dsl_custom_resource.rst
@@ -15,6 +15,53 @@ Use the Custom Resource DSL to define property behaviors within custom resources
 
 .. end_tag
 
+action_class
+=====================================================
+.. tag dsl_custom_resource_block_action_class
+
+Use the action_class block to make methods available to the actions in the custom resource.  Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the action_class block.  Code in the action_class block has access to the new_resource properties.
+
+Assume a helper module has been created in the cookbook libraries/helper.rb file.
+
+.. code-block:: ruby
+
+   module Sample
+     module Helper
+       def helper_method
+         # code
+       end
+     end
+   end
+
+Methods may be made available to the custom resource actions by using an action_class block.
+
+.. code-block:: ruby
+
+   property file, String
+
+   action_class do
+
+     def file_exist
+       ::File.exist?(file)
+     end
+
+     def file_ex
+       ::File.exist?(new_resource.file)
+     end
+
+     require 'fileutils'
+
+     include Sample::Helper
+
+   end
+
+   action :delete do
+     helper_method
+     FileUtils.rm(file) if file_ex
+   end
+
+.. end_tag
+
 converge_if_changed
 =====================================================
 .. tag dsl_custom_resource_method_converge_if_changed
@@ -41,7 +88,7 @@ For example, a custom resource defines two properties (``content`` and ``path``)
    property :path, String, name_property: true
 
    load_current_value do
-     if File.exist?(path)
+     if ::File.exist?(path)
        content IO.read(path)
      end
    end
@@ -76,9 +123,9 @@ The ``converge_if_changed`` method may be used multiple times. The following exa
    property :mode, String
 
    load_current_value do
-     if File.exist?(path)
+     if ::File.exist?(path)
        content IO.read(path)
-       mode File.stat(path).mode
+       mode ::File.stat(path).mode
      end
    end
 
@@ -87,7 +134,7 @@ The ``converge_if_changed`` method may be used multiple times. The following exa
        IO.write(path, content)
      end
      converge_if_changed :mode do
-       File.chmod(mode, path)
+       ::File.chmod(mode, path)
      end
    end
 
@@ -154,10 +201,10 @@ Use the ``load_current_value`` method to guard against property values being rep
    action :some_action do
 
      load_current_value do
-       if File.exist?('/var/www/html/index.html')
+       if ::File.exist?('/var/www/html/index.html')
          homepage IO.read('/var/www/html/index.html')
        end
-       if File.exist?('/var/www/html/404.html')
+       if ::File.exist?('/var/www/html/404.html')
          page_not_found IO.read('/var/www/html/404.html')
        end
      end

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -2623,9 +2623,9 @@ action_class
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. tag dsl_custom_resource_block_action_class
 
-Use the action_class block to make methods available to the actions in the custom resource.  Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the action_class block.  Code in the action_class block has access to the new_resource properties.
+Use the ``action_class`` block to make methods available to the actions in the custom resource.  Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the ``action_class`` block.  Code in the ``action_class`` block has access to the new_resource properties.
 
-Assume a helper module has been created in the cookbook libraries/helper.rb file.
+Assume a helper module has been created in the cookbook ``libraries/helper.rb`` file.
 
 .. code-block:: ruby
 
@@ -2637,7 +2637,7 @@ Assume a helper module has been created in the cookbook libraries/helper.rb file
      end
    end
 
-Methods may be made available to the custom resource actions by using an action_class block.
+Methods may be made available to the custom resource actions by using an ``action_class`` block.
 
 .. code-block:: ruby
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -2619,6 +2619,53 @@ Use the Custom Resource DSL to define property behaviors within custom resources
 
 .. end_tag
 
+action_class
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. tag dsl_custom_resource_block_action_class
+
+Use the action_class block to make methods available to the actions in the custom resource.  Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the action_class block.  Code in the action_class block has access to the new_resource properties.
+
+Assume a helper module has been created in the cookbook libraries/helper.rb file.
+
+.. code-block:: ruby
+
+   module Sample
+     module Helper
+       def helper_method
+         # code
+       end
+     end
+   end
+
+Methods may be made available to the custom resource actions by using an action_class block.
+
+.. code-block:: ruby
+
+   property file, String
+
+   action_class do
+
+     def file_exist
+       ::File.exist?(file)
+     end
+
+     def file_ex
+       ::File.exist?(new_resource.file)
+     end
+
+     require 'fileutils'
+
+     include Sample::Helper
+
+   end
+
+   action :delete do
+     helper_method
+     FileUtils.rm(file) if file_ex
+   end
+
+.. end_tag
+
 converge_if_changed
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. tag dsl_custom_resource_method_converge_if_changed
@@ -2645,7 +2692,7 @@ For example, a custom resource defines two properties (``content`` and ``path``)
    property :path, String, name_property: true
 
    load_current_value do
-     if File.exist?(path)
+     if ::File.exist?(path)
        content IO.read(path)
      end
    end
@@ -2680,9 +2727,9 @@ The ``converge_if_changed`` method may be used multiple times. The following exa
    property :mode, String
 
    load_current_value do
-     if File.exist?(path)
+     if ::File.exist?(path)
        content IO.read(path)
-       mode File.stat(path).mode
+       mode ::File.stat(path).mode
      end
    end
 
@@ -2691,7 +2738,7 @@ The ``converge_if_changed`` method may be used multiple times. The following exa
        IO.write(path, content)
      end
      converge_if_changed :mode do
-       File.chmod(mode, path)
+       ::File.chmod(mode, path)
      end
    end
 
@@ -2758,10 +2805,10 @@ Use the ``load_current_value`` method to guard against property values being rep
    action :some_action do
 
      load_current_value do
-       if File.exist?('/var/www/html/index.html')
+       if ::File.exist?('/var/www/html/index.html')
          homepage IO.read('/var/www/html/index.html')
        end
-       if File.exist?('/var/www/html/404.html')
+       if ::File.exist?('/var/www/html/404.html')
          page_not_found IO.read('/var/www/html/404.html')
        end
      end


### PR DESCRIPTION
Use ::File instead of File in the example code.

I hope the action_class block doc makes sense.  It's based more on how I've been using action class than the code..