### PR TITLE
add closing bracket to subscribes example code

### DIFF
--- a/chef_master/source/debug.rst
+++ b/chef_master/source/debug.rst
@@ -204,7 +204,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/ohai.rst
+++ b/chef_master/source/ohai.rst
@@ -544,7 +544,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/provisioning.rst
+++ b/chef_master/source/provisioning.rst
@@ -287,7 +287,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -674,7 +674,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -1019,7 +1019,7 @@ This resource has the following attributes:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -1290,7 +1290,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -1513,7 +1513,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -1787,7 +1787,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -1756,7 +1756,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -2258,7 +2258,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -2473,7 +2473,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -2745,7 +2745,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -3055,7 +3055,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -5141,7 +5141,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -6598,7 +6598,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -6809,7 +6809,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -7825,7 +7825,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -8080,7 +8080,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -8309,7 +8309,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -8600,7 +8600,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_apt_package.rst
+++ b/chef_master/source/resource_apt_package.rst
@@ -182,7 +182,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_apt_update.rst
+++ b/chef_master/source/resource_apt_update.rst
@@ -151,7 +151,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_bash.rst
+++ b/chef_master/source/resource_bash.rst
@@ -201,7 +201,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_batch.rst
+++ b/chef_master/source/resource_batch.rst
@@ -210,7 +210,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_bff_package.rst
+++ b/chef_master/source/resource_bff_package.rst
@@ -170,7 +170,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_acl.rst
+++ b/chef_master/source/resource_chef_acl.rst
@@ -194,7 +194,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_client.rst
+++ b/chef_master/source/resource_chef_client.rst
@@ -177,7 +177,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_container.rst
+++ b/chef_master/source/resource_chef_container.rst
@@ -135,7 +135,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_data_bag.rst
+++ b/chef_master/source/resource_chef_data_bag.rst
@@ -129,7 +129,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_data_bag_item.rst
+++ b/chef_master/source/resource_chef_data_bag_item.rst
@@ -162,7 +162,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_environment.rst
+++ b/chef_master/source/resource_chef_environment.rst
@@ -171,7 +171,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_gem.rst
+++ b/chef_master/source/resource_chef_gem.rst
@@ -226,7 +226,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_group.rst
+++ b/chef_master/source/resource_chef_group.rst
@@ -161,7 +161,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_handler.rst
+++ b/chef_master/source/resource_chef_handler.rst
@@ -273,7 +273,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_mirror.rst
+++ b/chef_master/source/resource_chef_mirror.rst
@@ -149,7 +149,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_node.rst
+++ b/chef_master/source/resource_chef_node.rst
@@ -193,7 +193,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_organization.rst
+++ b/chef_master/source/resource_chef_organization.rst
@@ -165,7 +165,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_role.rst
+++ b/chef_master/source/resource_chef_role.rst
@@ -176,7 +176,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chef_user.rst
+++ b/chef_master/source/resource_chef_user.rst
@@ -161,7 +161,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_chocolatey_package.rst
+++ b/chef_master/source/resource_chocolatey_package.rst
@@ -183,7 +183,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_common.rst
+++ b/chef_master/source/resource_common.rst
@@ -796,7 +796,7 @@ Note that ``subscribes`` does not apply the specified action to the resource tha
   end
 
   service 'nginx' do
-     subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+     subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
   end
 
 In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected. 

