### PR TITLE
Chef Vault incompatible with old-style client cert

### DIFF
--- a/chef_master/source/chef_vault.rst
+++ b/chef_master/source/chef_vault.rst
@@ -8,17 +8,18 @@ chef-vault is a RubyGems package that is included in the Chef development kit. c
 * For more information about the knife subcommands, its arguments, and other uses, see https://github.com/chef/chef-vault
 * For more information about using the ``chef-vault`` cookbook, its helper methods and resources, see https://github.com/chef-cookbooks/chef-vault
 
-.. warning:: chef-vault client certificate incompatibility
+The ``chef-vault`` cookbook is maintained by Chef. Use it along with chef-vault itself. This cookbook adds the ``chef_vault_item`` helper method to the Recipe DSL and the ``chef_vault_secret`` resource. Use them both in recipes to work with data bag secrets.
 
-   Chef-vault was written after having a chef-client with a private key in client.pem and a certificate set as it's public   identity in the Chef Server database had fallen out of fashion. Because of this, please only use chef-clients configured to  use a private/public keypair with chef-vault. By doing so, you will avoid an error that looks like this when the chef-vault  program tries to use the older style certificate auth content. You will need to reregister any chef-client systems using this  old auth method so that they can generate a private/public keypair and participate in a chef-vault installation.
+.. warning:: 
+
+   Chef vault is incompatible with the practice of using chef-client with a private key as ``client.pem`` and a certificate set as its public identity in the Chef server database. Chef vault requires the use of chef-client configured to use public/private key pairs. To update existing nodes to use chef-vault, first re-register your chef-client nodes with the Chef server, which will generate public/private key pairs, and then install Chef vault on each node. Chef vault will generate the following error if used with a chef-client with a private key as ``client.pem`` and a certificate set as its public identity in the Chef server database:
 
    .. code-block:: none
-   
+
       OpenSSL::PKey::RSAError
       -----------------------
       Neither PUB key nor PRIV key:: nested asn1 error
-   
-The ``chef-vault`` cookbook is maintained by Chef. Use it along with chef-vault itself. This cookbook adds the ``chef_vault_item`` helper method to the Recipe DSL and the ``chef_vault_secret`` resource. Use them both in recipes to work with data bag secrets.
+
 
 Options for knife bootstrap
 =====================================================

--- a/chef_master/source/chef_vault.rst
+++ b/chef_master/source/chef_vault.rst
@@ -8,6 +8,16 @@ chef-vault is a RubyGems package that is included in the Chef development kit. c
 * For more information about the knife subcommands, its arguments, and other uses, see https://github.com/chef/chef-vault
 * For more information about using the ``chef-vault`` cookbook, its helper methods and resources, see https://github.com/chef-cookbooks/chef-vault
 
+.. warning:: chef-vault client certificate incompatibility
+
+   Chef-vault was written after having a chef-client with a private key in client.pem and a certificate set as it's public   identity in the Chef Server database had fallen out of fashion. Because of this, please only use chef-clients configured to  use a private/public keypair with chef-vault. By doing so, you will avoid an error that looks like this when the chef-vault  program tries to use the older style certificate auth content. You will need to reregister any chef-client systems using this  old auth method so that they can generate a private/public keypair and participate in a chef-vault installation.
+
+   .. code-block:: none
+   
+      OpenSSL::PKey::RSAError
+      -----------------------
+      Neither PUB key nor PRIV key:: nested asn1 error
+   
 The ``chef-vault`` cookbook is maintained by Chef. Use it along with chef-vault itself. This cookbook adds the ``chef_vault_item`` helper method to the Recipe DSL and the ``chef_vault_secret`` resource. Use them both in recipes to work with data bag secrets.
 
 Options for knife bootstrap


### PR DESCRIPTION
Chef Vault does not work with old-style chef-client certs, only with current public/private keypairs