### PR TITLE
Update attributes.rst

### DIFF
--- a/chef_master/source/attributes.rst
+++ b/chef_master/source/attributes.rst
@@ -516,10 +516,7 @@ The following examples are listed from low to high precedence.
 
 .. code-block:: ruby
 
-   node.set['apache']['dir'] = '/etc/apache2'
-
-   node.normal['apache']['dir'] = '/etc/apache2' # Same as above
-   node['apache']['dir'] = '/etc/apache2'       # Same as above
+   node.normal['apache']['dir'] = '/etc/apache2'
 
 **Override attribute in /attributes/default.rb**
 


### PR DESCRIPTION
As per CHEF-4, I've removed two outdated examples for setting normal attributes in a recipe. 

These two examples will not work in Chef 13, as per the deprecation notice:
   node.set['apache']['dir'] = '/etc/apache2'

Also, if a precedence level is not set in Chef 12, an attribute is read-only, so this example is also invalid:
   node['apache']['dir'] = '/etc/apache2'       # Same as above