### PR TITLE
Deprecate Cisco platforms post 12.19 release

### DIFF
--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -55,12 +55,6 @@ The following table lists the Foundational platforms for the chef-client and oha
    * - Microsoft Windows
      - ``x86``, ``x86_64``
      - ``2008r2``, ``2012``, ``2012r2``, ``7``, ``8``, ``8.1``, ``10``
-   * - Cisco NX-OS
-     - ``x86_64``
-     - ``7``
-   * - Cisco IOS XR
-     - ``x86_64``
-     - ``6``
 
 Secondary Platforms
 -----------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

12.19 will be the final release where we natively build and test Cisco platforms.