### PR TITLE
Fix invalid long_description ruby code

### DIFF
--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -215,9 +215,7 @@ This configuration file has the following settings:
 
    .. code-block:: ruby
 
-      long_description IO.read(File.join
-        (File.dirname(__FILE__), 'README.rdoc')
-      )
+      long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 
 ``maintainer``
    The name of the person responsible for maintaining a cookbook, either an individual or an organization.

--- a/chef_master/source/cookbook_repo.rst
+++ b/chef_master/source/cookbook_repo.rst
@@ -251,9 +251,7 @@ This configuration file has the following settings:
 
    .. code-block:: ruby
 
-      long_description IO.read(File.join
-        (File.dirname(__FILE__), 'README.rdoc')
-      )
+      long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 
 ``maintainer``
    The name of the person responsible for maintaining a cookbook, either an individual or an organization.


### PR DESCRIPTION
It is invalid and it wouldn't work. New line can be placed after `(`, not before.