### PR TITLE
Update ctl_automate_server.rst

### DIFF
--- a/chef_master/source/ctl_automate_server.rst
+++ b/chef_master/source/ctl_automate_server.rst
@@ -327,7 +327,7 @@ The ``install-runner`` subcommand configures a remote node as a job runner, whic
 
 .. note:: The username provided must be a user who has sudo access on the remote node. If the user is a member of a domain, then the username value should be entered as ``user@domain``.
 .. note:: At least one of ``--password [PASSWORD]`` or ``--ssh-identity-file FILE`` are necessary for ssh access.
-.. note:: ``knife bootstrap`` is used underneath so custom configurations can be installed on the runner by using the ``client.d`` copying feature. All config files inside ``client.d`` directory are loaded and get copied into ``/etc/chef/client.rb``.
+.. note:: ``knife bootstrap`` is used underneath so custom configurations can be installed on the runner by using the ``client.d`` copying feature. All config files inside ``~/.chef/client.d`` directory on the Automate server get copied into ``/etc/chef/client.d`` on the runner.
 
 **Example**
 

--- a/chef_master/source/ctl_automate_server.rst
+++ b/chef_master/source/ctl_automate_server.rst
@@ -327,7 +327,7 @@ The ``install-runner`` subcommand configures a remote node as a job runner, whic
 
 .. note:: The username provided must be a user who has sudo access on the remote node. If the user is a member of a domain, then the username value should be entered as ``user@domain``.
 .. note:: At least one of ``--password [PASSWORD]`` or ``--ssh-identity-file FILE`` are necessary for ssh access.
-.. note:: ``knife bootstrap`` is used underneath so custom configurations can be installed on the runner by using the ``client.d`` copying feature. All config files inside ``~/.chef/client.d`` directory on the Automate server get copied into ``/etc/chef/client.d`` on the runner.
+.. note:: ``knife bootstrap`` is used underneath so custom configurations can be installed on the runner by using the :doc:`client.d copying feature </knife_bootstrap.html>`. All config files inside ``~/.chef/client.d`` directory on the Automate server get copied into ``/etc/chef/client.d`` on the runner.
 
 **Example**
 

--- a/chef_master/source/ctl_automate_server.rst
+++ b/chef_master/source/ctl_automate_server.rst
@@ -327,7 +327,7 @@ The ``install-runner`` subcommand configures a remote node as a job runner, whic
 
 .. note:: The username provided must be a user who has sudo access on the remote node. If the user is a member of a domain, then the username value should be entered as ``user@domain``.
 .. note:: At least one of ``--password [PASSWORD]`` or ``--ssh-identity-file FILE`` are necessary for ssh access.
-.. note:: ``knife bootstrap`` is used underneath so custom configurations can be installed on the runner by using the :doc:`client.d copying feature </knife_bootstrap.html>`. All config files inside ``~/.chef/client.d`` directory on the Automate server get copied into ``/etc/chef/client.d`` on the runner.
+.. note:: ``install-runner`` calls the ``knife bootstrap`` subcommand to configure the runner, so custom configurations can be installed on the runner by using the :doc:`client.d copying feature </knife_bootstrap>`. All config files inside ``~/.chef/client.d`` directory on the Chef Automate server get copied into the ``/etc/chef/client.d`` directory on the runner.
 
 **Example**
 


### PR DESCRIPTION
Files in `~/.chef/client.d` get copied to the runner's `/etc/chef/client.d` directory