### PR TITLE
Clarify use of --json-attributes

### DIFF
--- a/chef_master/source/chef_solo.rst
+++ b/chef_master/source/chef_solo.rst
@@ -266,7 +266,7 @@ This command has the following options:
 
    .. warning:: .. tag node_ctl_attribute
 
-                Any other attribute type that is contained in this JSON file will be treated as a ``normal`` attribute. For example, attempting to update ``override`` attributes using the ``-j`` option:
+                Any other attribute type that is contained in this JSON file will be treated as a ``normal`` attribute. Setting attributes at other precedence levels is not possible. For example, attempting to update ``override`` attributes using the ``-j`` option:
 
                 .. code-block:: javascript
 
@@ -288,7 +288,7 @@ This command has the following options:
                    {
                      "name": "maybe-dev-99",
                      "normal": {
-                     "name": "dev-99",
+                       "name": "dev-99",
                        "description": "Install some stuff",
                        "override_attributes": {
                          "apptastic": {

--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -153,7 +153,7 @@ This command has the following options:
 
    .. tag node_ctl_attribute
 
-   Any other attribute type that is contained in this JSON file will be treated as a ``normal`` attribute. Settings attributes at other precedence levels is not possible.  For example, attempting to update ``override`` attributes using the ``-j`` option:
+   Any other attribute type that is contained in this JSON file will be treated as a ``normal`` attribute. Setting attributes at other precedence levels is not possible. For example, attempting to update ``override`` attributes using the ``-j`` option:
 
    .. code-block:: javascript
 
@@ -188,7 +188,7 @@ This command has the following options:
 
    .. end_tag
    
-   Note that this has set the ``normal`` attribute ``node['override_attributes']['apptastic']``.
+   .. note:: This has set the ``normal`` attribute ``node['override_attributes']['apptastic']``.
 
    **Specify a policy**
 

--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -153,7 +153,7 @@ This command has the following options:
 
    .. tag node_ctl_attribute
 
-   Any other attribute type that is contained in this JSON file will be treated as a ``normal`` attribute. For example, attempting to update ``override`` attributes using the ``-j`` option:
+   Any other attribute type that is contained in this JSON file will be treated as a ``normal`` attribute. Settings attributes at other precedence levels is not possible.  For example, attempting to update ``override`` attributes using the ``-j`` option:
 
    .. code-block:: javascript
 
@@ -175,7 +175,7 @@ This command has the following options:
       {
         "name": "maybe-dev-99",
         "normal": {
-        "name": "dev-99",
+          "name": "dev-99",
           "description": "Install some stuff",
           "override_attributes": {
             "apptastic": {
@@ -187,6 +187,8 @@ This command has the following options:
       }
 
    .. end_tag
+   
+   Note that this has set the ``normal`` attribute ``node['override_attributes']['apptastic']``.
 
    **Specify a policy**
 

--- a/chef_master/source/ctl_chef_shell.rst
+++ b/chef_master/source/ctl_chef_shell.rst
@@ -75,7 +75,7 @@ This command has the following options:
 
    .. warning:: .. tag node_ctl_attribute
 
-                Any other attribute type that is contained in this JSON file will be treated as a ``normal`` attribute. For example, attempting to update ``override`` attributes using the ``-j`` option:
+                Any other attribute type that is contained in this JSON file will be treated as a ``normal`` attribute. Setting attributes at other precedence levels is not possible. For example, attempting to update ``override`` attributes using the ``-j`` option:
 
                 .. code-block:: javascript
 
@@ -97,7 +97,7 @@ This command has the following options:
                    {
                      "name": "maybe-dev-99",
                      "normal": {
-                     "name": "dev-99",
+                       "name": "dev-99",
                        "description": "Install some stuff",
                        "override_attributes": {
                          "apptastic": {

--- a/chef_master/source/ctl_chef_solo.rst
+++ b/chef_master/source/ctl_chef_solo.rst
@@ -106,7 +106,7 @@ This command has the following options:
 
    .. warning:: .. tag node_ctl_attribute
 
-                Any other attribute type that is contained in this JSON file will be treated as a ``normal`` attribute. For example, attempting to update ``override`` attributes using the ``-j`` option:
+                Any other attribute type that is contained in this JSON file will be treated as a ``normal`` attribute. Setting attributes at other precedence levels is not possible. For example, attempting to update ``override`` attributes using the ``-j`` option:
 
                 .. code-block:: javascript
 
@@ -128,7 +128,7 @@ This command has the following options:
                    {
                      "name": "maybe-dev-99",
                      "normal": {
-                     "name": "dev-99",
+                       "name": "dev-99",
                        "description": "Install some stuff",
                        "override_attributes": {
                          "apptastic": {

--- a/chef_master/source/debug.rst
+++ b/chef_master/source/debug.rst
@@ -982,7 +982,7 @@ This command has the following options:
 
    .. warning:: .. tag node_ctl_attribute
 
-                Any other attribute type that is contained in this JSON file will be treated as a ``normal`` attribute. For example, attempting to update ``override`` attributes using the ``-j`` option:
+                Any other attribute type that is contained in this JSON file will be treated as a ``normal`` attribute. Setting attributes at other precedence levels is not possible. For example, attempting to update ``override`` attributes using the ``-j`` option:
 
                 .. code-block:: javascript
 
@@ -1004,7 +1004,7 @@ This command has the following options:
                    {
                      "name": "maybe-dev-99",
                      "normal": {
-                     "name": "dev-99",
+                       "name": "dev-99",
                        "description": "Install some stuff",
                        "override_attributes": {
                          "apptastic": {


### PR DESCRIPTION
Someone in the #chef IRC channel was confused about use of this option - although they'd read this documentation, they mistook the example as being something that would work for setting override_attributes.  While the docs are accurate, I agree it's easy to misinterpret them if you're not paying close attention.