### PR TITLE
Update chocolatey_package to clarify source arg

### DIFF
--- a/chef_master/source/resource_chocolatey_package.rst
+++ b/chef_master/source/resource_chocolatey_package.rst
@@ -164,7 +164,7 @@ This resource has the following properties:
 ``source``
    **Ruby Type:** String
 
-   Optional. The path to a package in the local file system.
+   Optional. The path to a package in the local file system or a reachable UNC path. Ensure that the path specified is to the _folder_ containing the chocolatey package(s), not to the package itself.
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_chocolatey_package.rst
+++ b/chef_master/source/resource_chocolatey_package.rst
@@ -164,7 +164,7 @@ This resource has the following properties:
 ``source``
    **Ruby Type:** String
 
-   Optional. The path to a package in the local file system or a reachable UNC path. Ensure that the path specified is to the _folder_ containing the chocolatey package(s), not to the package itself.
+   Optional. The path to a package in the local file system or a reachable UNC path. Ensure that the path specified is to the **folder** containing the chocolatey package(s), not to the package itself.
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'


### PR DESCRIPTION
The source argument in the existing document may lead a naive user (like me!) to assume that the path _to the package_ must be specified, instead of the path _to the folder containing the package_. The error message for the former is the unhelpful `No candidate version available for <PackageName>`.

This also makes it clear that packages can be installed from UNC.