### PR TITLE
removing deprecated cookbook for chef-client updates

### DIFF
--- a/chef_master/source/upgrade_client.rst
+++ b/chef_master/source/upgrade_client.rst
@@ -19,4 +19,4 @@ Using the ``knife ssh`` subcommand is one way to do this.
 
 Upgrade via Cookbook
 =====================================================
-The `chef_client_updater <https://supermarket.chef.io/cookbooks/chef_client_updater>`__ cookbook can be used to install or upgrade the chef-client package on a node, and then be used to update the chef-client.
+The `chef_client_updater <https://supermarket.chef.io/cookbooks/chef_client_updater>`__ cookbook can be used to install or upgrade the chef-client package on a node.

--- a/chef_master/source/upgrade_client.rst
+++ b/chef_master/source/upgrade_client.rst
@@ -19,5 +19,4 @@ Using the ``knife ssh`` subcommand is one way to do this.
 
 Upgrade via Cookbook
 =====================================================
-The ``omnibus-updater`` cookbook can be used to install the omnibus chef-client package on a node, and then be used to update the chef-client: https://github.com/hw-cookbooks/omnibus_updater.
-
+The `chef_client_updater <https://supermarket.chef.io/cookbooks/chef_client_updater>`__ cookbook can be used to install or upgrade the chef-client package on a node, and then be used to update the chef-client.


### PR DESCRIPTION
The omnibus-updater cookbook is now deprecated in favor of the chef_client_updater cookbook. Updating documentation to reflect such.