### PR TITLE
Remove attributes from metadata.

### DIFF
--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -22,7 +22,7 @@ A metadata.rb file is:
 
 .. note:: A metadata.json file can be edited directly, should temporary changes be required. Any subsequent upload or action that generates metadata will cause the existing metadata.json file to be overwritten with the newly generated metadata. Therefore, any permanent changes to cookbook metadata should be done in the metadata.rb file, and then re-uploaded to the Chef server.
 
- New in 12.8, ``gem`` allows the specification of gem dependency installation via ``chef_gem``. New in 12.6, ``chef_version`` for supporting a range of chef-client versions in a cookbooks, ``ohai_version`` for supporting a range of Ohai versions in a cookbook.  Changed in Chef Client 12.0 to support version constraints, requires ``name``.  New in 12.0, ``issues_url`` to capture issues tracking, ``provides`` method for mapping a custom resource or provider to an existing resource or provider, and ``source_url`` to capture source capture. 
+ New in 12.8, ``gem`` allows the specification of gem dependency installation via ``chef_gem``. New in 12.6, ``chef_version`` for supporting a range of chef-client versions in a cookbooks, ``ohai_version`` for supporting a range of Ohai versions in a cookbook.  Changed in Chef Client 12.0 to support version constraints, requires ``name``.  New in 12.0, ``issues_url`` to capture issues tracking, ``provides`` method for mapping a custom resource or provider to an existing resource or provider, and ``source_url`` to capture source capture.
 
 Version Constraints
 ====================
@@ -61,32 +61,35 @@ Settings
 
 This configuration file has the following settings:
 
--``attribute``
-Deprecated in Chef Client 13.0, pending removal in 14.0.
+``attribute``
+   Deprecated in Chef Client 13.0, pending removal in 14.0.
 
-.. warning:: ``attribute`` in cookbook configuration is deprecated and will be removed. ``attribute`` often requires frequent updating in the code, in the README.md file, and in the metadata, which may lead to extensive technical debt. When used, the current version of foodcritic will throw a warning.
+   .. warning:: ``attribute`` in cookbook configuration is deprecated and will be removed. ``attribute`` often requires frequent updating in the code, in the README.md file, and in the metadata, which may lead to extensive technical debt. When used, the current version of foodcritic will throw a warning.
 
