### PR TITLE
Clear up the text for converge_by

### DIFF
--- a/chef_master/source/custom_resources_notes.rst
+++ b/chef_master/source/custom_resources_notes.rst
@@ -181,9 +181,9 @@ If you do need to write code which mutates the system through pure-Ruby then you
      end
    end
 
-The ``converge_by`` block gets why-run correct and will just touch "/tmp/foo" instead of actually doing it. The ``converge_by`` block is also responsible for setting ``update_by_last_action``.
+The ``converge_by`` block gets why-run correct and will print to ``Chef::Log.info`` "touch /tmp/foo" and not run ``::FileUtils.touch "/tmp/foo"``. The ``converge_by`` block is also responsible for setting ``update_by_last_action``.
 
-In order to use ``converge_by`` correctly you must ensure that you wrap the ``converge_by`` with an idempotency check otherwise your resource will be updated every time it is used and will always fire notifications on every run.
+The ``converge_by`` block does not deal with idempotency and will set the ``update_by_last_action`` to ``true`` everytime the block executes.  By wrapping this block with an idempotency check like ``converge_if_changed`` or ``unless File.exist?("/tmp/foo")`` this will stop ``update_by_last_action`` from being set.
 
 .. code-block:: ruby
 

--- a/chef_master/source/custom_resources_notes.rst
+++ b/chef_master/source/custom_resources_notes.rst
@@ -183,11 +183,9 @@ If you do need to write code which mutates the system through pure-Ruby then you
 
 When the ``converge_by`` block is run in why-run mode, it will only log ``touch "/tmp/foo"`` and will not run the code inside the block. 
 
-The ``converge_by`` block does not do any checking for idempotency and always sets ``updated_by_last_action``.  A
-``converge_by`` block that is not wrapped in an idempotency check will always cause the resource to be updated, and
-will always cause notifications to fire.  A properly written resource should wrap all ``converge_by`` checks with an
-idempotency check, or the [``converge_if_changed``](https://github.com/chef/chef-web-docs/blob/master/chef_master/source/custom_resources.rst#converge_if_changed) block should be used instead.   As the ``converge_if_changed`` API
-wraps a ``converge_by`` block with an idempotency check for you.
+A ``converge_by`` block that is not wrapped in an idempotency check will always cause the resource to be updated,
+and will always cause notifications to fire.  To prevent this, a properly written resource should wrap all
+``converge_by`` checks with an  idempotency check.  The [``converge_if_changed``](https://github.com/chef/chef-web-docs/blob/master/chef_master/source/custom_resources.rst#converge_if_changed) block may be used instead  which will wrap a ``converge_by`` block with an idempotency check for you.
 
 .. code-block:: ruby
 

--- a/chef_master/source/custom_resources_notes.rst
+++ b/chef_master/source/custom_resources_notes.rst
@@ -183,7 +183,11 @@ If you do need to write code which mutates the system through pure-Ruby then you
 
 When the ``converge_by`` block is run in why-run mode, it will only log ``touch "/tmp/foo"`` and will not run the code inside the block. 
 
-The ``converge_by`` block is also responsible for setting ``update_by_last_action``, however it does not deal with idempotency and will set the ``update_by_last_action`` to ``true`` everytime the block runs.  By wrapping this block with an idempotency check like ``converge_if_changed`` or ``unless File.exist?("/tmp/foo")`` this will stop ``update_by_last_action`` from being set.
+The ``converge_by`` block does not do any checking for idempotency and always sets ``updated_by_last_action``.  A
+``converge_by`` block that is not wrapped in an idempotency check will always cause the resource to be updated, and
+will always cause notifications to fire.  A properly written resource should wrap all ``converge_by`` checks with an
+idempotency check, or the ``converge_if_changed`` API should be used instead.   As the ``converge_if_changed`` API
+wraps a ``converge_by`` block with an idempotency check for you.
 
 .. code-block:: ruby
 

--- a/chef_master/source/custom_resources_notes.rst
+++ b/chef_master/source/custom_resources_notes.rst
@@ -186,7 +186,7 @@ When the ``converge_by`` block is run in why-run mode, it will only log ``touch 
 The ``converge_by`` block does not do any checking for idempotency and always sets ``updated_by_last_action``.  A
 ``converge_by`` block that is not wrapped in an idempotency check will always cause the resource to be updated, and
 will always cause notifications to fire.  A properly written resource should wrap all ``converge_by`` checks with an
-idempotency check, or the ``converge_if_changed`` API should be used instead.   As the ``converge_if_changed`` API
+idempotency check, or the [``converge_if_changed``](https://github.com/chef/chef-web-docs/blob/master/chef_master/source/custom_resources.rst#converge_if_changed) block should be used instead.   As the ``converge_if_changed`` API
 wraps a ``converge_by`` block with an idempotency check for you.
 
 .. code-block:: ruby

--- a/chef_master/source/custom_resources_notes.rst
+++ b/chef_master/source/custom_resources_notes.rst
@@ -181,9 +181,9 @@ If you do need to write code which mutates the system through pure-Ruby then you
      end
    end
 
-The ``converge_by`` block gets why-run correct and will print to ``Chef::Log.info`` "touch /tmp/foo" and not run ``::FileUtils.touch "/tmp/foo"``. The ``converge_by`` block is also responsible for setting ``update_by_last_action``.
+When the ``converge_by`` block is run in why-run mode, it will only log ``touch "/tmp/foo"`` and will not run the code inside the block. 
 
-The ``converge_by`` block does not deal with idempotency and will set the ``update_by_last_action`` to ``true`` everytime the block executes.  By wrapping this block with an idempotency check like ``converge_if_changed`` or ``unless File.exist?("/tmp/foo")`` this will stop ``update_by_last_action`` from being set.
+The ``converge_by`` block is also responsible for setting ``update_by_last_action``, however it does not deal with idempotency and will set the ``update_by_last_action`` to ``true`` everytime the block runs.  By wrapping this block with an idempotency check like ``converge_if_changed`` or ``unless File.exist?("/tmp/foo")`` this will stop ``update_by_last_action`` from being set.
 
 .. code-block:: ruby
 


### PR DESCRIPTION
Importantly removed it would `touch the file` which is what doesn't happen during a dry run.
To make it clear that `converge_by` doesn't deal with idempotency and is instead useful for `why-run`.

Peer-documented @iennae
Review Requested to @lamont-granquist