### PR TITLE
Fix typo in tagging example

### DIFF
--- a/chef_master/source/recipes.rst
+++ b/chef_master/source/recipes.rst
@@ -657,7 +657,7 @@ For example:
    tag('machine')
 
    if tagged?('machine')
-      Chef::Log.info('Hey I'm #{node[:tags]}')
+      Chef::Log.info("Hey I'm #{node[:tags]}")
    end
 
    untag('machine')


### PR DESCRIPTION
This fixes a typo that used an apostrophe inside a single-quoted string.