### PR TITLE
Move Enterprise Chef 11 into deprecated state in Platforms docs

### DIFF
--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -553,8 +553,8 @@ Versions and Status
      - n/a
    * - Enterprise Chef
      - 11.2.2 or later
-     - GA
-     - n/a
+     - Deprecated
+     - TBD
    * - Reporting
      - 1.5.5 or later
      - GA


### PR DESCRIPTION
Signed-off-by: David Wrede <dwrede@chef.io>