### PR TITLE
The guard's environment _is_ inherited from the parent resource.

### DIFF
--- a/chef_master/source/resource_execute.rst
+++ b/chef_master/source/resource_execute.rst
@@ -303,13 +303,13 @@ A guard property is useful for ensuring that a resource is idempotent by allowin
 
 .. note:: .. tag resources_common_guards_execute_resource
 
-          When using the ``not_if`` and ``only_if`` guards with the **execute** resource, the current working directory property (``cwd``) is **not** inherited from the resource. For example:
+          When using the ``not_if`` and ``only_if`` guards with the **execute** resource, the guard's environment is inherited from the resource's environment. For example:
 
           .. code-block:: ruby
 
              execute 'bundle install' do
                cwd '/myapp'
-               not_if 'bundle check' # This is not run inside /myapp
+               not_if 'bundle check' # This is run from /myapp
              end
 
           .. end_tag


### PR DESCRIPTION
fixes #887 