### PR TITLE
Show that push server 2.1 is now supported with automate

### DIFF
--- a/chef_master/source/install_chef_automate.rst
+++ b/chef_master/source/install_chef_automate.rst
@@ -243,7 +243,7 @@ Chef Automate can use push jobs to coordinate build jobs across build nodes when
 
 Push jobs is available as an add-on to Chef server. You can also use runners and the new job dispatch system instead of the previous push jobs-based system.
 
-.. note:: Chef Automate requires Push Jobs Server 1.x and is not compatible with Push Jobs Server 2.x.  If you are installing Chef Automate on Red Hat Enterprise Linux/CentOS 7, use the Red Hat Enterprise Linux/CentOS 6 package for Push Jobs Server 1.x (available at `<https://downloads.chef.io/push-jobs-server/stable/1.1.6>`_) and manually install it.  For other platforms, you can use the automated installation method for Push Jobs Server 1.x as described below.
+.. note:: Chef Automate is fully compatible with Push Jobs Server 1.x and 2.x. Please use 2.x for new installations.  Information about upgrading from Push Jobs Server 1 to 2 can be be found at `<https://docs.chef.iorelease_notes_push_jobs.html#upgrading-automate-installation>`_.
 
 Download the appropriate package for your platform from `<https://downloads.chef.io/push-jobs-server/>`_  and copy it to the Chef server.  The location that it's been saved to is referred to as `PATH_TO_DOWNLOADED_PACKAGE`.
 
@@ -265,7 +265,7 @@ configuration of Chef server and push jobs server.
    sudo opscode-push-jobs-server-ctl reconfigure
 
 Running this reconfigure may trigger a brief restart of Chef
-Server.  This will typically fall in the standard retry window for Chef
+Server.  This will typically fall within the standard retry window for Chef
 Clients, so no significant interruption of service is expected.
 
 Create a User and Organization to Manage Your Cluster

--- a/chef_master/source/install_chef_automate.rst
+++ b/chef_master/source/install_chef_automate.rst
@@ -243,7 +243,7 @@ Chef Automate can use push jobs to coordinate build jobs across build nodes when
 
 Push jobs is available as an add-on to Chef server. You can also use runners and the new job dispatch system instead of the previous push jobs-based system.
 
-.. note:: Chef Automate is fully compatible with Push Jobs Server 1.x and 2.x. Please use 2.x for new installations.  Information about upgrading from Push Jobs Server 1 to 2 can be be found at `<https://docs.chef.iorelease_notes_push_jobs.html#upgrading-automate-installation>`_.
+.. note:: Chef Automate is fully compatible with Push Jobs Server 1.x and 2.x. Please use 2.x for new installations. Information about upgrading from Push Jobs Server version 1.x to 2.x can be be found `here </release_notes_push_jobs.html#upgrading-chef-automate-installation-to-use-push-jobs-server-2-1>`_.
 
 Download the appropriate package for your platform from `<https://downloads.chef.io/push-jobs-server/>`_  and copy it to the Chef server.  The location that it's been saved to is referred to as `PATH_TO_DOWNLOADED_PACKAGE`.
 

--- a/chef_master/source/release_notes_push_jobs.rst
+++ b/chef_master/source/release_notes_push_jobs.rst
@@ -16,30 +16,33 @@ The following items are new for Chef push jobs:
 * STDOUT/STDERR can now optionally be captured from job execution and return it to the server. Users can retrieve the output via the ``knife job output`` command.
 * We now provide two SSE feed endpoints; one provides fine grained per-job events, while the other provides a per-org feed of jobs starting and completing.
 * Command communication now uses libsodium based encryption via zeromq4's CurveZMQ. This replaces the signing protocol used in 1.x. All zeromq packets are fully encrypted and signed, except for the server heartbeat broadcast, which is signed, but in the clear.
-* Push Server 2.1 is now certified for use with Chef Automate.
+* Push Jobs Server 2.1 is now certified for use with Chef Automate.
 
 Important Notes
 -----------------------------------------------------
 * **Push Jobs Server 2.1 is now fully supported for use with Chef Automate**.
-* **Push Jobs Server 2.0 is not compatible with Push Jobs Client 1.X**. Ensure that sll Push Jobs Clients are upgraded to 2.X before performing an upgrade of your Push Jobs Server.
+* **Push Jobs Server 2.0 is not compatible with Push Jobs Client 1.X**. Ensure that all Push Jobs Clients are upgraded to 2.X before performing an upgrade of your Push Jobs Server.
 
