### PR TITLE
--node-ssl-verify-mode options case sensativity

### DIFF
--- a/chef_master/source/knife_bootstrap.rst
+++ b/chef_master/source/knife_bootstrap.rst
@@ -22,7 +22,7 @@ Use the ``knife bootstrap`` subcommand to run a bootstrap operation that install
 
 .. note:: To bootstrap the chef-client on Microsoft Windows machines, the `knife-windows </plugin_knife_windows.html>`__ plugins is required, which includes the necessary bootstrap scripts that are used to do the actual installation.
 
-New in 12.6, ``-i IDENTITY_FILE``, ``--json-attribute-file FILE``, ``--sudo-preserve-home``.  Changed in 12.4, validatorless bootstrap requires ``-N node_name``. Changed in 12.1, ``knife-bootstrap`` has the options --bootstrap-vault-file, --bootstrap-vault-item, and --bootstrap-vault-json options to specify item stored in chef-vault. New in 12.0, ``--[no-]node-verify-api-cert``, ``--node-ssl-verify-mode PEER_OR_NONE``, ``-t TEMPLATE``,
+New in 12.6, ``-i IDENTITY_FILE``, ``--json-attribute-file FILE``, ``--sudo-preserve-home``.  Changed in 12.4, validatorless bootstrap requires ``-N node_name``. Changed in 12.1, ``knife-bootstrap`` has the options --bootstrap-vault-file, --bootstrap-vault-item, and --bootstrap-vault-json options to specify item stored in chef-vault. New in 12.0, ``--[no-]node-verify-api-cert``, ``--node-ssl-verify-mode peer_or_none``, ``-t TEMPLATE``,
 
 As of Chef 12.8 you can create a ``.chef/client.d`` directory on your workstation and the contents of that `client.d </config_rb_client.html>`__ directory will be copied to the system being bootstrapped by the ``knife bootstrap`` command. You can also set the ``client_d_dir`` option in ``knife.rb`` to point to an arbitrary directory instead of ``.chef/client.d`` and the contents of that directory will be copied to the system being bootstrapped. All config files inside ``client.d`` directory get copied into ``/etc/chef/client.d`` on the system being bootstrapped.
 


### PR DESCRIPTION
PEER_OR_NONE changed to peer_or_none as required by the command:
Valid values are: none, peer