### PR TITLE
Document new chef-server-ctl set-secret option.

### DIFF
--- a/chef_master/source/ctl_chef_server.rst
+++ b/chef_master/source/ctl_chef_server.rst
@@ -680,6 +680,17 @@ There are various ways to pass the secret to this command:
       Enter ldap bind_password:    (no terminal output)
       Re-enter ldap bind_password: (no terminal output)
 
+**Options**
+
+.. tag ctl_chef_server_set_secret_options
+
+This subcommand has the following options:
+
+``--with-restart``
+    If any services depend on the secret being changed, attempt to restart them
+    after changing the secret.
+
+.. end_tag
 
 .. _ctl_chef_server_remove_secret:
 


### PR DESCRIPTION
Documentation for the new option added to `chef-server-ctl set-secret` in chef/chef-server#1313.