### PR TITLE
Remove chef architectual information for the resources page

### DIFF
--- a/chef_master/source/resources.rst
+++ b/chef_master/source/resources.rst
@@ -15,31 +15,6 @@ A resource is a statement of configuration policy that:
 
 .. end_tag
 
-.. tag resources_common_provider
-
-Where a resource represents a piece of the system (and its desired state), a provider defines the steps that are needed to bring that piece of the system from its current state into the desired state.
-
-.. end_tag
-
-.. tag resources_common_provider_platform
-
-The ``Chef::Platform`` class maps providers to platforms (and platform versions). At the beginning of every chef-client run, Ohai verifies the ``platform`` and ``platform_version`` attributes on each node. The chef-client then uses those values to identify the correct provider, build an instance of that provider, identify the current state of the resource, do the specified action, and then mark the resource as updated (if changes were made).
-
-For example:
-
-.. code-block:: ruby
-
-   directory '/tmp/folder' do
-     owner 'root'
-     group 'root'
-     mode '0755'
-     action :create
-   end
-
-The chef-client will look up the provider for the ``directory`` resource, which happens to be ``Chef::Provider::Directory``, call ``load_current_resource`` to create a ``directory["/tmp/folder"]`` resource, and then, based on the current state of the directory, do the specified action, which in this case is to create a directory called ``/tmp/folder``. If the directory already exists, nothing will happen. If the directory was changed in any way, the resource is marked as updated.
-
-.. end_tag
-
 This reference describes each of the resources available to the chef-client, including a list of actions, a list of properties, (when applicable) a list of providers, and examples of using each resource.
 
 =====================================================


### PR DESCRIPTION
There's just no need for users to know this stuff. It's a resource. That's all they need to know unless they want to develop chef/chef.