### PR TITLE
Secrets loaded with IO.read need newline characters stripped

### DIFF
--- a/chef_master/source/data_bags.rst
+++ b/chef_master/source/data_bags.rst
@@ -549,7 +549,7 @@ To load the secret from a file:
 
 .. code-block:: ruby
 
-   data_bag_item('bag', 'item', IO.read('secret_file'))
+   data_bag_item('bag', 'item', IO.read('secret_file').strip)
 
 To load a single data bag item named ``admins``:
 

--- a/chef_master/source/data_bags.rst
+++ b/chef_master/source/data_bags.rst
@@ -549,6 +549,12 @@ To load the secret from a file:
 
 .. code-block:: ruby
 
+   data_bag_item('bag', 'item', IO.read('secret_file'))
+
+Appending ``.strip`` will remove newline characters from your encrypted secret. To load the secret from a file, and remove newline characters:
+
+.. code-block:: ruby
+
    data_bag_item('bag', 'item', IO.read('secret_file').strip)
 
 To load a single data bag item named ``admins``:

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -7509,6 +7509,12 @@ To load the secret from a file:
 
    data_bag_item('bag', 'item', IO.read('secret_file'))
 
+Appending ``.strip`` will remove newline characters from your encrypted secret. To load the secret from a file, and remove newline characters:
+
+.. code-block:: ruby
+
+   data_bag_item('bag', 'item', IO.read('secret_file').strip)
+
 To load a single data bag item named ``admins``:
 
 .. code-block:: ruby

--- a/chef_master/source/secrets.rst
+++ b/chef_master/source/secrets.rst
@@ -555,6 +555,12 @@ To load the secret from a file:
 
    data_bag_item('bag', 'item', IO.read('secret_file'))
 
+Appending ``.strip`` will remove newline characters from your encrypted secret. To load the secret from a file, and remove newline characters:
+
+.. code-block:: ruby
+
+   data_bag_item('bag', 'item', IO.read('secret_file').strip)
+
 To load a single data bag item named ``admins``:
 
 .. code-block:: ruby


### PR DESCRIPTION
Encrypted data bag secrets can contain newline characters that need to be removed in order to successfully load the data bag item.