### PR TITLE
Removing beta note and adding new note for 0.8.5 users

### DIFF
--- a/chef_master/source/chef_automate.rst
+++ b/chef_master/source/chef_automate.rst
@@ -22,9 +22,15 @@ comprehensive 24×7 support services for the entire platform, including open sou
 Compliance
 ======================================================
 
-Chef Automate 0.8.5 or later provides an easy way to view how successful the nodes in your infrastructure are at meeting the compliance requirements specified by your organization. Several built-in profiles are included in Chef Automate to scan for security risks, outdated software, and more. These profiles cover a variety of security frameworks, such as Center for Internet Security (CIS) benchmarks. If you have additional compliance requirements, you can also write your own compliance profiles in InSpec and upload them to Chef Automate. For more information how to view the compliance status across your cluster, see :doc:`Compliance Overview </chef_automate_compliance>`.
+Chef Automate 1.5.46 or later provides an easy way to view how successful the nodes in your infrastructure are at meeting the compliance requirements specified by your organization. Several built-in profiles are included in Chef Automate to scan for security risks, outdated software, and more. These profiles cover a variety of security frameworks, such as Center for Internet Security (CIS) benchmarks. If you have additional compliance requirements, you can also write your own compliance profiles in InSpec and upload them to Chef Automate. For more information how to view the compliance status across your cluster, see :doc:`Compliance Overview </chef_automate_compliance>`.
 
 If you are using an older version of Chef Automate, or your workflow requires you to use our standalone Chef Compliance server, you can find general information on Chef Compliance :doc:`here </chef_compliance>`. 
+
+.. tag beta_note
+
+If you are using Chef Automate 0.8.5, this functionality is hidden behind a ``beta`` feature flag. See the `Chef Automate 0.8.5 release notes </release_notes_chef_automate.html##what-s-new-in-0-8-5>`_ for more details.
+
+.. end_tag
 
 Visibility
 ======================================================

--- a/chef_master/source/chef_automate_compliance.rst
+++ b/chef_master/source/chef_automate_compliance.rst
@@ -11,15 +11,15 @@ An Overview of Compliance in Chef Automate
 
 .. end_tag
 
-.. tag compliance_beta
+Chef Automate 1.5.46 or later provides you the ability to store and manage compliance profiles, view compliance reports over time, and quickly filter compliance reports through a dashboard interface. In addition to seeing your compliance status, you can also easily see which controls failed and why to provide you immediate information for remediation. 
 
-.. important:: The new compliance functionality described in this topic is currently in Beta. To enable compliance reporting in the Chef Automate UI, navigate to the **Nodes** tab, make sure your cursor is not in any text box or field, and type ``beta``. A new ``Compliance`` tab should appear in the top-level menu of the UI. Note: Enabling the ``Compliance`` tab will allow you to view only new compliance scan data, not historical data. 
+.. note:: If you need to continue using the previous compliance view that was in earlier versions of Chef Automate, you can enable this view easily. We have included a new feature flag to activate the old compliance view by typing ``legacy`` in the UI and toggling on this view in the menu.
 
-   While we encourage customers to try out this new functionality, the new compliance features are not recommended for production use until they are made generally available in an upcoming Chef Automate release.
+.. tag beta_note
+
+If you are using Chef Automate 0.8.5, this functionality is hidden behind a ``beta`` feature flag. See the `Chef Automate 0.8.5 release notes </release_notes_chef_automate.html##what-s-new-in-0-8-5>`_ for more details.
 
 .. end_tag
-
-Chef Automate 0.8.5 or later provides you the ability to store and manage compliance profiles, view compliance reports over time, and quickly filter compliance reports through a dashboard interface. In addition to seeing your compliance status, you can also easily see which controls failed and why to provide you immediate information for remediation. 
 
 Profile storage
 =====================================================

--- a/chef_master/source/filter_compliance_scan.rst
+++ b/chef_master/source/filter_compliance_scan.rst
@@ -11,15 +11,13 @@ Filter Compliance Scans in Chef Automate
 
 .. end_tag
 
-.. tag compliance_beta
+The **Compliance** tab in your Chef Automate cluster allows you to upload, search, and view the profiles on your Chef Automate server, as well as the ability to filter on the compliance status of the nodes in your cluster. You can pivot your reports based on either the nodes or the profiles you have executed against those nodes. 
 
-.. important:: The new compliance functionality described in this topic is currently in Beta. To enable compliance reporting in the Chef Automate UI, navigate to the **Nodes** tab, make sure your cursor is not in any text box or field, and type ``beta``. A new ``Compliance`` tab should appear in the top-level menu of the UI. Note: Enabling the ``Compliance`` tab will allow you to view only new compliance scan data, not historical data.
+.. tag beta_note
 
-   While we encourage customers to try out this new functionality, the new compliance features are not recommended for production use until they are made generally available in an upcoming Chef Automate release.
+If you are using Chef Automate 0.8.5, this functionality is hidden behind a ``beta`` feature flag. See the `Chef Automate 0.8.5 release notes </release_notes_chef_automate.html##what-s-new-in-0-8-5>`_ for more details.
 
 .. end_tag
-
-The **Compliance** tab in your Chef Automate cluster allows you to upload, search, and view the profiles on your Chef Automate server, as well as the ability to filter on the compliance status of the nodes in your cluster. You can pivot your reports based on either the nodes or the profiles you have executed against those nodes. 
 
 Filter your report data
 ==============================================

