### PR TITLE
Added recommendation for resource name

### DIFF
--- a/chef_master/source/resource_apt_repository.rst
+++ b/chef_master/source/resource_apt_repository.rst
@@ -21,7 +21,7 @@ An **apt_repository** resource specifies APT repository information and adds an 
 where
 
 * ``apt_repository`` is the resource
-* ``name`` is the name of the resource block
+* ``name`` is the name of the resource block and should be spaceless
 * ``uri`` is a base URI for the distribution where the APT packages are located at
 * ``components`` is an array of package groupings in the repository
 
@@ -110,7 +110,7 @@ This resource has the following properties:
 
    If a keyserver is provided, this is assumed to be the fingerprint; otherwise it can be either the URI of GPG key for the repo, or a cookbook_file. Default value: empty array.
 
-   New in Chef client 13.4. 
+   New in Chef client 13.4.
 
 ``key_proxy``
    **Ruby Type:** String


### PR DESCRIPTION
In Ubuntu if name has spaces it won't be taken into account when doing apth-get update.

E.g.:

``apt_repository "A Repo"...``

Will become:

``/etc/apt/sources.list.d/A Repo.list``

Which won't load when ``apt-get update`` is ran.