### PR TITLE
Minor grammatical correction for execute resource

### DIFF
--- a/chef_master/source/resource_execute.rst
+++ b/chef_master/source/resource_execute.rst
@@ -15,7 +15,7 @@ Changed in 12.19 to support windows alternate user identity in execute resources
 
 Syntax
 =====================================================
-A **execute** resource block typically executes a single command that is unique to the environment in which a recipe will run. Some **execute** resource commands are run by themselves, but often they are run in combination with other Chef resources. For example, a single command that is run by itself:
+An **execute** resource block typically executes a single command that is unique to the environment in which a recipe will run. Some **execute** resource commands are run by themselves, but often they are run in combination with other Chef resources. For example, a single command that is run by itself:
 
 .. code-block:: ruby
 


### PR DESCRIPTION
This is just a tiny change to make the first sentence in the Syntax section more grammatically correct. Please let me know if there is a separate standard that is followed that would make `A resource` more desirable/correct.