### PR TITLE
Add a section on Chef server credentials

### DIFF
--- a/chef_master/source/config_rb_server.rst
+++ b/chef_master/source/config_rb_server.rst
@@ -5,7 +5,7 @@ chef-server.rb Settings
 
 .. tag config_rb_server_summary
 
-The chef-server.rb file contains all of the non-default configuration settings used by the Chef server. (The default settings are built-in to the Chef server configuration and should only be added to the chef-server.rb file to apply non-default values.) These configuration settings are processed when the ``chef-server-ctl reconfigure`` command is run, such as immediately after setting up the Chef server or after making a change to the underlying configuration settings after the server has been deployed. The chef-server.rb file is a Ruby file, which means that conditional statements can be used in the configuration file.
+The chef-server.rb file contains all of the non-default configuration settings used by the Chef server. The default settings are built-in to the Chef server configuration and should only be added to the chef-server.rb file to apply non-default values. These configuration settings are processed when the ``chef-server-ctl reconfigure`` command is run, such as immediately after setting up the Chef server or after making a change to the underlying configuration settings after the server has been deployed. The chef-server.rb file is a Ruby file, which means that conditional statements can be used in the configuration file.
 
 .. end_tag
 

--- a/chef_master/source/config_rb_server_optional_settings.rst
+++ b/chef_master/source/config_rb_server_optional_settings.rst
@@ -72,25 +72,7 @@ This configuration file has the following general settings:
 ``insecure_addon_compat``
    Set to ``true`` to keep Chef server compatible with older add-on versions by rendering secrets and credentials to ``/etc/opscode/chef-server-running.json`` and other files in ``/etc/opscode/`` (and ``/etc/opscode-analytics``). When set to ``false``, secrets are **only** written to ``/etc/opscode/private-chef-secrets.json`` and **not** to any other files. Default value: ``true``.
 
-   See this table for the minimum add-on versions supporting ``insecure_addon_compat false``:
-
-   .. list-table::
-      :widths: 1 1
-      :header-rows: 1
-
-      * - Add-on Name
-        - Minimum Version
-      * - Chef Backend
-        - *all*
-      * - Chef Manage
-        - 2.5.0
-      * - Push Jobs Server
-        - 2.2.0
-      * - Reporting
-        - 1.7.0
-      * - Analytics
-        - *none*
-
+   See `Add-on Compatibility </server_security.html#add-on-compatibility>`_ for the minimum add-on versions supporting ``insecure_addon_compat false``.
 
 ``install_path``
    The directory in which the Chef server is installed. Default value: ``'/opt/opscode'``.

--- a/chef_master/source/config_rb_server_optional_settings.rst
+++ b/chef_master/source/config_rb_server_optional_settings.rst
@@ -5,7 +5,7 @@ chef-server.rb Optional Settings
 
 .. tag config_rb_server_summary
 
-The chef-server.rb file contains all of the non-default configuration settings used by the Chef server. (The default settings are built-in to the Chef server configuration and should only be added to the chef-server.rb file to apply non-default values.) These configuration settings are processed when the ``chef-server-ctl reconfigure`` command is run, such as immediately after setting up the Chef server or after making a change to the underlying configuration settings after the server has been deployed. The chef-server.rb file is a Ruby file, which means that conditional statements can be used in the configuration file.
+The chef-server.rb file contains all of the non-default configuration settings used by the Chef server. The default settings are built-in to the Chef server configuration and should only be added to the chef-server.rb file to apply non-default values. These configuration settings are processed when the ``chef-server-ctl reconfigure`` command is run, such as immediately after setting up the Chef server or after making a change to the underlying configuration settings after the server has been deployed. The chef-server.rb file is a Ruby file, which means that conditional statements can be used in the configuration file.
 
 .. end_tag
 

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -268,6 +268,55 @@ To regenerate SSL certificates:
 
       $ chef-server-ctl start
 
+Chef Server Credentials Management
+=====================================================
+
+Since 12.14.0
+-----------------------------------------------------
+
+Chef server limits where it writes service passwords and keys to disk. In the default configuration, credentials are only written to files in ``/etc/opscode``.
+
+By default, to maintain compatibility with older add-on versions, Chef server writes service credentials to multiple locations inside ``/etc/opscode``. However, if you are not using add-ons or are using the latest releases of your add-ons, a new configuration item ``insecure_addon_compat`` allows you to further restrict where credentials are written. When set to ``false``, credentials are only written to ``/etc/opscode/private-chef-secrets.json``.
+
+User-provided secrets (such as the password for an external postgresql instance) can still be set in ``/etc/opscode/chef-server.rb`` or via the :ref:`ctl_chef_server_secrets_management` commands.  These commands allow you to provide external passwords without including them in your configuration file.
+
+Add-on Compatibility
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The following table lists which add-on versions support the more restrictive ``insecure_addon_compat false`` setting. These version also now **require** Chef server 12.14.0 or greater:
+
+.. list-table::
+   :widths: 1 1
+   :header-rows: 1
+
+   * - Add-on Name
+     - Minimum Version
+   * - Chef Backend
+     - *all*
+   * - Chef Manage
+     - 2.5.0
+   * - Push Jobs Server
+     - 2.2.0
+   * - Reporting
+     - 1.7.0
+   * - Analytics
+     - *none*
+
+These newer add-ons will also write all of their secrets to ``/etc/opscode/private-chef-secrets.json``. Older versions of the add-ons will still write their configuration to locations in ``/etc`` and ``/var/opt``.
+
+/etc/opscode/private-chef-secrets.json
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+``/etc/opscode/private-chef-secrets.json``'s default permissions only allow the root user to read or write the file. This file contains all of the secrets for access to the Chef server's underlying data stores, and thus access to it should be restricted to trusted users.
+
+While the file does not contain passwords in plaintext, it is not safe to share with untrusted users. The format of the secrets file allows deployments of Chef server to conform to regulations requiring that no sensitive data should appear in plain text in configuration files; however, it does not make the file meaningfully more secure.
+
+DRBD and Keepalived
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+In the DRBD-based HA configuration, Chef server will render passwords for keepalived and DRBD to configuration files in ``/var/opt/opscode``.
+
+
 Key Rotation
 =====================================================
 Use the following commands to manage public and private key rotation for users and clients.
