### PR TITLE
Update action_class docs to specify class_eval

### DIFF
--- a/chef_master/source/custom_resources.rst
+++ b/chef_master/source/custom_resources.rst
@@ -516,7 +516,7 @@ action_class
 -----------------------------------------------------
 .. tag dsl_custom_resource_block_action_class
 
-Use the ``action_class`` block to make methods available to the actions in the custom resource.  Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the ``action_class`` block.  Code in the ``action_class`` block has access to the new_resource properties.
+Use the ``action_class.class_eval`` block to make methods available to the actions in the custom resource. Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the ``action_class.class_eval`` block. Code in the ``action_class.class_eval`` block has access to the new_resource properties.
 
 Assume a helper module has been created in the cookbook ``libraries/helper.rb`` file.
 
@@ -530,7 +530,7 @@ Assume a helper module has been created in the cookbook ``libraries/helper.rb`` 
      end
    end
 
-Methods may be made available to the custom resource actions by using an ``action_class`` block.
+Methods may be made available to the custom resource actions by using an ``action_class.class_eval`` block.
 
 .. code-block:: ruby
 
@@ -540,8 +540,8 @@ Methods may be made available to the custom resource actions by using an ``actio
      helper_method
      FileUtils.rm(file) if file_ex
    end
- 
-   action_class do
+
+   action_class.class_eval do
 
      def file_exist
        ::File.exist?(file)

--- a/chef_master/source/custom_resources_notes.rst
+++ b/chef_master/source/custom_resources_notes.rst
@@ -11,8 +11,7 @@ Custom Resources 12.5-style
 =====================================================
 This is the recommended way of writing resources for all users. There are two gotchas which we're working through:
 
-#. For helper functions that you used to write in your provider code or used to mixin to your provider code, you have to use an ``action_class do ... end`` block.
-#. The 12.5 resources allow for a shorthand notation in provider code where you can refer to properties by their bare name ``my_property`` and it works most of the time.  Since it does not work all the time (because of the way Ruby scopes things), its recommended to stick to referring to properties by ``new_resource.my_property``.
+#. For helper functions that you used to write in your provider code or used to mixin to your provider code, you have to use an ``action_class.class_eval do ... end`` block.
 
 You cannot subclass, and must use mixins for code-sharing (which is really a best practice anyway -- e.g. see languages like rust which do not support subclassing).
 
@@ -35,7 +34,7 @@ in ``resources/whatever.rb``:
      puts new_resource.foo
    end
 
-   action_class do
+   action_class.class_eval do
      include MyProviderHelperFunctions
 
      def a_helper

--- a/chef_master/source/dsl_custom_resource.rst
+++ b/chef_master/source/dsl_custom_resource.rst
@@ -21,7 +21,7 @@ action_class
 =====================================================
 .. tag dsl_custom_resource_block_action_class
 
-Use the ``action_class`` block to make methods available to the actions in the custom resource.  Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the ``action_class`` block.  Code in the ``action_class`` block has access to the new_resource properties.
+Use the ``action_class.class_eval`` block to make methods available to the actions in the custom resource. Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the ``action_class.class_eval`` block. Code in the ``action_class.class_eval`` block has access to the new_resource properties.
 
 Assume a helper module has been created in the cookbook ``libraries/helper.rb`` file.
 
@@ -35,7 +35,7 @@ Assume a helper module has been created in the cookbook ``libraries/helper.rb`` 
      end
    end
 
-Methods may be made available to the custom resource actions by using an ``action_class`` block.
+Methods may be made available to the custom resource actions by using an ``action_class.class_eval`` block.
 
 .. code-block:: ruby
 
@@ -46,7 +46,7 @@ Methods may be made available to the custom resource actions by using an ``actio
      FileUtils.rm(file) if file_ex
    end
 
-   action_class do
+   action_class.class_eval do
 
      def file_exist
        ::File.exist?(file)

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -3211,7 +3211,7 @@ action_class
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. tag dsl_custom_resource_block_action_class
 
-Use the ``action_class`` block to make methods available to the actions in the custom resource.  Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the ``action_class`` block.  Code in the ``action_class`` block has access to the new_resource properties.
+Use the ``action_class.class_eval`` block to make methods available to the actions in the custom resource. Modules with helper methods created as files in the cookbook library directory may be included. New action methods may also be defined directly in the ``action_class.class_eval`` block. Code in the ``action_class.class_eval`` block has access to the new_resource properties.
 
 Assume a helper module has been created in the cookbook ``libraries/helper.rb`` file.
 
@@ -3225,7 +3225,7 @@ Assume a helper module has been created in the cookbook ``libraries/helper.rb`` 
      end
    end
 
-Methods may be made available to the custom resource actions by using an ``action_class`` block.
+Methods may be made available to the custom resource actions by using an ``action_class.class_eval`` block.
 
 .. code-block:: ruby
 
@@ -3236,7 +3236,7 @@ Methods may be made available to the custom resource actions by using an ``actio
      FileUtils.rm(file) if file_ex
    end
 
-   action_class do
+   action_class.class_eval do
 
      def file_exist
        ::File.exist?(file)


### PR DESCRIPTION
class_eval makes it work with Chef 12.5/12.6. Pointing everyone to that maintains backwards compatibility.

Signed-off-by: Tim Smith <tsmith@chef.io>