### PR TITLE
Replace `opscode-manage-ctl` with `chef-manage-ctl`

### DIFF
--- a/chef_master/source/server_backup_restore.rst
+++ b/chef_master/source/server_backup_restore.rst
@@ -118,11 +118,11 @@ When restoring Chef server data, the previously backed-up files will be required
 
       $ chef-server-ctl start
 
-#. Reconfigure the Chef management console:
+#. Reconfigure the Chef management console if ``chef-manage`` is installed:
 
    .. code-block:: bash
 
-      $ opscode-manage-ctl reconfigure
+      $ chef-manage-ctl reconfigure
 
 chef-server-ctl
 =====================================================


### PR DESCRIPTION
This patch mentions that `chef-manage-ctl` should be used to reconfigure
the Chef management console when `chef-manage` is installed.

`chef-manage` provides `chef-manage-ctl` for managing `chef-manage`.
`opscode-manage-ctl`, on the other hand, is merely a symlink that
ultimately points to `chef-manage-ctl` on the latest `chef-manage`
package (`2.4.1-1`):

```
$ readlink -f /usr/bin/opscode-manage-ctl
/opt/chef-manage/bin/chef-manage-ctl
```

The link is indirect:

```
$ ls -hl $(which opscode-manage-ctl)
lrwxrwxrwx 1 root root 39 Aug  5 06:34 /usr/bin/opscode-manage-ctl -> /opt/chef-manage/bin/opscode-manage-ctl
$ ls -hl /opt/chef-manage/bin/opscode-manage-ctl
lrwxrwxrwx 1 root root 36 Jul 25 17:17 /opt/chef-manage/bin/opscode-manage-ctl -> /opt/chef-manage/bin/chef-manage-ctl
```