### PR TITLE
Add warning to LDAP settings for AD requirements

### DIFF
--- a/chef_master/source/config_rb_server_optional_settings.rst
+++ b/chef_master/source/config_rb_server_optional_settings.rst
@@ -456,6 +456,15 @@ ldap
 -----------------------------------------------------
 .. tag config_rb_server_settings_ldap
 
+.. warning:: The following settings **MUST** be in the config file for LDAP authentication to Active Directory to work:
+
+   - ``base_dn``
+   - ``bind_dn``
+   - ``group_dn``
+   - ``host``
+
+   If those settings are missing, you will get authentication errors and be unable to proceed.
+
 This configuration file has the following settings for ``ldap``:
 
 ``ldap['base_dn']``

--- a/chef_master/source/install_server_post.rst
+++ b/chef_master/source/install_server_post.rst
@@ -31,6 +31,15 @@ To configure the Chef server to use Active Directory or LDAP do the following:
 
    .. tag config_rb_server_settings_ldap
 
+   .. warning:: The following settings **MUST** be in the config file for LDAP authentication to Active Directory to work:
+
+      - ``base_dn``
+      - ``bind_dn``
+      - ``group_dn``
+      - ``host``
+
+      If those settings are missing, you will get authentication errors and be unable to proceed.
+
    This configuration file has the following settings for ``ldap``:
 
    ``ldap['base_dn']``

--- a/chef_master/source/server_ldap.rst
+++ b/chef_master/source/server_ldap.rst
@@ -31,6 +31,15 @@ To configure the Chef server to use Active Directory or LDAP do the following:
 
    .. tag config_rb_server_settings_ldap
 
+   .. warning:: The following settings **MUST** be in the config file for LDAP authentication to Active Directory to work:
+
+      - ``base_dn``
+      - ``bind_dn``
+      - ``group_dn``
+      - ``host``
+
+      If those settings are missing, you will get authentication errors and be unable to proceed.
+
    This configuration file has the following settings for ``ldap``:
 
    ``ldap['base_dn']``


### PR DESCRIPTION
When setting up the LDAP integration to Active Directory, certain settings are *required*.
The documentation now includes clear instructions areound which settings are absolutely
required for the binding.