### PR TITLE
Revert "Secrets loaded with IO.read need newline characters stripped"

### DIFF
--- a/chef_master/source/data_bags.rst
+++ b/chef_master/source/data_bags.rst
@@ -551,12 +551,6 @@ To load the secret from a file:
 
    data_bag_item('bag', 'item', IO.read('secret_file'))
 
-Appending ``.strip`` will remove newline characters from your encrypted secret. To load the secret from a file, and remove newline characters:
-
-.. code-block:: ruby
-
-   data_bag_item('bag', 'item', IO.read('secret_file').strip)
-
 To load a single data bag item named ``admins``:
 
 .. code-block:: ruby

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -7509,12 +7509,6 @@ To load the secret from a file:
 
    data_bag_item('bag', 'item', IO.read('secret_file'))
 
-Appending ``.strip`` will remove newline characters from your encrypted secret. To load the secret from a file, and remove newline characters:
-
-.. code-block:: ruby
-
-   data_bag_item('bag', 'item', IO.read('secret_file').strip)
-
 To load a single data bag item named ``admins``:
 
 .. code-block:: ruby

--- a/chef_master/source/secrets.rst
+++ b/chef_master/source/secrets.rst
@@ -555,12 +555,6 @@ To load the secret from a file:
 
    data_bag_item('bag', 'item', IO.read('secret_file'))
 
-Appending ``.strip`` will remove newline characters from your encrypted secret. To load the secret from a file, and remove newline characters:
-
-.. code-block:: ruby
-
-   data_bag_item('bag', 'item', IO.read('secret_file').strip)
-
 To load a single data bag item named ``admins``:
 
 .. code-block:: ruby


### PR DESCRIPTION
Reverts chef/chef-web-docs#728