### PR TITLE
Correct config.json "build_cookbook" key

### DIFF
--- a/chef_master/source/config_json_delivery.rst
+++ b/chef_master/source/config_json_delivery.rst
@@ -47,7 +47,7 @@ The behavior of pipeline phases can be customized using the project's ``config.j
 
 .. end_tag
 
-``build-cookbook``
+``build_cookbook``
    **Required**
 
    .. tag delivery_config_json_setting_build_cookbook


### PR DESCRIPTION
From what I can tell, the correct key is `build_cookbook` as that is what is used in all the examples.