### PR TITLE
update lazy example to be functional

### DIFF
--- a/chef_master/source/resource_common.rst
+++ b/chef_master/source/resource_common.rst
@@ -501,9 +501,9 @@ The following example shows how to use lazy evaluation with template variables:
 
    template '/tmp/canvey_island.txt' do
      source 'canvey_island.txt.erb'
-     variables(
-       { :canvey_island => lazy { node.run_state['sea_power'] } }
-     )
+     variables(lazy {
+       { :canvey_island => node.run_state['sea_power'] }
+     })
    end
 
 .. end_tag


### PR DESCRIPTION
The current example given for how to use the lazy method for a variable into a template doesn't function unless you assume the template is aware it is being passed a proc object. This update makes it so it functions more as expected