### PR TITLE
Support Push Jobs Client on Windows Server 2016

### DIFF
--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -268,7 +268,7 @@ The following table lists the commercially-supported platforms for the Chef push
      - ``14.04``
    * - Microsoft Windows
      - ``x86``, ``x86_64``
-     - ``2008r2``, ``2012``, ``2012r2``, ``7``, ``8``, ``8.1``, ``10``
+     - ``2008r2``, ``2012``, ``2012r2``, ``2016``, ``7``, ``8``, ``8.1``, ``10``
 
 .. end_tag
 

--- a/chef_master/source/push_jobs.rst
+++ b/chef_master/source/push_jobs.rst
@@ -55,7 +55,7 @@ The following table lists the commercially-supported platforms for the Chef push
      - ``14.04``
    * - Microsoft Windows
      - ``x86``, ``x86_64``
-     - ``2008r2``, ``2012``, ``2012r2``, ``7``, ``8``, ``8.1``, ``10``
+     - ``2008r2``, ``2012``, ``2012r2``, ``2016``, ``7``, ``8``, ``8.1``, ``10``
 
 .. end_tag
 


### PR DESCRIPTION
Engineering has validated that Push Jobs Client works on Windows Server 2016, so we want to document that we do support it.
