### PR TITLE
Change all whitelist or blacklist attribute examples to automatic

### DIFF
--- a/chef_master/source/attributes.rst
+++ b/chef_master/source/attributes.rst
@@ -370,7 +370,7 @@ Attributes are blacklisted by attribute type, with each attribute type being bla
 
 .. warning:: The recommended practice is to use only ``automatic_attribute_blacklist`` for blacklisting attributes. This is primarily because automatic attributes generate the most data, but also that normal, default, and override attributes are typically much more important attributes and are more likely to cause issues if they are blacklisted incorrectly.
 
-For example, normal attribute data similar to:
+For example, automatic attribute data similar to:
 
 .. code-block:: javascript
 
@@ -395,9 +395,9 @@ To blacklist the ``filesystem`` attributes and allow the other attributes to be 
 
 .. code-block:: ruby
 
-   normal_attribute_blacklist ['filesystem']
+   automatic_attribute_blacklist ['filesystem']
 
-When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for normal attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
+When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for automatic attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
 
 For attributes that contain slashes (``/``) within the attribute value, such as the ``filesystem`` attribute ``'/dev/diskos2'``, use an array. For example:
 
@@ -434,7 +434,7 @@ Attributes are whitelisted by attribute type, with each attribute type being whi
 
 .. warning:: The recommended practice is to only use ``automatic_attribute_whitelist`` to whitelist attributes. This is primarily because automatic attributes generate the most data, but also that normal, default, and override attributes are typically much more important attributes and are more likely to cause issues if they are whitelisted incorrectly.
 
-For example, normal attribute data similar to:
+For example, automatic attribute data similar to:
 
 .. code-block:: javascript
 
@@ -459,15 +459,15 @@ To whitelist the ``network`` attributes and prevent the other attributes from be
 
 .. code-block:: ruby
 
-   normal_attribute_whitelist ['network/interfaces/']
+   automatic_attribute_whitelist ['network/interfaces/']
 
-When a whitelist is defined, any attribute of that type that is not specified in that attribute whitelist **will not** be saved. So based on the previous whitelist for normal attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
+When a whitelist is defined, any attribute of that type that is not specified in that attribute whitelist **will not** be saved. So based on the previous whitelist for automatic attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
 
 Leave the value empty to prevent all attributes of that attribute type from being saved:
 
 .. code-block:: ruby
 
-   normal_attribute_whitelist []
+   automatic_attribute_whitelist []
 
 For attributes that contain slashes (``/``) within the attribute value, such as the ``filesystem`` attribute ``'/dev/diskos2'``, use an array. For example:
 

--- a/chef_master/source/environments.rst
+++ b/chef_master/source/environments.rst
@@ -127,7 +127,7 @@ Attributes are blacklisted by attribute type, with each attribute type being bla
 
 .. warning:: The recommended practice is to use only ``automatic_attribute_blacklist`` for blacklisting attributes. This is primarily because automatic attributes generate the most data, but also that normal, default, and override attributes are typically much more important attributes and are more likely to cause issues if they are blacklisted incorrectly.
 
-For example, normal attribute data similar to:
+For example, automatic attribute data similar to:
 
 .. code-block:: javascript
 
@@ -152,9 +152,9 @@ To blacklist the ``filesystem`` attributes and allow the other attributes to be 
 
 .. code-block:: ruby
 
-   normal_attribute_blacklist ['filesystem']
+   automatic_attribute_blacklist ['filesystem']
 
-When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for normal attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
+When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for automatic attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
 
 For attributes that contain slashes (``/``) within the attribute value, such as the ``filesystem`` attribute ``'/dev/diskos2'``, use an array. For example:
 
@@ -191,7 +191,7 @@ Attributes are whitelisted by attribute type, with each attribute type being whi
 
 .. warning:: The recommended practice is to only use ``automatic_attribute_whitelist`` to whitelist attributes. This is primarily because automatic attributes generate the most data, but also that normal, default, and override attributes are typically much more important attributes and are more likely to cause issues if they are whitelisted incorrectly.
 
-For example, normal attribute data similar to:
+For example, automatic attribute data similar to:
 
 .. code-block:: javascript
 
