### PR TITLE
Update Ruby types in custom resources

### DIFF
--- a/chef_master/source/custom_resources.rst
+++ b/chef_master/source/custom_resources.rst
@@ -245,11 +245,11 @@ In the custom resource, add the following custom properties:
 .. code-block:: ruby
 
    property :instance_name, String, name_property: true
-   property :port, Fixnum, required: true
+   property :port, Integer, required: true
 
 where
 
-* ``String`` and ``Fixnum`` are Ruby types (all custom properties must have an assigned Ruby type)
+* ``String`` and ``Integer`` are Ruby types (all custom properties must have an assigned Ruby type)
 * ``name_property: true`` allows the value for this property to be equal to the ``'name'`` of the resource block
 
 The ``instance_name`` property is then used within the custom resource in many locations, including defining paths to configuration files, services, and virtual hosts.
@@ -431,7 +431,7 @@ Final Resource
 .. code-block:: ruby
 
    property :instance_name, String, name_property: true
-   property :port, Fixnum, required: true
+   property :port, Integer, required: true
 
    action :create do
      package 'httpd' do
@@ -733,7 +733,7 @@ Custom resources are designed to use core resources that are built into Chef. In
    property :cwd, String
    property :environment, Hash, default: {}
    property :user, [String, Integer]
-   property :sensitive, [TrueClass, FalseClass], default: false
+   property :sensitive, [true, false], default: false
 
    prefix = '/opt/languages/node'
 
@@ -776,7 +776,7 @@ To prevent this behavior, use ``new_resource.`` to tell the chef-client to proce
    property :cwd, String
    property :environment, Hash, default: {}
    property :user, [String, Integer]
-   property :sensitive, [TrueClass, FalseClass], default: false
+   property :sensitive, [true, false], default: false
 
    prefix = '/opt/languages/node'
 
@@ -815,7 +815,7 @@ Use the ``property`` method to define properties for the custom resource. The sy
 where
 
 * ``:name`` is the name of the property
-* ``ruby_type`` is the optional Ruby type or array of types, such as ``String``, ``Integer``, ``TrueClass``, or ``FalseClass``
+* ``ruby_type`` is the optional Ruby type or array of types, such as ``String``, ``Integer``, ``true``, or ``false``
 * ``default: 'value'`` is the optional default value loaded into the resource
 * ``parameter: 'value'`` optional parameters
 
@@ -832,7 +832,7 @@ ruby_type
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. tag dsl_custom_resource_method_property_ruby_type
 
-The property ruby_type is a positional parameter. Use to ensure a property value is of a particular ruby class, such as ``TrueClass``, ``FalseClass``, ``NilClass``, ``String``, ``Array``, ``Hash``. Use an array of ruby classes to allow a value to be of more than one type. For example:
+The property ruby_type is a positional parameter. Use to ensure a property value is of a particular ruby class, such as ``true``, ``false``, ``nil``, ``String``, ``Array``, ``Hash``, ``Integer``, ``Symbol``. Use an array of ruby classes to allow a value to be of more than one type. For example:
 
        .. code-block:: ruby
 
@@ -840,7 +840,7 @@ The property ruby_type is a positional parameter. Use to ensure a property value
 
        .. code-block:: ruby
 
-          property :name, Fixnum
+          property :name, Integer
 
        .. code-block:: ruby
 
@@ -848,11 +848,11 @@ The property ruby_type is a positional parameter. Use to ensure a property value
 
        .. code-block:: ruby
 
-          property :name, [TrueClass, FalseClass]
+          property :name, [true, false]
 
        .. code-block:: ruby
 
-          property :name, [String, NilClass]
+          property :name, [String, nil]
 
        .. code-block:: ruby
 

--- a/chef_master/source/dsl_custom_resource.rst
+++ b/chef_master/source/dsl_custom_resource.rst
@@ -41,6 +41,11 @@ Methods may be made available to the custom resource actions by using an ``actio
 
    property file, String
 
+   action :delete do
+     helper_method
+     FileUtils.rm(file) if file_ex
+   end
+
    action_class do
 
      def file_exist
@@ -55,11 +60,6 @@ Methods may be made available to the custom resource actions by using an ``actio
 
      include Sample::Helper
 
-   end
-
-   action :delete do
-     helper_method
-     FileUtils.rm(file) if file_ex
    end
 
 .. end_tag
@@ -234,7 +234,7 @@ Custom resources are designed to use core resources that are built into Chef. In
    property :cwd, String
    property :environment, Hash, default: {}
    property :user, [String, Integer]
-   property :sensitive, [TrueClass, FalseClass], default: false
+   property :sensitive, [true, false], default: false
 
    prefix = '/opt/languages/node'
 
@@ -277,7 +277,7 @@ To prevent this behavior, use ``new_resource.`` to tell the chef-client to proce
    property :cwd, String
    property :environment, Hash, default: {}
    property :user, [String, Integer]
-   property :sensitive, [TrueClass, FalseClass], default: false
+   property :sensitive, [true, false], default: false
 
    prefix = '/opt/languages/node'
 
@@ -316,7 +316,7 @@ Use the ``property`` method to define properties for the custom resource. The sy
 where
 
 * ``:name`` is the name of the property
