### PR TITLE
Replace references to management console with Automate

### DIFF
--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -558,7 +558,7 @@ Some important aspects of policy include:
        * An ordered list of roles and/or recipes that are run in the exact order defined in the run-list; if a recipe appears more than once in the run-list, the chef-client will not run it twice
        * Always specific to the node on which it runs; nodes may have a run-list that is identical to the run-list used by other nodes
        * Stored as part of the node object on the Chef server
-       * Maintained using knife, and then uploaded from the workstation to the Chef server, or is maintained using the Chef management console
+       * Maintained using knife and then uploaded from the workstation to the Chef server, or maintained using Chef Automate
 
        .. end_tag
 

--- a/chef_master/source/knife_node.rst
+++ b/chef_master/source/knife_node.rst
@@ -289,7 +289,7 @@ A run-list defines all of the information necessary for Chef to configure a node
 * An ordered list of roles and/or recipes that are run in the exact order defined in the run-list; if a recipe appears more than once in the run-list, the chef-client will not run it twice
 * Always specific to the node on which it runs; nodes may have a run-list that is identical to the run-list used by other nodes
 * Stored as part of the node object on the Chef server
-* Maintained using knife, and then uploaded from the workstation to the Chef server, or is maintained using the Chef management console
+* Maintained using knife and then uploaded from the workstation to the Chef server, or maintained using Chef Automate
 
 .. end_tag
 

--- a/chef_master/source/nodes.rst
+++ b/chef_master/source/nodes.rst
@@ -116,7 +116,7 @@ A run-list defines all of the information necessary for Chef to configure a node
 * An ordered list of roles and/or recipes that are run in the exact order defined in the run-list; if a recipe appears more than once in the run-list, the chef-client will not run it twice
 * Always specific to the node on which it runs; nodes may have a run-list that is identical to the run-list used by other nodes
 * Stored as part of the node object on the Chef server
-* Maintained using knife, and then uploaded from the workstation to the Chef server, or is maintained using the Chef management console
+* Maintained using knife, and then uploaded from the workstation to the Chef server, or is maintained using Chef Automate
 
 .. end_tag
 
@@ -171,11 +171,11 @@ Manage Nodes
 
 .. This section is just tossed in here to keep track of it. Probably needs a super-heavy edit. And much of it probably lives elsewhere.
 
-There are several ways to manage nodes directly, including by using knife, the Chef management console add-on for the Chef server, or by using command-line tools that are specific to chef-client.
+There are several ways to manage nodes directly, including by using knife, Chef Automate, or by using command-line tools that are specific to chef-client.
 
 * knife can be used to create, edit, view, list, tag, and delete nodes.
 * knife plug-ins can be used to create, edit, and manage nodes that are located on cloud providers.
-* The Chef management console add-on can be used to create, edit, view, list, tag, and delete nodes. In addition, node attributes can be modified and nodes can be moved between environments.
+* Chef Automate can be used to create, edit, view, list, tag, and delete nodes. In addition, node attributes can be modified and nodes can be moved between environments.
 * The chef-client can be used to manage node data using the command line and JSON files. Each JSON file contains a hash, the elements of which are added as node attributes. In addition, the ``run_list`` setting allows roles and/or recipes to be added to the node.
 * chef-solo can be used to manage node data using the command line and JSON files. Each JSON file contains a hash, the elements of which are added as node attributes. In addition, the ``run_list`` setting allows roles and/or recipes to be added to the node.
 * The command line can also be used to edit JSON files and files that are related to third-party services, such as Amazon EC2, where the JSON files can contain per-instance metadata that is stored in a file on-disk and then read by chef-solo or chef-client as required.

--- a/chef_master/source/nodes.rst
+++ b/chef_master/source/nodes.rst
@@ -116,7 +116,7 @@ A run-list defines all of the information necessary for Chef to configure a node
 * An ordered list of roles and/or recipes that are run in the exact order defined in the run-list; if a recipe appears more than once in the run-list, the chef-client will not run it twice
 * Always specific to the node on which it runs; nodes may have a run-list that is identical to the run-list used by other nodes
 * Stored as part of the node object on the Chef server
-* Maintained using knife, and then uploaded from the workstation to the Chef server, or is maintained using Chef Automate
+* Maintained using knife and then uploaded from the workstation to the Chef server, or maintained using Chef Automate
 
 .. end_tag
 
@@ -171,7 +171,7 @@ Manage Nodes
 
 .. This section is just tossed in here to keep track of it. Probably needs a super-heavy edit. And much of it probably lives elsewhere.
 
