### PR TITLE
Chef resource tuneables are properties. Node tuneables are attributes

### DIFF
--- a/chef_master/source/ohai.rst
+++ b/chef_master/source/ohai.rst
@@ -456,7 +456,7 @@ This resource has the following actions:
 
 .. end_tag
 
-Attributes
+Properties
 -----------------------------------------------------
 .. tag resource_ohai_attributes
 


### PR DESCRIPTION
We used to call them attributes, which was super confusing.