### PR TITLE
Added info on updating runners

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -2124,9 +2124,9 @@
             "url": "/publish_cookbooks_multiple_servers.html"
           },
           {
-            "title": "Job Dispatch",
+            "title": "Runners",
             "hasSubItems": false,
-            "url": "/job_dispatch.html"
+            "url": "/runners.html"
           }
         ]
       },

--- a/chef_master/source/config_json_delivery.rst
+++ b/chef_master/source/config_json_delivery.rst
@@ -119,7 +119,7 @@ The behavior of pipeline phases can be customized using the project's ``config.j
 ``job_dispatch``
    **Optional**
 
-   The ``job_dispatch`` setting is needed to use the :doc:`improved SSH job dispatch system </job_dispatch>`. If you use this setting, you must remove any ``build_nodes`` settings from your configuration file.
+   The ``job_dispatch`` setting is needed to use the :doc:`improved SSH job dispatch system </runners>`. If you use this setting, you must remove any ``build_nodes`` settings from your configuration file.
 
    * ``"version"``
      Set the value to "v2" if you wish to use runners and the new job dispatch system:

--- a/chef_master/source/ctl_automate_server.rst
+++ b/chef_master/source/ctl_automate_server.rst
@@ -292,7 +292,7 @@ This subcommand has the following syntax:
 
 install-runner
 =====================================================
-The ``install-runner`` subcommand configures a remote node as a job runner, which are used by Chef Automate to run phase jobs. For more information on runners, please see :doc:`job_dispatch`.
+The ``install-runner`` subcommand configures a remote node as a job runner, which are used by Chef Automate to run phase jobs. For more information on runners, please see :doc:`runners`.
 
 **Syntax**
 

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -267,10 +267,10 @@ Workflow DSL
 
 :doc:`Workflow DSL </dsl_delivery>`
 
-Job Dispatch
+Runners
 -----------------------------------------------------
 
-:doc:`Job Dispatch </job_dispatch>`
+:doc:`Runners </runners>`
 
 Managing the Server
 -----------------------------------------------------
@@ -532,7 +532,6 @@ Addenda
    deprecations_verify_file
    dsl_custom_resource
    dsl_delivery
-   job_dispatch
    dsl_handler
    dsl_recipe
    elasticsearch_and_kibana_auth
@@ -746,6 +745,7 @@ Addenda
    roles
    ruby
    run_lists
+   runners
    runbook
    search_query_chef_automate
    secrets

--- a/chef_master/source/install_chef_automate.rst
+++ b/chef_master/source/install_chef_automate.rst
@@ -363,7 +363,7 @@ The following steps show how to set up a runner from a Chef Automate server. For
  
    .. important:: The ``install-runner`` command will create a new file called ``job_runner`` in the ``/etc/sudoers.d`` directory to give the runner the appropriate ``sudo`` access. If your runner does not have the ``#includedir /etc/sudoers.d`` directive included in its ``/etc/sudoers`` file, you must put that directive in before you run the ``install-runner`` command.
 
-   .. note:: You can optionally download the latest ChefDK from `<https://downloads.chef.io/chefdk/>`_ to specify a local package via ``--installer``. Doing so is useful if you are in an air-gapped environment. Version 0.15.16 or greater of the ChefDK is required. The download location is referred to below as ``OPTIONAL_CHEF_DK_PACKAGE_PATH``.
+   .. note:: You can optionally download the latest ChefDK from `<https://downloads.chef.io/chefdk/>`_ to specify a local package via ``--installer``. Doing so is useful if you are in an air-gapped environment. Version 0.15.16 or greater of the ChefDK is required. The download location is referred to below as ``OPTIONAL_CHEF_DK_PACKAGE_PATH``. This option cannot be used with the ``--chef-dk-version`` as the version of the local package will be used. 
 
    .. code-block:: bash
 
@@ -372,11 +372,14 @@ The following steps show how to set up a runner from a Chef Automate server. For
                                   [--password OPTIONAL_SSH_OR_SUDO_PASSWORD] \
                                   [--installer OPTIONAL_CHEF_DK_PACKAGE_PATH] \
                                   [--ssh-identity-file OPTIONAL_SSH_IDENTITY_FILE] \
+                                  [--chef-dk-version VERSION] \
                                   [--port SSH_PORT]
 
    The ``SSH_USERNAME`` provided must have ``sudo`` access on the intended runner, and at least one of ``--password PASSWORD`` or ``--ssh-identity-file FILE`` is required by Chef Automate in order to communicate with it.
 
