### PR TITLE
[MSYS-736]Allow setting environment variables at the user level

### DIFF
--- a/chef_master/source/resource_env.rst
+++ b/chef_master/source/resource_env.rst
@@ -35,6 +35,7 @@ The full syntax for all of the properties that are available to the **env** reso
      subscribes                 # see description
      value                      String
      action                     Symbol # defaults to :create if not specified
+     user                       String # defaults to SYSTEM
    end
 
 where
@@ -42,7 +43,7 @@ where
 * ``env`` is the resource
 * ``name`` is the name of the resource block
 * ``action`` identifies the steps the chef-client will take to bring the node into the desired state
-* ``delim``, ``key_name``, ``provider``, and ``value`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
+* ``delim``, ``key_name``, ``provider``, ``value``, and ``user`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
 .. end_tag
 
@@ -193,6 +194,11 @@ This resource has the following properties:
    **Ruby Type:** String
 
    The value with which ``key_name`` is set.
+
+``user``
+   **Ruby Type:** String | **Default Value:** ``'SYSTEM'``
+
+   The user name with which ``key_name`` is set.
 
 .. end_tag
 

--- a/chef_master/source/resource_windows_env.rst
+++ b/chef_master/source/resource_windows_env.rst
@@ -1,33 +1,54 @@
 =====================================================
-env
+windows_env
 =====================================================
-`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_env.rst>`__
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_windows_env.rst>`__
 
-.. tag resource_env_summary
+.. tag resource_windows_env_summary
 
-Use the **env** resource to manage environment keys in Microsoft Windows. After an environment key is set, Microsoft Windows must be restarted before the environment key will be available to the Task Scheduler.
+Use the **windows_env** resource to manage environment keys in Microsoft Windows. After an environment key is set, Microsoft Windows must be restarted before the environment key will be available to the Task Scheduler.
 
 .. end_tag
 
-.. note:: On UNIX-based systems, the best way to manipulate environment keys is with the ``ENV`` variable in Ruby; however, this approach does not have the same permanent effect as using the **env** resource.
+.. note:: On UNIX-based systems, the best way to manipulate environment keys is with the ``ENV`` variable in Ruby; however, this approach does not have the same permanent effect as using the **windows_env** resource.
+
+Deprecation: Deprecation of resource_env (CHEF-14 (14.0.55+))
+=====================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_windows_env.rst>`__
+
+.. tag deprecations_resource_env
+
+The old env resource has been replaced by windows_env resource.
+
+.. end_tag
 
 Syntax
 =====================================================
 .. tag resource_env_syntax
-
-A **env** resource block manages environment keys in Microsoft Windows:
+Previously a **env** resource block manages environment keys in Microsoft Windows:
 
 .. code-block:: ruby
 
    env 'ComSpec' do
      value 'C:\\Windows\\system32\\cmd.exe'
    end
+   
+.. end_tag
 
-The full syntax for all of the properties that are available to the **env** resource is:
+.. tag resource_windows_env_syntax
+
+A **windows_env** resource block manages environment keys in Microsoft Windows:
 
 .. code-block:: ruby
 
-   env 'name' do
+   windows_env 'ComSpec' do
+     value 'C:\\Windows\\system32\\cmd.exe'
+   end
+
+The full syntax for all of the properties that are available to the **windows_env** resource is:
+
+.. code-block:: ruby
+
+   windows_env 'name' do
      delim                      String
      key_name                   String # defaults to 'name' if not specified
      notifies                   # see description
@@ -35,21 +56,20 @@ The full syntax for all of the properties that are available to the **env** reso
      subscribes                 # see description
      value                      String
      action                     Symbol # defaults to :create if not specified
-     user                       String # defaults to SYSTEM
    end
 
 where
 
-* ``env`` is the resource
+* ``windows_env`` is the resource
 * ``name`` is the name of the resource block
 * ``action`` identifies the steps the chef-client will take to bring the node into the desired state
-* ``delim``, ``key_name``, ``provider``, ``value``, and ``user`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
+* ``delim``, ``key_name``, ``provider``, and ``value`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
 .. end_tag
 
 Actions
 =====================================================
-.. tag resource_env_actions
+.. tag resource_windows_env_actions
 
 This resource has the following actions:
 
@@ -73,7 +93,7 @@ This resource has the following actions:
 
 Properties
 =====================================================
-.. tag resource_env_attributes
+.. tag resource_windows_env_attributes
 
 This resource has the following properties:
 
@@ -195,11 +215,6 @@ This resource has the following properties:
 
    The value with which ``key_name`` is set.
 
-``user``
-   **Ruby Type:** String | **Default Value:** ``'SYSTEM'``
-
-   The user name with which ``key_name`` is set.
-
 .. end_tag
 
 Guards
@@ -286,7 +301,7 @@ The following examples demonstrate various approaches for using resources in rec
 
 .. code-block:: ruby
 
-   env 'ComSpec' do
+   windows_env 'ComSpec' do
      value "C:\\Windows\\system32\\cmd.exe"
    end
 


### PR DESCRIPTION
The `env` resource allows you to set a system environment variable, but windows also allow per-user environment variables.
https://blogs.technet.microsoft.com/heyscriptingguy/2005/03/18/how-can-i-create-an-environment-variable-using-a-script/
It looks like we could simply add a user property.
Acceptance criteria:
Doc updates for the env resource for docs.chef.io
Related: chef/chef#6612