### PR TITLE
Remove FIPS note that referred to an old release

### DIFF
--- a/chef_master/source/fips.rst
+++ b/chef_master/source/fips.rst
@@ -3,8 +3,6 @@ FIPS (Federal Information Processing Standards)
 ==================================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/fips.rst>`__
 
-.. warning:: There is a known issue on the Windows platform that prevents FIPS usage. If this would affect you, please continue to use ChefDK 1.2.22 until we resolve this issue with a patch release.
-
 What is FIPS?
 ==================================================================
 .. tag fips_intro


### PR DESCRIPTION
ChefDK 1.3.40 had a FIPS bug on Windows which was fixed in omnibus-software#823
and released ten days later in ChefDK 1.3.43. This note is cruft and should
have been removed then.