### PR TITLE
Round brackets for git resource environment attribute

### DIFF
--- a/chef_master/source/resource_git.rst
+++ b/chef_master/source/resource_git.rst
@@ -388,7 +388,7 @@ The following example uses the **git** resource to upgrade packages:
    git '/opt/mysources/couch' do
      repository 'git://git.apache.org/couchdb.git'
      revision 'master'
-     environment  { 'VAR' => 'whatever' }
+     environment( 'VAR' => 'whatever' )
      action :sync
    end
 


### PR DESCRIPTION
I found in testing that curly brackets in the environment attribute causes my chef runs to break. 
I tested using ruby versions 2.2.1 and 2.4.1

Note: There should be no space between `environment` and the open bracket. Having a space there also breaks too.