-Upgrading Automate Installation
------------------------------------------------------
-If your Automate installation uses Push Server to manage build nodes, upgrading to Push Server 2.1 is now fully supported.  To upgrade:
+Upgrading Chef Automate Installation to use Push Jobs Server 2.1
+-----------------------------------------------------------------
+If your Chef Automate installation uses Push Jobs Server to manage build nodes, upgrading to Push Jobs Server 2.1 is now fully supported.  To upgrade:
+
+* On each build node, upgrade to the latest Push Jobs Client 2.x release by `downloading it <https://downloads.chef.io/push-jobs-client/2.1.4>`_ and following the `instructions on how to install it </install_push_jobs.html#install-the-client>`_ on each build node. If the build node was set up using ``automate-ctl install-build-node``, then no upgrade needs to be performed.
+  
+  .. warning:: Do not restart the Push Jobs Client until after the Push Jobs Server upgrade is completed in the steps below.
+
+* On the Push Jobs Server node:
+
+  * Install the `Push Jobs Server 2.1 package <https://downloads.chef.io/push-jobs-server/2.1.1>`_. 
+  * Run ``sudo opscode-push-jobs-server-ctl upgrade``.
+  * Run ``sudo opscode-push-jobs-server-ctl reconfigure``.
+
+    .. note:: Once the ``upgrade`` command above is issued, build nodes and other push clients will not be in communication with the server until they are restarted.
 
 * On each build node:
-    * upgrade to the latest 2.x Push Jobs Client release. If the build node was set up using ``automate-ctl install-build-node`` then no upgrade needs to be performed.
-    * **Important**: Do not restart the Push Jobs Client until after the Push Server upgrade is completed in the steps below.
-* On the Push Server node:
-    * Install the Push Server 2.1 package.
-    * Run ``sudo opscode-push-jobs-server-ctl upgrade``
-    * Run ``sudo opscode-push-jobs-server-ctl reconfigure``
-    * **Note**: once the ``upgrade`` command above is issued, build nodes and other push clients will not be in communication with the server until they are restarted.
-* On each build node:
-    * Remove the ``allow_unencrypted`` entry from ``/etc/chef/push-jobs-client.rb`` if it is present.
-    * Restart push jobs client as appropriate for the system:
-    * ``sudo systemctl restart push-jobs-client`` OR
-    * ``sudo service restart push-jobs-client``
+
+  * Remove the ``allow_unencrypted`` entry from ``/etc/chef/push-jobs-client.rb``, if present.
+  * Restart Push Jobs Client as appropriate for the system: ``sudo systemctl restart push-jobs-client`` OR ``sudo service restart push-jobs-client``
 
 Encryption
 =====================================================