-   For more ``install-runner`` usage examples, see :ref:`install-runner`, and for more information on the SSH-based job dispatch system, see :doc:`job_dispatch`.
+   If you require a specific version of the ChefDK to be downloaded and installed on your runners, you can specify it in the ``--chef-dk-version`` option. This is useful if your cookbooks are not compatible the Chef client that comes with the latest version of the ChefDK.
+
+   For more ``install-runner`` usage examples, see :ref:`install-runner`, and for more information on runners and the SSH-based job dispatch system, see :doc:`runners`.
 
    .. tag chef_automate_build_nodes
 

--- a/chef_master/source/release_notes_chef_automate.rst
+++ b/chef_master/source/release_notes_chef_automate.rst
@@ -80,7 +80,7 @@ There is a new ``automate-ctl`` command that issues a temporary token and URL to
 Support for macOS Runners
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Chef Automate can now support runners for workflow job dispatch on macOS 10.12. Installation follows the same `procedure </job_dispatch.html#adding-a-runner>`_ as Linux runners. Note that macOS is not a supported platform for the Chef Automate server.
+Chef Automate can now support runners for workflow job dispatch on macOS 10.12. Installation follows the same `procedure </runners.html#adding-a-runner>`_ as Linux runners. Note that macOS is not a supported platform for the Chef Automate server.
 
 Anonymized Usage Tracking
 +++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/chef_master/source/release_notes_chefdk.rst
+++ b/chef_master/source/release_notes_chefdk.rst
@@ -131,7 +131,7 @@ Policyfiles
 Automate Workflow Adopts SSH for Cookbook Generation
 -----------------------------------------------------
 
-The ``chef generate cookbook`` command now uses the SSH based job dispatch system as its default behavior. For more details on this new system and how to use it, see `Job Dispatch Docs <https://docs.chef.io/job_dispatch.html>`_
+The ``chef generate cookbook`` command now uses the SSH based job dispatch system as its default behavior. For more details on this new system and how to use it, see `Job Dispatch Docs <https://docs.chef.io/runners.html>`_
 
 FIPS (Windows and RHEL only)
 -----------------------------------------------------

--- a/chef_master/source/runners.rst
+++ b/chef_master/source/runners.rst
@@ -1,32 +1,13 @@
 =====================================================
-Job Dispatch
+Runners
 =====================================================
-`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/job_dispatch.rst>`__
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/runners.rst>`__
 
 .. tag runner_summary
 
 Chef Automate's workflow engine automatically creates phase jobs as project code is promoted through the phases of a workflow pipeline. These phase jobs are dispatched to special nodes, called runners, that automatically execute each job as it is created.
 
 .. end_tag
-
-Recent Changes
---------------
-
-Chef Automate release 0.6.0 includes a new SSH-based job execution layer. Under the new system, you can more easily:
-
-- Add and remove runners
-- Cancel running phase jobs
-- View the queue of jobs in the Chef Automate UI
-- View and test runner status via the Chef Automate UI
-
-Job Dispatch and Push Jobs
------------------------------------------------------
-
-Any project configured to use Job Dispatch will not use Push Jobs as the transport mechanism for managing the phase builds (unit, lint, provision, etc.) on runner nodes. Push Jobs is still required to execute the `delivery_push_job` resource that the delivery-sugar cookbook exposes. This means that if you use the default `deploy.rb  <https://github.com/chef-cookbooks/delivery-truck/blob/b9e386e720376f7f3173ca03311cba667eb7ef4b/recipes/deploy.rb>`__ recipe from delivery-truck then Push Jobs is still used within the deploy phase.
-
-Job Dispatch is not a replacement for Push Jobs. Job Dispatch is a targeted solution for managing phase builds and Push Jobs allows users to perform remote tasks on pools of nodes. Job Dispatch uses SSH connections and allows additional features, such as cancelling jobs. 
-
-
 
 Terms
 =====================================================
@@ -43,13 +24,15 @@ Managing Runners
 Adding a Runner
 -----------------------------------------------------
 
