### PR TITLE
Remove 'chef-verify' from ChefDK install docs

### DIFF
--- a/chef_master/source/install_dk.rst
+++ b/chef_master/source/install_dk.rst
@@ -47,21 +47,6 @@ To install the Chef development kit:
 #. Select a platform, and then a package. (chef-docs uses the macOS setup within the documentation.)
 #. Click the download button.
 #. Follow the steps in the installer and install the Chef development kit to your machine. The Chef development kit is installed to ``/opt/chefdk/`` on UNIX and Linux systems.
-#. When finished, open a command window and enter the following:
-
-   .. code-block:: bash
-
-      $ chef verify
-
-   This will verify the main components of the Chef development kit: the chef-client, the Chef development kit library, and the tools that are built into the Chef development kit. The output should be similar to:
-
-   .. code-block:: bash
-
-      Running verification for component '...'
-      ..........
-      ---------------------------------------------
-      Verification of component '...' succeeded.
-
 #. Optional. Set the default shell. On Microsoft Windows it is strongly recommended to use Windows PowerShell and cmd.exe.
 
 Set System Ruby


### PR DESCRIPTION
Behavior around the 'chef verify' command was changed to discourage users from running it and it has been removed from the --help output (https://github.com/chef/chef-dk/pull/1261).  The step suggesting users run 'chef verify' should be removed from the docs on installing ChefDK to remove confusion around it's warning message

Signed-off-by: Paul Mooring <paul@chef.io>