### PR TITLE
Document `required_recipe` feature and configuration

### DIFF
--- a/chef_master/source/config_rb_server_optional_settings.rst
+++ b/chef_master/source/config_rb_server_optional_settings.rst
@@ -1637,7 +1637,7 @@ This configuration file has the following settings for ``user``:
 required_recipe
 -----------------------------------------------------
 
-``required_recipe`` is a feature of the Chef Server that allows the administrator to specify a recipe that will be run by all Chef Clients that connect to it, regardless of the node's run list. This feature is targeted at expert level practitioners who are delivering isolated configuration changes to the target systems, such as self-contained agent software. Further explanation of the feature can be found in RFC_089_.
+``required_recipe`` is a feature in Chef server versions 12.15.0 and above that allows an administrator to specify a recipe that will be run by all Chef Clients that connect to it, regardless of the node's run list. This feature is targeted at expert level practitioners who are delivering isolated configuration changes to the target systems, such as self-contained agent software. Further explanation of the feature can be found in RFC_089_.
 
 .. _RFC_089: https://github.com/chef/chef-rfc/blob/master/rfc089-server-enforced-recipe.md
 

--- a/chef_master/source/config_rb_server_optional_settings.rst
+++ b/chef_master/source/config_rb_server_optional_settings.rst
@@ -1632,3 +1632,21 @@ This configuration file has the following settings for ``user``:
 
 ``user['username']``
    The user name under which Chef server services run. Default value: ``opscode``.
+
+
+required_recipe
+-----------------------------------------------------
+
+``required_recipe`` is a feature of the Chef Server that allows the administrator to specify a recipe that will be run by all Chef Clients that connect to it, regardless of the node's run list. This feature is targeted at expert level practitioners who are delivering isolated configuration changes to the target systems, such as self-contained agent software. Further explanation of the feature can be found in RFC_089_.
+
+.. _RFC_089: https://github.com/chef/chef-rfc/blob/master/rfc089-server-enforced-recipe.md
+
+This feature requires Chef Client 12.20.3 or greater.
+
+This configuration file has the following settings for ``required_recipe``:
+
+``required_recipe["enable"]``
+   Whether the feature is enabled. Default value: ``false``.
+``required_recipe["path"]``
+   The location of the recipe to serve. The file must be owned by the root user and group, and may not be group or world-writeable. Default value: ``nil``.
+


### PR DESCRIPTION
As described in the change, this feature is intended for expert use
only, therefore it should be okay to just document it with the optional
settings.

References:

* https://discourse.chef.io/t/chef-12-20-3-released/10857
* https://github.com/chef/chef-rfc/blob/master/rfc089-server-enforced-recipe.md

The feature also requires Chef Server 12.15+:
https://discourse.chef.io/t/chef-server-12-15-0-released/10851

Signed-off-by: Daniel DeLeo <dan@chef.io>