### PR TITLE
Remove erl_call and deploy resource from the nav menu

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -763,11 +763,6 @@
                 "url": "/resource_csh.html"
               },
               {
-                "title": "deploy",
-                "hasSubItems": false,
-                "url": "/resource_deploy.html"
-              },
-              {
                 "title": "directory",
                 "hasSubItems": false,
                 "url": "/resource_directory.html"
@@ -796,11 +791,6 @@
                 "title": "dsc_script",
                 "hasSubItems": false,
                 "url": "/resource_dsc_script.html"
-              },
-              {
-                "title": "erl_call",
-                "hasSubItems": false,
-                "url": "/resource_erlang_call.html"
               },
               {
                 "title": "execute",


### PR DESCRIPTION
These were removed in Chef 14