### PR TITLE
Update release_notes_push_jobs.rst

### DIFF
--- a/chef_master/source/release_notes_push_jobs.rst
+++ b/chef_master/source/release_notes_push_jobs.rst
@@ -11,7 +11,7 @@ What's New in 2.1
 =====================================================
 The following items are new for Chef push jobs:
 
-* **Push Jobs client 2.1** is backwards-compatible with the Chef push jobs 1.x server when the ``allow_unencrypted`` option to be set to ``true`` in ``/etc/chef/opscode-push-jobs-server.rb``.
+* **Push Jobs client 2.1** is backwards-compatible with the Chef push jobs 1.x server when the ``allow_unencrypted`` option to be set to ``true`` in ``/etc/chef/push-jobs-client.rb``.
 * Allow the job execution environment to be set. This includes user, working directory, environment variables and a data file to be set.
 * STDOUT/STDERR can now optionally be captured from job execution and return it to the server. Users can retrieve the output via the ``knife job output`` command.
 * We now provide two SSE feed endpoints; one provides fine grained per-job events, while the other provides a per-org feed of jobs starting and completing.


### PR DESCRIPTION
Push Jobs client uses push-jobs-client.rb, not opscode-push-jobs-server.rb