### PR TITLE
Correct error in `solaris_package` resource docs.

### DIFF
--- a/chef_master/source/resource_examples.rst
+++ b/chef_master/source/resource_examples.rst
@@ -6337,6 +6337,7 @@ The **solaris_package** resource is used to manage packages for the Solaris plat
 .. code-block:: ruby
 
    solaris_package 'name of package' do
+     source '/packages_directory'
      action :install
    end
 

--- a/chef_master/source/resource_solaris_package.rst
+++ b/chef_master/source/resource_solaris_package.rst
@@ -69,6 +69,11 @@ Properties
 =====================================================
 This resource has the following properties:
 
+``source``
+   **Ruby Type:** String
+
+   Required. The path to a package in the local file system.
+
 ``ignore_failure``
    **Ruby Types:** TrueClass, FalseClass
 
@@ -132,11 +137,6 @@ This resource has the following properties:
    **Ruby Type:** Integer
 
    The retry delay (in seconds). Default value: ``2``.
-
-``source``
-   **Ruby Type:** String
-
-   Optional. The path to a package in the local file system.
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -222,6 +222,7 @@ The following examples demonstrate various approaches for using resources in rec
 .. code-block:: ruby
 
    solaris_package 'name of package' do
+     source '/packages_directory'
      action :install
    end
 


### PR DESCRIPTION
According to git, the `source` property has been required for the `solaris_package` resource since Chef 10.14.0. This updates the document by making it consistent with the code expectations.