### PR TITLE
Remove openssl mention that isn't relevant

### DIFF
--- a/chef_master/source/auth.rst
+++ b/chef_master/source/auth.rst
@@ -7,8 +7,6 @@ Authentication, Authorization
 
 All communication with the Chef server must be authenticated using the Chef server API, which is a REST API that allows requests to be made to the Chef server. Only authenticated requests will be authorized. Most of the time, and especially when using knife, the chef-client, or the Chef server web interface, the use of the Chef server API is transparent. In some cases, the use of the Chef server API requires more detail, such as when making the request in Ruby code, with a knife plugin, or when using cURL.
 
-Changed in Chef Client 12.8 to use OpenSSL version 1.0.1.
-
 .. end_tag
 
 Authentication

--- a/chef_master/source/chef_client_overview.rst
+++ b/chef_master/source/chef_client_overview.rst
@@ -1,7 +1,7 @@
 =====================================================
 Chef Client Overview
 =====================================================
-`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/chef_client.rst>`__
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/chef_client_overview.rst>`__
 
 
 
@@ -104,8 +104,6 @@ Authentication
 .. tag chef_auth
 
 All communication with the Chef server must be authenticated using the Chef server API, which is a REST API that allows requests to be made to the Chef server. Only authenticated requests will be authorized. Most of the time, and especially when using knife, the chef-client, or the Chef server web interface, the use of the Chef server API is transparent. In some cases, the use of the Chef server API requires more detail, such as when making the request in Ruby code, with a knife plugin, or when using cURL.
-
-Changed in Chef Client 12.8 to use OpenSSL version 1.0.1.
 
 .. end_tag
 

--- a/chef_master/source/chef_client_security.rst
+++ b/chef_master/source/chef_client_security.rst
@@ -7,8 +7,6 @@ chef-client Security
 
 All communication with the Chef server must be authenticated using the Chef server API, which is a REST API that allows requests to be made to the Chef server. Only authenticated requests will be authorized. Most of the time, and especially when using knife, the chef-client, or the Chef server web interface, the use of the Chef server API is transparent. In some cases, the use of the Chef server API requires more detail, such as when making the request in Ruby code, with a knife plugin, or when using cURL.
 
-Changed in Chef Client 12.8 to use OpenSSL version 1.0.1.
-
 .. end_tag
 
 Authentication


### PR DESCRIPTION
We've changed the openssl version multiple times and it has no impact on the users. They don't need to know this.