### PR TITLE
Don't need to use double quotes for basic strings

### DIFF
--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -90,7 +90,7 @@ This configuration file has the following settings:
 
    .. code-block:: ruby
 
-      chef_version "~> 12"
+      chef_version '~> 12'
 
    .. end_tag
 

--- a/chef_master/source/cookbook_repo.rst
+++ b/chef_master/source/cookbook_repo.rst
@@ -126,7 +126,7 @@ This configuration file has the following settings:
 
    .. code-block:: ruby
 
-      chef_version "~> 12"
+      chef_version '~> 12'
 
    .. end_tag
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -2626,7 +2626,7 @@ The following settings are new for metadata.rb:
 
        .. code-block:: ruby
 
-          chef_version "~> 12"
+          chef_version '~> 12'
 
        .. end_tag
 


### PR DESCRIPTION
Signed-off-by: David Wrede <dwrede@chef.io>