- -   The list of attributes that are required to configure a cookbook. An attribute name is required, followed by any of these options: ``display_name`` (the name that appears in the user interface), ``description`` (a short description), ``choice`` (an array of choices that are presented to a user), ``calculated`` (the default value is calculated by the recipe), ``type`` (the type of value, either ``string``, ``array``, or ``hash``), ``required`` (the level of user input, either ``required``, ``recommended``, or ``optional``), ``recipes`` (an array of recipes), or ``default`` (the attribute's default value).		
- -		
- -   For example:		
- -		
- -   .. code-block:: ruby		
- -		
- -      attribute 'pets/cat/name',		
- -        :display_name => 'Cat Name',		
- -        :description => 'The name of your cat',		
- -        :choice => \[		
- -          'kitty kitty',		
- -          'peanut',		
- -          'einstein',		
- -          'honey' \],		
- -        :type => 'string',		
- -        :required => 'recommended',		
- -        :recipes => \[ 'cats::eat' \],		
- -        :default => 'kitty kitty'		
- -
+   The list of attributes that are required to configure a cookbook. An attribute name is required, followed by any of these options: ``display_name`` (the name that appears in the user interface), ``description`` (a short description), ``choice`` (an array of choices that are presented to a user), ``calculated`` (the default value is calculated by the recipe), ``type`` (the type of value, either ``string``, ``array``, or ``hash``), ``required`` (the level of user input, either ``required``, ``recommended``, or ``optional``), ``recipes`` (an array of recipes), or ``default`` (the attribute's default value).
+
+    For example:
+
+    .. code-block:: ruby
+
+       attribute 'pets/cat/name',
+         :display_name => 'Cat Name',
+         :description => 'The name of your cat',
+         :choice => \[
+           'kitty kitty',
+           'peanut',
+           'einstein',
+           'honey' \],
+         :type => 'string',
+         :required => 'recommended',
+         :recipes => \[ 'cats::eat' \],
+         :default => 'kitty kitty'
+
 ``chef_version``
+   New in Chef Client 12.6.
+   .. note:: This setting is not visible in Chef Supermarket.
    A range of chef-client versions that are supported by this cookbook. All :ref:`version constraint operators <cookbook_version_constraints>` are applicable to this field.
+
 
    .. tag config_rb_metadata_settings_example_chef_version
 
@@ -97,10 +100,6 @@ Deprecated in Chef Client 13.0, pending removal in 14.0.
       chef_version '~> 12'
 
    .. end_tag
-
-   .. note:: This setting is not visible in Chef Supermarket.
-
-   New in Chef Client 12.6.
 
 ``depends``
    This field requires that a cookbook with a matching name and version exists on the Chef server. When the match exists, the Chef server includes the dependency as part of the set of cookbooks that are sent to the node when the chef-client runs. It is very important that the ``depends`` field contain accurate data. If a dependency statement is inaccurate, the chef-client may not be able to complete the configuration of the system. All :ref:`version constraint operators <cookbook_version_constraints>` are applicable to this field.

--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -61,26 +61,6 @@ Settings
 
 This configuration file has the following settings:
 
-``attribute``
-   The list of attributes that are required to configure a cookbook. An attribute name is required, followed by any of these options: ``display_name`` (the name that appears in the user interface), ``description`` (a short description), ``choice`` (an array of choices that are presented to a user), ``calculated`` (the default value is calculated by the recipe), ``type`` (the type of value, either ``string``, ``array``, or ``hash``), ``required`` (the level of user input, either ``required``, ``recommended``, or ``optional``), ``recipes`` (an array of recipes), or ``default`` (the attribute's default value).
-
-   For example:
-
-   .. code-block:: ruby
-
-      attribute 'pets/cat/name',
-        :display_name => 'Cat Name',
-        :description => 'The name of your cat',
-        :choice => \[
-          'kitty kitty',
-          'peanut',
-          'einstein',
-          'honey' \],
-        :type => 'string',
-        :required => 'recommended',
-        :recipes => \[ 'cats::eat' \],
-        :default => 'kitty kitty'
-
 ``chef_version``
    A range of chef-client versions that are supported by this cookbook. All :ref:`version constraint operators <cookbook_version_constraints>` are applicable to this field.
 

--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -61,6 +61,30 @@ Settings
 
 This configuration file has the following settings:
 
+-``attribute``
+Deprecated in Chef Client 13.0, pending removal in 14.0.
+
+.. warning:: ``attribute`` in cookbook configuration is deprecated and will be removed. ``attribute`` often requires frequent updating in the code, in the README.md file, and in the metadata, which may lead to extensive technical debt. When used, the current version of foodcritic will throw a warning.
+
+ -   The list of attributes that are required to configure a cookbook. An attribute name is required, followed by any of these options: ``display_name`` (the name that appears in the user interface), ``description`` (a short description), ``choice`` (an array of choices that are presented to a user), ``calculated`` (the default value is calculated by the recipe), ``type`` (the type of value, either ``string``, ``array``, or ``hash``), ``required`` (the level of user input, either ``required``, ``recommended``, or ``optional``), ``recipes`` (an array of recipes), or ``default`` (the attribute's default value).		
+ -		
+ -   For example:		
+ -		
+ -   .. code-block:: ruby		
+ -		
+ -      attribute 'pets/cat/name',		
+ -        :display_name => 'Cat Name',		
+ -        :description => 'The name of your cat',		
+ -        :choice => \[		
+ -          'kitty kitty',		
+ -          'peanut',		
+ -          'einstein',		
+ -          'honey' \],		
+ -        :type => 'string',		
+ -        :required => 'recommended',		
+ -        :recipes => \[ 'cats::eat' \],		
+ -        :default => 'kitty kitty'		
+ -
 ``chef_version``
    A range of chef-client versions that are supported by this cookbook. All :ref:`version constraint operators <cookbook_version_constraints>` are applicable to this field.
 

--- a/chef_master/source/cookbook_repo.rst
+++ b/chef_master/source/cookbook_repo.rst
@@ -98,27 +98,34 @@ Settings
 This configuration file has the following settings:
 
 ``attribute``
+   Deprecated in Chef Client 13.0, pending removal in 14.0.
+
+   .. warning:: ``attribute`` in cookbook configuration is deprecated and will be removed. ``attribute`` often requires frequent updating in the code, in the README.md file, and in the metadata, which may lead to extensive technical debt. When used, the current version of foodcritic will throw a warning.
+
    The list of attributes that are required to configure a cookbook. An attribute name is required, followed by any of these options: ``display_name`` (the name that appears in the user interface), ``description`` (a short description), ``choice`` (an array of choices that are presented to a user), ``calculated`` (the default value is calculated by the recipe), ``type`` (the type of value, either ``string``, ``array``, or ``hash``), ``required`` (the level of user input, either ``required``, ``recommended``, or ``optional``), ``recipes`` (an array of recipes), or ``default`` (the attribute's default value).
 
-   For example:
+    For example:
 
-   .. code-block:: ruby
+    .. code-block:: ruby
 
-      attribute 'pets/cat/name',
-        :display_name => 'Cat Name',
-        :description => 'The name of your cat',
-        :choice => \[
-          'kitty kitty',
-          'peanut',
-          'einstein',
-          'honey' \],
-        :type => 'string',
-        :required => 'recommended',
-        :recipes => \[ 'cats::eat' \],
-        :default => 'kitty kitty'
+       attribute 'pets/cat/name',
+         :display_name => 'Cat Name',
+         :description => 'The name of your cat',
+         :choice => \[
+           'kitty kitty',
+           'peanut',
+           'einstein',
+           'honey' \],
+         :type => 'string',
+         :required => 'recommended',
+         :recipes => \[ 'cats::eat' \],
+         :default => 'kitty kitty'
 
 ``chef_version``
+   New in Chef Client 12.6.
+   .. note:: This setting is not visible in Chef Supermarket.
    A range of chef-client versions that are supported by this cookbook. All :ref:`version constraint operators <cookbook_version_constraints>` are applicable to this field.
+
 
    .. tag config_rb_metadata_settings_example_chef_version
 
@@ -129,10 +136,6 @@ This configuration file has the following settings:
       chef_version '~> 12'
 
    .. end_tag
-
-   .. note:: This setting is not visible in Chef Supermarket.
-
-   New in Chef Client 12.6.
 
 ``depends``
    This field requires that a cookbook with a matching name and version exists on the Chef server. When the match exists, the Chef server includes the dependency as part of the set of cookbooks that are sent to the node when the chef-client runs. It is very important that the ``depends`` field contain accurate data. If a dependency statement is inaccurate, the chef-client may not be able to complete the configuration of the system. All :ref:`version constraint operators <cookbook_version_constraints>` are applicable to this field.


### PR DESCRIPTION
Attributes hasn't been removed (yet), but is not advised for current use.
Use of attributes creates immediate technical debt because it becomes
outdated as the cookbook evolves. To use it requires folks to update
information in three places within the code itself, the documentation
in the README, and the metadata. When it gets uploaded to be shared
it's converted into JSON which isn't human readable so using attributes
is not helpful. The newest foodcritic includes it as a warning if it's used.
