### PR TITLE
fix a typo in ruby type of mount resource's supports

### DIFF
--- a/chef_master/source/resource_mount.rst
+++ b/chef_master/source/resource_mount.rst
@@ -41,7 +41,7 @@ The full syntax for all of the properties that are available to the **mount** re
      password                   String
      provider                   Chef::Provider::Mount
      subscribes                 # see description
-     supports                   Array
+     supports                   Hash # defaults to { :remount => false }
      username                   String
      action                     Symbol # defaults to :mount if not specified
    end
@@ -239,9 +239,9 @@ This resource has the following properties:
    .. end_tag
 
 ``supports``
-   **Ruby Type:** Array
+   **Ruby Type:** Hash
 
-   An array of options for supported mount features. Default value: ``:remount``.
+   Specify a Hash of supported mount features. Default value: ``remount: false``.
 
 ``username``
    **Ruby Type:** String

--- a/chef_master/source/resource_mount.rst
+++ b/chef_master/source/resource_mount.rst
@@ -41,7 +41,8 @@ The full syntax for all of the properties that are available to the **mount** re
      password                   String
      provider                   Chef::Provider::Mount
      subscribes                 # see description
-     supports                   Hash # defaults to { :remount => false }
+     supports                   Hash # defaults to { :remount => false } (preferred)
+                                Array # defaults to { :remount => true } (non-preferred)
      username                   String
      action                     Symbol # defaults to :mount if not specified
    end


### PR DESCRIPTION
See https://github.com/chef/chef/blob/master/lib/chef/resource/mount.rb#L45