### PR TITLE
Docs for Server Tuning: Drop a duplicated Note item

### DIFF
--- a/chef_master/source/server_tuning.rst
+++ b/chef_master/source/server_tuning.rst
@@ -270,8 +270,6 @@ The following setting is often modified from the default as part of the tuning e
 rabbitmq
 -----------------------------------------------------
 
-.. note:: Chef Analytics has been replaced by Chef Automate.
-
 .. tag server_tuning_rabbitmq
 
 .. note:: Chef Analytics has been replaced by Chef Automate.


### PR DESCRIPTION
This PR removes one of the duplicate `.note` blocks in the `rabbitmq` section of the "Server Tuning" chapter.

What it looks like, before this change:

<img width="898" alt="screenshot 2017-04-25 15 58 29" src="https://cloud.githubusercontent.com/assets/211/25389138/153791b2-29d0-11e7-8238-c5f4be667645.png">
