### PR TITLE
Minor build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 language: python
 python:
   - "2.7"

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ BUILD_COMMAND_AND_ARGS = $(BUILD_COMMAND) $(PARALLEL_BUILD)
 # make master PARALLEL_BUILD="-j 6"
 #
 
-clean:
-	@rm -rf $(BUILDDIR)
-
 master:
 	mkdir -p $(BUILDDIR)
 	cp -r misc/robots.txt build/
@@ -54,6 +51,9 @@ master:
 	cp -r misc/google69a8711569b2fcce.html build/
 	$(BUILD_COMMAND_AND_ARGS) chef_master/source $(BUILDDIR)
 	bash doctools/rundtags.sh
+
+clean:
+	@rm -rf $(BUILDDIR)
 
 decks:
 	mkdir -p $(BUILDDIR)/decks/

--- a/README.md
+++ b/README.md
@@ -40,13 +40,15 @@ forked repo. After you fork `chef/chef-web-docs` using the GitHub web
 interface, clone the forked repo to your workstation, following these [instructions](https://docs.chef.io/community_contributions.html#use-git).
 
 After making your changes but before submitting a PR, run the shell
-command `make master` to check for errors and build a local version of
-the doc set in HTML for testing. Before running `make master` for the first time, you'll need to
+command `make` at the root of your local `chef-web-docs` repo to check for errors and build a local version of
+the doc set in HTML for testing. Before running `make` for the first time, you'll need to
 install Sphinx, the documentation generator, possibly using `sudo`:
 
 ```bash
   pip install sphinx==1.2.3
 ```
+
+> Note: The default `make` target is `master`. This is the target that creates the appropriate `build` directory on your local machine and references in the source files in the `chef_master/source` directory of your local repo.
 
 We currently require version 1.2.3 of
 [Sphinx](http://sphinx-doc.org/). You may also need to install Python,


### PR DESCRIPTION
- Avoid double testing of PR branches (PRs will still be tested, just
  once instead of twice)

- Move `clean` down in the make file so it isn't the default target

Signed-off-by: Steven Danna <steve@chef.io>