### PR TITLE
Adding back in apt cookbook reference to docs-builder cookbook

### DIFF
--- a/cookbooks/docs-builder/Berksfile
+++ b/cookbooks/docs-builder/Berksfile
@@ -1,3 +1,5 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+cookbook 'apt'

--- a/cookbooks/docs-builder/metadata.rb
+++ b/cookbooks/docs-builder/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'docs@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures docs-builder'
 long_description 'Installs/Configures docs-builder'
-version '0.3.2'
+version '0.3.3'
 
 depends 'aws'
 depends 'fancy_execute'


### PR DESCRIPTION
The apt cookbook is referenced in the delivery kitchen erb template file. Adding it back in and bumping the version again so that our docs build. We can investigate doing a more permanent fix later on.

Signed-off-by: David Wrede <dwrede@chef.io>