### PR TITLE
remove references to provider-internal resource-state properties of systemd_unit

### DIFF
--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -593,26 +593,6 @@ Properties
 
 This resource has the following properties:
 
-``enabled``
-   **Ruby Types:** TrueClass, FalseClass
-
-   Specifies whether the unit is enabled or disabled.
-
-``active``
-   **Ruby Type:** TrueClass, FalseClass
-
-   Specifies whether the unit is started or stopped.
-
-``masked``
-   **Ruby Type:** TrueClass, FalseClass
-
-   Specifies whether the unit is masked or not.
-
-``static``
-   **Ruby Type:** TrueClass, FalseClass
-
-   Specifies whether the unit is static or not. Static units cannot be enabled or disabled.
-
 ``user``
    **Ruby Type:** String
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -511,8 +511,18 @@ A **systemd_unit** resource describes the configuration behavior for systemd uni
 .. code-block:: ruby
 
    systemd_unit 'sysstat-collect.timer' do
-     enabled true
-     content '[Unit]\nDescription=Run system activity accounting tool every 10 minutes\n\n[Timer]\nOnCalendar=*:00/10\n\n[Install]\nWantedBy=sysstat.service'
+     content({
+       'Unit' => {
+         'Description' => 'Run system activity accounting tool every 10 minutes'
+       },
+       'Timer' => {
+         'OnCalendar' => '*:00/10'
+       },
+       'Install' => {
+         'WantedBy' => 'sysstat.service'
+       }
+     })
+     action [:create, :enable, :start]
    end
 
 The full syntax for all of the properties that are available to the **systemd_unit** resource is:
@@ -520,10 +530,6 @@ The full syntax for all of the properties that are available to the **systemd_un
 .. code-block:: ruby
 
    systemd_unit 'name' do
-     enabled                Boolean
-     active                 Boolean
-     masked                 Boolean
-     static                 Boolean
      user                   String
      content                String or Hash
      triggers_reload        Boolean
@@ -532,10 +538,9 @@ The full syntax for all of the properties that are available to the **systemd_un
 where
 
 * ``name`` is the name of the unit
-* ``active`` specifies if the service unit type should be started
 * ``user`` is the user account that systemd units run under. If not specified, systemd units will run under the system account.
 * ``content`` describes the behavior of the unit
-
+* ``triggers_reload`` controls if a `daemon-reload` is executed to load the unit
 
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/chef_master/source/resource_systemd_unit.rst
+++ b/chef_master/source/resource_systemd_unit.rst
@@ -5,7 +5,7 @@ systemd_unit
 
 Use the **systemd_unit** resource to create, manage, and run `systemd units <https://www.freedesktop.org/software/systemd/man/systemd.html#Concepts>`_.
 
-New in Chef Client 12.11. Changed in 12.19 to verify systemd files before installation (using the external ``systemd-analyze verify`` command).
+New in Chef Client 12.11. Changed in 12.19 to verify systemd unit-files before installation (using the external ``systemd-analyze verify`` command).
 
 Syntax
 =====================================================
@@ -27,8 +27,7 @@ A **systemd_unit** resource describes the configuration behavior for systemd uni
      WantedBy=sysstat.service
      EOU
 
-     enabled true
-     action :create
+     action [:create, :enable]
    end
 
 The full syntax for all of the properties that are available to the **systemd_unit** resource is:
@@ -37,10 +36,6 @@ The full syntax for all of the properties that are available to the **systemd_un
 
    systemd_unit 'name.service' do
      content                String or Hash
-     enabled                Boolean
-     active                 Boolean
-     masked                 Boolean
-     static                 Boolean
      user                   String
      triggers_reload        Boolean
    end
@@ -48,7 +43,6 @@ The full syntax for all of the properties that are available to the **systemd_un
 where
 
 * ``name`` is the name of the unit. Must include the type/suffix (e.g. `name.socket` or `name.service`).
-* ``active`` specifies if the service unit type should be started
 * ``user`` is the user account that systemd units run under. If not specified, systemd units will run under the system account.
 * ``content`` describes the behavior of the unit
 
@@ -109,26 +103,6 @@ Properties
 .. tag resource_systemd_unit_attributes
 
 This resource has the following properties:
-
-``enabled``
-   **Ruby Types:** TrueClass, FalseClass
-
-   Specifies whether the unit is enabled or disabled.
-
-``active``
-   **Ruby Type:** TrueClass, FalseClass
-
-   Specifies whether the unit is started or stopped.
-
-``masked``
-   **Ruby Type:** TrueClass, FalseClass
-
-   Specifies whether the unit is masked or not.
-
-``static``
-   **Ruby Type:** TrueClass, FalseClass
-
-   Specifies whether the unit is static or not. Static units cannot be enabled or disabled.
 
 ``user``
    **Ruby Type:** String


### PR DESCRIPTION
enabled, active, static, masked are internal state-properties that shouldn't be user-facing (the user-provided values are ignored and overwritten by the provider). this updates the docs to remove misleading references to these properties, and instead demonstrates the intended use of the corresponding actions.