### PR TITLE
clarify systemd_unit documentation

### DIFF
--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -505,7 +505,6 @@ Use the **systemd_unit** resource to create, manage, and run `systemd units <htt
 
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_systemd_unit_syntax
 
 A **systemd_unit** resource describes the configuration behavior for systemd units. For example:
 
@@ -537,7 +536,6 @@ where
 * ``user`` is the user account that systemd units run under. If not specified, systemd units will run under the system account.
 * ``content`` describes the behavior of the unit
 
-.. end_tag
 
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/chef_master/source/resource_systemd_unit.rst
+++ b/chef_master/source/resource_systemd_unit.rst
@@ -5,7 +5,7 @@ systemd_unit
 
 Use the **systemd_unit** resource to create, manage, and run `systemd units <https://www.freedesktop.org/software/systemd/man/systemd.html#Concepts>`_.
 
-New in Chef Client 12.11. Changed in 12.19 to verify systemd files before installation (using the external `systemd-analyze verify` command).
+New in Chef Client 12.11. Changed in 12.19 to verify systemd files before installation (using the external ``systemd-analyze verify`` command).
 
 Syntax
 =====================================================

--- a/chef_master/source/resource_systemd_unit.rst
+++ b/chef_master/source/resource_systemd_unit.rst
@@ -5,7 +5,7 @@ systemd_unit
 
 Use the **systemd_unit** resource to create, manage, and run `systemd units <https://www.freedesktop.org/software/systemd/man/systemd.html#Concepts>`_.
 
-New in Chef Client 12.11. Changed in 12.19 to verify systemd files before installation.
+New in Chef Client 12.11. Changed in 12.19 to verify systemd files before installation (using the external `systemd-analyze verify` command).
 
 Syntax
 =====================================================
@@ -16,27 +16,38 @@ A **systemd_unit** resource describes the configuration behavior for systemd uni
 .. code-block:: ruby
 
    systemd_unit 'sysstat-collect.timer' do
+     content <<-EOU.gsub(/^\s+/, '')
+     [Unit]
+     Description=Run system activity accounting tool every 10 minutes
+
+     [Timer]
+     OnCalendar=*:00/10
+
+     [Install]
+     WantedBy=sysstat.service
+     EOU
+
      enabled true
-     content '[Unit]\nDescription=Run system activity accounting tool every 10 minutes\n\n[Timer]\nOnCalendar=*:00/10\n\n[Install]\nWantedBy=sysstat.service'
+     action :create
    end
 
 The full syntax for all of the properties that are available to the **systemd_unit** resource is:
 
 .. code-block:: ruby
 
-   systemd_unit 'name' do
+   systemd_unit 'name.service' do
+     content                String or Hash
      enabled                Boolean
      active                 Boolean
      masked                 Boolean
      static                 Boolean
      user                   String
-     content                String or Hash
      triggers_reload        Boolean
    end
 
 where
 
-* ``name`` is the name of the unit
+* ``name`` is the name of the unit. Must include the type/suffix (e.g. `name.socket` or `name.service`).
 * ``active`` specifies if the service unit type should be started
 * ``user`` is the user account that systemd units run under. If not specified, systemd units will run under the system account.
 * ``content`` describes the behavior of the unit


### PR DESCRIPTION
- tune example: add action, use shortcut to write more readable unit files inside recipe
- clarify, that the name property must include the type (or `systemd-analyze verify` will fail`) 
- explain, which verification command is used (`systemd-analyze verify`)