### PR TITLE
Expand ext elastic

### DIFF
--- a/chef_master/source/setup_visibility_chef_automate.rst
+++ b/chef_master/source/setup_visibility_chef_automate.rst
@@ -209,6 +209,11 @@ To utilize an external Elasticsearch installation, set the following configurati
 
    elasticsearch['urls'] = ['https://my-elaticsearch-cluster.mycompany.com']
 
+Or for a three node on premise install
+
+.. code-block:: ruby
+  elasticserach['urls'] = ['http://172.16.0.100:9200', 'http://172.16.0.101:9200', 'http://172.16.0.100:9202']
+
 The ``elasticsearch['urls']`` attribute should be an array of Elasticsearch nodes over
 which Chef Automate will round-robin requests. You can also supply a single entry which corresponds to
 a load-balancer or a third-party Elasticsearch-as-a-service offering.

--- a/chef_master/source/setup_visibility_chef_automate.rst
+++ b/chef_master/source/setup_visibility_chef_automate.rst
@@ -212,7 +212,8 @@ To utilize an external Elasticsearch installation, set the following configurati
 Or for a three node on premise install
 
 .. code-block:: ruby
-  elasticserach['urls'] = ['http://172.16.0.100:9200', 'http://172.16.0.101:9200', 'http://172.16.0.100:9202']
+
+   elasticserach['urls'] = ['http://172.16.0.100:9200', 'http://172.16.0.101:9200', 'http://172.16.0.100:9202']
 
 The ``elasticsearch['urls']`` attribute should be an array of Elasticsearch nodes over
 which Chef Automate will round-robin requests. You can also supply a single entry which corresponds to


### PR DESCRIPTION
We've had some confusion from customers about setting up External ES clusters since the only example is https with no custom port specified. I added an example of multi-host, with non-ssl and the default ES port to cover some ground.