### PR TITLE
Fix the url for `windows_feature_dism` in nav

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -1130,7 +1130,7 @@
               {
                 "title": "windows_feature_dism",
                 "hasSubItems": false,
-                "url": "/resource_windows_dism.html"
+                "url": "/resource_windows_feature_dism.html"
               },
               {
                 "title": "windows_feature_powershell",


### PR DESCRIPTION
Both `windows_feature_powershell` and `windows_feature_dism` are unavailable on the live docs. It appears the path for powershell was already fixed in master, but dism is also wrong.