### PR TITLE
Update Chef Server prereq docs for ipv4 installs

### DIFF
--- a/chef_master/source/install_server_pre.rst
+++ b/chef_master/source/install_server_pre.rst
@@ -213,6 +213,12 @@ Enterprise Linux Updates
 -----------------------------------------------------
 The Chef server requires an x86_64 compatible systems architecture. When the Chef server is installed on Red Hat Enterprise Linux or CentOS, run ``yum update`` prior to installing the Chef server. This will ensure those platforms are fully compatible with this requirement.
 
+IP Addresses
+-----------------------------------------------------
+Unless you intend to operate the Chef Server in IPv6 mode, you should disable ipv6 in the system's /etc/hosts file by commenting out or removing all references to IPv6 addresses like "::1" or "fe80:db8:85a3:8d3:1319:8a2e:370:7348".
+
+Without these changes, a Chef Server install intended to run in ipv4 mode will mistakenly only start the postgres service on the ipv6 loopback address of "::1" rather than the ipv4 loopback address of 127.0.0.1 . This will make further progress through an initial reconfiguration impossible.
+
 Hostnames
 -----------------------------------------------------
 The hostname for the Chef server may be specified using a FQDN or an IP address. This hostname must be resolvable. For example, a Chef server running in a production environment with a resolvable FQDN hostname can be added the DNS system. But when deploying Chef server into a testing environment, adding the hostname to the ``/etc/hosts`` file is enough to ensure that hostname is resolvable.

--- a/chef_master/source/install_server_pre.rst
+++ b/chef_master/source/install_server_pre.rst
@@ -215,9 +215,9 @@ The Chef server requires an x86_64 compatible systems architecture. When the Che
 
 IP Addresses
 -----------------------------------------------------
-Unless you intend to operate the Chef Server in IPv6 mode, you should disable ipv6 in the system's /etc/hosts file by commenting out or removing all references to IPv6 addresses like "::1" or "fe80:db8:85a3:8d3:1319:8a2e:370:7348".
+Unless you intend to operate the Chef server in IPv6 mode, you should disable ipv6 in the system's ``/etc/hosts`` file by commenting out or removing all references to IPv6 addresses like "::1" or "fe80:db8:85a3:8d3:1319:8a2e:370:7348".
 
-Without these changes, a Chef Server install intended to run in ipv4 mode will mistakenly only start the postgres service on the ipv6 loopback address of "::1" rather than the ipv4 loopback address of 127.0.0.1 . This will make further progress through an initial reconfiguration impossible.
+Without these changes, a Chef server install intended to run in ipv4 mode will mistakenly only start the postgres service on the ipv6 loopback address of "::1" rather than the ipv4 loopback address of 127.0.0.1. This will make further progress through an initial reconfiguration impossible.
 
 Hostnames
 -----------------------------------------------------


### PR DESCRIPTION
Chef Servers intended to run in ipv4 mode should not have any references to ipv6 addresses in their /etc/hosts file.

Clarify this requirement in the prereqs section.
Without this prereq, ipv4 mode Chef Server install/reconfigure fails because postgres will not be available at 127.0.0.1:5432 during the reconfiguration.