### PR TITLE
Split the chef provisioning resources into their own category

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -733,69 +733,9 @@
                 "url": "/resource_chef_gem.html"
               },
               {
-                "title": "chef_acl",
-                "hasSubItems": false,
-                "url": "/resource_chef_acl.html"
-              },
-              {
-                "title": "chef_client",
-                "hasSubItems": false,
-                "url": "/resource_chef_client.html"
-              },
-              {
-                "title": "chef_container",
-                "hasSubItems": false,
-                "url": "/resource_chef_container.html"
-              },
-              {
-                "title": "chef_data_bag_item",
-                "hasSubItems": false,
-                "url": "/resource_chef_data_bag_item.html"
-              },
-              {
-                "title": "chef_data_bag",
-                "hasSubItems": false,
-                "url": "/resource_chef_data_bag.html"
-              },
-              {
-                "title": "chef_environment",
-                "hasSubItems": false,
-                "url": "/resource_chef_environment.html"
-              },
-              {
-                "title": "chef_group",
-                "hasSubItems": false,
-                "url": "/resource_chef_group.html"
-              },
-              {
                 "title": "chef_handler",
                 "hasSubItems": false,
                 "url": "/resource_chef_handler.html"
-              },
-              {
-                "title": "chef_mirror",
-                "hasSubItems": false,
-                "url": "/resource_chef_mirror.html"
-              },
-              {
-                "title": "chef_node",
-                "hasSubItems": false,
-                "url": "/resource_chef_node.html"
-              },
-              {
-                "title": "chef_organization",
-                "hasSubItems": false,
-                "url": "/resource_chef_organization.html"
-              },
-              {
-                "title": "chef_role",
-                "hasSubItems": false,
-                "url": "/resource_chef_role.html"
-              },
-              {
-                "title": "chef_user",
-                "hasSubItems": false,
-                "url": "/resource_chef_user.html"
               },
               {
                 "title": "chocolatey_package",
@@ -998,16 +938,6 @@
                 "url": "/resource_powershell_script.html"
               },
               {
-                "title": "private_key",
-                "hasSubItems": false,
-                "url": "/resource_private_key.html"
-              },
-              {
-                "title": "public_key",
-                "hasSubItems": false,
-                "url": "/resource_public_key.html"
-              },
-              {
                 "title": "python",
                 "hasSubItems": false,
                 "url": "/resource_python.html"
@@ -1137,6 +1067,82 @@
                 "hasSubItems": false,
                 "url": "/resource_examples.html"
               }
