### PR TITLE
Remove references to deploy resource in the SCM resources

### DIFF
--- a/chef_master/source/resource_git.rst
+++ b/chef_master/source/resource_git.rst
@@ -9,12 +9,6 @@ Use the **git** resource to manage source control resources that exist in a git 
 
 .. end_tag
 
-.. note:: .. tag notes_scm_resource_use_with_resource_deploy
-
-          This resource is often used in conjunction with the **deploy** resource.
-
-          .. end_tag
-
 Syntax
 =====================================================
 A **git** resource block manages source control resources that exist in a git repository:

--- a/chef_master/source/resource_subversion.rst
+++ b/chef_master/source/resource_subversion.rst
@@ -11,12 +11,6 @@ Use the **subversion** resource to manage source control resources that exist in
 
 .. warning:: The subversion resource has known bugs and may not work as expected. For more information see Chef GitHub issues, particularly `#4050 <https://github.com/chef/chef/issues/4050>`_ and `#4257 <https://github.com/chef/chef/issues/4257>`_.
 
-.. note:: .. tag notes_scm_resource_use_with_resource_deploy
-
-          This resource is often used in conjunction with the **deploy** resource.
-
-          .. end_tag
-
 Syntax
 =====================================================
 A **subversion** resource block manages source control resources that exist in a Subversion repository:


### PR DESCRIPTION
Deploy is going away in Chef 14 so lets not point people towards it. Also this resource is used all over outside deploy.

Signed-off-by: Tim Smith <tsmith@chef.io>