-* ``ruby_type`` is the optional Ruby type or array of types, such as ``String``, ``Integer``, ``TrueClass``, or ``FalseClass``
+* ``ruby_type`` is the optional Ruby type or array of types, such as ``String``, ``Integer``, ``true``, or ``false``
 * ``default: 'value'`` is the optional default value loaded into the resource
 * ``parameter: 'value'`` optional parameters
 
@@ -333,7 +333,7 @@ ruby_type
 -----------------------------------------------------
 .. tag dsl_custom_resource_method_property_ruby_type
 
-The property ruby_type is a positional parameter. Use to ensure a property value is of a particular ruby class, such as ``TrueClass``, ``FalseClass``, ``NilClass``, ``String``, ``Array``, ``Hash``. Use an array of ruby classes to allow a value to be of more than one type. For example:
+The property ruby_type is a positional parameter. Use to ensure a property value is of a particular ruby class, such as ``true``, ``false``, ``nil``, ``String``, ``Array``, ``Hash``, ``Integer``, ``Symbol``. Use an array of ruby classes to allow a value to be of more than one type. For example:
 
        .. code-block:: ruby
 
@@ -341,7 +341,7 @@ The property ruby_type is a positional parameter. Use to ensure a property value
 
        .. code-block:: ruby
 
-          property :name, Fixnum
+          property :name, Integer
 
        .. code-block:: ruby
 
@@ -349,11 +349,11 @@ The property ruby_type is a positional parameter. Use to ensure a property value
 
        .. code-block:: ruby
 
-          property :name, [TrueClass, FalseClass]
+          property :name, [true, false]
 
        .. code-block:: ruby
 
-          property :name, [String, NilClass]
+          property :name, [String, nil]
 
        .. code-block:: ruby
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -2843,6 +2843,11 @@ Methods may be made available to the custom resource actions by using an ``actio
 
    property file, String
 
+   action :delete do
+     helper_method
+     FileUtils.rm(file) if file_ex
+   end
+
    action_class do
 
      def file_exist
@@ -2857,11 +2862,6 @@ Methods may be made available to the custom resource actions by using an ``actio
 
      include Sample::Helper
 
-   end
-
-   action :delete do
-     helper_method
-     FileUtils.rm(file) if file_ex
    end
 
 .. end_tag
@@ -3036,7 +3036,7 @@ Custom resources are designed to use core resources that are built into Chef. In
    property :cwd, String
    property :environment, Hash, default: {}
    property :user, [String, Integer]
-   property :sensitive, [TrueClass, FalseClass], default: false
+   property :sensitive, [true, false], default: false
 
    prefix = '/opt/languages/node'
 
@@ -3079,7 +3079,7 @@ To prevent this behavior, use ``new_resource.`` to tell the chef-client to proce
    property :cwd, String
    property :environment, Hash, default: {}
    property :user, [String, Integer]
-   property :sensitive, [TrueClass, FalseClass], default: false
+   property :sensitive, [true, false], default: false
 
    prefix = '/opt/languages/node'
 
@@ -3118,7 +3118,7 @@ Use the ``property`` method to define properties for the custom resource. The sy
 where
 
 * ``:name`` is the name of the property
-* ``ruby_type`` is the optional Ruby type or array of types, such as ``String``, ``Integer``, ``TrueClass``, or ``FalseClass``
+* ``ruby_type`` is the optional Ruby type or array of types, such as ``String``, ``Integer``, ``true``, or ``false``
 * ``default: 'value'`` is the optional default value loaded into the resource
 * ``parameter: 'value'`` optional parameters
 
@@ -3135,7 +3135,7 @@ ruby_type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. tag dsl_custom_resource_method_property_ruby_type
 
-The property ruby_type is a positional parameter. Use to ensure a property value is of a particular ruby class, such as ``TrueClass``, ``FalseClass``, ``NilClass``, ``String``, ``Array``, ``Hash``. Use an array of ruby classes to allow a value to be of more than one type. For example:
+The property ruby_type is a positional parameter. Use to ensure a property value is of a particular ruby class, such as ``true``, ``false``, ``nil``, ``String``, ``Array``, ``Hash``, ``Integer``, ``Symbol``. Use an array of ruby classes to allow a value to be of more than one type. For example:
 
        .. code-block:: ruby
 
@@ -3143,7 +3143,7 @@ The property ruby_type is a positional parameter. Use to ensure a property value
 
        .. code-block:: ruby
 
-          property :name, Fixnum
+          property :name, Integer
 
        .. code-block:: ruby
 
@@ -3151,11 +3151,11 @@ The property ruby_type is a positional parameter. Use to ensure a property value
 
        .. code-block:: ruby
 
-          property :name, [TrueClass, FalseClass]
+          property :name, [true, false]
 
        .. code-block:: ruby
 
-          property :name, [String, NilClass]
+          property :name, [String, nil]
 
        .. code-block:: ruby
 


### PR DESCRIPTION
Fixnum has been deprecated in favor of Integer in Ruby
NilClass, TrueClass, and FalseClass are confusing and aren't necessary. You can just use true/false/nil