### PR TITLE
no_proxy does not honor IP ranges

### DIFF
--- a/chef_master/source/config_rb_knife.rst
+++ b/chef_master/source/config_rb_knife.rst
@@ -107,7 +107,7 @@ This configuration file has the following settings:
 
    .. code-block:: ruby
 
-      no_proxy 'localhost, 10.*, *.example.com, *.dev.example.com'
+      no_proxy 'localhost, 10.0.1.35, *.example.com, *.dev.example.com'
 
 ``ssh_timeout``
    The amount of time (in seconds) to wait for an SSH connection time out.


### PR DESCRIPTION
most HTTP clients including curl, wget and ruby's net/http do not honor IP ranges in the no_proxy setting