--- a/chef_master/source/release_notes_push_jobs.rst
+++ b/chef_master/source/release_notes_push_jobs.rst
@@ -3,7 +3,7 @@ Release Notes: Chef Push Jobs 1.0 - 2.1
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/release_notes_push_jobs.rst>`__
 
-Chef push jobs is an extension of the Chef server that allows jobs to be run against nodes independently of a chef-client run. A job is an action or a command to be executed against a subset of nodes; the nodes against which a job is run are determined by the results of a search query made to the Chef server. 
+Chef push jobs is an extension of the Chef server that allows jobs to be run against nodes independently of a chef-client run. A job is an action or a command to be executed against a subset of nodes; the nodes against which a job is run are determined by the results of a search query made to the Chef server.
 
 Chef push jobs uses the Chef server API and a Ruby client to initiate all connections to the Chef server. Connections use the same authentication and authorization model as any other request made to the Chef server. A knife plugin is used to initiate job creation and job tracking.
 
@@ -16,11 +16,30 @@ The following items are new for Chef push jobs:
 * STDOUT/STDERR can now optionally be captured from job execution and return it to the server. Users can retrieve the output via the ``knife job output`` command.
 * We now provide two SSE feed endpoints; one provides fine grained per-job events, while the other provides a per-org feed of jobs starting and completing.
 * Command communication now uses libsodium based encryption via zeromq4's CurveZMQ. This replaces the signing protocol used in 1.x. All zeromq packets are fully encrypted and signed, except for the server heartbeat broadcast, which is signed, but in the clear.
+* Push Server 2.1 is now certified for use with Chef Automate.
 
 Important Notes
 -----------------------------------------------------
-* **Push Jobs 2.1 is not currently supported for use with Chef Automate**.
-* **Push Jobs Server 2.X is not compatible with Push Jobs Client 1.X**. We recommend that you upgrade all your Push Jobs Clients to 2.X before performing an upgrade of your Push Jobs Server.
+* **Push Jobs Server 2.1 is now fully supported for use with Chef Automate**.
+* **Push Jobs Server 2.0 is not compatible with Push Jobs Client 1.X**. Ensure that sll Push Jobs Clients are upgraded to 2.X before performing an upgrade of your Push Jobs Server.
+
+Upgrading Automate Installation
+-----------------------------------------------------
+If your Automate installation uses Push Server to manage build nodes, upgrading to Push Server 2.1 is now fully supported.  To upgrade:
+
+* On each build node:
+    * upgrade to the latest 2.x Push Jobs Client release. If the build node was set up using ``automate-ctl install-build-node`` then no upgrade needs to be performed.
+    * **Important**: Do not restart the Push Jobs Client until after the Push Server upgrade is completed in the steps below.
+* On the Push Server node:
+    * Install the Push Server 2.1 package.
+    * Run ``sudo opscode-push-jobs-server-ctl upgrade``
+    * Run ``sudo opscode-push-jobs-server-ctl reconfigure``
+    * **Note**: once the ``upgrade`` command above is issued, build nodes and other push clients will not be in communication with the server until they are restarted.
+* On each build node:
+    * Remove the ``allow_unencrypted`` entry from ``/etc/chef/push-jobs-client.rb`` if it is present.
+    * Restart push jobs client as appropriate for the system:
+    * ``sudo systemctl restart push-jobs-client`` OR
+    * ``sudo service restart push-jobs-client``
 
 Encryption
 =====================================================

--- a/chef_master/source/upgrade_chef_automate.rst
+++ b/chef_master/source/upgrade_chef_automate.rst
@@ -50,7 +50,7 @@ If you need to update a license on a Chef Automate server, perform the following
 
       sudo automate-ctl reconfigure && sudo automate-ctl restart
 
-Upgrade 
+Upgrade
 =====================================================
 
 To upgrade to the latest version of Chef Automate, do the following:
@@ -109,3 +109,8 @@ Upgrading and the ``automate-ctl setup`` command
 -------------------------------------------------------------------
 
 The ``automate-ctl setup`` command used during the Chef Automate installation process is intended to simplify the initial configuration of your Chef Automate cluster. If your cluster is up and running, you don't need to run this command; however to set up additional runners with the ``automate-ctl install-runner`` command, running ``automate-ctl setup`` is recomended to ensure all required files are in the correct place.
+
+Upgrading to Push Jobs Server 2.1 and Later
+-------------------------------------------------------------------
+
+If you are using Push Server to orchestrate your build nodes, 2.1.0 and later are now fully supported for use with Automate. Instructions for this upgrade can be found here: `<https://docs-archive.chef.io/release/push_jobs_2-1/release_notes.html#upgrading-automate-installation>`_.

--- a/chef_master/source/upgrade_chef_automate.rst
+++ b/chef_master/source/upgrade_chef_automate.rst
@@ -113,4 +113,4 @@ The ``automate-ctl setup`` command used during the Chef Automate installation pr
 Upgrading to Push Jobs Server 2.1 and Later
 -------------------------------------------------------------------
 
-If you are using Push Server to orchestrate your build nodes, 2.1.0 and later are now fully supported for use with Automate. Instructions for this upgrade can be found here: `<https://docs-archive.chef.io/release/push_jobs_2-1/release_notes.html#upgrading-automate-installation>`_.
+If you are using Push Jobs Server to orchestrate your build nodes, 2.1.0 and later are now fully supported for use with Chef Automate. Instructions for this upgrade can be found `here </release_notes_push_jobs.html#upgrading-chef-automate-installation-to-use-push-jobs-server-2-1>`_.


### PR DESCRIPTION
This adds upgrade instructions to the push jobs release notes
and references to them in install/upgrade automate docs.

The documented 1.x automate restrictions has also been removed.

Note that the release notes are not the ideal place for this change, but
it's the best available option that doesn't involve making a new page
that's more difficult to discover.

Signed-off-by: Marc Paradise <marc@chef.io>