### PR TITLE
Remove Windows 8 and 8.1 support as of January 9, 2018

### DIFF
--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -66,7 +66,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``14.04``, ``16.04``
    * - Microsoft Windows
      - ``x86``, ``x86_64``
-     - ``2012``, ``2012r2``, ``2016``, ``8``, ``8.1``, ``10``
+     - ``2012``, ``2012r2``, ``2016``, ``10``
 
 Community Support
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -134,7 +134,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``14.04``, ``16.04``
    * - Microsoft Windows
      -
-     - ``8``, ``8.1``, ``10``, ``2012``, ``2012 R2``, ``2016``
+     - ``10``, ``2012``, ``2012 R2``, ``2016``
 
 Community Support
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -268,7 +268,7 @@ The following table lists the commercially-supported platforms for the Chef push
      - ``14.04``, ``16.04``
    * - Microsoft Windows
      - ``x86``, ``x86_64``
-     - ``2012``, ``2012r2``, ``2016``, ``8``, ``8.1``, ``10``
+     - ``2012``, ``2012r2``, ``2016``, ``10``
 
 .. end_tag
 


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

Microsoft's mainstream [support for Windows 8 and Windows 8.1 ended on January 9, 2018](https://support.microsoft.com/en-gb/lifecycle/search?alpha=windows%208.1).  This PR removes Windows 8 and 8.1 in accordance with the platform support policy.