### PR TITLE
Updates to edit link lint checker

### DIFF
--- a/doctools/lint_edit_check
+++ b/doctools/lint_edit_check
@@ -2,7 +2,8 @@
 
 # This script checks if the 'edit on GitHub' link is present at the top of the source file.
 
-GHLINKREGEX = /(`\[.*`_)/
+GHLINKREGEX = /(`\[edit on GitHub\] <.*>`_)/
+@errors = []
 
 # Do regex for `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/filename.rst>`__
 def check_gh_link(file)
@@ -12,8 +13,11 @@ def check_gh_link(file)
     # If the link is present, return nil so the next file can be parsed.
     return nil if line.match(GHLINKREGEX)
 
-    # Return an error message if a file is missing the 'edit on GitHub' link.
-    $stderr.puts("No edit link found in #{file}") if line_num == 7
+    # Return an error message if the 'edit on GitHub' link is not present by line number 7.
+    if line_num == 7
+      @errors << "No edit link found in #{file}"
+      break
+    end
   end
 end
 
@@ -21,3 +25,6 @@ end
 Dir.glob("*.rst") do |result|
   check_gh_link(result)
 end
+
+@errors.each { |error| $stderr.puts(error) }
+exit(!@errors.empty? ? 1 : 0)

--- a/doctools/rundtags.sh
+++ b/doctools/rundtags.sh
@@ -5,18 +5,29 @@ echo 'running dtags check'
 cd chef_master/source
 ../../doctools/dtags check
 
-RESULT=$?
-if [ $RESULT -ne 0 ]; then
+DTAGSRESULT=$?
+if [ $DTAGSRESULT -ne 0 ]; then
   (>&2 echo 'dtags checked failed')
   (>&2 echo '  The Chef docs team will make tagged regions consistent prior' )
   (>&2 echo '  prior to merging your PR (may take a few days longer), or you can' )
   (>&2 echo '  use the dtags tool yourself. See chef-web-docs README.md for more ' )
   (>&2 echo '  information about tagged regions. ' )
-  exit 1
 fi
 
 echo 'checking for edit links'
 
 ../../doctools/lint_edit_check
+
+EDITRESULT=$?
+if [ $EDITRESULT -ne 0 ]; then
+  (>&2 echo 'lint_edit_check failed')
+  (>&2 echo '  The edit on GitHub link must be added to the top of every topic in our doc set.' )
+  (>&2 echo '  The Chef docs team will add this in prior to merging your PR ' )
+  (>&2 echo '  or you can add the link in yourself. ' )
+fi
+
+if [ $DTAGSRESULT -ne 0 ] || [ $EDITRESULT -ne 0 ]; then
+  exit 1
+fi
 
 echo 'Done.'


### PR DESCRIPTION
- Made regex more specific
- Capture errors in array and send them out to stderr
- Send exit status of 1 when script fails
- Added break in file when edit link hasn't been found

Signed-off-by: David Wrede <dwrede@chef.io>