### PR TITLE
Remove provider references from user resource

### DIFF
--- a/chef_master/source/resource_user.rst
+++ b/chef_master/source/resource_user.rst
@@ -40,7 +40,6 @@ The full syntax for all of the properties that are available to the **user** res
      non_unique                 TrueClass, FalseClass
      notifies                   # see description
      password                   String
-     provider                   Chef::Provider::User
      salt                       String
      shell                      String
      subscribes                 # see description
@@ -55,7 +54,7 @@ where
 * ``user`` is the resource
 * ``name`` is the name of the resource block
 * ``action`` identifies the steps the chef-client will take to bring the node into the desired state
-* ``comment``, ``force``, ``gid``, ``home``, ``iterations``, ``manage_home``, ``non_unique``, ``password``, ``provider``, ``salt``, ``shell``, ``system``, ``uid``, and ``username`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
+* ``comment``, ``force``, ``gid``, ``home``, ``iterations``, ``manage_home``, ``non_unique``, ``password``, ``salt``, ``shell``, ``system``, ``uid``, and ``username`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
 Actions
 =====================================================
@@ -181,12 +180,7 @@ This resource has the following properties:
    **Ruby Type:** String
 
    The password shadow hash. This property requires that ``ruby-shadow`` be installed. This is part of the Debian package: ``libshadow-ruby1.8``.
-
-``provider``
-   **Ruby Type:** Chef Class
-
-   Optional. Explicitly specifies a provider. See "Providers" section below for more information.
-
+ 
 ``retries``
    **Ruby Type:** Integer
 
@@ -291,58 +285,6 @@ For more information:
 
 * https://www.openssl.org/docs/manmaster/man1/passwd.html
 * Check the local documentation or package repository for the distribution that is being used. For example, on Ubuntu 9.10-10.04, the ``mkpasswd`` package is required and on Ubuntu 10.10+ the ``whois`` package is required.
-
-Providers
-=====================================================
-.. tag resources_common_provider
-
-Where a resource represents a piece of the system (and its desired state), a provider defines the steps that are needed to bring that piece of the system from its current state into the desired state.
-
-.. end_tag
-
-.. tag resources_common_provider_attributes
-
-The chef-client will determine the correct provider based on configuration data collected by Ohai at the start of the chef-client run. This configuration data is then mapped to a platform and an associated list of providers.
-
-Generally, it's best to let the chef-client choose the provider, and this is (by far) the most common approach. However, in some cases, specifying a provider may be desirable. There are two approaches:
-
-* Use a more specific short name---``yum_package "foo" do`` instead of ``package "foo" do``, ``script "foo" do`` instead of ``bash "foo" do``, and so on---when available
-* Use ``declare_resource``. This replaces all previous use cases where the provider class was passed in through the ``provider`` property:
-
-  .. code-block:: ruby
-
-     pkg_resource = case node['platform_family']
-       when 'debian'
-         :dpkg_package
-       when 'fedora', 'rhel', 'amazon'
-         :rpm_package
-       end
-
-     pkg_path = (pkg_resource == :dpkg_package) ? '/tmp/foo.deb' : '/tmp/foo.rpm'
-
-     declare_resource(pkg_resource, pkg_path) do
-       action :install
-     end
-
-.. end_tag
-
-.. tag resource_provider_list_note
-
-For reference, the providers available for this resource are listed below. However please note that specifying a provider via its long name (such as ``Chef::Provider::Package``) using the ``provider`` property is not recommended. If a provider needs to be called manually, use one of the two approaches detailed above.
-
-.. end_tag
-
-``Chef::Provider::User::Useradd``, ``user``
-   The default provider for the **user** resource.
-
-``Chef::Provider::User::Pw``, ``user``
-   The provider for the FreeBSD platform.
-
-``Chef::Provider::User::Dscl``, ``user``
-   The provider for the macOS platform.
-
-``Chef::Provider::User::Windows``, ``user``
-   The provider for all Microsoft Windows platforms.
 
 Examples
 =====================================================


### PR DESCRIPTION
We don't want people mucking with the providers here. They need to just let Chef pick the right one.