-You can add a new runner via automate-ctl from your Chef Automate server. Log in to your Chef Automate server and run the :ref:`install-runner` command.
+You can add a new runner via ``automate-ctl`` from your Chef Automate server. Log in to your Chef Automate server and run the :ref:`install-runner` command.
+
+.. note:: You can pin to a specific ChefDK version through the ``--chef-dk-version`` option on the ``install-runner`` command or by using a version of the ChefDK that you have installed locally on your Chef Automate server using the ``-I`` option. As an example, this is useful if you have not upgraded your cookbooks to be Chef 13 compliant and the latest version of the ChefDK installs Chef 13 on your runner.
 
 After the :ref:`install-runner` command succeeds, the new runner should show up in the UI under ``Workflow -> Runners -> Manage Runners``. If you see it there, click the ``Test`` button. That will test an ssh connection to your runner to verify that jobs can be dispatched to it. If there are any issues, you should get an error in the UI.
 
 Supported runner platforms are listed `here </platforms.html#runners>`_. 
 
-Remove a Runner
+Removing a Runner
 -----------------------------------------------------
 
 To remove a runner, you will need to use the :ref:`delivery-cli-api` command.
@@ -68,10 +51,19 @@ To delete a runner:
 
 For a full list of additional options, refer to the :ref:`delivery-cli-api` documentation.
 
-Configuring Chef Automate Projects for Job Dispatch
-=====================================================
+.. _upgrade_dk_runner:
 
-To setup a Chef Automate project to use the SSH-based job dispatch system, you must edit its :doc:`config.json </config_json_delivery>`.
+Upgrading the version of ChefDK on a Runner
+-----------------------------------------------------
+
+If you need to upgrade the version of ChefDK on your runner, you can do so by logging into the runner, upgrading the ChefDK, and manually appending the Chef Automate server certificate to the cert file that ships in the ChefDK. 
+
+Typically, we recommend re-running the ``install-runner`` command rather than manually updating as the installation process will take care of this certification change for you when it bootstraps the node.
+
+Configuring Chef Automate Projects
+===================================
+
+Chef Automate 0.6 or later can use runners, and when setting up a project using ``delivery setup``, ChefDK v1.1.16 or later specifies the use of runners in the ``./delivery/config.json`` file. If you are running an older version of ChefDK, or your ``config.json`` was set up to use push jobs-based build nodes, you must edit the file in the following manner:
 
 At the bare minimum, you must set the version to v2:
 
@@ -95,6 +87,9 @@ and remove the ``build_nodes`` setting from ``config.json``.
 
 You can also set which runners you want jobs to run on for your project. You can set default, per phase, and matrix per phase filters to customize exactly which runners are targeted at various points of your pipeline. Refer to :ref:`job_dispatch config setting <job-dispatch-config-settings>` for more details and examples.
 
+For more detail on ``config.json``, see its :doc:`config.json </config_json_delivery>` .
+
+
 Cancelling Jobs
 =====================================================
 
@@ -104,3 +99,10 @@ Managing and Inspecting Jobs
 =====================================================
 
 You can see the job queue, runnning jobs, what your runners are currently doing, runner health, and so on. Navigate to `Workflow -> Runners` in the UI to see all the possibilities.
+
+Job Dispatch and Push Jobs
+=====================================================
+
+Any project configured to use runners will not use Push Jobs as the transport mechanism for managing the phase builds (unit, lint, provision, etc.). Push Jobs is still required to execute the `delivery_push_job` resource that the delivery-sugar cookbook exposes. This means that if you use the default `deploy.rb  <https://github.com/chef-cookbooks/delivery-truck/blob/b9e386e720376f7f3173ca03311cba667eb7ef4b/recipes/deploy.rb>`__ recipe from delivery-truck, then Push Jobs is still used within the deploy phase.
+
+The SSH-based Job Dispatch system used with runners is not a replacement for Push Jobs. Job Dispatch is a targeted solution for managing phase builds and Push Jobs allows users to perform remote tasks on pools of nodes. Job Dispatch uses SSH connections and allows additional features, such as cancelling jobs. 

--- a/config/redirects.json
+++ b/config/redirects.json
@@ -4888,5 +4888,6 @@
   "compliance.html": "/chef_compliance.html",
   "ctl_delivery_server.html": "/ctl_automate_server.html",
   "api_delivery.html": "/api_automate.html",
-  "integrate_compliance_chef_automate.html": "/perform_compliance_scan.html"
+  "integrate_compliance_chef_automate.html": "/perform_compliance_scan.html",
+  "job_dispatch.html": "/runners.html"
 }


### PR DESCRIPTION
- Included info on pinning to a ChefDK version when bootstrapping runners
- Did job_dispatch -> runner file rename

Signed-off-by: David Wrede <dwrede@chef.io>