### PR TITLE
Document new family option in ifconfig resource

### DIFF
--- a/chef_master/source/resource_ifconfig.rst
+++ b/chef_master/source/resource_ifconfig.rst
@@ -29,6 +29,7 @@ The full syntax for all of the properties that are available to the **ifconfig**
      bootproto                  String
      device                     String
      ethtool_opts               String
+     family                     String # defaults to 'inet' if not specified
      hwaddr                     String
      inet_addr                  String
      mask                       String
@@ -108,6 +109,11 @@ This resource has the following properties:
    Options to be passed to ethtool(8). For example: ``-A eth0 autoneg off rx off tx off``
 
    New in Chef Client 13.4
+
+``family``
+   **Ruby Type:** String
+
+   Networking family option for Debian based systems. For example: `inet` or `inet6`. Default value: `inet`.
 
 ``hwaddr``
    **Ruby Type:** String


### PR DESCRIPTION
Now that https://github.com/chef/chef/pull/6883 is merged I have created some documentation for the new option. I can add an example to the bottom of the examples section if needed, but I'd have to get some tips on marking it as a Debian specific thing.

I am also unsure which Chef release this will make it into so I have not marked which Chef Client version yet. I'm assuming Chef 13.7? If not, then 14.