### PR TITLE
Take out generic examples text

### DIFF
--- a/chef_master/source/resource_apt_package.rst
+++ b/chef_master/source/resource_apt_package.rst
@@ -291,11 +291,8 @@ Notifications, via an implicit name:
 
 Examples
 =====================================================
-.. tag resources_common_examples_intro
 
-The following examples demonstrate various approaches for using resources in recipes. If you want to see examples of how Chef uses resources in recipes, take a closer look at the cookbooks that Chef authors and maintains: https://github.com/chef-cookbooks.
-
-.. end_tag
+The following examples demonstrate various approaches for using apt_update in recipes.
 
 **Install a package using package manager**
 


### PR DESCRIPTION
People really shouldn't read our cookbooks as examples