### PR TITLE
Update documentation on recipe inclusion.

### DIFF
--- a/chef_master/source/dsl_recipe.rst
+++ b/chef_master/source/dsl_recipe.rst
@@ -119,7 +119,7 @@ Include Recipes
 =====================================================
 .. tag cookbooks_recipe_include_in_recipe
 
-A recipe can include one (or more) recipes located in external cookbooks by using the ``include_recipe`` method. When a recipe is included, the resources found in that recipe will be inserted (in the same exact order) at the point where the ``include_recipe`` keyword is located.
+A recipe can include one (or more) recipes from cookbooks by using the ``include_recipe`` method. When a recipe is included, the resources found in that recipe will be inserted (in the same exact order) at the point where the ``include_recipe`` keyword is located.
 
 The syntax for including a recipe is like this:
 
@@ -133,7 +133,15 @@ For example:
 
    include_recipe 'apache2::mod_ssl'
 
-If the ``include_recipe`` method is used more than once to include a recipe, only the first inclusion is processed and any subsequent inclusions are ignored.
+Multiple recipes can be included within a recipe. For example:
+
+.. code-block:: ruby
+
+   include_recipe 'cookbook::setup'
+   include_recipe 'cookbook::install'
+   include_recipe 'cookbook::configure'
+
+If a specific recipe is included more than once with the ``include_recipe`` method or elsewhere in the run_list directly, only the first instance is processed and subsequent inclusions are ignored.
 
 .. end_tag
 

--- a/chef_master/source/recipes.rst
+++ b/chef_master/source/recipes.rst
@@ -330,7 +330,7 @@ Include Recipes
 -----------------------------------------------------
 .. tag cookbooks_recipe_include_in_recipe
 
-A recipe can include one (or more) recipes located in external cookbooks by using the ``include_recipe`` method. When a recipe is included, the resources found in that recipe will be inserted (in the same exact order) at the point where the ``include_recipe`` keyword is located.
+A recipe can include one (or more) recipes from cookbooks by using the ``include_recipe`` method. When a recipe is included, the resources found in that recipe will be inserted (in the same exact order) at the point where the ``include_recipe`` keyword is located.
 
 The syntax for including a recipe is like this:
 
@@ -344,7 +344,15 @@ For example:
 
    include_recipe 'apache2::mod_ssl'
 
-If the ``include_recipe`` method is used more than once to include a recipe, only the first inclusion is processed and any subsequent inclusions are ignored.
+Multiple recipes can be included within a recipe. For example:
+
+.. code-block:: ruby
+
+   include_recipe 'cookbook::setup'
+   include_recipe 'cookbook::install'
+   include_recipe 'cookbook::configure'
+
+If a specific recipe is included more than once with the ``include_recipe`` method or elsewhere in the run_list directly, only the first instance is processed and subsequent inclusions are ignored.
 
 .. end_tag
 


### PR DESCRIPTION
Based on discussion in Community Chef slack, the include_recipe directive may be a little confusing. This is an attempt to clarify what the method is doing, and how to use it.

Signed-off-by: Jennifer Davis <iennae@gmail.com>