### PR TITLE
Updating config.json content

### DIFF
--- a/chef_master/source/config_json_delivery.rst
+++ b/chef_master/source/config_json_delivery.rst
@@ -68,7 +68,7 @@ The behavior of pipeline phases can be customized using the project's ``config.j
 
    The ``build_nodes`` setting specifies which build nodes to use for specific phases in the Chef Automate pipeline. The build node may be defined as well as queried via wildcard search.
 
-   .. note:: This setting should only be used with build nodes that use the previous job dispatch system. Use the ``job_dispatch`` setting when using the new job dispatch system.
+   .. note:: This setting should only be used with build nodes that use the previous push job-based dispatch system. Use the ``job_dispatch`` setting when using the new ssh-based job dispatch system.
 
    .. end_tag
 
@@ -118,7 +118,7 @@ The behavior of pipeline phases can be customized using the project's ``config.j
 ``job_dispatch``
    **Optional**
 
-   The ``job_dispatch`` setting is needed to use the :doc:`improved SSH job dispatch system </job_dispatch>`.
+   The ``job_dispatch`` setting is needed to use the :doc:`improved SSH job dispatch system </job_dispatch>`. If you use this setting, you must remove any ``build_nodes`` settings from your configuration file.
 
    * ``"version"``
      Set the value to "v2" if you wish to use runners and the new job dispatch system:

--- a/chef_master/source/delivery_pipeline.rst
+++ b/chef_master/source/delivery_pipeline.rst
@@ -105,7 +105,7 @@ The behavior of pipeline phases can be customized using the project's ``config.j
 
    The ``build_nodes`` setting specifies which build nodes to use for specific phases in the Chef Automate pipeline. The build node may be defined as well as queried via wildcard search.
 
-   .. note:: This setting should only be used with build nodes that use the previous job dispatch system. Use the ``job_dispatch`` setting when using the new job dispatch system.
+   .. note:: This setting should only be used with build nodes that use the previous push job-based dispatch system. Use the ``job_dispatch`` setting when using the new ssh-based job dispatch system.
 
    .. end_tag
 

--- a/chef_master/source/job_dispatch.rst
+++ b/chef_master/source/job_dispatch.rst
@@ -74,6 +74,14 @@ At the bare minimum, you must set the version to v2:
       ...
    }
 
+and remove the ``build_nodes`` setting from ``config.json``.
+
+.. code-block:: none
+
+   "build_nodes": {
+     "default"    : ["name:name_of_builder"]
+   },
+
 You can also set which runners you want jobs to run on for your project. You can set default, per phase, and matrix per phase filters to customize exactly which runners are targeted at various points of your pipeline. Refer to :ref:`job_dispatch config setting <job-dispatch-config-settings>` for more details and examples.
 
 Cancelling Jobs


### PR DESCRIPTION
Mention removal of `build_nodes` setting from config.json when using SSH job dispatch system.

Signed-off-by: David Wrede <dwrede@chef.io>