### PR TITLE
MSYS-758: Update docs for knife node set policy

### DIFF
--- a/chef_master/source/knife_node.rst
+++ b/chef_master/source/knife_node.rst
@@ -280,6 +280,26 @@ to return something similar to:
    i-12345678
    rs-123456
 
+policy set
+=====================================================
+Use the ``policy set`` argument to set the policy group and policy name for a node.
+
+Syntax
+-----------------------------------------------------
+This argument has the following syntax:
+
+.. code-block:: bash
+
+   $ knife node policy set NODE POLICY_GROUP POLICY_NAME (options)
+
+Options
+-----------------------------------------------------
+This command does not have any specific options.
+
+Examples
+-----------------------------------------------------
+None.
+
 run_list add
 =====================================================
 .. tag node_run_list

--- a/chef_master/source/policyfile.rst
+++ b/chef_master/source/policyfile.rst
@@ -87,6 +87,19 @@ Environment Cookbooks
 -----------------------------------------------------
 Policyfile replaces the environment cookbook pattern that is often required by Berkshelf, along with a dependency solver and fetcher. That said, Policyfile does not replace all Berkshelf scenarios.
 
+Knife Commands
+=====================================================
+.. tag set_policy_group_and_name
+
+The following knife commands used to set the 'policy group' and 'policy name' on the Chef server. For example:
+
+.. code-block:: bash
+
+   $ knife node policy set test-node 'test-policy-group-name' 'test-policy-name'
+
+.. end_tag
+
+
 Policyfile.rb
 =====================================================
 .. tag policyfile_rb


### PR DESCRIPTION
MSYS-758: Update docs for knife node set policy.

**Docs updated for following:**

1. https://docs.chef.io/knife_node.html
2. https://docs.chef.io/policyfile.html

Reference PR: https://github.com/chef/chef/pull/6656

Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>