### PR TITLE
Adding new lint tests for docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ build/
 
 /.delivery/cli.toml
 
+/.vscode
+
 /.venv
 
 *.*~

--- a/doctools/dtags
+++ b/doctools/dtags
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#!/usr/bin/env ruby
 
 #
 # dtags utility

--- a/doctools/lint_edit_check
+++ b/doctools/lint_edit_check
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+
+# This script checks if the 'edit on GitHub' link is present at the top of the source file.
+
+GHLINKREGEX = /(`\[.*`_)/
+
+# Do regex for `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/filename.rst>`__
+def check_gh_link(file)
+
+  File.foreach(file).with_index do |line, line_num|
+
+    # If the link is present, return nil so the next file can be parsed.
+    return nil if line.match(GHLINKREGEX)
+
+    # Return an error message if a file is missing the 'edit on GitHub' link.
+    $stderr.puts("No edit link found in #{file}") if line_num == 7
+  end
+end
+
+# Search through all source files in the current directory. It's assumed that the cwd is chef_master/source.
+Dir.glob("*.rst") do |result|
+  check_gh_link(result)
+end

--- a/doctools/lint_nav_check
+++ b/doctools/lint_nav_check
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+
+# This script checks if the topic is present in the left-nav and on the index page (i.e. the sitemap).
+
+NAVREGEX = /\"url\": \"\/(\S+).html.*\"/
+RELREGEX = /<\/(\S+)>/
+ABSREGEX = /<https:\/\/docs\.chef\.io\/(\S+).html#\S+>/
+
+@files = []
+
+def list_entries(file, regexoptions = {})
+
+  # Output all matching entries to a temp array for further processing.
+  temp = File.read(file).scan(regexoptions[:regex1]).flatten
+
+  #Do another pass through the target file with a different regex and then append the results to the previous array.
+  if regexoptions.key?(:regex2)
+    temp2 = File.read(file).scan(regexoptions[:regex2]).flatten
+    temp.push(*temp2)
+  end
+
+  # Remove the duplicate entries in the array.
+  temp.uniq!
+
+  # Sort the array so that it can be compared against the list of source files.
+  temp.sort!
+
+  # Return the entries that are in the source array, but not in the array created from the target file.
+  @files - temp
+end
+
+def generate_source_array
+
+  # Source files that should be excluded from nav and sitemap lists.
+  whitelisted = ['index', 'page_not_found', 'feedback']
+
+  # Array from source dir to check against array from left nav.
+  @files = Dir.glob("*.rst")
+  @files.each { |file| file.gsub!(/(.*).rst/, '\1') }
+
+  # Source topics that are whitelisted and should not be included in the returned list of source files.
+  @files -= whitelisted
+end
+
+generate_source_array
+
+puts 'Source files that are not included in the left nav:'
+nav = list_entries('./_templates/nav-docs.html', regex1: NAVREGEX)
+puts nav
+puts
+
+puts 'Source files that are not included in the index:'
+index = list_entries('index.rst', regex1: RELREGEX, regex2: ABSREGEX)
+puts index
+puts
+
+puts 'Here links to files that are in the nav but not the index:'
+puts (nav - index)

--- a/doctools/rundtags.sh
+++ b/doctools/rundtags.sh
@@ -14,3 +14,9 @@ if [ $RESULT -ne 0 ]; then
   (>&2 echo '  information about tagged regions. ' )
   exit 1
 fi
+
+echo 'checking for edit links'
+
+../../doctools/lint_edit_check
+
+echo 'Done.'


### PR DESCRIPTION
Added two new linting tests:

 - lint_edit_check verifies that the `edit on GitHub` link is near the top of every source file.
 - lint_nav_check reports on which source files are not in the left nav and index (sitemap) files. 

Out of the two, only lint_edit_check is run as part of the build process. At a later point in time, we may add the nav check in there as well.

Signed-off-by: David Wrede <dwrede@chef.io>