### PR TITLE
Edit data_collector token reference

### DIFF
--- a/chef_master/source/setup_visibility_chef_automate.rst
+++ b/chef_master/source/setup_visibility_chef_automate.rst
@@ -50,7 +50,7 @@ To enable this feature, add the following settings to ``/etc/opscode/chef-server
    data_collector['token'] = 'TOKEN'
 
 where ``my-automate-server.mycompany.com`` is the fully-qualified domain name of your Chef Automate server, and
-``TOKEN`` is the token value you configured in the `prior section <#configure-a-data-collector-token-in-chef-automate>`__.
+``TOKEN`` is either the default value or the token value you configured in the `prior section <#configure-a-data-collector-token-in-chef-automate>`__.
 
 Save the file and run ``chef-server-ctl reconfigure`` to complete the process.
 


### PR DESCRIPTION
Clarify and be explicit that even the token value (even if default is used) must be added to chef server config...
Signed-off-by: Larry Eichenbaum <larryebaum@chef.io>