### PR TITLE
Pinned dependencies to fix sphinx builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: python
 python:
   - "2.7"
 # command to install dependencies
-install: "pip install sphinx==1.2.3"
+install: 
+  - "pip install -r requirements.txt"
 # command to run tests
 script: make master

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
-sphinx==1.2.3
 sphinxjp.themes.revealjs==0.2.3
-Pygments==2.1.3
+docutils==0.12
+jinja2==2.8               # via sphinx
+markupsafe==0.23          # via jinja2
+pygments==2.1.3           # via sphinx
+sphinx==1.2.3


### PR DESCRIPTION
The latest version of docutils (0.13.1) breaks building docs with Sphinx, so this PR is to both revert back to 0.12 as well as pin the remaining dependencies to ensure stable builds until we are ready to upgrade.

Signed-off-by: David Wrede <dwrede@chef.io>