### PR TITLE
Update ctl_chef_server.rst

### DIFF
--- a/chef_master/source/ctl_chef_server.rst
+++ b/chef_master/source/ctl_chef_server.rst
@@ -142,6 +142,13 @@ This subcommand has the following syntax:
 
 ha-status
 =====================================================
+
+.. warning:: .. tag chef_license_note_current
+
+            The ``ha-status`` command no longer returns meaningful information as of the 12.9 release. Use ``status`` instead.
+
+             .. end_tag
+
 The ``ha-status`` subcommand is used to check the status for services running in a high availability topology. This command will verify the following:
 
 * The Keepalived daemon is enabled in the config


### PR DESCRIPTION
In newer versions of Chef Server, ha-status only returns an error message (`[ERROR] keepalived HA services not enabled, please configure keepalived according to documentation.`). As far as I can tell this has been the case since 12.9 when the old HA architecture was deprecated.