@@ -216,15 +216,15 @@ To whitelist the ``network`` attributes and prevent the other attributes from be
 
 .. code-block:: ruby
 
-   normal_attribute_whitelist ['network/interfaces/']
+   automatic_attribute_whitelist ['network/interfaces/']
 
-When a whitelist is defined, any attribute of that type that is not specified in that attribute whitelist **will not** be saved. So based on the previous whitelist for normal attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
+When a whitelist is defined, any attribute of that type that is not specified in that attribute whitelist **will not** be saved. So based on the previous whitelist for automatic attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
 
 Leave the value empty to prevent all attributes of that attribute type from being saved:
 
 .. code-block:: ruby
 
-   normal_attribute_whitelist []
+   automatic_attribute_whitelist []
 
 For attributes that contain slashes (``/``) within the attribute value, such as the ``filesystem`` attribute ``'/dev/diskos2'``, use an array. For example:
 

--- a/chef_master/source/nodes.rst
+++ b/chef_master/source/nodes.rst
@@ -367,7 +367,7 @@ Attributes are blacklisted by attribute type, with each attribute type being bla
 
 .. warning:: The recommended practice is to use only ``automatic_attribute_blacklist`` for blacklisting attributes. This is primarily because automatic attributes generate the most data, but also that normal, default, and override attributes are typically much more important attributes and are more likely to cause issues if they are blacklisted incorrectly.
 
-For example, normal attribute data similar to:
+For example, automatic attribute data similar to:
 
 .. code-block:: javascript
 
@@ -392,9 +392,9 @@ To blacklist the ``filesystem`` attributes and allow the other attributes to be 
 
 .. code-block:: ruby
 
-   normal_attribute_blacklist ['filesystem']
+   automatic_attribute_blacklist ['filesystem']
 
-When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for normal attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
+When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for automatic attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
 
 For attributes that contain slashes (``/``) within the attribute value, such as the ``filesystem`` attribute ``'/dev/diskos2'``, use an array. For example:
 
@@ -431,7 +431,7 @@ Attributes are whitelisted by attribute type, with each attribute type being whi
 
 .. warning:: The recommended practice is to only use ``automatic_attribute_whitelist`` to whitelist attributes. This is primarily because automatic attributes generate the most data, but also that normal, default, and override attributes are typically much more important attributes and are more likely to cause issues if they are whitelisted incorrectly.
 
-For example, normal attribute data similar to:
+For example, automatic attribute data similar to:
 
 .. code-block:: javascript
 
@@ -456,15 +456,15 @@ To whitelist the ``network`` attributes and prevent the other attributes from be
 
 .. code-block:: ruby
 
-   normal_attribute_whitelist ['network/interfaces/']
+   automatic_attribute_whitelist ['network/interfaces/']
 
-When a whitelist is defined, any attribute of that type that is not specified in that attribute whitelist **will not** be saved. So based on the previous whitelist for normal attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
+When a whitelist is defined, any attribute of that type that is not specified in that attribute whitelist **will not** be saved. So based on the previous whitelist for automatic attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
 
 Leave the value empty to prevent all attributes of that attribute type from being saved:
 
 .. code-block:: ruby
 
-   normal_attribute_whitelist []
+   automatic_attribute_whitelist []
 
 For attributes that contain slashes (``/``) within the attribute value, such as the ``filesystem`` attribute ``'/dev/diskos2'``, use an array. For example:
 

--- a/chef_master/source/ohai.rst
+++ b/chef_master/source/ohai.rst
@@ -109,7 +109,7 @@ Attributes are blacklisted by attribute type, with each attribute type being bla
 
 .. warning:: The recommended practice is to use only ``automatic_attribute_blacklist`` for blacklisting attributes. This is primarily because automatic attributes generate the most data, but also that normal, default, and override attributes are typically much more important attributes and are more likely to cause issues if they are blacklisted incorrectly.
 
-For example, normal attribute data similar to:
+For example, automatic attribute data similar to:
 
 .. code-block:: javascript
 
@@ -134,9 +134,9 @@ To blacklist the ``filesystem`` attributes and allow the other attributes to be 
 
 .. code-block:: ruby
 
