### PR TITLE
Updated the license examples for metadata.rb

### DIFF
--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -172,7 +172,7 @@ This configuration file has the following settings:
 
    .. code-block:: ruby
 
-      license 'GPL v3'
+      license 'GPL-3.0'
 
    or:
 

--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -166,7 +166,7 @@ This configuration file has the following settings:
 
    .. code-block:: ruby
 
-      license 'Apache v2.0'
+      license 'Apache-2.0'
 
    or:
 


### PR DESCRIPTION
Updated the examples for licenses to comply with the list foodcritic [FC069](https://github.com/Foodcritic/foodcritic/blob/master/lib/foodcritic/rules/fc069.rb) accepts