### PR TITLE
Changing version of latest Chef Automate to 0.6.64

### DIFF
--- a/chef_master/source/ctl_delivery_server.rst
+++ b/chef_master/source/ctl_delivery_server.rst
@@ -484,7 +484,7 @@ preflight-check
  
  The ``preflight-check`` subcommand is used to check for common problems in your infrastructure environment before setup and configuration of Chef Automate begins.
 
- New in Chef Automate 0.6.8.
+ New in Chef Automate 0.6.64.
 
  This subcommand has the following syntax:
 

--- a/chef_master/source/install_chef_automate.rst
+++ b/chef_master/source/install_chef_automate.rst
@@ -306,7 +306,7 @@ To install Chef Automate:
 
       rpm -Uvh PATH_TO_AUTOMATE_SERVER_PACKAGE
 
-#. (Optional) In Chef Automate 0.6.8, you have the option of running the ``preflight-check`` command. This command is optional, but you are encouraged to use it, as it can uncover common environmental problems prior to the actual setup process. For example, there may be required ports that are unavailable, which would have to be rectified prior to setup.
+#. (Optional) In Chef Automate 0.6.64, you have the option of running the ``preflight-check`` command. This command is optional, but you are encouraged to use it, as it can uncover common environmental problems prior to the actual setup process. For example, there may be required ports that are unavailable, which would have to be rectified prior to setup.
 
    .. code-block:: bash
 


### PR DESCRIPTION
Version was incorrectly stated as 0.6.8. This change corrects it to 0.6.64.

Signed-off-by: David Wrede <dwrede@chef.io>