### PR TITLE
MSYS-679 - Added doc for full ohai tag 

### DIFF
--- a/chef_master/source/ctl_automate_server.rst
+++ b/chef_master/source/ctl_automate_server.rst
@@ -468,6 +468,7 @@ The ``install-runner`` subcommand configures a remote node as a job runner, whic
       -y, --yes                             Skip configuration confirmation and overwrite any existing Chef Server nodes of the same name as FQDN
       -e, --enterprise                      Legacy option, only required if you have more than one enterprise configured. Workflow enterprise to add the runner into
       --fips-custom-cert-filename FILENAME  If you have a self-signed or self-owned Certificate Authority (CA) and wish to operate in FIPS mode, pass this flag the path to a file containing your custom certificate chain on your Automate server. This file will be copied to the runner and used when running jobs in FIPS mode. If you have purchased a certificate from a known CA for Automate server, you can ignore this flag. Please see the Automate FIPS docs for details.
+      --full-ohai                           If `--full-ohai` flag set, Chef will run with full Ohai plugins.
 
 
 .. note:: The username provided must be a user who has sudo access on the remote node. If the user is a member of a domain, then the username value should be entered as ``user@domain``.

--- a/chef_master/source/setup_build_node.rst
+++ b/chef_master/source/setup_build_node.rst
@@ -20,10 +20,17 @@ The following steps should be performed on a Chef Automate server:
                                       --password [$OPTIONAL_SSH_OR_SUDO_PASSWORD] \
                                       --installer $CHEF_DK_PACKAGE_PATH \
                                       --ssh-identity-file $SSH_IDENTITY_FILE \
-                                      --port $SSH_PORT            
+                                      --port $SSH_PORT \
+                                      --full-ohai
    .. tag chef_automate_build_nodes
 
    .. note:: Legacy build nodes created by ``delivery-cluster`` can be used with a Chef Automate server.  Some node visibility features are designed to only work with new build nodes and runners installed through the command line process, but the workflow feature in Chef Automate can use legacy, new, or mixed node pools; however, you cannot upgrade a legacy build node to the new build node or runner models.  If you would like to use new build nodes/runners, please use fresh hosts or completely wipe your legacy build nodes before attempting to run ``automate-ctl install-build-node`` or ``automate-ctl install-runner``.
+
+   .. end_tag
+
+   .. tag chef_automate_build_nodes_with_full_ohai
+
+   .. note:: If ``--full-ohai`` flag is set, Chef runs with full Ohai plugins. By default, Chef runs with bare Ohai plugins that are required for the node.
 
    .. end_tag
 


### PR DESCRIPTION
Added doc for the full ohai tag with install-runner and install-build-node.

As: If `--full-ohai` flag is set, Chef runs with full Ohai plugins. By default, Chef runs with bare Ohai plugins that are required for the node.