-   normal_attribute_blacklist ['filesystem']
+   automatic_attribute_blacklist ['filesystem']
 
-When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for normal attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
+When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for automatic attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
 
 For attributes that contain slashes (``/``) within the attribute value, such as the ``filesystem`` attribute ``'/dev/diskos2'``, use an array. For example:
 
@@ -173,7 +173,7 @@ Attributes are whitelisted by attribute type, with each attribute type being whi
 
 .. warning:: The recommended practice is to only use ``automatic_attribute_whitelist`` to whitelist attributes. This is primarily because automatic attributes generate the most data, but also that normal, default, and override attributes are typically much more important attributes and are more likely to cause issues if they are whitelisted incorrectly.
 
-For example, normal attribute data similar to:
+For example, automatic attribute data similar to:
 
 .. code-block:: javascript
 
@@ -198,15 +198,15 @@ To whitelist the ``network`` attributes and prevent the other attributes from be
 
 .. code-block:: ruby
 
-   normal_attribute_whitelist ['network/interfaces/']
+   automatic_attribute_whitelist ['network/interfaces/']
 
-When a whitelist is defined, any attribute of that type that is not specified in that attribute whitelist **will not** be saved. So based on the previous whitelist for normal attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
+When a whitelist is defined, any attribute of that type that is not specified in that attribute whitelist **will not** be saved. So based on the previous whitelist for automatic attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
 
 Leave the value empty to prevent all attributes of that attribute type from being saved:
 
 .. code-block:: ruby
 
-   normal_attribute_whitelist []
+   automatic_attribute_whitelist []
 
 For attributes that contain slashes (``/``) within the attribute value, such as the ``filesystem`` attribute ``'/dev/diskos2'``, use an array. For example:
 

--- a/chef_master/source/recipes.rst
+++ b/chef_master/source/recipes.rst
@@ -154,7 +154,7 @@ Attributes are blacklisted by attribute type, with each attribute type being bla
 
 .. warning:: The recommended practice is to use only ``automatic_attribute_blacklist`` for blacklisting attributes. This is primarily because automatic attributes generate the most data, but also that normal, default, and override attributes are typically much more important attributes and are more likely to cause issues if they are blacklisted incorrectly.
 
-For example, normal attribute data similar to:
+For example, automatic attribute data similar to:
 
 .. code-block:: javascript
 
@@ -179,9 +179,9 @@ To blacklist the ``filesystem`` attributes and allow the other attributes to be 
 
 .. code-block:: ruby
 
-   normal_attribute_blacklist ['filesystem']
+   automatic_attribute_blacklist ['filesystem']
 
-When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for normal attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
+When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for automatic attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
 
 For attributes that contain slashes (``/``) within the attribute value, such as the ``filesystem`` attribute ``'/dev/diskos2'``, use an array. For example:
 
@@ -218,7 +218,7 @@ Attributes are whitelisted by attribute type, with each attribute type being whi
 
 .. warning:: The recommended practice is to only use ``automatic_attribute_whitelist`` to whitelist attributes. This is primarily because automatic attributes generate the most data, but also that normal, default, and override attributes are typically much more important attributes and are more likely to cause issues if they are whitelisted incorrectly.
 
-For example, normal attribute data similar to:
+For example, automatic attribute data similar to:
 
 .. code-block:: javascript
 
@@ -243,15 +243,15 @@ To whitelist the ``network`` attributes and prevent the other attributes from be
 
 .. code-block:: ruby
 
-   normal_attribute_whitelist ['network/interfaces/']
+   automatic_attribute_whitelist ['network/interfaces/']
 
-When a whitelist is defined, any attribute of that type that is not specified in that attribute whitelist **will not** be saved. So based on the previous whitelist for normal attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
+When a whitelist is defined, any attribute of that type that is not specified in that attribute whitelist **will not** be saved. So based on the previous whitelist for automatic attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
 
 Leave the value empty to prevent all attributes of that attribute type from being saved:
 
 .. code-block:: ruby
 
