### PR TITLE
Remove redundant step in Example Project App

### DIFF
--- a/chef_master/source/delivery_truck.rst
+++ b/chef_master/source/delivery_truck.rst
@@ -399,12 +399,6 @@ This example shows how to use project applications to deploy a package into a ``
 
    When the publish phase is run, an application is created, versioned by timestamp, and including all of the information needed to install that version of the application. The provisioning code in ``delivery-truck`` will automatically pin based on this version.
 
-#. Configure the ``build-cookbook`` to know about the application. Add the following to ``.delivery/build-cookbook/attributes/default.rb``:
-
-   .. code-block:: ruby
-
-      default['delivery']['project_apps'] = ["<APPLICATION_NAME>"]
-
 #. Configure the ``build-cookbook`` to know how to install the application. Add the following to ``.delivery/build-cookbook/deploy.rb``:
 
    .. code-block:: ruby


### PR DESCRIPTION
This is the same thing as the step immediately above it.