### PR TITLE
knife status --hide-healthy is deprecated

### DIFF
--- a/chef_master/source/knife_status.rst
+++ b/chef_master/source/knife_status.rst
@@ -31,8 +31,11 @@ This subcommand has the following options:
    The search query used to identify a list of items on a Chef server. This option uses the same syntax as the ``search`` subcommand.
 
 ``-H``, ``--hide-healthy``
-   Hide nodes on which a chef-client run has occurred within the previous hour.
+   Hide nodes on which a chef-client run has occurred within the previous hour. [DEPRECATED] in Chef 12.6.x+, 13.x+, and 14.x+ in favor of --hide-by-mins
 
+``--hide-by-mins``
+   Hide nodes on which a chef-client run has occurred within the previous X mins.
+   
 ``-l``, ``--long``
    Display all attributes in the output and show the output as JSON.
 
@@ -82,6 +85,19 @@ to return something like:
 **View status using a date range**
 
 To show the status for nodes on which the chef-client did not run successfully within the past hour, enter:
+
+.. code-block:: bash 
+
+# knife status --hide-by-mins 60
+
+to return something like:
+
+.. code-block:: bash 
+
+422492 hours ago, runner-1-432.lxc, centos 6.8.
+27 hours ago, union-3-432.lxc, centos 7.3.1611.
+
+The above usage is preferred to the following, deprecated usage before Knife 12.6.0
 
 .. code-block:: bash
 

--- a/chef_master/source/knife_status.rst
+++ b/chef_master/source/knife_status.rst
@@ -30,11 +30,15 @@ This subcommand has the following options:
 ``QUERY``
    The search query used to identify a list of items on a Chef server. This option uses the same syntax as the ``search`` subcommand.
 
-``-H``, ``--hide-healthy``
-   Hide nodes on which a chef-client run has occurred within the previous hour. [DEPRECATED] in Chef 12.6.x+, 13.x+, and 14.x+ in favor of --hide-by-mins
-
 ``--hide-by-mins``
-   Hide nodes on which a chef-client run has occurred within the previous X mins.
+   Hide nodes that have performed a successful chef-client run within the last specified number of minutes. The number of minutes to hide is provided as an integer, such as ``--hide-by-mins 10``. 
+
+   New in Chef Client 12.6
+
+``-H``, ``--hide-healthy``
+   Hide nodes on which a chef-client run has occurred within the previous hour.
+
+   Deprecated in favor of the ``--hide-by-mins`` option in Chef Client 12.6 and above.
    
 ``-l``, ``--long``
    Display all attributes in the output and show the output as JSON.
@@ -82,9 +86,9 @@ to return something like:
 
 .. end_tag
 
-**View status using a date range**
+**View status using a time range**
 
-To show the status for nodes on which the chef-client did not run successfully within the past hour, enter:
+To show the status of nodes on which the chef-client did not run successfully within the past hour, enter:
 
 .. code-block:: bash 
 
@@ -97,7 +101,7 @@ to return something like:
 422492 hours ago, runner-1-432.lxc, centos 6.8.
 27 hours ago, union-3-432.lxc, centos 7.3.1611.
 
-The above usage is preferred to the following, deprecated usage before Knife 12.6.0
+On systems running Chef Client 12.5 or prior:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Point out the `--hide-by-mins` option and `--hide-healthy` deprecation in the knife docs for Knife 12.6.0 and beyond

Signed-off-by: Sean horn <sean_horn@chef.io>