-There are several ways to manage nodes directly, including by using knife, Chef Automate, or by using command-line tools that are specific to chef-client.
+There are several ways to manage nodes directly: via knife, Chef Automate, or by using command-line tools that are specific to chef-client.
 
 * knife can be used to create, edit, view, list, tag, and delete nodes.
 * knife plug-ins can be used to create, edit, and manage nodes that are located on cloud providers.

--- a/chef_master/source/provisioning.rst
+++ b/chef_master/source/provisioning.rst
@@ -1744,7 +1744,7 @@ This resource has the following properties:
    * An ordered list of roles and/or recipes that are run in the exact order defined in the run-list; if a recipe appears more than once in the run-list, the chef-client will not run it twice
    * Always specific to the node on which it runs; nodes may have a run-list that is identical to the run-list used by other nodes
    * Stored as part of the node object on the Chef server
-   * Maintained using knife, and then uploaded from the workstation to the Chef server, or is maintained using the Chef management console
+   * Maintained using knife and then uploaded from the workstation to the Chef server, or maintained using Chef Automate
 
    .. end_tag
 

--- a/chef_master/source/resource_machine_image.rst
+++ b/chef_master/source/resource_machine_image.rst
@@ -165,7 +165,7 @@ This resource has the following properties:
    * An ordered list of roles and/or recipes that are run in the exact order defined in the run-list; if a recipe appears more than once in the run-list, the chef-client will not run it twice
    * Always specific to the node on which it runs; nodes may have a run-list that is identical to the run-list used by other nodes
    * Stored as part of the node object on the Chef server
-   * Maintained using knife, and then uploaded from the workstation to the Chef server, or is maintained using the Chef management console
+   * Maintained using knife and then uploaded from the workstation to the Chef server, or maintained using Chef Automate
 
    .. end_tag
 

--- a/chef_master/source/run_lists.rst
+++ b/chef_master/source/run_lists.rst
@@ -10,7 +10,7 @@ A run-list defines all of the information necessary for Chef to configure a node
 * An ordered list of roles and/or recipes that are run in the exact order defined in the run-list; if a recipe appears more than once in the run-list, the chef-client will not run it twice
 * Always specific to the node on which it runs; nodes may have a run-list that is identical to the run-list used by other nodes
 * Stored as part of the node object on the Chef server
-* Maintained using knife, and then uploaded from the workstation to the Chef server, or is maintained using the Chef management console
+* Maintained using knife and then uploaded from the workstation to the Chef server, or maintained using Chef Automate
 
 .. end_tag
 
@@ -132,7 +132,7 @@ A run-list defines all of the information necessary for Chef to configure a node
 * An ordered list of roles and/or recipes that are run in the exact order defined in the run-list; if a recipe appears more than once in the run-list, the chef-client will not run it twice
 * Always specific to the node on which it runs; nodes may have a run-list that is identical to the run-list used by other nodes
 * Stored as part of the node object on the Chef server
-* Maintained using knife, and then uploaded from the workstation to the Chef server, or is maintained using the Chef management console
+* Maintained using knife and then uploaded from the workstation to the Chef server, or maintained using Chef Automate
 
 .. end_tag
 

--- a/chef_master/source/server_manage_nodes.rst
+++ b/chef_master/source/server_manage_nodes.rst
@@ -124,7 +124,7 @@ A run-list defines all of the information necessary for Chef to configure a node
 * An ordered list of roles and/or recipes that are run in the exact order defined in the run-list; if a recipe appears more than once in the run-list, the chef-client will not run it twice
 * Always specific to the node on which it runs; nodes may have a run-list that is identical to the run-list used by other nodes
 * Stored as part of the node object on the Chef server
-* Maintained using knife, and then uploaded from the workstation to the Chef server, or is maintained using the Chef management console
+* Maintained using knife and then uploaded from the workstation to the Chef server, or maintained using Chef Automate
 
 .. end_tag
 

--- a/chef_master/source/server_manage_roles.rst
+++ b/chef_master/source/server_manage_roles.rst
@@ -81,7 +81,7 @@ A run-list defines all of the information necessary for Chef to configure a node
 * An ordered list of roles and/or recipes that are run in the exact order defined in the run-list; if a recipe appears more than once in the run-list, the chef-client will not run it twice
 * Always specific to the node on which it runs; nodes may have a run-list that is identical to the run-list used by other nodes
 * Stored as part of the node object on the Chef server
-* Maintained using knife, and then uploaded from the workstation to the Chef server, or is maintained using the Chef management console
+* Maintained using knife and then uploaded from the workstation to the Chef server, or maintained using Chef Automate
 
 .. end_tag
 


### PR DESCRIPTION
Management console isn't really a think. I think we meant "manage" here, which isn't really a thing anymore.