### PR TITLE
Remove references to knife cookbook test

### DIFF
--- a/chef_master/source/config_rb_knife_optional_settings.rst
+++ b/chef_master/source/config_rb_knife_optional_settings.rst
@@ -46,8 +46,8 @@ The following list describes all of the optional settings that can be added to t
    .. code-block:: ruby
 
       knife[:authentication_protocol_version] = '1.3'
-      
-   Note that authentication protocol 1.3 is only supported on Chef server versions 12.4.0 and above. 
+
+   Note that authentication protocol 1.3 is only supported on Chef server versions 12.4.0 and above.
 
 ``knife[:bare_directories]``
    Prevent a directory's children from showing when a directory matches a pattern.
@@ -555,13 +555,6 @@ The following ``knife cookbook show`` settings can be added to the knife.rb file
 
 ``knife[:platform_version]``
    Adds the the ``--platform-version`` option.
-
-cookbook test
------------------------------------------------------
-The following ``knife cookbook test`` settings can be added to the knife.rb file:
-
-``knife[:all]``
-   Adds the the ``--all`` option.
 
 cookbook upload
 -----------------------------------------------------

--- a/chef_master/source/config_rb_knife_optional_settings.rst
+++ b/chef_master/source/config_rb_knife_optional_settings.rst
@@ -46,8 +46,8 @@ The following list describes all of the optional settings that can be added to t
    .. code-block:: ruby
 
       knife[:authentication_protocol_version] = '1.3'
-
-   Note that authentication protocol 1.3 is only supported on Chef server versions 12.4.0 and above.
+      
+   Note that authentication protocol 1.3 is only supported on Chef server versions 12.4.0 and above. 
 
 ``knife[:bare_directories]``
    Prevent a directory's children from showing when a directory matches a pattern.
@@ -555,6 +555,15 @@ The following ``knife cookbook show`` settings can be added to the knife.rb file
 
 ``knife[:platform_version]``
    Adds the the ``--platform-version`` option.
+
+cookbook test
+-----------------------------------------------------
+The following ``knife cookbook test`` settings can be added to the knife.rb file:
+
+``knife[:all]``
+   Adds the the ``--all`` option.
+
+.. warning:: This feature is deprecated in favor of :doc:`Cookstyle </cookstyle>` and :doc:`ChefSpec </chefspec>`
 
 cookbook upload
 -----------------------------------------------------

--- a/chef_master/source/knife_cookbook.rst
+++ b/chef_master/source/knife_cookbook.rst
@@ -444,46 +444,6 @@ To view information in JSON format, use the ``-F`` common option as part of the 
 
 Other formats available include ``text``, ``yaml``, and ``pp``.
 
-test
-=====================================================
-Use the ``test`` argument to test a cookbook for syntax errors. This argument uses Ruby syntax checking to verify every file in a cookbook that ends in .rb and Embedded Ruby (ERB). This argument will respect chefignore files when determining which cookbooks to test for syntax errors.
-
-Syntax
------------------------------------------------------
-This argument has the following syntax:
-
-.. code-block:: bash
-
-   $ knife cookbook test COOKBOOK_NAME (options)
-
-Options
------------------------------------------------------
-This argument has the following options:
-
-``-a``, ``--all``
-   Test all cookbooks.
-
-``-o PATH:PATH``, ``--cookbook-path PATH:PATH``
-   The directory in which cookbooks are created. This can be a colon-separated path.
-
-.. note:: .. tag knife_common_see_all_config_options
-
-          See :doc:`knife.rb </config_rb_knife_optional_settings>` for more information about how to add certain knife options as settings in the knife.rb file.
-
-          .. end_tag
-
-Examples
------------------------------------------------------
-The following examples show how to use this knife subcommand:
-
-**Test a cookbook**
-
-.. To test a cookbook named "getting-started", enter:
-
-.. code-block:: bash
-
-   $ knife cookbook test cookbook_name
-
 upload
 =====================================================
 Use the ``upload`` argument to upload one or more cookbooks (and any files that are associated with those cookbooks) from a local repository to the Chef server. Only files that do not already exist on the Chef server will be uploaded.
@@ -564,4 +524,3 @@ If a cookbook is frozen and the ``--force`` option is not specified, knife will 
 
    Uploading redis...
    ERROR: Version 0.1.6 of cookbook redis is frozen. Use --force to override.
-

--- a/chef_master/source/knife_cookbook.rst
+++ b/chef_master/source/knife_cookbook.rst
@@ -444,6 +444,48 @@ To view information in JSON format, use the ``-F`` common option as part of the 
 
 Other formats available include ``text``, ``yaml``, and ``pp``.
 
