### PR TITLE
Correct `pck` to `pcb`

### DIFF
--- a/chef_master/source/delivery_build_cookbook.rst
+++ b/chef_master/source/delivery_build_cookbook.rst
@@ -281,7 +281,7 @@ The pipeline cookbook---``pcb``---is available on GitHub at https://github.com/c
 
 Generate the build-cookbook
 -------------------------------------------------------
-The following commands clone the ``pcb`` cookbook from GitHub, and then uses the ``chef generate`` command to generate a ``build-cookbook`` using the ``pck`` cookbook as a template:
+The following commands clone the ``pcb`` cookbook from GitHub, and then uses the ``chef generate`` command to generate a ``build-cookbook`` using the ``pcb`` cookbook as a template:
 
 .. code-block:: bash
 

--- a/snapshots/release_automate/source/delivery_build_cookbook.rst
+++ b/snapshots/release_automate/source/delivery_build_cookbook.rst
@@ -284,7 +284,7 @@ The pipeline cookbook---``pcb``---is available on GitHub at https://github.com/c
 
 Generate the build-cookbook
 -------------------------------------------------------
-The following commands clone the ``pcb`` cookbook from GitHub, and then uses the ``chef generate`` command to generate a ``build-cookbook`` using the ``pck`` cookbook as a template:
+The following commands clone the ``pcb`` cookbook from GitHub, and then uses the ``chef generate`` command to generate a ``build-cookbook`` using the ``pcb`` cookbook as a template:
 
 .. code-block:: bash
 


### PR DESCRIPTION
This fixes the `pck` typo regarding build cookbooks.