### PR TITLE
Updated deprecation/removed warning to the supports property.

### DIFF
--- a/chef_master/source/resource_common.rst
+++ b/chef_master/source/resource_common.rst
@@ -79,11 +79,12 @@ The following properties are common to every resource:
    Ensure that sensitive resource data is not logged by the chef-client. Default value: ``false``. This property only applies to the **execute**, **file** and **template** resources.
 
 ``supports``
+   .. warning:: This property was deprecated in Chef 12.14 and removed in Chef 13.0.
+
    **Ruby Type:** Hash
 
    A hash of options that contains hints about the capabilities of a resource. The chef-client may use these hints to help identify the correct provider. This property is only used by a small number of providers, including **user** and **service**.
-   
-   .. note:: This property was deprecated in Chef 12.14 and removed in Chef 13.0.
+
 
 .. end_tag
 

--- a/chef_master/source/resource_common.rst
+++ b/chef_master/source/resource_common.rst
@@ -82,6 +82,8 @@ The following properties are common to every resource:
    **Ruby Type:** Hash
 
    A hash of options that contains hints about the capabilities of a resource. The chef-client may use these hints to help identify the correct provider. This property is only used by a small number of providers, including **user** and **service**.
+   
+   .. note:: This property was deprecated in Chef 12.14 and removed in Chef 13.0.
 
 .. end_tag
 

--- a/chef_master/source/resources.rst
+++ b/chef_master/source/resources.rst
@@ -113,9 +113,12 @@ The following properties are common to every resource:
    Ensure that sensitive resource data is not logged by the chef-client. Default value: ``false``. This property only applies to the **execute**, **file** and **template** resources.
 
 ``supports``
+   .. warning:: This property was deprecated in Chef 12.14 and removed in Chef 13.0.
+
    **Ruby Type:** Hash
 
    A hash of options that contains hints about the capabilities of a resource. The chef-client may use these hints to help identify the correct provider. This property is only used by a small number of providers, including **user** and **service**.
+
 
 .. end_tag
 


### PR DESCRIPTION
This is mentioned on the deprecation page but hasn't been updated for this page. I'm not sure what the right mechanism to label this property as deprecated is but I gave this a go. Correct it if this isn't appropriate. It could be deleted as well but that might not provide information to folks as to what happened if they look at this page first. 