### PR TITLE
Add missing instruction to upgrade remaining frontend servers

### DIFF
--- a/chef_master/source/install_server_ha.rst
+++ b/chef_master/source/install_server_ha.rst
@@ -319,6 +319,8 @@ Upgrading Chef Server on the Frontend Machines
 
 #. On each of the remaining frontends, copy ``/var/opt/opscode/upgrades/migration-level`` from first upgraded frontend to ``/var/opt/opscode/upgrades/migration-level`` on the current box.
 
+#. On each of the remaining frontends follow documentation from `</upgrade_server.html#standalone>`_ to upgrade.
+
 Configuring Frontend and Backend Members on Different Networks
 ----------------------------------------------------------------
 


### PR DESCRIPTION
Chef Server HA cluster frontend upgrade instructions omit the step to upgrade the remaining frontend servers after the first frontend has been upgraded and the migration-level copied to the remaining servers.