### PR TITLE
Automate backups should be initiated outside root-controlled directories

### DIFF
--- a/chef_master/source/ctl_automate_server.rst
+++ b/chef_master/source/ctl_automate_server.rst
@@ -46,7 +46,7 @@ create-backup
 
 .. tag automate_ctl_create_backup
 
-The ``create-backup`` subcommand is used to create Chef Automate backups. By default, it creates Automate backup archives and Elasticsearch snapshots. 
+The ``create-backup`` subcommand is used to create Chef Automate backups. By default, it creates Automate backup archives and Elasticsearch snapshots.
 
 **Syntax**
 
@@ -73,7 +73,9 @@ The ``create-backup`` subcommand is used to create Chef Automate backups. By def
 
 The ``NAME`` value is optional. If omitted, a default name with the current time will be used.
 
-.. warning:: In rare circumstances, jobs that are running at the time of backup creation may be left in an unrecoverable state. For this reason, it's recommended to take a backup when no critical jobs are running. 
+.. warning:: In rare circumstances, jobs that are running at the time of backup creation may be left in an unrecoverable state. For this reason, it's recommended to take a backup when no critical jobs are running.
+
+.. note:: ``create-backup`` should be run outside of root-only directories like ``/root``, as it tries to chpst to the user chef-pgsql. This user will have problems running with a current working directory owned by root.
 
 **Examples**
 

--- a/chef_master/source/delivery_server_backup.rst
+++ b/chef_master/source/delivery_server_backup.rst
@@ -163,6 +163,8 @@ The ``NAME`` value is optional. If omitted, a default name with the current time
 
 .. warning:: In rare circumstances, jobs that are running at the time of backup creation may be left in an unrecoverable state. For this reason, it's recommended to take a backup when no critical jobs are running.
 
+.. note:: ``$ automate-ctl create-backup`` should be run outside of root only directories like /root, as it tries to chpst to the user chef-pgsql. This user will have problems running with a current working directory owned by root.
+
 **Examples**
 
 Complete backup:

--- a/chef_master/source/delivery_server_backup.rst
+++ b/chef_master/source/delivery_server_backup.rst
@@ -163,7 +163,7 @@ The ``NAME`` value is optional. If omitted, a default name with the current time
 
 .. warning:: In rare circumstances, jobs that are running at the time of backup creation may be left in an unrecoverable state. For this reason, it's recommended to take a backup when no critical jobs are running.
 
-.. note:: ``$ automate-ctl create-backup`` should be run outside of root only directories like /root, as it tries to chpst to the user chef-pgsql. This user will have problems running with a current working directory owned by root.
+.. note:: ``create-backup`` should be run outside of root-only directories like ``/root``, as it tries to chpst to the user chef-pgsql. This user will have problems running with a current working directory owned by root.
 
 **Examples**
 


### PR DESCRIPTION
root-only working directories cause failures during `automate-ctl create-backup` runs as the chpst command immediately tries to change into the user chef-pgsql's home directory and fails, causing follow on problems with the backup.

Zendesk 15110