### PR TITLE
Update chef_repo to reflect valid chefignore locations

### DIFF
--- a/chef_master/source/chef_repo.rst
+++ b/chef_master/source/chef_repo.rst
@@ -77,7 +77,7 @@ The chefignore file is used to tell knife which cookbook files in the chef-repo 
 * A pattern may contain relative directory names
 * A pattern may match all files in a directory
 
-The chefignore file is located at the root of the ``/cookbooks`` subdirectory in the chef-repo. It should contain sections similar to the following:
+The chefignore file can be located in any subdirectory of a chef-repo: ``/``, ``/cookbooks``, ``/cookbooks/COOKBOOK_NAME/``, ``roles``, etc. It should contain sections similar to the following:
 
 .. code-block:: none
 


### PR DESCRIPTION
chefignore files can technically go anywhere in a chef-repo at any level. The most common are either at the root of the chef-repo or in a cookbook itself.