@@ -584,4 +633,3 @@ Use following client.rb settings to manage SSL certificate preferences:
      - Verify the SSL certificate on the Chef server. When ``true``, the chef-client always verifies the SSL certificate. When ``false``, the chef-client uses the value of ``ssl_verify_mode`` to determine if the SSL certificate requires verification. Default value: ``false``.
 
 .. end_tag
-

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -271,12 +271,14 @@ To regenerate SSL certificates:
 Chef Server Credentials Management
 =====================================================
 
-Since 12.14.0
+Credentials Security
 -----------------------------------------------------
+
+**New in Chef server 12.14**
 
 Chef server limits where it writes service passwords and keys to disk. In the default configuration, credentials are only written to files in ``/etc/opscode``.
 
-By default, to maintain compatibility with older add-on versions, Chef server writes service credentials to multiple locations inside ``/etc/opscode``. However, if you are not using add-ons or are using the latest releases of your add-ons, a new configuration item ``insecure_addon_compat`` allows you to further restrict where credentials are written. When set to ``false``, credentials are only written to ``/etc/opscode/private-chef-secrets.json``.
+By default, Chef server still writes service credentials to multiple locations inside ``/etc/opscode``.  This is designed to maintain compatibility with add-ons, which are downloadable components that extended Chef server functionality. Chef server 12.14 introduces a new configuration option, ``insecure_addon_compat``, which allows you to further restrict where credentials are written.  ``insecure_addon_compat`` can be used if you are not using add-ons or if you are using the latest releases of your add-ons. However, ``insecure_addon_compat`` _cannot_ be used with Analytics. Setting ``insecure_addon_compat`` to ``false`` writes credentials to only one location,  ``/etc/opscode/private-chef-secrets.json``.
 
 User-provided secrets (such as the password for an external postgresql instance) can still be set in ``/etc/opscode/chef-server.rb`` or via the :ref:`ctl_chef_server_secrets_management` commands.  These commands allow you to provide external passwords without including them in your configuration file.
 
@@ -307,9 +309,9 @@ These newer add-ons will also write all of their secrets to ``/etc/opscode/priva
 /etc/opscode/private-chef-secrets.json
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-``/etc/opscode/private-chef-secrets.json``'s default permissions only allow the root user to read or write the file. This file contains all of the secrets for access to the Chef server's underlying data stores, and thus access to it should be restricted to trusted users.
+``/etc/opscode/private-chef-secrets.json``'s default permissions allow only the root user to read or write the file. This file contains all of the secrets for access to the Chef server's underlying data stores and thus access to it should be restricted to trusted users.
 
-While the file does not contain passwords in plaintext, it is not safe to share with untrusted users. The format of the secrets file allows deployments of Chef server to conform to regulations requiring that no sensitive data should appear in plain text in configuration files; however, it does not make the file meaningfully more secure.
+While the file does not contain passwords in plaintext, it is not safe to share with untrusted users. The format of the secrets file allows Chef server deployments to conform to regulations that forbid the appearance of sensitive data in plain text in configuration files; however, it does not make the file meaningfully more secure.
 
 DRBD and Keepalived
 +++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/chef_master/source/server_tuning.rst
+++ b/chef_master/source/server_tuning.rst
@@ -11,7 +11,7 @@ Customize the Config File
 =====================================================
 .. tag config_rb_server_summary
 
-The chef-server.rb file contains all of the non-default configuration settings used by the Chef server. (The default settings are built-in to the Chef server configuration and should only be added to the chef-server.rb file to apply non-default values.) These configuration settings are processed when the ``chef-server-ctl reconfigure`` command is run, such as immediately after setting up the Chef server or after making a change to the underlying configuration settings after the server has been deployed. The chef-server.rb file is a Ruby file, which means that conditional statements can be used in the configuration file.
+The chef-server.rb file contains all of the non-default configuration settings used by the Chef server. The default settings are built-in to the Chef server configuration and should only be added to the chef-server.rb file to apply non-default values. These configuration settings are processed when the ``chef-server-ctl reconfigure`` command is run, such as immediately after setting up the Chef server or after making a change to the underlying configuration settings after the server has been deployed. The chef-server.rb file is a Ruby file, which means that conditional statements can be used in the configuration file.
 
 .. end_tag
 


### PR DESCRIPTION
This provides users with a single place to read about the current
state of credentials management in Chef server and the related
add-ons.

Signed-off-by: Steven Danna <steve@chef.io>