### PR TITLE
Automate disk space protection

### DIFF
--- a/chef_master/source/data_collection.rst
+++ b/chef_master/source/data_collection.rst
@@ -51,7 +51,7 @@ Step 2: Configure your Chef server to point to Chef Automate
 -----------------------------------------------------------------
 In addition to forwarding Chef run data to Automate, Chef server will send messages to Chef Automate whenever an action is taken on a Chef server object, such as when a cookbook is uploaded to the Chef server or when a user edits a role.
 
-.. warning:: Please disable the Ohai Passwd and Sessions plugins on your nodes in ``/etc/chef/client.rb`` or using the chef-client cookbook to keep the data being sent to your Automate system to a minimum. This will improve search performance and significantly reduce the disk space requirements.
+.. warning:: Please disable the Ohai Passwd and Sessions plugins on your nodes in ``/etc/chef/client.rb`` or using the chef-client cookbook to keep the data sent to your Automate system to a minimum. This improves search performance and reduces disk space requirements.
 
    .. code-block:: shell
 

--- a/chef_master/source/data_collection.rst
+++ b/chef_master/source/data_collection.rst
@@ -51,6 +51,14 @@ Step 2: Configure your Chef server to point to Chef Automate
 -----------------------------------------------------------------
 In addition to forwarding Chef run data to Automate, Chef server will send messages to Chef Automate whenever an action is taken on a Chef server object, such as when a cookbook is uploaded to the Chef server or when a user edits a role.
 
+.. warning:: Please disable the Ohai Passwd and Sessions plugins on your nodes in ``/etc/chef/client.rb`` or using the chef-client cookbook to keep the data being sent to your Automate system to a minimum. This will improve search performance and significantly reduce the disk space requirements.
+
+   .. code-block:: shell
+
+      ohai.disabled_plugins = [ :Passwd, :Sessions ]
+
+`Ohai Plugin Detail </ohai.html#ohai-settings-in-client-rb>`__
+
 Setting up data collection on Chef server versions 12.14 and higher
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 Channel the token setting through the veil secrets library because the token is considered a secret, and cannot appear in ``/etc/opscode/chef-server.rb``:


### PR DESCRIPTION
Lately, the Ohai Sessions plugin has been causing no end of trouble in Automate installations.
Let's just go ahead and make sure people know it's going to be a potential problem so that they can address it as they get started with sending node data to their new Automate system.