--- a/chef_master/source/install_chef_automate.rst
+++ b/chef_master/source/install_chef_automate.rst
@@ -433,7 +433,7 @@ Profiles
 
 Chef Automate contains a compliance profiles asset store that provides several built-in profiles covering baseline security checks through CIS benchmarks across multiple operating systems. 
 
-In Chef Automate 0.8.5, the compliance profiles asset store is enabled by default. You can manage your profiles through :doc:`api_automate` as well as through the Chef Automate UI. See :doc:`/chef_automate_compliance` for more information on the new integrated compliance functionality. 
+In Chef Automate 0.8.5 or later, the compliance profiles asset store is enabled by default. You can manage your profiles through :doc:`api_automate` as well as through the Chef Automate UI. See :doc:`/chef_automate_compliance` for more information on the new integrated compliance functionality. 
 
 In Chef Automate version 0.6, the profiles asset store functionality is available; however, you must enable the service by adding this line:
 

--- a/chef_master/source/perform_compliance_scan.rst
+++ b/chef_master/source/perform_compliance_scan.rst
@@ -11,14 +11,6 @@ Perform a Compliance Scan in Chef Automate
 
 .. end_tag
 
-.. tag compliance_beta
-
-.. important:: The new compliance functionality described in this topic is currently in Beta. To enable compliance reporting in the Chef Automate UI, navigate to the **Nodes** tab, make sure your cursor is not in any text box or field, and type ``beta``. A new ``Compliance`` tab should appear in the top-level menu of the UI. Note: Enabling the ``Compliance`` tab will allow you to view only new compliance scan data, not historical data.
-
-   While we encourage customers to try out this new functionality, the new compliance features are not recommended for production use until they are made generally available in an upcoming Chef Automate release.
-
-.. end_tag
-
 Scanning nodes in your Chef Automate cluster is enabled through the audit cookbook. This cookbook allows you to run InSpec profiles as part of a chef-client run. It downloads configured profiles from various sources like a standalone Chef Compliance server, Chef Automate, Chef Supermarket, or Git, and reports audit runs to Chef Compliance or Chef Automate.
 
 This flexibility means chef-client runs using the audit cookbook can be performed in several different usage scenarios; however, this topic describes how to use the audit cookbook with the integrated profile storage and audit reporting functionality of Chef Automate to perform compliance testing.
@@ -29,13 +21,19 @@ If your workflow requires the use of the standalone Chef Compliance server, or y
 
 .. note:: Remote scanning capabilities currently part of Chef Compliance and will be available in Chef Automate in the future.
 
+.. tag beta_note
+
+If you are using Chef Automate 0.8.5, this functionality is hidden behind a ``beta`` feature flag. See the `Chef Automate 0.8.5 release notes </release_notes_chef_automate.html##what-s-new-in-0-8-5>`_ for more details.
+
+.. end_tag
+
 Prerequisites
 -----------------------------------------------------
 
 The following are required when using the built-in compliance capabilities of Chef Automate:
 
 * Chef client 12.16.42 or later must be installed on your nodes
-* Chef Automate server 0.8.5 or later
+* Chef Automate server 1.5.46 or later (the compliance view was previously enabled through a ``beta`` flag in 0.8.5)
 * Chef server 12.11.1 or later (when using Chef server to report node data to Chef Automate)
 * The audit cookbook 4.0 or later
 * ChefDK 1.4.3 or later installed on your workstation

--- a/chef_master/source/visibility.rst
+++ b/chef_master/source/visibility.rst
@@ -50,13 +50,21 @@ If you wish to share your filtered search with others, you can do so with the sh
 Compliance status
 ------------------------------------------------------
 
-In addition to converge data, Chef Automate also provides information on the compliance state of your nodes. By participating in the open Beta for the new compliance integration in Chef Automate, you can view compliance scan data in the **Compliance** tab at the top of the page. To enable the **Compliance** tab, follow the instructions at the top of :doc:`/chef_automate_compliance`. 
+In addition to converge data, Chef Automate also provides information on the compliance state of your nodes. By using Chef Automate 1.5.46 or later, you can view compliance scan data in the **Compliance** tab at the top of the page. See :doc:`/chef_automate_compliance` for more information. 
 
 .. image:: ../../images/compliance_node.png
 
 This tab provides a summary of the compliance status across all nodes of your cluster and allows you to pivot and search through that data from either a node perspective or a profile perspective. In addition, you can manage your compliance profiles and perform powerful filtering against your compliance data. See the link above for more information.
 
-Chef Automate also continues to support the reporting of compliance data through the **Nodes** tab. If you are either not participating in the compliance open beta, or have turned it off, your compliance data will be available by clicking **Compliance Status** under the **Nodes** tab.
+.. tag beta_note
+
+If you are using Chef Automate 0.8.5, this functionality is hidden behind a ``beta`` feature flag. See the `Chef Automate 0.8.5 release notes </release_notes_chef_automate.html##what-s-new-in-0-8-5>`_ for more details.
+
+.. end_tag
+
+Chef Automate also continues to support the reporting of compliance data through the **Nodes** tab. If you need to continue using the previous compliance view, you can enable it easily by typing ``legacy`` in the UI and toggling on this view in the menu.
+
+Your compliance data will be available by clicking **Compliance Status** under the **Nodes** tab.
 
 .. image:: ../../images/visibility_compliance_overview.png
 


### PR DESCRIPTION
With the release of Chef Automate 1.5.46, the integrated compliance functionality went GA, so we need to remove the beta disclaimers.

However, for those users still on 0.8.5, a new note was added to point them to the spot in the docs that describes how to enable the new compliance view/tab.

Signed-off-by: David Wrede <dwrede@chef.io>