### PR TITLE
Change all ip addresses to RFC5737 documentation ip addresses

### DIFF
--- a/chef_master/source/api_automate.rst
+++ b/chef_master/source/api_automate.rst
@@ -151,7 +151,7 @@ For the primary server in a disaster recovery pair, the response will be similar
        {
          "postgres": {
            "status": "pong",
-           "standby_ip_address": "192.168.33.13",
+           "standby_ip_address": "192.0.2.0",
            "pg_current_xlog_location": "0/3000D48"
          },
          "lsyncd": {

--- a/chef_master/source/api_chef_server.rst
+++ b/chef_master/source/api_chef_server.rst
@@ -5192,8 +5192,8 @@ An example of a ``.chef/pivotal.rb`` file is shown below:
 
    current_dir = File.dirname(__FILE__)
    node_name "pivotal"
-   chef_server_url "https://192.168.1.2:443"
-   chef_server_root "https://192.168.1.2:443"
+   chef_server_url "https://192.0.2.0:443"
+   chef_server_root "https://192.0.2.0:443"
    client_key "#{current_dir}/pivotal.pem"
 
 .. note:: The ``pivotal.pem`` file must exist in the specified location and the IP addresses must be correct for the Chef server.

--- a/chef_master/source/api_compliance.rst
+++ b/chef_master/source/api_compliance.rst
@@ -1147,8 +1147,8 @@ The response will return a JSON object similar to:
        "id": "d850ba44-7a82-4177-50db-79be1143d632",
        "environment": "b771e025-6445-4ead-5cac-b466ea725177",
        "owner": "7ae9dd7d-5201-4ae3-4949-60eb4b902e77",
-       "name": "192.168.100.200",
-       "hostname": "192.168.100.200",
+       "name": "192.0.2.0",
+       "hostname": "192.0.2.0",
        "loginMethod": "ssh",
        "loginUser": "root",
        "loginPassword": "",
@@ -1194,8 +1194,8 @@ The response will return a JSON object similar to:
      "id": "6f7336b5-380e-4e75-4b06-781950c9a1a5",
      "environment": "b771e025-6445-4ead-5cac-b466ea725177",
      "owner": "7ae9dd7d-5201-4ae3-4949-60eb4b902e77",
-     "name": "192.168.100.200",
-     "hostname": "192.168.100.200",
+     "name": "192.0.2.0",
+     "hostname": "192.0.2.0",
      "loginMethod": "ssh",
      "loginUser": "root",
      "loginPassword": "",
@@ -1229,8 +1229,8 @@ with a JSON object similar to:
 .. code-block:: javascript
 
    {
-     "name": "192.168.100.200",
-     "hostname": "192.168.100.200",
+     "name": "192.0.2.0",
+     "hostname": "192.0.2.0",
      "loginUser": "root",
      "loginMethod": "ssh",
      "loginKey": "john/vagrant",
@@ -1252,8 +1252,8 @@ The response will return a JSON object similar to:
 
    {
      "id":"67243304-0909-4bc3-5ed0-3637a5d0fe93",
-     "hostname": "192.168.100.200",
-     "name": "192.168.100.200",
+     "hostname": "192.0.2.0",
+     "name": "192.0.2.0",
      "loginUser": "root",
      "loginMethod": "ssh",
      "loginKey": "john/vagrant"
@@ -2007,7 +2007,7 @@ The response will return a JSON object similar to:
    [
      {
        "environment": "b771e025-6445-4ead-5cac-b466ea725177",
-       "node": "192.168.59.107:11024",
+       "node": "192.0.2.0:11024",
        "complianceStatus": 0,
        "patchlevelStatus": -1,
        "unknownStatus": 0,
@@ -2015,7 +2015,7 @@ The response will return a JSON object similar to:
        "family": "",
        "release": "",
        "connectSuccess": false,
-       "connectMessage": "Failed to verify connectivity to sshPassword://root@192.168.56.239:0 using login password : exit status 1",
+       "connectMessage": "Failed to verify connectivity to sshPassword://root@192.0.2.0:0 using login password : exit status 1",
        "complianceSummary": {
          "success": 0,
          "minor": 0,

--- a/chef_master/source/chef_search.rst
+++ b/chef_master/source/chef_search.rst
@@ -311,7 +311,7 @@ Consider the following snippet of JSON data:
              "f8:1e:df:d8:63:a2": {
                "family": "lladdr"
              },
-             "192.168.0.195": {
+             "192.0.2.0": {
                "netmask": "255.255.255.0",
                "broadcast": "192.168.0.255",
                "family": "inet"
@@ -371,26 +371,26 @@ This data is also flattened into various compound fields, which follow the same 
 .. code-block:: none
 
      # ...snip...
-     "network_interfaces_en1_addresses_192.168.0.195_broadcast" => "192.168.0.255",
+     "network_interfaces_en1_addresses_192.0.2.0_broadcast" => "192.168.0.255",
      "network_interfaces_en1_addresses_fe80::fa1e:tldr_family"  => "inet6",
-     "network_interfaces_en1_addresses"                         => ["fe80::fa1e:tldr","f8:1e:df:tldr","192.168.0.195"]
+     "network_interfaces_en1_addresses"                         => ["fe80::fa1e:tldr","f8:1e:df:tldr","192.0.2.0"]
      # ...snip...
 
 which allows searches like the following to find data that is present in this node:
 
 .. code-block:: ruby
 
-   node "network_interfaces_en1_addresses:192.168.0.195"
+   node "network_interfaces_en1_addresses:192.0.2.0"
 
 This flattened data structure also supports using wildcard compound fields, which allow searches to omit levels within the JSON data structure that are not important to the search query. In the following example, an asterisk (``*``) is used to show where the wildcard can exist when searching for a nested field:
 
 .. code-block:: ruby
 
    "network_interfaces_*_flags"     => ["UP", "BROADCAST", "SMART", "RUNNING", "SIMPLEX", "MULTICAST"]
-   "network_interfaces_*_addresses" => ["fe80::fa1e:dfff:fed8:63a2", "192.168.0.195", "f8:1e:df:d8:63:a2"]
+   "network_interfaces_*_addresses" => ["fe80::fa1e:dfff:fed8:63a2", "192.0.2.0", "f8:1e:df:d8:63:a2"]
    "network_interfaces_en0_media_*" => ["autoselect", "none", "1000baseT", "10baseT/UTP", "100baseTX"]
    "network_interfaces_en1_*"       => ["1", "UP", "BROADCAST", "SMART", "RUNNING", "SIMPLEX", "MULTICAST",
-                                        "fe80::fa1e:dfff:fed8:63a2", "f8:1e:df:d8:63:a2", "192.168.0.195",
+                                        "fe80::fa1e:dfff:fed8:63a2", "f8:1e:df:d8:63:a2", "192.0.2.0",
                                         "1500", "supported", "selected", "en", "active", "Ethernet"]
 
 For each of the wildcard examples above, the possible values are shown contained within the brackets. When running a search query, the query syntax for wildcards is to simply omit the name of the node (while preserving the underscores), similar to:
@@ -455,9 +455,9 @@ To use a range search to find IP addresses within a subnet, enter the following:
 
 .. code-block:: bash
 
-   $ knife search node 'ipaddress:[192.168.0.* TO 192.168.127.*]'
+   $ knife search node 'ipaddress:[192.168.0.* TO 192.0.2.*]'
 
-where ``192.168.0.* TO 192.168.127.*`` defines the subnet range.
+where ``192.168.0.* TO 192.0.2.*`` defines the subnet range.
 
 .. end_tag
 

--- a/chef_master/source/config_rb_delivery.rst
+++ b/chef_master/source/config_rb_delivery.rst
@@ -91,7 +91,7 @@ Proxy Settings
 If you wish to operate your Chef Automate server from behind a proxy, you may specify you proxy host name and configuration using these options.
 
 ``delivery['proxy']['host']``
-    The hostname to your proxy server such as ``foo.bar.com`` or ``192.168.1.10``.
+    The hostname to your proxy server such as ``foo.bar.com`` or ``192.0.2.00``.
 
 ``delivery['proxy']['port']``
     The port to connect on. This will be used for all connections (http and https).

--- a/chef_master/source/config_rb_delivery_optional_settings.rst
+++ b/chef_master/source/config_rb_delivery_optional_settings.rst
@@ -909,7 +909,7 @@ This configuration file has the following settings for ``postgresql``:
    The home directory for PostgreSQL. Default value: ``"/var/opt/delivery/postgresql"``.
 
 ``postgresql['listen_address']``
-   The connection source to which PostgreSQL is to respond. Default value: ``'localhost'``. In a disaster recovery configuration, this value is similar to: ``'localhost,192.168.10.11'``.
+   The connection source to which PostgreSQL is to respond. Default value: ``'localhost'``. In a disaster recovery configuration, this value is similar to: ``'localhost,192.0.2.0'``.
 
 ``postgresql['log_directory']``
    The directory in which log data is stored. The default value is the recommended value. Default value:

--- a/chef_master/source/ctl_chef_backend.rst
+++ b/chef_master/source/ctl_chef_backend.rst
@@ -423,11 +423,11 @@ The following example shows the results of running the ``chef-backend-ctl gen-se
 
    fqdn "frontend1.chef-demo.com"
    postgresql['external'] = true
-   postgresql['vip'] = '192.168.33.220'
+   postgresql['vip'] = '192.0.2.0'
    postgresql['db_superuser'] = 'chef_pgsql'
    postgresql['db_superuser_password'] = '...6810e52a01e562'
    opscode_solr4['external'] = true
-   opscode_solr4['external_url'] = 'http://192.168.33.220:9200'
+   opscode_solr4['external_url'] = 'http://192.0.2.0:9200'
    opscode_erchef['search_provider'] = 'elasticsearch'
    opscode_erchef['search_queue_mode'] = 'batch'
    bookshelf['storage_type'] = :sql

--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -440,7 +440,7 @@ Changed in Chef server 12.13 to expose FIPS runtime flag on RHEL. New in Chef Cl
 
 .. code-block:: bash
 
-   $ knife bootstrap 12.34.56.789 -P vanilla -x root -r 'recipe[apt],recipe[xfs],recipe[vim]' --fips
+   $ knife bootstrap 192.0.2.0 -P vanilla -x root -r 'recipe[apt],recipe[xfs],recipe[vim]' --fips
 
 which shows something similar to:
 
@@ -448,7 +448,7 @@ which shows something similar to:
 
    OpenSSL FIPS 140 mode enabled
    ...
-   12.34.56.789 Chef Client finished, 12/12 resources updated in 78.942455583 seconds
+   192.0.2.0 Chef Client finished, 12/12 resources updated in 78.942455583 seconds
 
 .. end_tag
 

--- a/chef_master/source/ctl_kitchen.rst
+++ b/chef_master/source/ctl_kitchen.rst
@@ -492,7 +492,7 @@ Use the ``--loader`` option to include diagnostic data in the output:
        raw_data:
          driver:
            name: vagrant
-           socket: tcp://192.168.12.34:1234
+           socket: tcp://192.0.2.0:1234
        provisioner:
         #...
 
@@ -547,7 +547,7 @@ When Kitchen is being used to test cookbooks, Kitchen will track state data:
    instances:
      default-ubuntu-1404
        state_file:
-         hostname: 192.168.123.456
+         hostname: 192.0.2.0
          last_action: create
          port: '22'
          ssh_key: "/Users/username/path/to/key"

--- a/chef_master/source/delivery_server_disaster_recovery.rst
+++ b/chef_master/source/delivery_server_disaster_recovery.rst
@@ -195,8 +195,8 @@ To promote a standby Chef Automate server to primary, do the following:
    .. code-block:: ruby
 
       delivery["primary"] = false
-      delivery["primary_ip"] = '192.168.10.10'
-      postgresql["listen_address"] = 'localhost,192.168.10.11'
+      delivery["primary_ip"] = '192.0.2.0'
+      postgresql["listen_address"] = 'localhost,192.0.2.0'
 
 #. On the standby server, run the following command as the root user:
 

--- a/chef_master/source/dsl_recipe.rst
+++ b/chef_master/source/dsl_recipe.rst
@@ -1929,7 +1929,7 @@ Consider the following snippet of JSON data:
              "f8:1e:df:d8:63:a2": {
                "family": "lladdr"
              },
-             "192.168.0.195": {
+             "192.0.2.0": {
                "netmask": "255.255.255.0",
                "broadcast": "192.168.0.255",
                "family": "inet"
@@ -1989,26 +1989,26 @@ This data is also flattened into various compound fields, which follow the same 
 .. code-block:: none
 
      # ...snip...
-     "network_interfaces_en1_addresses_192.168.0.195_broadcast" => "192.168.0.255",
+     "network_interfaces_en1_addresses_192.0.2.0_broadcast" => "192.168.0.255",
      "network_interfaces_en1_addresses_fe80::fa1e:tldr_family"  => "inet6",
-     "network_interfaces_en1_addresses"                         => ["fe80::fa1e:tldr","f8:1e:df:tldr","192.168.0.195"]
+     "network_interfaces_en1_addresses"                         => ["fe80::fa1e:tldr","f8:1e:df:tldr","192.0.2.0"]
      # ...snip...
 
 which allows searches like the following to find data that is present in this node:
 
 .. code-block:: ruby
 
-   node "network_interfaces_en1_addresses:192.168.0.195"
+   node "network_interfaces_en1_addresses:192.0.2.0"
 
 This flattened data structure also supports using wildcard compound fields, which allow searches to omit levels within the JSON data structure that are not important to the search query. In the following example, an asterisk (``*``) is used to show where the wildcard can exist when searching for a nested field:
 
 .. code-block:: ruby
 
    "network_interfaces_*_flags"     => ["UP", "BROADCAST", "SMART", "RUNNING", "SIMPLEX", "MULTICAST"]
-   "network_interfaces_*_addresses" => ["fe80::fa1e:dfff:fed8:63a2", "192.168.0.195", "f8:1e:df:d8:63:a2"]
+   "network_interfaces_*_addresses" => ["fe80::fa1e:dfff:fed8:63a2", "192.0.2.0", "f8:1e:df:d8:63:a2"]
    "network_interfaces_en0_media_*" => ["autoselect", "none", "1000baseT", "10baseT/UTP", "100baseTX"]
    "network_interfaces_en1_*"       => ["1", "UP", "BROADCAST", "SMART", "RUNNING", "SIMPLEX", "MULTICAST",
-                                        "fe80::fa1e:dfff:fed8:63a2", "f8:1e:df:d8:63:a2", "192.168.0.195",
+                                        "fe80::fa1e:dfff:fed8:63a2", "f8:1e:df:d8:63:a2", "192.0.2.0",
                                         "1500", "supported", "selected", "en", "active", "Ethernet"]
 
 For each of the wildcard examples above, the possible values are shown contained within the brackets. When running a search query, the query syntax for wildcards is to simply omit the name of the node (while preserving the underscores), similar to:

--- a/chef_master/source/error_messages.rst
+++ b/chef_master/source/error_messages.rst
@@ -66,13 +66,13 @@ Cannot connect to PostgreSQL on the remote server because rules in ``pg_hba`` ar
 
 **Resolution**
 
-* Entries in the ``pg_hba.conf`` file should allow all user names that originate from any Chef server instance using ``md5`` authentication. For example, a ``pg_hba.conf`` entry for a valid username and password from the 192.168.18.0 subnet:
+* Entries in the ``pg_hba.conf`` file should allow all user names that originate from any Chef server instance using ``md5`` authentication. For example, a ``pg_hba.conf`` entry for a valid username and password from the 192.0.2.0 subnet:
 
   .. code-block:: bash
 
-	 host     postgres     all     192.168.18.0/24     md5
+	 host     postgres     all     192.0.2.0/24     md5
 
-  or, specific named users with a valid password originating from the 192.168.18.0 subnet. A file named ``$PGDATA/chef_users`` with the following content must be created:
+  or, specific named users with a valid password originating from the 192.0.2.0 subnet. A file named ``$PGDATA/chef_users`` with the following content must be created:
 
   .. code-block:: bash
 
@@ -89,16 +89,16 @@ Cannot connect to PostgreSQL on the remote server because rules in ``pg_hba`` ar
 
      host     postgres     @chef_users     192.168.93.0/24     md5
 
-  or, using the same ``$PGDATA/chef_users`` file (from the previous example), the following example shows a way to limit connections to specific nodes that are running components of the Chef server. This approach requires more maintenance because the ``pg_hba.conf`` file must be updated when machines are added to or removed from the Chef server configuration. For example, a high availability configuration with four nodes: ``backend-1`` (192.168.18.100), ``backend-2`` (192.168.18.101), ``frontend-1`` (192.168.18.110), and ``frontend-2`` (192.168.18.111).
+  or, using the same ``$PGDATA/chef_users`` file (from the previous example), the following example shows a way to limit connections to specific nodes that are running components of the Chef server. This approach requires more maintenance because the ``pg_hba.conf`` file must be updated when machines are added to or removed from the Chef server configuration. For example, a high availability configuration with four nodes: ``backend-1`` (192.0.2.100), ``backend-2`` (192.0.2.101), ``frontend-1`` (192.0.2.110), and ``frontend-2`` (192.0.2.111).
 
   The corresponding ``pg_hba.conf`` entry is similar to:
 
   .. code-block:: bash
 
-     host     postgres     @chef_users     192.168.18.100     md5
-     host     postgres     @chef_users     192.168.18.101     md5
-     host     postgres     @chef_users     192.168.18.110     md5
-     host     postgres     @chef_users     192.168.18.111     md5
+     host     postgres     @chef_users     192.0.2.100     md5
+     host     postgres     @chef_users     192.0.2.101     md5
+     host     postgres     @chef_users     192.0.2.110     md5
+     host     postgres     @chef_users     192.0.2.111     md5
 
   These changes also require a configuration reload for PostgreSQL:
 

--- a/chef_master/source/fips.rst
+++ b/chef_master/source/fips.rst
@@ -80,7 +80,7 @@ default to running in FIPS mode. Otherwise you can add ``fips true`` to the
 
 .. code-block:: bash
 
-   $ knife bootstrap 12.34.56.789 -P vanilla -x root -r 'recipe[apt],recipe[xfs],recipe[vim]' --fips
+   $ knife bootstrap 192.0.2.0 -P vanilla -x root -r 'recipe[apt],recipe[xfs],recipe[vim]' --fips
 
 which shows something similar to:
 
@@ -88,7 +88,7 @@ which shows something similar to:
 
    OpenSSL FIPS 140 mode enabled
    ...
-   12.34.56.789 Chef Client finished, 12/12 resources updated in 78.942455583 seconds
+   192.0.2.0 Chef Client finished, 12/12 resources updated in 78.942455583 seconds
 
 .. end_tag
 

--- a/chef_master/source/install_server_ha_drbd.rst
+++ b/chef_master/source/install_server_ha_drbd.rst
@@ -711,7 +711,7 @@ A completed chef-server.rb configuration file for a four server tiered Chef serv
      - Cluster IP Address
      - Role
    * - be1.example.com
-     - 192.168.4.1
+     - 192.0.2.0
      - 10.1.2.10
      - backend
    * - be2.example.com
@@ -746,7 +746,7 @@ Looks like this:
    topology "ha"
 
    server "be1.example.com",
-     :ipaddress => "192.168.4.1",
+     :ipaddress => "192.0.2.0",
      :role => "backend",
      :bootstrap => true,
      :cluster_ipaddress => "10.1.2.10"

--- a/chef_master/source/install_server_tiered.rst
+++ b/chef_master/source/install_server_tiered.rst
@@ -402,7 +402,7 @@ A completed chef-server.rb configuration file for a four server tiered Chef serv
      - Real IP Address
      - Role
    * - be1.example.com
-     - 192.168.4.1
+     - 192.0.2.0
      - backend
    * - fe1.example.com
      - 192.168.4.2
@@ -427,7 +427,7 @@ Looks like this:
    topology "tier"
 
    server "be1.example.com",
-     :ipaddress => "192.168.4.1",
+     :ipaddress => "192.0.2.0",
      :role => "backend",
      :bootstrap => true
 

--- a/chef_master/source/knife_bootstrap.rst
+++ b/chef_master/source/knife_bootstrap.rst
@@ -312,7 +312,7 @@ Changed in Chef server 12.13 to expose FIPS runtime flag on RHEL. New in Chef Cl
 
 .. code-block:: bash
 
-   $ knife bootstrap 12.34.56.789 -P vanilla -x root -r 'recipe[apt],recipe[xfs],recipe[vim]' --fips
+   $ knife bootstrap 192.0.2.0 -P vanilla -x root -r 'recipe[apt],recipe[xfs],recipe[vim]' --fips
 
 which shows something similar to:
 
@@ -320,7 +320,7 @@ which shows something similar to:
 
    OpenSSL FIPS 140 mode enabled
    ...
-   12.34.56.789 Chef Client finished, 12/12 resources updated in 78.942455583 seconds
+   192.0.2.0 Chef Client finished, 12/12 resources updated in 78.942455583 seconds
 
 .. end_tag
 
@@ -402,14 +402,14 @@ The following examples show how to use this knife subcommand:
 
 .. code-block:: bash
 
-   $ knife bootstrap 12.34.56.789 -P vanilla -x root -r 'recipe[apt],recipe[xfs],recipe[vim]'
+   $ knife bootstrap 192.0.2.0 -P vanilla -x root -r 'recipe[apt],recipe[xfs],recipe[vim]'
 
 which shows something similar to:
 
 .. code-block:: none
 
    ...
-   12.34.56.789 Chef Client finished, 12/12 resources updated in 78.942455583 seconds
+   192.0.2.0 Chef Client finished, 12/12 resources updated in 78.942455583 seconds
 
 Use ``knife node show`` to verify:
 
@@ -424,7 +424,7 @@ which returns something similar to:
    Node Name:   debian-wheezy.int.domain.org
    Environment: _default
    FQDN:        debian-wheezy.int.domain.org
-   IP:          12.34.56.789
+   IP:          192.0.2.0
    Run List:    recipe[apt], recipe[xfs], recipe[vim]
    Roles:
    Recipes:     apt, xfs, vim, apt::default, xfs::default, vim::default
@@ -437,7 +437,7 @@ which returns something similar to:
 
 .. code-block:: bash
 
-   $ knife bootstrap 192.168.1.1 -x username -P PASSWORD --sudo
+   $ knife bootstrap 192.0.2.0 -x username -P PASSWORD --sudo
 
 **Use a file that contains a private key**
 
@@ -445,7 +445,7 @@ which returns something similar to:
 
 .. code-block:: bash
 
-   $ knife bootstrap 192.168.1.1 -x username -i ~/.ssh/id_rsa --sudo
+   $ knife bootstrap 192.0.2.0 -x username -i ~/.ssh/id_rsa --sudo
 
 **Specify options when using cURL**
 

--- a/chef_master/source/knife_search.rst
+++ b/chef_master/source/knife_search.rst
@@ -123,7 +123,7 @@ Consider the following snippet of JSON data:
              "f8:1e:df:d8:63:a2": {
                "family": "lladdr"
              },
-             "192.168.0.195": {
+             "192.0.2.0": {
                "netmask": "255.255.255.0",
                "broadcast": "192.168.0.255",
                "family": "inet"
@@ -183,26 +183,26 @@ This data is also flattened into various compound fields, which follow the same 
 .. code-block:: none
 
      # ...snip...
-     "network_interfaces_en1_addresses_192.168.0.195_broadcast" => "192.168.0.255",
+     "network_interfaces_en1_addresses_192.0.2.0_broadcast" => "192.168.0.255",
      "network_interfaces_en1_addresses_fe80::fa1e:tldr_family"  => "inet6",
-     "network_interfaces_en1_addresses"                         => ["fe80::fa1e:tldr","f8:1e:df:tldr","192.168.0.195"]
+     "network_interfaces_en1_addresses"                         => ["fe80::fa1e:tldr","f8:1e:df:tldr","192.0.2.0"]
      # ...snip...
 
 which allows searches like the following to find data that is present in this node:
 
 .. code-block:: ruby
 
-   node "network_interfaces_en1_addresses:192.168.0.195"
+   node "network_interfaces_en1_addresses:192.0.2.0"
 
 This flattened data structure also supports using wildcard compound fields, which allow searches to omit levels within the JSON data structure that are not important to the search query. In the following example, an asterisk (``*``) is used to show where the wildcard can exist when searching for a nested field:
 
 .. code-block:: ruby
 
    "network_interfaces_*_flags"     => ["UP", "BROADCAST", "SMART", "RUNNING", "SIMPLEX", "MULTICAST"]
-   "network_interfaces_*_addresses" => ["fe80::fa1e:dfff:fed8:63a2", "192.168.0.195", "f8:1e:df:d8:63:a2"]
+   "network_interfaces_*_addresses" => ["fe80::fa1e:dfff:fed8:63a2", "192.0.2.0", "f8:1e:df:d8:63:a2"]
    "network_interfaces_en0_media_*" => ["autoselect", "none", "1000baseT", "10baseT/UTP", "100baseTX"]
    "network_interfaces_en1_*"       => ["1", "UP", "BROADCAST", "SMART", "RUNNING", "SIMPLEX", "MULTICAST",
-                                        "fe80::fa1e:dfff:fed8:63a2", "f8:1e:df:d8:63:a2", "192.168.0.195",
+                                        "fe80::fa1e:dfff:fed8:63a2", "f8:1e:df:d8:63:a2", "192.0.2.0",
                                         "1500", "supported", "selected", "en", "active", "Ethernet"]
 
 For each of the wildcard examples above, the possible values are shown contained within the brackets. When running a search query, the query syntax for wildcards is to simply omit the name of the node (while preserving the underscores), similar to:
@@ -267,9 +267,9 @@ To use a range search to find IP addresses within a subnet, enter the following:
 
 .. code-block:: bash
 
-   $ knife search node 'ipaddress:[192.168.0.* TO 192.168.127.*]'
+   $ knife search node 'ipaddress:[192.168.0.* TO 192.0.2.*]'
 
-where ``192.168.0.* TO 192.168.127.*`` defines the subnet range.
+where ``192.168.0.* TO 192.0.2.*`` defines the subnet range.
 
 .. end_tag
 

--- a/chef_master/source/manage.rst
+++ b/chef_master/source/manage.rst
@@ -102,7 +102,7 @@ Consider the following snippet of JSON data:
              "f8:1e:df:d8:63:a2": {
                "family": "lladdr"
              },
-             "192.168.0.195": {
+             "192.0.2.0": {
                "netmask": "255.255.255.0",
                "broadcast": "192.168.0.255",
                "family": "inet"
@@ -162,26 +162,26 @@ This data is also flattened into various compound fields, which follow the same 
 .. code-block:: none
 
      # ...snip...
-     "network_interfaces_en1_addresses_192.168.0.195_broadcast" => "192.168.0.255",
+     "network_interfaces_en1_addresses_192.0.2.0_broadcast" => "192.168.0.255",
      "network_interfaces_en1_addresses_fe80::fa1e:tldr_family"  => "inet6",
-     "network_interfaces_en1_addresses"                         => ["fe80::fa1e:tldr","f8:1e:df:tldr","192.168.0.195"]
+     "network_interfaces_en1_addresses"                         => ["fe80::fa1e:tldr","f8:1e:df:tldr","192.0.2.0"]
      # ...snip...
 
 which allows searches like the following to find data that is present in this node:
 
 .. code-block:: ruby
 
-   node "network_interfaces_en1_addresses:192.168.0.195"
+   node "network_interfaces_en1_addresses:192.0.2.0"
 
 This flattened data structure also supports using wildcard compound fields, which allow searches to omit levels within the JSON data structure that are not important to the search query. In the following example, an asterisk (``*``) is used to show where the wildcard can exist when searching for a nested field:
 
 .. code-block:: ruby
 
    "network_interfaces_*_flags"     => ["UP", "BROADCAST", "SMART", "RUNNING", "SIMPLEX", "MULTICAST"]
-   "network_interfaces_*_addresses" => ["fe80::fa1e:dfff:fed8:63a2", "192.168.0.195", "f8:1e:df:d8:63:a2"]
+   "network_interfaces_*_addresses" => ["fe80::fa1e:dfff:fed8:63a2", "192.0.2.0", "f8:1e:df:d8:63:a2"]
    "network_interfaces_en0_media_*" => ["autoselect", "none", "1000baseT", "10baseT/UTP", "100baseTX"]
    "network_interfaces_en1_*"       => ["1", "UP", "BROADCAST", "SMART", "RUNNING", "SIMPLEX", "MULTICAST",
-                                        "fe80::fa1e:dfff:fed8:63a2", "f8:1e:df:d8:63:a2", "192.168.0.195",
+                                        "fe80::fa1e:dfff:fed8:63a2", "f8:1e:df:d8:63:a2", "192.0.2.0",
                                         "1500", "supported", "selected", "en", "active", "Ethernet"]
 
 For each of the wildcard examples above, the possible values are shown contained within the brackets. When running a search query, the query syntax for wildcards is to simply omit the name of the node (while preserving the underscores), similar to:

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -1579,7 +1579,7 @@ The following command-line option may be used to with a knife or chef-client exe
 
 .. code-block:: bash
 
-   $ knife bootstrap 12.34.56.789 -P vanilla -x root -r 'recipe[apt],recipe[xfs],recipe[vim]' --fips
+   $ knife bootstrap 192.0.2.0 -P vanilla -x root -r 'recipe[apt],recipe[xfs],recipe[vim]' --fips
 
 which shows something similar to:
 
@@ -1587,7 +1587,7 @@ which shows something similar to:
 
    OpenSSL FIPS 140 mode enabled
    ...
-   12.34.56.789 Chef Client finished, 12/12 resources updated in 78.942455583 seconds
+   192.0.2.0 Chef Client finished, 12/12 resources updated in 78.942455583 seconds
 
 .. end_tag
 

--- a/chef_master/source/server_logs.rst
+++ b/chef_master/source/server_logs.rst
@@ -185,7 +185,7 @@ A sample log line:
 
 .. code-block:: bash
 
-   192.168.4.1 - - [17/Feb/2012:16:02:42 -0800]
+   192.0.2.0 - - [17/Feb/2012:16:02:42 -0800]
      "GET /organizations/nginx/cookbooks HTTP/1.1" 200
      "0.346" 12 "-"
      "Chef Knife/0.10.4 (ruby-1.9.3-p0;

--- a/misc/kitchen.txt
+++ b/misc/kitchen.txt
@@ -160,7 +160,7 @@ Preparing...                #####  ########################################### [
         -server 1.centos.pool.ntp.org
         -server 2.centos.pool.ntp.org
         -
-        -#broadcast 192.168.1.255 autokey	# broadcast server
+        -#broadcast 192.0.2.055 autokey	# broadcast server
         -#broadcastclient			# broadcast client
         -#broadcast 224.0.1.1 autokey		# multicast server
         -#multicastclient 224.0.1.1		# multicast client


### PR DESCRIPTION
The documentation currently references real ip addresses. 
Change all ip addresses to use RFC5737 documentation ip addresses

- 192.0.2.0/24  
- 198.51.100.0/24  
- 203.0.113.0/24  

https://tools.ietf.org/html/rfc5737