### PR TITLE
Mention that `chef-server-ctl backup` is broken

### DIFF
--- a/chef_master/source/server_backup_restore.rst
+++ b/chef_master/source/server_backup_restore.rst
@@ -134,6 +134,7 @@ backup
 
 The ``backup`` subcommand is used to back up all Chef server data. This subcommand:
 
+* Is currently broken across many versions, so do not use it: `https://github.com/chef/chef_backup/issues/26 <https://github.com/chef/chef_backup/issues/26>`__
 * Requires rsync to be installed on the Chef server prior to running the command
 * Requires a ``chef-server-ctl reconfigure`` prior to running the command
 * Should not be run in a Chef server configuration with an external PostgreSQL database; `use knife ec backup <https://github.com/chef/knife-ec-backup>`__ instead
@@ -170,6 +171,7 @@ restore
 
 The ``restore`` subcommand is used to restore Chef server data from a backup that was created by the ``backup`` subcommand. This subcommand may also be used to add Chef server data to a newly-installed server. This subcommand:
 
+* Is currently broken across many versions, so do not use it: `https://github.com/chef/chef_backup/issues/26 <https://github.com/chef/chef_backup/issues/26>`__
 * Requires rsync to be installed on the Chef server prior to running the command
 * Requires a ``chef-server-ctl reconfigure`` prior to running the command
 * Should not be run in a Chef server configuration with an external PostgreSQL database; `use knife ec backup <https://github.com/chef/knife-ec-backup>`__ instead

--- a/chef_master/source/server_backup_restore.rst
+++ b/chef_master/source/server_backup_restore.rst
@@ -128,13 +128,14 @@ chef-server-ctl
 =====================================================
 Use the following commands to manage backups of Chef server data, and then to restore those backups.
 
+.. note :: As of Chef Version 12.10 backups created with the ``chef-server-ctl backup`` command cannot be restored.
+
 backup
 -----------------------------------------------------
 .. tag ctl_chef_server_backup
 
 The ``backup`` subcommand is used to back up all Chef server data. This subcommand:
 
-* Is currently broken across many versions, so do not use it: `https://github.com/chef/chef_backup/issues/26 <https://github.com/chef/chef_backup/issues/26>`__
 * Requires rsync to be installed on the Chef server prior to running the command
 * Requires a ``chef-server-ctl reconfigure`` prior to running the command
 * Should not be run in a Chef server configuration with an external PostgreSQL database; `use knife ec backup <https://github.com/chef/knife-ec-backup>`__ instead
@@ -167,11 +168,11 @@ This subcommand has the following syntax:
 
 restore
 -----------------------------------------------------
+
 .. tag ctl_chef_server_restore
 
 The ``restore`` subcommand is used to restore Chef server data from a backup that was created by the ``backup`` subcommand. This subcommand may also be used to add Chef server data to a newly-installed server. This subcommand:
 
-* Is currently broken across many versions, so do not use it: `https://github.com/chef/chef_backup/issues/26 <https://github.com/chef/chef_backup/issues/26>`__
 * Requires rsync to be installed on the Chef server prior to running the command
 * Requires a ``chef-server-ctl reconfigure`` prior to running the command
 * Should not be run in a Chef server configuration with an external PostgreSQL database; `use knife ec backup <https://github.com/chef/knife-ec-backup>`__ instead
@@ -210,4 +211,3 @@ This subcommand has the following syntax:
 .. code-block:: bash
 
    $ chef-server-ctl restore /path/to/tar/archive.tar.gz
-


### PR DESCRIPTION
For several releases now, Chef's built-in backup and restore have been
broken. This patch notes the break and where its progress can be
tracked.

See:
* https://github.com/chef/chef-server/issues/1020
* https://github.com/chef/chef_backup/issues/26
* https://github.com/chef/chef-server/issues/959