### PR TITLE
Move Test Driven Infrastructure into general chef books

### DIFF
--- a/chef_master/source/community.rst
+++ b/chef_master/source/community.rst
@@ -11,10 +11,9 @@ Read
 =====================================================
 Recommended reading:
 
-* `Effective DevOps (Building a Culture of Collaboration, Affinity, and Tooling at Scale) -- Early Release <http://shop.oreilly.com/product/0636920039846.do>`_
+* `Effective DevOps (Building a Culture of Collaboration, Affinity, and Tooling at Scale) <http://shop.oreilly.com/product/0636920039846.do>`_
 * `Learning Chef (A Guide to Configuration Management and Automation) <http://shop.oreilly.com/product/0636920032397.do>`_
 * `Customizing Chef (Getting the Most Out of Your Infrastructure Automation) <http://shop.oreilly.com/product/0636920032984.do>`_
-* `Test-Driven Infrastructure with Chef, 2nd Edition <http://shop.oreilly.com/product/0636920030973.do>`_
 
 More books about Chef:
 
@@ -26,6 +25,7 @@ More books about Chef:
 * `Mastering Chef [Packt Publishing] <https://www.packtpub.com/networking-and-servers/mastering-chef/?utm_source=GC-chef.io&utm_medium=pod&utm_campaign=1783981563>`_
 * `Mastering Chef Provisioning [Packt Publishing] <https://www.packtpub.com/networking-and-servers/mastering-chef-provisioning>`_
 * `Managing Windows Servers with Chef <https://www.packtpub.com/networking-and-servers/managing-windows-servers-chef>`_
+* `Test-Driven Infrastructure with Chef, 2nd Edition <http://shop.oreilly.com/product/0636920030973.do>`_
 
 Meet
 =====================================================

--- a/chef_master/source/kitchen.rst
+++ b/chef_master/source/kitchen.rst
@@ -313,6 +313,4 @@ For more information about test-driven development and Kitchen:
 
 * `kitchen.ci <http://kitchen.ci>`_
 * `Getting Started with Kitchen <http://kitchen.ci/docs/getting-started/>`_
-* `Test-Driven Infrastructure with Chef, 2nd Edition <http://shop.oreilly.com/product/0636920030973.do>`_, by Stephen Nelson-Smith (O'Reilly Media)
 * `How Can I Combine Berks and Local Cookbooks? <https://coderwall.com/p/j72egw/organise-your-site-cookbooks-with-berkshelf-and-this-trick>`_
-


### PR DESCRIPTION
This book is 3 years old and is getting a bit dated. It's still helpful,
but we shouldn't feature it as the definitive guide for new users. A
third edition would be super helpful.

Signed-off-by: Tim Smith <tsmith@chef.io>