### PR TITLE
Updating DCO exclusions to include project-embedded docs

### DIFF
--- a/chef_master/source/community_contributions.rst
+++ b/chef_master/source/community_contributions.rst
@@ -114,7 +114,11 @@ The DCO is an attestation attached to every contribution made by every developer
         consistent with this project or the open source license(s)
         involved.
 
-Chef does not merge any pull requests made against an Chef-managed open source repository until each commit has been signed for the DCO, with two exceptions: "Obvious Fixes" and pull requests made against the documentation repository (https://github.com/chef/chef-web-docs).
+Chef does not merge any pull requests made against an Chef-managed open source repository until each commit has been signed for the DCO, with three exceptions:
+
+* "Obvious Fixes" (as described below)
+* Pull requests made against the docs.chef.io documentation repository (https://github.com/chef/chef-web-docs)
+* Pull requests that contain only documentation updates made against projects where the documentation is embedded in the project's repository (i.e. the ``docs`` directory in the ``chef/inspec`` repository)
 
 The "Obvious Fix" Rule
 =====================================================


### PR DESCRIPTION
PRs where the only content changes are within the documentation directories
for projects where the docs are embedded in the project repo (such
as chef/inspec) are excluded from requiring DCO sign-off.

See also: chef/chef-rfc#253