### PR TITLE
cleanup example audit wrapper attribute formatting

### DIFF
--- a/chef_master/source/perform_compliance_scan.rst
+++ b/chef_master/source/perform_compliance_scan.rst
@@ -131,17 +131,17 @@ add the following code in mycompany_audit/attributes/default.rb:
   case node['os']
   when 'linux'
     default['audit']['profiles'] = [
-     {
-        'name': 'DevSec Linux Security Baseline',
-        'compliance': 'admin/linux-baseline'
-      }
+      {
+        name: 'DevSec Linux Security Baseline',
+        compliance: 'admin/linux-baseline',
+      },
     ]
-    when 'windows'
+  when 'windows'
     default['audit']['profiles'] = [
       {
         'name': 'DevSec Windows Security Baseline',
-        'compliance': 'admin/windows-baseline'
-      }
+        'compliance': 'admin/windows-baseline',
+      },
     ]
   end
 


### PR DESCRIPTION
The current example's quoted keys isn't valid syntax. Updated to correct this and adjusted some stylistic issues that will throw foodcritic/cookstyle errors (extra commas, indentation issues)