### PR TITLE
Server 12.12 rel notes and config additions

### DIFF
--- a/chef_master/source/config_rb_server_optional_settings.rst
+++ b/chef_master/source/config_rb_server_optional_settings.rst
@@ -61,6 +61,9 @@ This configuration file has the following general settings:
 ``flavor``
    Default value: ``'cs'``.
 
+``from_email``
+   Default value: ``'"Opscode" <donotreply@chef.io>"'``.
+
 ``install_path``
    The directory in which the Chef server is installed. Default value: ``'/opt/opscode'``.
 
@@ -807,6 +810,11 @@ This configuration file has the following settings for ``oc-id``:
 ``oc_id['enable']``
    Enable a service. Default value: ``true``.
 
+``oc_id['email_from_address']``
+   New in Chef server 12.12.
+   
+   Outbound email address. Defaults to the ``'from_email'`` value.
+
 ``oc_id['ha']``
    Run the Chef server in a high availability topology. When ``topology`` is set to ``ha``, this setting defaults to ``true``. Default value: ``false``.
 
@@ -819,6 +827,11 @@ This configuration file has the following settings for ``oc-id``:
    .. code-block:: ruby
 
       { 'file_maxbytes' => 104857600, 'num_to_keep' => 10 }
+
+``oc_id['origin']
+   New in Chef server 12.12.
+ 
+   The FQDN for the server that is sending outbound email. Defaults to the ``'api_fqdn'`` value, which is the FQDN for the Chef server.
 
 ``oc_id['num_to_keep']``
    The number of log files to keep. Default value: ``10``.

--- a/chef_master/source/config_rb_server_optional_settings.rst
+++ b/chef_master/source/config_rb_server_optional_settings.rst
@@ -828,7 +828,7 @@ This configuration file has the following settings for ``oc-id``:
 
       { 'file_maxbytes' => 104857600, 'num_to_keep' => 10 }
 
-``oc_id['origin']
+``oc_id['origin']``
    New in Chef server 12.12.
  
    The FQDN for the server that is sending outbound email. Defaults to the ``'api_fqdn'`` value, which is the FQDN for the Chef server.
@@ -1162,6 +1162,11 @@ This configuration file has the following settings for ``opscode-solr4``:
    .. code-block:: ruby
 
       /var/log/opscode/opscode-solr4
+
+``opscode_solr4['log_gc']``
+   New in Chef server 12.12.
+
+   Enable or disable GC logging. Default is ``true``.
 
 ``opscode_solr4['log_rotation']``
    The log rotation policy for this service. Log files are rotated when they exceed ``file_maxbytes``. The maximum number of log files in the rotation is defined by ``num_to_keep``. Default value:

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -1,5 +1,5 @@
 =====================================================
-Release Notes: Chef Server 12.0 - 12.11
+Release Notes: Chef Server 12.0 - 12.12
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/release_notes_server.rst>`__
 
@@ -10,6 +10,45 @@ Release Notes: Chef Server 12.0 - 12.11
 Chef is a systems and cloud infrastructure automation framework that makes it easy to deploy servers and applications to any physical, virtual, or cloud location, no matter the size of the infrastructure. Each organization is comprised of one (or more) workstations, a single server, and every node that will be configured and maintained by the chef-client. Cookbooks (and recipes) are used to tell the chef-client how each node in your organization should be configured. The chef-client (which is installed on every node) does the actual configuration.
 
 .. end_tag
+
+What's New in 12.12
+=====================================================
+The following items are new for Chef server 12.12:
+
+* **chef-server-ctl backup correctly backs up configuration data** Starting in version 12.10.0, a bug in the ``backup`` command produced backups that did not include the configuration data in the resulting tarball. This bug is now resolved. We recommend taking a new backup after upgrading to 12.12.0.
+* **Correct number of rows are returned when searching with ElasticSearch** When configured to use ElasticSearch, Chef server now correctly respects the ``rows`` parameter in search requests rather than returning all rows. 
+* **Solr 4 GC logging is now used by Chef server** Java's native rotation is used for the gclog.
+* **New oc_id email configuration options** Outbound email address can now be configured.
+
+Solr 4 GC Logging
+=====================================================
+Chef server now uses Java's native rotation for the gclog. This prevents situations where logrotate creates large sparse files on disk, which may be problematic to manage with tools that can't handle sparse files.
+
+The Solr 4 GC log can now be found at ``/var/log/opscode/opscode-solr4/gclog.log.N.current`` where *N* is an integer. The ``.current`` extension denotes the log currently being written to.
+
+To remove the older GC logs, run ``sudo chef-server-ctl cleanup`` after upgrading to Chef server 12.12.
+
+To suppress the GC log completely, set the following option in ``/etc/opscode/chef-server.rb``:
+
+.. code-block:: ruby
+
+   # true (default) to enable gc logging,
+   # false to disable gc logging
+   opscode-solr4['log_gc'] = false
+
+oc_id Email Configuration Options
+=====================================================
+The ``oc_id`` service now includes configuration for outbound email to ensure password reset emails can be sent correctly. 
+
+You can now set the following options in ``/etc/opscode/chef-server.rb``:
+
+.. code-block:: ruby
+
+   # defaults to the value of the from_email configuration option
+   oc_id['email_from_address'] = "oc_id@example.com"
+   # defaults to the api_fqdn
+   oc_id['origin'] = "mail.yourco.io"
+
 
 What's New in 12.11
 =====================================================

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -34,7 +34,7 @@ To suppress the GC log completely, set the following option in ``/etc/opscode/ch
 
    # true (default) to enable gc logging,
    # false to disable gc logging
-   opscode-solr4['log_gc'] = false
+   opscode_solr4['log_gc'] = false
 
 oc_id Email Configuration Options
 =====================================================

--- a/chef_master/source/server_backup_restore.rst
+++ b/chef_master/source/server_backup_restore.rst
@@ -128,7 +128,7 @@ chef-server-ctl
 =====================================================
 Use the following commands to manage backups of Chef server data, and then to restore those backups.
 
-.. note :: As of Chef Version 12.10 backups created with the ``chef-server-ctl backup`` command cannot be restored.
+.. note :: Starting in Chef server 12.10.0, a bug in the ``backup`` command produced backups that did not include the configuration data in the resulting tarball. This bug is now resolved. We recommend taking a new backup after upgrading to 12.12.0.
 
 backup
 -----------------------------------------------------


### PR DESCRIPTION
- Added server 12.12 release notes
- Added new config settings to chef server rb config doc
- Filled in some previously missing config settings
- Updated note about `chef-server-ctl backup` command.