### PR TITLE
Add important notice about postgres subnet config

### DIFF
--- a/chef_master/source/install_server_ha.rst
+++ b/chef_master/source/install_server_ha.rst
@@ -326,6 +326,8 @@ which would result in the following two entries being added to the ``pg_hba.conf
 
 Running ``chef-backend-ctl reconfigure`` on all the backends will allow that frontend to complete its connection.
 
+.. important:: All members of both the frontends and backend clusters MUST contain identical sets of the ``postgresql.md5_auth_cidr_addresses`` subnet rules set for all systems, frontend and backend. This guarantees that when a cluster change of state occurs, all members can still speak with one another as needed. Any other configuration is at risk of having unsuccessful failovers where followers are unable to communicate with the new leader, or the frontend cluster is unable to communicate with the new leader.
+
 Cluster Security Considerations
 ===============================
 


### PR DESCRIPTION
Add an extended explanation of why postgres subnet rules for frontend/backend access should be replicated identically throughout the cluster.