### PR TITLE
Added an alternative way to define the proxy settings

### DIFF
--- a/chef_master/source/config_rb_client.rst
+++ b/chef_master/source/config_rb_client.rst
@@ -34,7 +34,7 @@ This configuration file has the following settings:
    .. code-block:: ruby
 
       knife[:authentication_protocol_version] = '1.3'
-      
+
    Note that authentication protocol 1.3 is only supported on Chef server versions 12.4.0 and above.
 
 ``automatic_attribute_blacklist``
@@ -410,6 +410,12 @@ If ``http_proxy``, ``https_proxy``, ``ftp_proxy``, or ``no_proxy`` is set in the
    http_proxy 'http://proxy.example.org:8080'
    http_proxy_user 'myself'
    http_proxy_pass 'Password1'
+
+Or an alternative way to define the proxy (if the previous version does not work):
+
+.. code-block:: ruby
+
+   http_proxy 'http://myself:Password1@proxy.example.org:8080'
 
 will be set to:
 

--- a/chef_master/source/proxies.rst
+++ b/chef_master/source/proxies.rst
@@ -139,6 +139,12 @@ If ``http_proxy``, ``https_proxy``, ``ftp_proxy``, or ``no_proxy`` is set in the
    http_proxy_user 'myself'
    http_proxy_pass 'Password1'
 
+Or an alternative way to define the proxy (if the previous version does not work):
+
+.. code-block:: ruby
+
+   http_proxy 'http://myself:Password1@proxy.example.org:8080'
+
 will be set to:
 
 .. code-block:: ruby


### PR DESCRIPTION
According to the official docs, the proxy shall be specified by `proxy_user` and `proxy_pass`. We lost a lot of time because we tried to do so, but did not work out. Even the chef support (official ticket) was not able to solve it right away. 

As soon as we defined the proxy in a one-liner, it worked. I don't doubt that the described way is wrong - it simply did not work in our case. Thus, I would love to add this comment to the official docs. I hope other people could save time if the face similar issues. 

This is also documented here
https://github.com/chef-cookbooks/chef-server/issues/145