### PR TITLE
Specify correct ChefDK version

### DIFF
--- a/chef_master/source/aws_opsworks_chef_automate.rst
+++ b/chef_master/source/aws_opsworks_chef_automate.rst
@@ -29,11 +29,11 @@ In order to add runners to your "AWS OpsWorks for Chef Automate" instance you ne
 #. Your runner should be reachable via SSH from your Chef Automate instance. For this to succeed, you need to make sure its subnet, security groups, and SSH key pair are configured correctly. We also recommend setting up a dedicated SSH key pair in AWS and copying the private key to your Chef Automate instance and use it while running :ref:`install-runner` command.
 #. You can find the FQDN of your "AWS OpsWorks for Chef Automate" instance in the OpsWorks console. You can use ``ec2-user`` as the username to SSH into your instance. Assuming you have configured the SSH keys correctly, the SSH command should look like ``ssh ec2-user@<instance-name>-<random-chars>.gamma.opsworks-cm.io``.
 
-.. warning:: Runners on AWS OpsWorks must use Chef DK version 1.5. Use ``automate-ctl`` to configure a runner with Chef DK 1.5:
+.. warning:: Runners on AWS OpsWorks must use Chef DK version 1.5.0. Use ``automate-ctl`` to configure a runner with Chef DK 1.5.0:
 
    .. code-block:: ruby
 
-      automate-ctl install-runner --chefdk-version 1.5 RUNNER_FQDN
+      automate-ctl install-runner --chefdk-version 1.5.0 RUNNER_FQDN
 
 Pushing a change through AWS OpsWorks for Chef Automate
 ========================================================


### PR DESCRIPTION
If you specify `--chefdk-version 1.5`, you get this error:

```
Downloading the 1.5 version of the ChefDK. This make take a few minutes...
ERROR: You requested ChefDK version 1.5 via --chefdk-version but the package did not exist.
For a valid list of versions for your platform, see https://downloads.chef.io/chef-dk/.
```

You need to specify `--chefdk-version 1.5.0` to make things work.

See also the version number at [downloads.chef.io](https://downloads.chef.io/chefdk/stable/1.5.0).

Signed-off-by: tpetchel <tpetchel@gmail.com>