### PR TITLE
Switch from GCSE to Swiftype for site search

### DIFF
--- a/_templates/search.html
+++ b/_templates/search.html
@@ -1,35 +1,6 @@
 {% extends "layout.html" %}
 
-{# This is the script for the Google search box. #}
-
 {% set title = _('Search') %}
-
-{% block extrahead %}
-
-{{ super() }}
-<!-- Put the following javascript before the closing </head> tag. -->
-<script>
- (function() {
-   var cx = '002253161482252482270:qevo820vfhm';
-   var gcse = document.createElement('script');
-   gcse.type = 'text/javascript';
-   gcse.async = true;
-   gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
-       '//cse.google.com/cse.js?cx=' + cx;
-   var s = document.getElementsByTagName('script')[0];
-   s.parentNode.insertBefore(gcse, s);
- })();
-
-  setTimeout( function(){
-    $(".gsc-input").attr("placeholder", "Search");
-    $("input.gsc-search-button").attr("src", "");
-  }
- , 1000 );
-</script>
-
-
-{% endblock %}
-
 
 {% block body %}
 
@@ -41,8 +12,9 @@
 {% trans %}From here you can use a scoped Google search query to search all of the documentation about Chef that is located at docs.chef.io. (This page requires JavaScript be enabled to view the search box.){% endtrans %}
 </p>
 
-<!-- Place this tag where you want both of the search box and the search results to render -->
-<gcse:search defaultToRefinement="Chef Documentation" webSearchResultSetSize="20"></gcse:search>
+<input type="text" placeholder="Search" id="docs-search" name="q" class="st-default-search-input">
+
+<div class="st-search-container"></div>
 
 &nbsp;<br>
 &nbsp;<br>

--- a/_themes/chefv3/javascripts.html
+++ b/_themes/chefv3/javascripts.html
@@ -7,6 +7,17 @@
     HAS_SOURCE:  {{ has_source|lower }}
   };
 </script>
+
+<!-- Swiftype JS code snippet -->
+<script type="text/javascript">
+  (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
+  (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
+  e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
+  })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
+
+  _st('install','s1Pemn_yrUKJw9_K5zRT','2.0.0');
+</script>
+
 {%- for scriptfile in script_files %}
 <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
 {%- endfor %}

--- a/_themes/chefv3/nav-docs.html
+++ b/_themes/chefv3/nav-docs.html
@@ -2,11 +2,11 @@
   <ul class="nav-docs-items" id="nav-docs-list">
     <li class="main-item dark-item docs-search">
       <form action="/search.html" method="get">
-        <input type="text" placeholder="Search" id="docs-search" name="q">
+        <input type="text" placeholder="Search" id="docs-search" name="q" class="st-default-search-input">
         <input type="submit" class="submit-button" value="">
         <i class="fa fa-search icon-search"></i>
       </form>
-   
+
 
     </li>
     {% block leftnav %}

--- a/_themes/chefv3/static/chefv2.css_t
+++ b/_themes/chefv3/static/chefv2.css_t
@@ -671,7 +671,10 @@ nav.nav-main {
     border: 2px solid #e9ebec;
     color: #989fa4;
     display: inline-block;
-    width: 100%; }
+    width: 100%;
+    height: auto;
+    box-sizing: border-box;
+    border-radius: 0; }
   .nav-docs ::-webkit-input-placeholder {
     color: #989fa4; }
   .nav-docs :-moz-placeholder {
@@ -779,6 +782,15 @@ nav.nav-main {
   .sphinxsidebar > a.sphinxsidebar-ad > img {
     width: 100%;
     margin: 8px 0 1px; }
+
+input.st-default-search-input {
+  width: 100%;
+  height: auto;
+  box-sizing: border-box;
+  border-radius: 0; }
+
+.st-search-container {
+  margin-top: 20px; }
 
 .left {
   float: left; }

--- a/_themes/chefv3/static/scss/_nav-docs.scss
+++ b/_themes/chefv3/static/scss/_nav-docs.scss
@@ -61,6 +61,9 @@ $nav-docs-width: 260px;
     color: $input-text-color;
     display: inline-block;
     width: 100%;
+    height: auto;
+    box-sizing: border-box;
+    border-radius: 0;
   }
   ::-webkit-input-placeholder {
     color: $input-text-color;

--- a/_themes/chefv3/static/scss/_search.scss
+++ b/_themes/chefv3/static/scss/_search.scss
@@ -1,0 +1,10 @@
+input.st-default-search-input {
+  width: 100%;
+  height: auto;
+  box-sizing: border-box;
+  border-radius: 0;
+}
+
+.st-search-container {
+  margin-top: 20px;
+}

--- a/_themes/chefv3/static/scss/chef.scss
+++ b/_themes/chefv3/static/scss/chef.scss
@@ -1,7 +1,7 @@
 // TO COMPILE CSS
 // In command line switch to _themes/chefv3/static/ and run :
 // sass --watch scss/chef.scss:chefv2.css_t
-@import 'reset', 'config', 'sphinx', 'nav', 'nav-docs', 'sidebar-ad';
+@import 'reset', 'config', 'sphinx', 'nav', 'nav-docs', 'sidebar-ad', 'search';
 
 .left {
   float: left;


### PR DESCRIPTION
Since Google is deprecating Google Custom Search, we are switching
to Swiftype for our site search. This updates the necessary markup,
JS, and styles to make that happen.

![screen shot 2017-06-22 at 1 57 36 pm](https://user-images.githubusercontent.com/7217000/27455634-da769536-5752-11e7-99ef-43bfc6c5f7ae.png)

