### PR TITLE
Fix incorrect source example for chef server

### DIFF
--- a/chef_master/source/berkshelf.rst
+++ b/chef_master/source/berkshelf.rst
@@ -96,7 +96,7 @@ To add a Chef Server:
 .. code-block:: ruby
 
    source "https://supermarket.chef.io"
-   source :chef_server
+   source chef_server: "https://chef-server.example.com"
 
 To add a local Chef repository:
 


### PR DESCRIPTION
I believe the example for getting Berkshelf to work with open source chef is incorrect. I think the syntax should be similar to the local Chef repository example below. If I am wrong let me know and I will withdraw this PR but this is how I had to configure my `Berksfile` on my system to get it working.