### PR TITLE
Have data_bag_item use Chef::EncryptedDataBagItem.load_secret instead…

### DIFF
--- a/chef_master/source/data_bags.rst
+++ b/chef_master/source/data_bags.rst
@@ -549,7 +549,7 @@ To load the secret from a file:
 
 .. code-block:: ruby
 
-   data_bag_item('bag', 'item', IO.read('secret_file'))
+   data_bag_item('bag', 'item', Chef::EncryptedDataBagItem.load_secret(secret_file))
 
 To load a single data bag item named ``admins``:
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -7507,7 +7507,7 @@ To load the secret from a file:
 
 .. code-block:: ruby
 
-   data_bag_item('bag', 'item', IO.read('secret_file'))
+   data_bag_item('bag', 'item', Chef::EncryptedDataBagItem.load_secret(secret_file))
 
 To load a single data bag item named ``admins``:
 

--- a/chef_master/source/secrets.rst
+++ b/chef_master/source/secrets.rst
@@ -553,7 +553,7 @@ To load the secret from a file:
 
 .. code-block:: ruby
 
-   data_bag_item('bag', 'item', IO.read('secret_file'))
+   data_bag_item('bag', 'item', Chef::EncryptedDataBagItem.load_secret(secret_file))
 
 To load a single data bag item named ``admins``:
 


### PR DESCRIPTION
… of IO.read

A small change to use the load_secret method, which supports both IO.Read, and well as Kernel.open for remote key support.

Signed-off-by: Josh Hudson <jhudson@chef.io>