### PR TITLE
[Chef Compliance] Add fqdn as a documented option to settings page

### DIFF
--- a/chef_master/source/config_rb_compliance.rst
+++ b/chef_master/source/config_rb_compliance.rst
@@ -35,6 +35,9 @@ This configuration file has the following settings:
 ``core.log_level``
    Changes the log level of Chef Compliance from the default value of ``'debug'``, which is the most verbose. These are all the supported levels, sorted by verbosity: ``'debug'``, ``'info'``, ``'notice'``, ``'warning'``, ``'error'`` and ``'critical'``. Requires Chef Compliance version ``1.5.13`` or newer.
 
+``fqdn``
+  Sets the FQDN of the Chef Compliance server. By default this is derived from your system's hostname. Please do *not* use the ``=`` to set the option. For example: ``fqdn 'chef-compliance.example.com'``.
+
 ``ssl.certificate``
    Full path to the SSL certificate file that is used by the Chef Compliance web UI. Default value: ``/var/opt/chef-compliance/ssl/ca/HOSTNAME.crt``.
 
@@ -50,6 +53,7 @@ Here's an example content for ``/etc/chef-compliance/chef-compliance.rb``:
 
    core.licensed_node_count 100
    core.log_level      'info'
+   fqdn                'chef-compliance.example.com'
    ssl.certificate     '/etc/chef-compliance/ssl/my.crt'
    ssl.certificate_key '/etc/chef-compliance/ssl/my.key'
    verify_tls          true

--- a/chef_master/source/config_rb_compliance.rst
+++ b/chef_master/source/config_rb_compliance.rst
@@ -36,7 +36,7 @@ This configuration file has the following settings:
    Changes the log level of Chef Compliance from the default value of ``'debug'``, which is the most verbose. These are all the supported levels, sorted by verbosity: ``'debug'``, ``'info'``, ``'notice'``, ``'warning'``, ``'error'`` and ``'critical'``. Requires Chef Compliance version ``1.5.13`` or newer.
 
 ``fqdn``
-  Sets the FQDN of the Chef Compliance server. By default this is derived from your system's hostname. Please do *not* use the ``=`` to set the option. For example: ``fqdn 'chef-compliance.example.com'``.
+  Sets the FQDN of the Chef Compliance server. By default, this is derived from your system's hostname. Do **not** use the ``=`` to set the option. For example: ``fqdn 'chef-compliance.example.com'``.
 
 ``ssl.certificate``
    Full path to the SSL certificate file that is used by the Chef Compliance web UI. Default value: ``/var/opt/chef-compliance/ssl/ca/HOSTNAME.crt``.


### PR DESCRIPTION
While we instruct the user to look at the running JSON file, setting the FQDN comes up often with customers. 

This documents how to do it and leaves no guessing to anyone on how to set the Compliance FQDN. 