### PR TITLE
Use double quotes to expand variable.

### DIFF
--- a/chef_master/source/resource_template.rst
+++ b/chef_master/source/resource_template.rst
@@ -615,7 +615,7 @@ Use an array with the ``source`` property to define an explicit lookup path. For
 .. code-block:: ruby
 
    template '/test' do
-     source ['#{node.chef_environment}.erb', 'default.erb']
+     source ["#{node.chef_environment}.erb", 'default.erb']
    end
 
 The following example emulates the entire file specificity pattern by defining it as an explicit path:

--- a/chef_master/source/templates.rst
+++ b/chef_master/source/templates.rst
@@ -152,7 +152,7 @@ Use an array with the ``source`` property to define an explicit lookup path. For
 .. code-block:: ruby
 
    template '/test' do
-     source ['#{node.chef_environment}.erb', 'default.erb']
+     source ["#{node.chef_environment}.erb", 'default.erb']
    end
 
 The following example emulates the entire file specificity pattern by defining it as an explicit path:


### PR DESCRIPTION
To expand a variable a in string literal (in ruby), they have to use double quotes instead of single quotes.
Thus I cannot get the template '#{node.chef_environment}.erb' in my cookbook.