### PR TITLE
Remove partial changelog and update CLI options

### DIFF
--- a/chef_master/source/foodcritic.rst
+++ b/chef_master/source/foodcritic.rst
@@ -3,8 +3,6 @@ About Foodcritic
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/foodcritic.rst>`__
 
-Changed in Chef DK 1.3: false positives in FC007 and FC016 have been resolved; new rules have been added requiring the license (FC068), supports (FC067), and chef_version (FC066) metadata properties in cookbooks. Removed in Chef DK 1.3: FC003, which required gating certain code when running on Chef Solo has been removed; FC023, which preferred conditional (only_if / not_if) code within resources has been removed.
-
 Use Foodcritic to check cookbooks for common problems:
 
 * Style
@@ -100,11 +98,23 @@ This command has the following syntax:
 
 This command has the following options:
 
-``-C``, ``--[no-]context``
-   Use to show lines matched against Foodcritic rules, rather than the default summary.
+``-t TAGS``, ``--tags TAGS``
+   Use to specify tags to include or exclude when running Foodcritic.
+
+``-l``, ``--list``
+   List the name and description of all rules.
 
 ``-f TAGS``, ``--epic-fail TAGS``
    Use to trigger a build failure if any of the specified tags are matched.
+
+``-c VERSION``, ``--chef-version VERSION``
+   Use to specify the chef version to evaluate against instead of Foodcritic's default.
+
+``-B PATH``, ``--cookbook-path PATH``
+   Use to specify the path to a cookbook to check
+
+``-C``, ``--[no-]context``
+   Use to show lines matched against Foodcritic rules, rather than the default summary.
 
 ``-I PATH``, ``--include PATH``
    Use to specify the path to a file that contains additional Foodcritic rules.
@@ -115,8 +125,6 @@ This command has the following options:
 ``-S PATH``, ``--search-grammar PATH``
    Use to specify the path to a file that contains additional grammar used when validating search syntax.
 
-``-t TAGS``, ``--tags TAGS``
-   Use to only the specified tags when checking against Foodcritic rules.
 
 ``-V``, ``--version``
    Use to display the version of Foodcritic.


### PR DESCRIPTION
The CLI options were missing a few things. I've also removed the changelog. The changelog for Foodcritic is pretty extensive and we just can't fit the list of changes in this way. It'll get entirely out of hand within a few months. We have a changelog for that.