### PR TITLE
[MSYS-821]Add ssl cert parameter for rabbitmq

### DIFF
--- a/chef_master/source/config_rb_delivery_optional_settings.rst
+++ b/chef_master/source/config_rb_delivery_optional_settings.rst
@@ -1040,6 +1040,17 @@ This configuration file has the following settings for ``rabbitmq``:
 ``rabbitmq['vip']``
    The virtual IP address. Default value: ``'127.0.0.1'``.
 
+``rabbitmq['use_ssl']``
+   Whether or not to enable the ssl service. Default value: ``true``.
+
+``rabbitmq['ssl_certificate']`` and ``rabbitmq['ssl_certificate_key']``
+  SSL certificate used for rabbitmq communication only if ``rabbitmq['use_ssl']`` is ``true``.
+  Certificates provide by user will be readable by the `delivery` user.
+  If both of these are nil, we generate a self-signed certificate. Default value: ``nil``.
+
+``rabbitmq['ssl_versions']``
+   The version for the ssl service. Default value: ``[ 'tlsv1.2', 'tlsv1.1' ]``.
+
 ssh_git
 -----------------------------------------------------
 This configuration file has the following settings for ``ssh_git``:


### PR DESCRIPTION
Added rabbitmq ssl certifcate parameters in chef doc :https://docs.chef.io/config_rb_delivery_optional_settings.html as :
```
rabbitmq['enable']
rabbitmq['ssl_certificate']
rabbitmq['ssl_certificate_key'] 
```

These parameters are added with reference to PR: https://github.com/chef/automate/pull/1219/files and https://github.com/chef/automate/pull/1427

Signed-off-by: NAshwini <ashwini.nehate@msystechnologies.com>