### PR TITLE
config.rb change - no_proxy does not honor IP ranges

### DIFF
--- a/chef_master/source/config_rb.rst
+++ b/chef_master/source/config_rb.rst
@@ -92,7 +92,7 @@ This configuration file has the following settings:
 
    .. code-block:: ruby
 
-      no_proxy 'localhost, 10.*, *.example.com, *.dev.example.com'
+      no_proxy 'localhost, 10.0.1.35, *.example.com, *.dev.example.com'
 
 ``ssl_verify_mode``
    Set the verify mode for HTTPS requests.


### PR DESCRIPTION
most HTTP clients including curl, wget and ruby's net/http do not honor IP ranges in the no_proxy setting