### PR TITLE
Updating the supported versions to deprecate Reporting

### DIFF
--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -560,8 +560,8 @@ Versions and Status
      - TBD
    * - Reporting
      - 1.5.5 or later
-     - GA
-     - n/a
+     - Deprecated
+     - TBD
    * - Analytics
      - 1.5.0 or later
      - Deprecated


### PR DESCRIPTION
Marking Reporting as Deprecated. At the end of May I'll change the status of Reporting, Analytics, and Enterprise Chef to EOL with a date of December 31, 2018. 