### PR TITLE
Remove an untruth about the .chef dir on a chef-repo

### DIFF
--- a/chef_master/source/chef_private_keys.rst
+++ b/chef_master/source/chef_private_keys.rst
@@ -80,7 +80,7 @@ knife is used to upload data to the Chef server from the chef-repo directory. On
 
 .. tag all_directory_chef
 
-The .chef directory is a hidden directory that is used to store validation key files and the knife.rb file. These files are required for interaction with a Chef server.
+The .chef directory is a hidden directory that is used to store validation key files and the knife.rb file.
 
 .. end_tag
 

--- a/chef_master/source/chef_repo.rst
+++ b/chef_master/source/chef_repo.rst
@@ -49,7 +49,7 @@ The sub-directories in the chef-repo are:
 -----------------------------------------------------
 .. tag all_directory_chef
 
-The .chef directory is a hidden directory that is used to store validation key files and the knife.rb file. These files are required for interaction with a Chef server.
+The .chef directory is a hidden directory that is used to store validation key files and the knife.rb file.
 
 .. end_tag
 


### PR DESCRIPTION
You don't need these to work with a server. You need a knife.rb, but it can be your personal knife.rb file