### PR TITLE
Don't give and example of a package resource with a provider

### DIFF
--- a/chef_master/source/resource_common.rst
+++ b/chef_master/source/resource_common.rst
@@ -110,14 +110,15 @@ The following examples show how to use common properties in a recipe.
 
 **Use the provider common property**
 
-.. tag resource_package_use_provider_attribute
+.. tag resource_service_use_provider_attribute
 
 .. To use the ``:provider`` common attribute in a recipe:
 
 .. code-block:: ruby
 
-   package 'some_package' do
-     provider Chef::Provider::Package::Rubygems
+   service 'some_service' do
+     provider Chef::Provider::Service::Upstart
+     action [ :enable, :start ]
    end
 
 .. end_tag
@@ -131,7 +132,7 @@ The following examples show how to use common properties in a recipe.
 .. code-block:: ruby
 
    service 'apache' do
-     action :start
+     action [ :enable, :start ]
      retries 3
    end
 

--- a/chef_master/source/resource_examples.rst
+++ b/chef_master/source/resource_examples.rst
@@ -61,7 +61,7 @@ The examples in this section show functionality that is common across all resour
 .. code-block:: ruby
 
    service 'apache' do
-     action :start
+     action [ :enable, :start ]
      retries 3
    end
 
@@ -5973,7 +5973,7 @@ Use the **service** resource to manage a service.
 .. code-block:: ruby
 
    service 'apache' do
-     action :start
+     action [ :enable, :start ]
      retries 3
    end
 

--- a/chef_master/source/resource_service.rst
+++ b/chef_master/source/resource_service.rst
@@ -397,7 +397,7 @@ The following examples demonstrate various approaches for using resources in rec
 .. code-block:: ruby
 
    service 'apache' do
-     action :start
+     action [ :enable, :start ]
      retries 3
    end
 

--- a/chef_master/source/resources.rst
+++ b/chef_master/source/resources.rst
@@ -193,7 +193,7 @@ The following examples show how to use common properties in a recipe.
 .. code-block:: ruby
 
    service 'apache' do
-     action :start
+     action [ :enable, :start ]
      retries 3
    end
 


### PR DESCRIPTION
We have an entire foodcritic rule now to try to convince people to stop doing this. It breaks things