-   normal_attribute_whitelist []
+   automatic_attribute_whitelist []
 
 For attributes that contain slashes (``/``) within the attribute value, such as the ``filesystem`` attribute ``'/dev/diskos2'``, use an array. For example:
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -250,7 +250,7 @@ Attributes are blacklisted by attribute type, with each attribute type being bla
 
 .. warning:: The recommended practice is to use only ``automatic_attribute_blacklist`` for blacklisting attributes. This is primarily because automatic attributes generate the most data, but also that normal, default, and override attributes are typically much more important attributes and are more likely to cause issues if they are blacklisted incorrectly.
 
-For example, normal attribute data similar to:
+For example, automatic attribute data similar to:
 
 .. code-block:: javascript
 
@@ -275,9 +275,9 @@ To blacklist the ``filesystem`` attributes and allow the other attributes to be 
 
 .. code-block:: ruby
 
-   normal_attribute_blacklist ['filesystem']
+   automatic_attribute_blacklist ['filesystem']
 
-When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for normal attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
+When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for automatic attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
 
 For attributes that contain slashes (``/``) within the attribute value, such as the ``filesystem`` attribute ``'/dev/diskos2'``, use an array. For example:
 

--- a/chef_master/source/roles.rst
+++ b/chef_master/source/roles.rst
@@ -123,7 +123,7 @@ Attributes are blacklisted by attribute type, with each attribute type being bla
 
 .. warning:: The recommended practice is to use only ``automatic_attribute_blacklist`` for blacklisting attributes. This is primarily because automatic attributes generate the most data, but also that normal, default, and override attributes are typically much more important attributes and are more likely to cause issues if they are blacklisted incorrectly.
 
-For example, normal attribute data similar to:
+For example, automatic attribute data similar to:
 
 .. code-block:: javascript
 
@@ -148,9 +148,9 @@ To blacklist the ``filesystem`` attributes and allow the other attributes to be 
 
 .. code-block:: ruby
 
-   normal_attribute_blacklist ['filesystem']
+   automatic_attribute_blacklist ['filesystem']
 
-When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for normal attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
+When a blacklist is defined, any attribute of that type that is not specified in that attribute blacklist **will** be saved. So based on the previous blacklist for automatic attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
 
 For attributes that contain slashes (``/``) within the attribute value, such as the ``filesystem`` attribute ``'/dev/diskos2'``, use an array. For example:
 
@@ -187,7 +187,7 @@ Attributes are whitelisted by attribute type, with each attribute type being whi
 
 .. warning:: The recommended practice is to only use ``automatic_attribute_whitelist`` to whitelist attributes. This is primarily because automatic attributes generate the most data, but also that normal, default, and override attributes are typically much more important attributes and are more likely to cause issues if they are whitelisted incorrectly.
 
-For example, normal attribute data similar to:
+For example, automatic attribute data similar to:
 
 .. code-block:: javascript
 
@@ -212,15 +212,15 @@ To whitelist the ``network`` attributes and prevent the other attributes from be
 
 .. code-block:: ruby
 
-   normal_attribute_whitelist ['network/interfaces/']
+   automatic_attribute_whitelist ['network/interfaces/']
 
-When a whitelist is defined, any attribute of that type that is not specified in that attribute whitelist **will not** be saved. So based on the previous whitelist for normal attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
+When a whitelist is defined, any attribute of that type that is not specified in that attribute whitelist **will not** be saved. So based on the previous whitelist for automatic attributes, the ``filesystem`` and ``map - autohome`` attributes will not be saved, but the ``network`` attributes will.
 
 Leave the value empty to prevent all attributes of that attribute type from being saved:
 
 .. code-block:: ruby
 
-   normal_attribute_whitelist []
+   automatic_attribute_whitelist []
 
 For attributes that contain slashes (``/``) within the attribute value, such as the ``filesystem`` attribute ``'/dev/diskos2'``, use an array. For example:
 


### PR DESCRIPTION
Signed-off-by: Sean Horn <sean_horn@chef.io>

We should stay away from normal attribs as examples, as they are persistent. Better to stick with automatic, as we are almost always concerned with Ohai auto attribs when blacklist/whitelist/disabling plugins