### PR TITLE
Remove Windows 2008 and Windows 2008 R2 support as of January 13, 2018.

### DIFF
--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -66,7 +66,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``14.04``, ``16.04``
    * - Microsoft Windows
      - ``x86``, ``x86_64``
-     - ``2012``, ``2012r2``, ``2016``, ``7``, ``8``, ``8.1``, ``10``
+     - ``2012``, ``2012r2``, ``2016``, ``8``, ``8.1``, ``10``
 
 Community Support
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -134,7 +134,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``14.04``, ``16.04``
    * - Microsoft Windows
      -
-     - ``7``, ``8``, ``8.1``, ``10``, ``2012``, ``2012 R2``, ``2016``
+     - ``8``, ``8.1``, ``10``, ``2012``, ``2012 R2``, ``2016``
 
 Community Support
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -268,7 +268,7 @@ The following table lists the commercially-supported platforms for the Chef push
      - ``14.04``, ``16.04``
    * - Microsoft Windows
      - ``x86``, ``x86_64``
-     - ``2012``, ``2012r2``, ``2016``, ``7``, ``8``, ``8.1``, ``10``
+     - ``2012``, ``2012r2``, ``2016``, ``8``, ``8.1``, ``10``
 
 .. end_tag
 

--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -66,7 +66,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``14.04``, ``16.04``
    * - Microsoft Windows
      - ``x86``, ``x86_64``
-     - ``2008r2``, ``2012``, ``2012r2``, ``2016``, ``7``, ``8``, ``8.1``, ``10``
+     - ``2012``, ``2012r2``, ``2016``, ``7``, ``8``, ``8.1``, ``10``
 
 Community Support
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -134,7 +134,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``14.04``, ``16.04``
    * - Microsoft Windows
      -
-     - ``7``, ``8``, ``8.1``, ``10``, ``2008 R2``, ``2012``, ``2012 R2``, ``2016``
+     - ``7``, ``8``, ``8.1``, ``10``, ``2012``, ``2012 R2``, ``2016``
 
 Community Support
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -268,7 +268,7 @@ The following table lists the commercially-supported platforms for the Chef push
      - ``14.04``, ``16.04``
    * - Microsoft Windows
      - ``x86``, ``x86_64``
-     - ``2008r2``, ``2012``, ``2012r2``, ``2016``, ``7``, ``8``, ``8.1``, ``10``
+     - ``2012``, ``2012r2``, ``2016``, ``7``, ``8``, ``8.1``, ``10``
 
 .. end_tag
 


### PR DESCRIPTION
Per the platform support policy in this document, we will no longer support Chef's products on Windows 2008 and Windows 2008 R2 as of January 13, 2018.