--- a/chef_master/source/resource_cookbook_file.rst
+++ b/chef_master/source/resource_cookbook_file.rst
@@ -228,7 +228,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_cron.rst
+++ b/chef_master/source/resource_cron.rst
@@ -231,7 +231,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_csh.rst
+++ b/chef_master/source/resource_csh.rst
@@ -196,7 +196,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_deploy.rst
+++ b/chef_master/source/resource_deploy.rst
@@ -455,7 +455,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_directory.rst
+++ b/chef_master/source/resource_directory.rst
@@ -185,7 +185,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_dnf_package.rst
+++ b/chef_master/source/resource_dnf_package.rst
@@ -216,7 +216,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_dpkg_package.rst
+++ b/chef_master/source/resource_dpkg_package.rst
@@ -158,7 +158,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_dsc_resource.rst
+++ b/chef_master/source/resource_dsc_resource.rst
@@ -273,7 +273,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_dsc_script.rst
+++ b/chef_master/source/resource_dsc_script.rst
@@ -245,7 +245,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_env.rst
+++ b/chef_master/source/resource_env.rst
@@ -157,7 +157,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_erlang_call.rst
+++ b/chef_master/source/resource_erlang_call.rst
@@ -156,7 +156,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_execute.rst
+++ b/chef_master/source/resource_execute.rst
@@ -229,7 +229,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_file.rst
+++ b/chef_master/source/resource_file.rst
@@ -239,7 +239,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_freebsd_package.rst
+++ b/chef_master/source/resource_freebsd_package.rst
@@ -155,7 +155,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_gem_package.rst
+++ b/chef_master/source/resource_gem_package.rst
@@ -311,7 +311,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_git.rst
+++ b/chef_master/source/resource_git.rst
@@ -236,7 +236,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_group.rst
+++ b/chef_master/source/resource_group.rst
@@ -174,7 +174,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_homebrew_package.rst
+++ b/chef_master/source/resource_homebrew_package.rst
@@ -183,7 +183,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_http_request.rst
+++ b/chef_master/source/resource_http_request.rst
@@ -159,7 +159,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_ifconfig.rst
+++ b/chef_master/source/resource_ifconfig.rst
@@ -202,7 +202,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_ips_package.rst
+++ b/chef_master/source/resource_ips_package.rst
@@ -164,7 +164,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_ksh.rst
+++ b/chef_master/source/resource_ksh.rst
@@ -206,7 +206,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_launchd.rst
+++ b/chef_master/source/resource_launchd.rst
@@ -256,7 +256,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_link.rst
+++ b/chef_master/source/resource_link.rst
@@ -174,7 +174,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_load_balancer.rst
+++ b/chef_master/source/resource_load_balancer.rst
@@ -146,7 +146,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_log.rst
+++ b/chef_master/source/resource_log.rst
@@ -152,7 +152,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_machine.rst
+++ b/chef_master/source/resource_machine.rst
@@ -421,7 +421,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_machine_batch.rst
+++ b/chef_master/source/resource_machine_batch.rst
@@ -237,7 +237,7 @@ This resource has the following attributes:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_machine_execute.rst
+++ b/chef_master/source/resource_machine_execute.rst
@@ -153,7 +153,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_machine_file.rst
+++ b/chef_master/source/resource_machine_file.rst
@@ -185,7 +185,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_machine_image.rst
+++ b/chef_master/source/resource_machine_image.rst
@@ -208,7 +208,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_macports_package.rst
+++ b/chef_master/source/resource_macports_package.rst
@@ -160,7 +160,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_mdadm.rst
+++ b/chef_master/source/resource_mdadm.rst
@@ -192,7 +192,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_mount.rst
+++ b/chef_master/source/resource_mount.rst
@@ -224,7 +224,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_ohai.rst
+++ b/chef_master/source/resource_ohai.rst
@@ -148,7 +148,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_openbsd_package.rst
+++ b/chef_master/source/resource_openbsd_package.rst
@@ -165,7 +165,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_osx_profile.rst
+++ b/chef_master/source/resource_osx_profile.rst
@@ -157,7 +157,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_package.rst
+++ b/chef_master/source/resource_package.rst
@@ -394,7 +394,7 @@ This resource has the following attributes:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_pacman_package.rst
+++ b/chef_master/source/resource_pacman_package.rst
@@ -161,7 +161,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_paludis_package.rst
+++ b/chef_master/source/resource_paludis_package.rst
@@ -168,7 +168,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_perl.rst
+++ b/chef_master/source/resource_perl.rst
@@ -201,7 +201,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_portage_package.rst
+++ b/chef_master/source/resource_portage_package.rst
@@ -161,7 +161,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_powershell_script.rst
+++ b/chef_master/source/resource_powershell_script.rst
@@ -238,7 +238,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_private_key.rst
+++ b/chef_master/source/resource_private_key.rst
@@ -156,7 +156,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_public_key.rst
+++ b/chef_master/source/resource_public_key.rst
@@ -132,7 +132,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_python.rst
+++ b/chef_master/source/resource_python.rst
@@ -195,7 +195,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_reboot.rst
+++ b/chef_master/source/resource_reboot.rst
@@ -134,7 +134,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_registry_key.rst
+++ b/chef_master/source/resource_registry_key.rst
@@ -466,7 +466,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_remote_directory.rst
+++ b/chef_master/source/resource_remote_directory.rst
@@ -242,7 +242,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_remote_file.rst
+++ b/chef_master/source/resource_remote_file.rst
@@ -323,7 +323,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_route.rst
+++ b/chef_master/source/resource_route.rst
@@ -149,7 +149,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_rpm_package.rst
+++ b/chef_master/source/resource_rpm_package.rst
@@ -164,7 +164,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_ruby.rst
+++ b/chef_master/source/resource_ruby.rst
@@ -201,7 +201,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_ruby_block.rst
+++ b/chef_master/source/resource_ruby_block.rst
@@ -145,7 +145,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_script.rst
+++ b/chef_master/source/resource_script.rst
@@ -238,7 +238,7 @@ This resource has the following attributes:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_service.rst
+++ b/chef_master/source/resource_service.rst
@@ -203,7 +203,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_smartos_package.rst
+++ b/chef_master/source/resource_smartos_package.rst
@@ -158,7 +158,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_solaris_package.rst
+++ b/chef_master/source/resource_solaris_package.rst
@@ -155,7 +155,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_subversion.rst
+++ b/chef_master/source/resource_subversion.rst
@@ -176,7 +176,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_template.rst
+++ b/chef_master/source/resource_template.rst
@@ -269,7 +269,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_user.rst
+++ b/chef_master/source/resource_user.rst
@@ -226,7 +226,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_windows_package.rst
+++ b/chef_master/source/resource_windows_package.rst
@@ -197,7 +197,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_windows_service.rst
+++ b/chef_master/source/resource_windows_service.rst
@@ -225,7 +225,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_yum.rst
+++ b/chef_master/source/resource_yum.rst
@@ -221,7 +221,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resource_zypper_package.rst
+++ b/chef_master/source/resource_zypper_package.rst
@@ -182,7 +182,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/resources.rst
+++ b/chef_master/source/resources.rst
@@ -877,7 +877,7 @@ Note that ``subscribes`` does not apply the specified action to the resource tha
   end
 
   service 'nginx' do
-     subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+     subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
   end
 
 In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -2466,7 +2466,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -2830,7 +2830,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -3225,7 +3225,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -3622,7 +3622,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -3914,7 +3914,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -4508,7 +4508,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -4840,7 +4840,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
@@ -5219,7 +5219,7 @@ This resource has the following properties:
      end
 
      service 'nginx' do
-        subscribes :reload, 'file[/etc/nginx/ssl/example.crt', :immediately
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
      end
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.


### PR DESCRIPTION
It appears like the example snippet for `subscribes` has been used in a bunch of places but is missing the closing `]`.