+test
+=====================================================
+Use the ``test`` argument to test a cookbook for syntax errors. This argument uses Ruby syntax checking to verify every file in a cookbook that ends in .rb and Embedded Ruby (ERB). This argument will respect chefignore files when determining which cookbooks to test for syntax errors.
+
+.. warning:: This feature is deprecated in favor of :doc:`Cookstyle </cookstyle>` and :doc:`ChefSpec </chefspec>`
+
+Syntax
+-----------------------------------------------------
+This argument has the following syntax:
+
+.. code-block:: bash
+
+   $ knife cookbook test COOKBOOK_NAME (options)
+
+Options
+-----------------------------------------------------
+This argument has the following options:
+
+``-a``, ``--all``
+   Test all cookbooks.
+
+``-o PATH:PATH``, ``--cookbook-path PATH:PATH``
+   The directory in which cookbooks are created. This can be a colon-separated path.
+
+.. note:: .. tag knife_common_see_all_config_options
+
+          See :doc:`knife.rb </config_rb_knife_optional_settings>` for more information about how to add certain knife options as settings in the knife.rb file.
+
+          .. end_tag
+
+Examples
+-----------------------------------------------------
+The following examples show how to use this knife subcommand:
+
+**Test a cookbook**
+
+.. To test a cookbook named "getting-started", enter:
+
+.. code-block:: bash
+
+   $ knife cookbook test cookbook_name
+
 upload
 =====================================================
 Use the ``upload`` argument to upload one or more cookbooks (and any files that are associated with those cookbooks) from a local repository to the Chef server. Only files that do not already exist on the Chef server will be uploaded.
@@ -524,3 +566,4 @@ If a cookbook is frozen and the ``--force`` option is not specified, knife will 
 
    Uploading redis...
    ERROR: Version 0.1.6 of cookbook redis is frozen. Use --force to override.
+

--- a/chef_master/source/upgrade_client.rst
+++ b/chef_master/source/upgrade_client.rst
@@ -40,7 +40,6 @@ Ensure that all of the cookbooks used by your organization are correctly located
  * Delete unused cookbook versions. First, run ``knife cookbook list`` to view a list of cookbooks. Next, for each cookbook, run ``knife cookbook show COOKBOOK_NAME`` to view its versions. Then, delete each unused version with ``knife cookbook delete -v VERSION_NAME``.
 
 Download all cookbooks and validate the following against each cookbook:
- * Run ``knife cookbook test``. Does each cookbook pass validation with the version of chef client you plan on using?
  * Run ``egrep -L ^name */metadata.rb``. Does each have a ``metadata.rb`` file?
  * Does the cookbook name in the ``metadata.rb`` file match the name in the run-list? (Some older versions of the Chef client used the cookbook name for the run-list based on the directory name of the cookbook and not the cookbook_name in the ``metadata.rb`` file.)
 

--- a/chef_master/source/upgrade_client_notes.rst
+++ b/chef_master/source/upgrade_client_notes.rst
@@ -19,7 +19,6 @@ Verify Nodes and Cookbooks
 
 Install the latest version of the chef-client on a small number of test nodes. Download all cookbooks, and then and check the following:
 
-* Run ``knife cookbook test``. Do they all pass validation with the version of the chef-client you plan on using?
 * Run ``egrep -L ^name */metadata.rb``. Do they all have a metadata.rb file?
 * Does the cookbook name in the metadata.rb file match the name in the run-list? (Some older versions of the chef-client used the cookbook name for the run-list based on the directory name of the cookbook and not the value of the ``cookbook_name`` setting in the metadata.rb file.)
 * Do all cookbooks have a metadata.rb file or metadata.json file?

--- a/chef_master/source/upgrade_server_open_source_notes.rst
+++ b/chef_master/source/upgrade_server_open_source_notes.rst
@@ -270,7 +270,6 @@ Verify Nodes and Cookbooks
 
 Install the latest version of the chef-client on a small number of test nodes. Download all cookbooks, and then and check the following:
 
-* Run ``knife cookbook test``. Do they all pass validation with the version of the chef-client you plan on using?
 * Run ``egrep -L ^name */metadata.rb``. Do they all have a metadata.rb file?
 * Does the cookbook name in the metadata.rb file match the name in the run-list? (Some older versions of the chef-client used the cookbook name for the run-list based on the directory name of the cookbook and not the value of the ``cookbook_name`` setting in the metadata.rb file.)
 * Do all cookbooks have a metadata.rb file or metadata.json file?


### PR DESCRIPTION
We don't suggest or support this anymore. It doesn't entirely work and there's better tooling out there to perform syntax checking at this point (cookstyle/chefspec)

Signed-off-by: Tim Smith <tsmith@chef.io>