### PR TITLE
Adding deprecations 11 and 12

### DIFF
--- a/chef_master/source/chef_deprecations_client.rst
+++ b/chef_master/source/chef_deprecations_client.rst
@@ -77,6 +77,14 @@ All Deprecations
   * - :doc:`CHEF-10 </deprecations_dnf_package_allow_downgrade>`
     - DNF package provider and resource do not require ``--allow-downgrade`` anymore.
     - 12.18.31
+    -
+  * - :doc:`CHEF-11 </deprecations_property_name_collision>`
+    - An exception will be raised if a resource property conflicts with an already-existing property or method. 
+    - 12.19.x
+    - 
+  * - :doc:`CHEF-12 </deprecations_launchd_hash_property>`
+    - An exception will be raised whenever the ``hash`` property in the launchd resource is used.
+    - 12.19.x
     - 
   * - :doc:`CHEF-13 </deprecations_chef_platform_methods>`
     - Deprecated ``Chef::Platform`` methods

--- a/chef_master/source/deprecations_chef_rest.rst
+++ b/chef_master/source/deprecations_chef_rest.rst
@@ -9,7 +9,7 @@ The ``Chef::REST`` class will be removed.
 
 .. end_tag
 
-``Chef::REST`` was deprecated in 12.7.2, and will be removed in Chef 13
+``Chef::REST`` was deprecated in 12.7.2, and will be removed in Chef 13.
 
 Remediation
 =============

--- a/chef_master/source/deprecations_launchd_hash_property.rst
+++ b/chef_master/source/deprecations_launchd_hash_property.rst
@@ -1,0 +1,19 @@
+=====================================================
+Deprecation: Launchd hash Property (CHEF-12)
+=====================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_launchd_hash_property.rst>`__
+
+.. tag deprecation_launchd_hash_property
+
+The launchd resource has a property called ``hash`` which conflicts with the already-existing Ruby ``hash`` method that exists on every object.
+
+.. end_tag
+
+The `CHEF-11 </deprecations_property_name_collision.html>`__ deprecation warns whenever a resource property is named the same as an existing Ruby method. Chef's core ``launchd`` resource is guilty of this behavior. The ``hash`` property accepts a Ruby Hash containing the data to be output to the launchd property list. However, ``hash`` is an already-existing Ruby method.
+
+A deprecation warning is logged when the ``hash`` property is used. In Chef 13, this will raise an exception and your Chef run will fail.
+
+Remediation
+=============
+
+When using the ``launchd`` resource and passing a hash for the launchd property list, use the ``plist_hash`` property instead of the ``hash`` property.

--- a/chef_master/source/deprecations_property_name_collision.rst
+++ b/chef_master/source/deprecations_property_name_collision.rst
@@ -1,0 +1,21 @@
+=======================================================
+Deprecation: Resource Property Name Collision (CHEF-11)
+=======================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_property_name_collection.rst>`__
+
+.. tag deprecation_property_name_collision
+
+A resource property, defined with the `property` method, conflicts with an already-existing property or method. This could indicate an error that could lead to unintended behavior.
+
+.. end_tag
+
+All Ruby objects have a number of methods that are expected to always be available. When a resource property is created, Ruby methods for setting and getting the property value are created for you. If a resource creates a property which is named the same as an existing method, the original method will be overwritten.
+
+For example, every Ruby object has a ``hash`` method which is expected to return a number. If a resource creates a property named ``hash`` and stores a string instead, it could cause errors in your Chef run.
+
+A deprecation warning is logged when this occurs. In Chef 13, this will raise an exception and your Chef run will fail.
+
+Remediation
+=============
+
+Modify the resource and choose a different name for the property that does not conflict with an already-existing method name.

--- a/chef_master/source/deprecations_property_name_collision.rst
+++ b/chef_master/source/deprecations_property_name_collision.rst
@@ -5,7 +5,7 @@ Deprecation: Resource Property Name Collision (CHEF-11)
 
 .. tag deprecation_property_name_collision
 
-A resource property, defined with the `property` method, conflicts with an already-existing property or method. This could indicate an error that could lead to unintended behavior.
+A resource property, defined with the ``property`` method, conflicts with an already-existing property or method. This could indicate an error that could lead to unintended behavior.
 
 .. end_tag
 

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -527,6 +527,8 @@ Addenda
    deprecations_exit_code
    deprecations_internal_api
    deprecations_json_auto_inflate
+   deprecations_launchd_hash_property
+   deprecations_property_name_collision
    deprecations_resource_cloning
    deprecations_run_command
    deprecations_supports_property


### PR DESCRIPTION
 * 11: property names that conflict with existing methods are disallowed
 * 12: the launchd `hash` property is renamed due to deprecation 11

Related to chef/chef#5606

/cc @thommay @lamont-granquist 