### PR TITLE
Remove providers and supports docs from the resources page

### DIFF
--- a/chef_master/source/resource_common.rst
+++ b/chef_master/source/resource_common.rst
@@ -72,15 +72,6 @@ The following properties are common to every resource:
 
    Ensure that sensitive resource data is not logged by the chef-client. Default value: ``false``.
 
-``supports``
-   .. warning:: This property was deprecated in Chef 12.14; it will generate a warning when used in Chef 12 versions 12.14 and above, and it was entirely removed in Chef 13. See the `deprecation notice </deprecations_supports_property.html>`_ for details and remediation.
-
-   .. note:: This property is not the same as the ``supports`` property that was previously available for the `user </resource_user.html>`_ resource, or that which is currently available for the `service </resource_service.html>`_ resource. These resources use entirely separate implementations of the ``supports`` property.
-
-   **Ruby Type:** Hash
-
-   A hash of options that contains hints about the capabilities of a resource. The chef-client may use these hints to help identify the correct provider.
-
 
 .. end_tag
 

--- a/chef_master/source/resource_reference.rst
+++ b/chef_master/source/resource_reference.rst
@@ -69,43 +69,6 @@ The following properties are common to every resource:
 
    Ensure that sensitive resource data is not logged by the chef-client. Default value: ``false``.
 
-``supports``
-   .. warning:: This property was deprecated in Chef 12.14; it will generate a warning when used in Chef 12 versions 12.14 and above, and it was entirely removed in Chef 13. See the `deprecation notice </deprecations_supports_property.html>`_ for details and remediation.
-
-   .. note:: This property is not the same as the ``supports`` property that was previously available for the `user </resource_user.html>`_ resource, or that which is currently available for the `service </resource_service.html>`_ resource. These resources use entirely separate implementations of the ``supports`` property.
-
-   **Ruby Type:** Hash
-
-   A hash of options that contains hints about the capabilities of a resource. The chef-client may use these hints to help identify the correct provider.
-
-
-.. end_tag
-
-Provider
------------------------------------------------------
-.. tag resources_common_provider_attributes
-
-The chef-client will determine the correct provider based on configuration data collected by Ohai at the start of the chef-client run. This configuration data is then mapped to a platform and an associated list of providers.
-
-Generally, it's best to let the chef-client choose the provider, and this is (by far) the most common approach. However, in some cases, specifying a provider may be desirable. There are two approaches:
-
-* Use a more specific short name---``yum_package "foo" do`` instead of ``package "foo" do``, ``script "foo" do`` instead of ``bash "foo" do``, and so on---when available
-* Use ``declare_resource``. This replaces all previous use cases where the provider class was passed in through the ``provider`` property:
-
-  .. code-block:: ruby
-
-     pkg_resource = case node['platform_family']
-       when 'debian'
-         :dpkg_package
-       when 'fedora', 'rhel', 'amazon'
-         :rpm_package
-       end
-
-     pkg_path = (pkg_resource == :dpkg_package) ? '/tmp/foo.deb' : '/tmp/foo.rpm'
-
-     declare_resource(pkg_resource, pkg_path) do
-       action :install
-     end
 
 .. end_tag
 


### PR DESCRIPTION
Supports is dead. There's no reason for anyone to be reading about it. Providers are pretty similar.