### PR TITLE
list chef 13 as deprecated

### DIFF
--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -492,7 +492,7 @@ Versions and Status
      - April 30, 2018
    * - Chef Client
      - 13.x
-     - GA
+     - Deprecated
      - n/a
    * - Chef DK
      - 1.x


### PR DESCRIPTION
Signed-off-by: brewn <nbrewer@chef.io>

In keeping with: https://www.chef.io/eol-chef12-and-chefdk1/