### PR TITLE
Change --chef-dk-version to --chefdk-version fix typo

### DIFF
--- a/chef_master/source/install_chef_automate.rst
+++ b/chef_master/source/install_chef_automate.rst
@@ -363,7 +363,7 @@ The following steps show how to set up a runner from a Chef Automate server. For
  
    .. important:: The ``install-runner`` command will create a new file called ``job_runner`` in the ``/etc/sudoers.d`` directory to give the runner the appropriate ``sudo`` access. If your runner does not have the ``#includedir /etc/sudoers.d`` directive included in its ``/etc/sudoers`` file, you must put that directive in before you run the ``install-runner`` command.
 
-   .. note:: You can optionally download the latest ChefDK from `<https://downloads.chef.io/chefdk/>`_ to specify a local package via ``--installer``. Doing so is useful if you are in an air-gapped environment. Version 0.15.16 or greater of the ChefDK is required. The download location is referred to below as ``OPTIONAL_CHEF_DK_PACKAGE_PATH``. This option cannot be used with the ``--chef-dk-version`` as the version of the local package will be used. 
+   .. note:: You can optionally download the latest ChefDK from `<https://downloads.chef.io/chefdk/>`_ to specify a local package via ``--installer``. Doing so is useful if you are in an air-gapped environment. Version 0.15.16 or greater of the ChefDK is required. The download location is referred to below as ``OPTIONAL_CHEF_DK_PACKAGE_PATH``. This option cannot be used with the ``--chefdk-version`` as the version of the local package will be used. 
 
    .. code-block:: bash
 
@@ -372,12 +372,12 @@ The following steps show how to set up a runner from a Chef Automate server. For
                                   [--password OPTIONAL_SSH_OR_SUDO_PASSWORD] \
                                   [--installer OPTIONAL_CHEF_DK_PACKAGE_PATH] \
                                   [--ssh-identity-file OPTIONAL_SSH_IDENTITY_FILE] \
-                                  [--chef-dk-version VERSION] \
+                                  [--chefdk-version VERSION] \
                                   [--port SSH_PORT]
 
    The ``SSH_USERNAME`` provided must have ``sudo`` access on the intended runner, and at least one of ``--password PASSWORD`` or ``--ssh-identity-file FILE`` is required by Chef Automate in order to communicate with it.
 
-   If you require a specific version of the ChefDK to be downloaded and installed on your runners, you can specify it in the ``--chef-dk-version`` option. This is useful if your cookbooks are not compatible the Chef client that comes with the latest version of the ChefDK.
+   If you require a specific version of the ChefDK to be downloaded and installed on your runners, you can specify it in the ``--chefdk-version`` option. This is useful if your cookbooks are not compatible the Chef client that comes with the latest version of the ChefDK.
 
    For more ``install-runner`` usage examples, see :ref:`install-runner`, and for more information on runners and the SSH-based job dispatch system, see :doc:`runners`.
 


### PR DESCRIPTION
when you install automate 1.5.46 and you want to add a runner node with a specific version the right option is --chefdk-version