+            ]
+          },
+          {
+            "title": "Chef Provisiong Resources",
+            "hasSubItems": true,
+            "subItems": [
+            {
+              "title": "chef_acl",
+              "hasSubItems": false,
+              "url": "/resource_chef_acl.html"
+            },
+            {
+              "title": "chef_client",
+              "hasSubItems": false,
+              "url": "/resource_chef_client.html"
+            },
+            {
+              "title": "chef_container",
+              "hasSubItems": false,
+              "url": "/resource_chef_container.html"
+            },
+            {
+              "title": "chef_data_bag_item",
+              "hasSubItems": false,
+              "url": "/resource_chef_data_bag_item.html"
+            },
+            {
+              "title": "chef_data_bag",
+              "hasSubItems": false,
+              "url": "/resource_chef_data_bag.html"
+            },
+            {
+              "title": "chef_environment",
+              "hasSubItems": false,
+              "url": "/resource_chef_environment.html"
+            },
+            {
+              "title": "chef_group",
+              "hasSubItems": false,
+              "url": "/resource_chef_group.html"
+            },
+            {
+              "title": "chef_mirror",
+              "hasSubItems": false,
+              "url": "/resource_chef_mirror.html"
+            },
+            {
+              "title": "chef_node",
+              "hasSubItems": false,
+              "url": "/resource_chef_node.html"
+            },
+            {
+              "title": "chef_organization",
+              "hasSubItems": false,
+              "url": "/resource_chef_organization.html"
+            },
+            {
+              "title": "chef_role",
+              "hasSubItems": false,
+              "url": "/resource_chef_role.html"
+            },
+            {
+              "title": "chef_user",
+              "hasSubItems": false,
+              "url": "/resource_chef_user.html"
+            },
+            {
+              "title": "private_key",
+              "hasSubItems": false,
+              "url": "/resource_private_key.html"
+            },
+            {
+              "title": "public_key",
+              "hasSubItems": false,
+              "url": "/resource_public_key.html"
+            }
             ]
           },
           {

--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -1070,7 +1070,7 @@
             ]
           },
           {
-            "title": "Chef Provisioning Resources",
+            "title": "Provisioning Resources",
             "hasSubItems": true,
             "subItems": [
             {

--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -212,6 +212,11 @@
             ]
           },
           {
+            "title": "Provisioning",
+            "hasSubItems": false,
+            "url": "/provisioning.html"
+          },
+          {
             "title": "Push Jobs",
             "hasSubItems": false,
             "url": "/push_jobs.html"
@@ -1134,14 +1139,54 @@
               "url": "/resource_chef_user.html"
             },
             {
-              "title": "private_key",
+              "title": "load_balancer resource",
               "hasSubItems": false,
-              "url": "/resource_private_key.html"
+              "url": "/resource_load_balancer.html"
+            },
+            {
+              "title": "machine resource",
+              "hasSubItems": false,
+              "url": "/resource_machine.html"
+            },
+            {
+              "title": "machine_batch resource",
+              "hasSubItems": false,
+              "url": "/resource_machine_batch.html"
+            },
+            {
+              "title": "machine_execute resource",
+              "hasSubItems": false,
+              "url": "/resource_machine_execute.html"
+            },
+            {
+              "title": "machine_file resource",
+              "hasSubItems": false,
+              "url": "/resource_machine_file.html"
+            },
+            {
+              "title": "machine_image resource",
+              "hasSubItems": false,
+              "url": "/resource_machine_image.html"
             },
             {
               "title": "public_key",
               "hasSubItems": false,
               "url": "/resource_public_key.html"
+            },
+            {
+              "title": "AWS Driver Resources",
+              "hasSubItems": false,
+              "url": "/provisioning_aws.html"
+            },
+            {
+              "title": "Fog Driver Resources",
+              "hasSubItems": false,
+              "url": "/provisioning_fog.html"
+            },
+            {
+              "title": "Vagrant Driver Resources",
+              "hasSubItems": false,
+              "url": "/provisioning_vagrant.html"
             }
             ]
           },
@@ -1580,62 +1625,6 @@
                 "title": "Policyfile.rb",
                 "hasSubItems": false,
                 "url": "/config_rb_policyfile.html"
-              }
-            ]
-          },
-          {
-            "title": "Provisioning",
-            "hasSubItems": true,
-            "subItems": [
-              {
-                "title": "About Provisioning",
-                "hasSubItems": false,
-                "url": "/provisioning.html"
-              },
-              {
-                "title": "load_balancer resource",
-                "hasSubItems": false,
-                "url": "/resource_load_balancer.html"
-              },
-              {
-                "title": "machine resource",
-                "hasSubItems": false,
-                "url": "/resource_machine.html"
-              },
-              {
-                "title": "machine_batch resource",
-                "hasSubItems": false,
-                "url": "/resource_machine_batch.html"
-              },
-              {
-                "title": "machine_execute resource",
-                "hasSubItems": false,
-                "url": "/resource_machine_execute.html"
-              },
-              {
-                "title": "machine_file resource",
-                "hasSubItems": false,
-                "url": "/resource_machine_file.html"
-              },
-              {
-                "title": "machine_image resource",
-                "hasSubItems": false,
-                "url": "/resource_machine_image.html"
-              },
-              {
-                "title": "AWS Driver Resources",
-                "hasSubItems": false,
-                "url": "/provisioning_aws.html"
-              },
-              {
-                "title": "Fog Driver Resources",
-                "hasSubItems": false,
-                "url": "/provisioning_fog.html"
-              },
-              {
-                "title": "Vagrant Driver Resources",
-                "hasSubItems": false,
-                "url": "/provisioning_vagrant.html"
               }
             ]
           },

--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -1070,7 +1070,7 @@
             ]
           },
           {
-            "title": "Chef Provisiong Resources",
+            "title": "Chef Provisioning Resources",
             "hasSubItems": true,
             "subItems": [
             {


### PR DESCRIPTION
This is the way we used to have it. The other resources aren't actual chef resources and we shouldn't list them as such.

Signed-off-by: Tim Smith <tsmith@chef.io>