### PR TITLE
[chef-backend] New defaults for etcd and leaderl tunables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ BUILD_COMMAND_AND_ARGS = $(BUILD_COMMAND) $(PARALLEL_BUILD)
 # make master PARALLEL_BUILD="-j 6"
 #
 
-clean:
-	@rm -rf $(BUILDDIR)
-
 master:
 	mkdir -p $(BUILDDIR)
 	cp -r misc/robots.txt build/
@@ -54,6 +51,9 @@ master:
 	cp -r misc/google69a8711569b2fcce.html build/
 	$(BUILD_COMMAND_AND_ARGS) chef_master/source $(BUILDDIR)
 	bash doctools/rundtags.sh
+
+clean:
+	@rm -rf $(BUILDDIR)
 
 decks:
 	mkdir -p $(BUILDDIR)/decks/


### PR DESCRIPTION
Chef Backend 1.2 will ship with different default values for a few
etcd and leaderl tunables. This change updates the documentation to
reflect the new defaults.

In the sections I modified, I allowed my editor to auto-fill the
paragraphs. This doesn't affect the final rendering as far as I can
see, but does make it much easier to read in an editor.