### PR TITLE
Remove duplicate 12.5 warning

### DIFF
--- a/chef_master/source/custom_resources.rst
+++ b/chef_master/source/custom_resources.rst
@@ -5,8 +5,6 @@ Custom Resources
 
 As of Chef client version 12.5, this recommended approach for all custom resources. If you are using an older version of the chef-client, please use the version picker (in the top left of the navigation) to select your version, and then choose the same topic from the navigation tree ("Extend Chef > Custom Resources"). See also https://github.com/chef-cookbooks/compat_resource for using custom resources with chef-client 12.1 - 12.4.
 
-As of Chef client version 12.5, "resource attributes" are now known as "resource properties".
-
 As of Chef client 12.14, individual properties can be marked as `sensitive: true`, which suppresses the value of that property when exporting the resource's state.
 
 As of 12.14, individual properties can be marked as `sensitive: true`, which suppresses the value of that property when exporting the resource's state.


### PR DESCRIPTION
Custom resource themselves are entirely new for 12.5. There's no need to call out this one small change between LWRPs and custom resources.