### PR TITLE
Documented default_source :artifactory

### DIFF
--- a/chef_master/source/config_rb_policyfile.rst
+++ b/chef_master/source/config_rb_policyfile.rst
@@ -50,7 +50,7 @@ A ``Policyfile.rb`` file may contain the following settings:
    Required. The run-list the chef-client will use to apply the policy to one (or more) nodes.
 
 ``default_source :SOURCE_TYPE, *args``
-   The location in which any cookbooks not specified by ``cookbook`` are located. Possible values: ``chef_repo``, ``chef_server``, ``:community``, and ``:supermarket``. Use more than one ``default_source`` to specify more than one location for cookbooks.
+   The location in which any cookbooks not specified by ``cookbook`` are located. Possible values: ``chef_repo``, ``chef_server``, ``:community``, ``:supermarket``, and ``:artifactory``. Use more than one ``default_source`` to specify more than one location for cookbooks.
 
    ``default_source :supermarket`` pulls cookbooks from the public Chef Supermarket.
 
@@ -61,6 +61,8 @@ A ``Policyfile.rb`` file may contain the following settings:
    ``default_source :community`` is an alias for ``:supermarket``.
 
    ``default_source :chef_repo, "path/to/repo"`` pulls cookbooks from a monolithic cookbook repository. This may be a path to the top-level of a cookbook repository or to the ``/cookbooks`` directory within that repository.
+
+   ``default_source :artifactory, "https://artifactory.example/api/chef/my-supermarket" pulls cookbooks from an Artifactory server. Requires either ``artifactory_api_key`` to be set in ``knife.rb`` or ``ARTIFACTORY_API_KEY`` to be set in your environment.
 
    Multiple cookbook sources may be specified. For example from the public Chef Supermarket and a monolithic repository:
 

--- a/chef_master/source/policyfile.rst
+++ b/chef_master/source/policyfile.rst
@@ -136,7 +136,7 @@ A ``Policyfile.rb`` file may contain the following settings:
    Required. The run-list the chef-client will use to apply the policy to one (or more) nodes.
 
 ``default_source :SOURCE_TYPE, *args``
-   The location in which any cookbooks not specified by ``cookbook`` are located. Possible values: ``chef_repo``, ``chef_server``, ``:community``, and ``:supermarket``. Use more than one ``default_source`` to specify more than one location for cookbooks.
+   The location in which any cookbooks not specified by ``cookbook`` are located. Possible values: ``chef_repo``, ``chef_server``, ``:community``, ``:supermarket``, and ``:artifactory``. Use more than one ``default_source`` to specify more than one location for cookbooks.
 
    ``default_source :supermarket`` pulls cookbooks from the public Chef Supermarket.
 
@@ -147,6 +147,8 @@ A ``Policyfile.rb`` file may contain the following settings:
    ``default_source :community`` is an alias for ``:supermarket``.
 
    ``default_source :chef_repo, "path/to/repo"`` pulls cookbooks from a monolithic cookbook repository. This may be a path to the top-level of a cookbook repository or to the ``/cookbooks`` directory within that repository.
+
+   ``default_source :artifactory, "https://artifactory.example/api/chef/my-supermarket" pulls cookbooks from an Artifactory server. Requires either ``artifactory_api_key`` to be set in ``knife.rb`` or ``ARTIFACTORY_API_KEY`` to be set in your environment.
 
    Multiple cookbook sources may be specified. For example from the public Chef Supermarket and a monolithic repository:
 

--- a/doctools/dtags_help.md
+++ b/doctools/dtags_help.md
@@ -3,23 +3,20 @@
 The `dtags` command lets you query and manipulate regions of
 restructuredText files that use `.. tag` and `.. end_tag` comments to
 annotate shared content. Here is a tagged region named `foo_summary`:
- 
-```
+
+```bash
    .. tag foo_summary
-   
+
    **Foo** does lots of things.
-   
+
    .. end_tag
 ```
 
-* Tagged regions may be indented, and if so, the whitespace to the 
-left of the indentation until the `.. end_tag` is not considered part
-of the tagged region. 
-* The `..tag ` and `.. end_tag` must have the same 
-indentation, and the body must have at least that indentation.
-* The ``tag`` line should be followed by a blank line.
-* The ``end_tag`` line should be preceded by a blank line.
-* The name that follows ``tag`` must use only lowercase letters, digits and the underscore character.
+* Tagged regions may be indented, and if so, the whitespace to the left of the indentation until the `.. end_tag` is not considered part of the tagged region.
+* The `..tag` and `.. end_tag` must have the same indentation, and the body must have at least that indentation.
+* The `tag` line should be followed by a blank line.
+* The `end_tag` line should be preceded by a blank line.
+* The name that follows `tag` must use only lowercase letters, digits and the underscore character.
 * It's ok for tagged regions to be nested.
 * We recommend that you use tags only for content that appears in more than one place.
 
@@ -27,11 +24,11 @@ Note that `.. tag` and `.. tag_end` are comments in
 restructuredText. They are ignored by the Sphinx documentation
 generator.
 
-`dtags`searches for files in the current working directory. For convenience, you'll want to put it in your path, make a symbolic link or create an alias. The `dtags` script is located in the the `doctools` directory of this repo.
+`dtags` searches for files in the current working directory. For convenience, you'll want to put it in your path, make a symbolic link or create an alias. The `dtags` script is located in the the `doctools` directory of this repo.
 
 Usage:
 
-```
+```bash
    dtags [--help] <command> [<args>]
 ```
 
@@ -47,9 +44,11 @@ The `dtags` command has subcommands. These are:
 ## dtags check
 
 Usage:
-```
+
+```bash
   dtags check [(<regexp> | "--") [<topic> [<topic2>]]]
 ```
+
 The `dtags check` command lists tags with multiple (inconsistent)
 definitions. If `<regexp>` is given, only tags whose names match
 `<regexp>` are checked. `dtags` uses Ruby regex syntax, but it assumes
@@ -71,20 +70,21 @@ The command exits with status 1 if the check fails.
 
 For example,
 
-```
+```bash
      dtags check foo
 ```
 
-processes only tag `foo` while 
+processes only tag `foo` while
 
-```
+```bash
      dtags check "foo.*"
-```	 
+```
 
 checks all tags starting with "foo" in the current working directory.
 
-**Example**
-```
+### Example
+
+```bash
 dtags check
 Inconsistent tagged regions:
   foo_summary e8ae754 foo.rst:6
@@ -93,8 +93,9 @@ Inconsistent tagged regions:
 
 ## dtags replicate
 
-Usage: 
-```
+Usage:
+
+```bash
   dtags replicate (<regexp> | "--") <topic> [<topic2>]
 ```
 
@@ -126,8 +127,9 @@ single file, you'll need to resolve the conflict by editing the file.
 
 ## dtags whereis
 
-Usage: 
-```
+Usage:
+
+```bash
   dtags whereis (<regexp> | "--") [<topic> [<topic2>]]
 ```
 
@@ -149,10 +151,12 @@ and line number where each tagged region begins.
 
 ## dtags list
 
-Usage: 
-```
+Usage:
+
+```bash
   dtags list [(<regexp> | "--") [<topic> [<topic2>]]
 ```
+
 The `dtags list` command scans the current directory and subdirectory
 (or just `<topic2>`, if provided) and prints tag names that match
 `<regexp>`, possibly limiting them to tags found in `<topic>`.
@@ -167,8 +171,9 @@ The results are in alphabetical order.
 
 ## dtags print
 
-Usage: 
-```
+Usage:
+
+```bash
   dtags print (<regexp> | "--") [`<topic> [`<topic2>]]
 ```
 
@@ -184,8 +189,9 @@ used as a placeholder if no regex is needed.
 
 ## dtags help
 
-Usage: 
-```
+Usage:
+
+```bash
   dtags help <command>
 ```
 

--- a/doctools/dtags_readme.md
+++ b/doctools/dtags_readme.md
@@ -18,14 +18,15 @@ there is a directive `.. include::` to bring in shared content from
 another file. Here's an example:
 
 `A.rst`
+
 ```rst
    Foo
    =======================================
-   
+
    Let's introduce **Foo**.
-   
+
    .. include ../../includes/foo_summary.rst
-   
+
    As mentioned above, **Foo** is a powerful feature of our product.
 ```
 
@@ -34,17 +35,20 @@ The file `../../includes/foo_summary.rst` contains the reusable content:
 ```rst
 **Foo** does lots of things.
 ```
+
 Of course, the whole point is that `../../includes/foo_summary.rst`
 can appear in lots of places, for example, in `B.rst`:
 
 `B.rst`
+
 ```rst
    **Enterprise Foo** is based on Foo.
-   
+
    .. include ../../includes/foo_summary.rst
-   
+
    But as impressive as **Foo** is, **Enterprise Foo** does even more.
 ```
+
 Using include files for structured content starts innocently enough.
 
 It quickly becomes difficult. Include files can themselves be included
@@ -80,35 +84,38 @@ content as being reused. The restructuredText from the previous
 example becomes:
 
 `A.rst`
+
 ```rst
    Foo
    =======================================
-   
+
    Let's introduce **Foo**.
-   
+
    .. tag foo_summary
-   
+
    **Foo** does lots of things.
-   
+
    .. end_tag
-   
+
    As mentioned above, **Foo** is a powerful feature of our product.
 ```
 
 and
 
 `B.rst`
+
 ```rst
    **Enterprise Foo** is based on Foo.
-   
+
    .. tag foo_summary
-   
+
    **Foo** does lots of things.
-   
+
    .. end_tag
-   
+
    But as impressive as **Foo** is, **Enterprise Foo** does even more.
 ```
+
 Include files like `../../includes/foo_summary.rst` go away.
 
 How do we keep the tagged regions in sync? They are, after all, in two
@@ -138,23 +145,25 @@ let's say that `A.rst` is the one that we want to work on. Here's our
 change:
 
 `A.rst`
+
 ```rst
    Foo
    =======================================
-   
+
    Let's introduce **Foo**.
-   
+
    .. tag foo_summary
-   
+
    **Foo** does lots of really important things and it does them fast.
-   
+
    .. end_tag
-   
+
    As mentioned above, **Foo** is a powerful feature of our product.
 ```
 
 Our version control system sees the change:
-```
+
+```bash
 git status
 On branch master
 Your branch is up-to-date with 'origin/master'.
@@ -163,13 +172,13 @@ Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
 
-	modified:   A.rst
+  modified:   A.rst
 ```
 
 We can review the change by looking at diffs.
 
 ```bash
-git diff 
+git diff
 diff --git a/src/examples/A.rst b/src/examples/A.rst
  index 8e7ea54..3d5a97a 100644
  --- a/src/examples/A.rst
@@ -197,8 +206,8 @@ location. We can do this by adding our change to the git index, the
 staging area for changes prior to commiting them. The `git add`
 command is what we want.
 
-```
-git add A.rst 
+```bash
+git add A.rst
 git status
 
 On branch master
@@ -214,13 +223,14 @@ shared content and to replicate changes.
 
 We start by running the `dtags check` subcommand.
 
-```
+```bash
 dtags check
 Inconsistent tagged regions:
   foo_summary e8ae754 A.rst:6
 
   foo_summary 5a93da7 B.rst:3
 ```
+
 The `dtags` tool compares the tags across the doc set (the current working
 directory) and reports inconsistencies.
 
@@ -230,7 +240,7 @@ file name and line number where the tag is seen.
 We can apply the changes to all or part of the documentation set
 in our working set with the `dtags replicate` subcommand.
 
-```
+```bash
 dtags replicate foo_summary A.rst
 
   tag foo_summary 5a93da7 -> e8ae754 B.rst:3
@@ -243,7 +253,7 @@ options for using `dtags replicate`.)
 
 We can check that a change was made by looking at the `git status`.
 
-```
+```bash
 git status
 On branch master
 Your branch is up-to-date with 'origin/master'.
@@ -251,13 +261,13 @@ Your branch is up-to-date with 'origin/master'.
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
-	modified:   A.rst
+  modified:   A.rst
 
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
 
-	modified:   B.rst
+  modified:   B.rst
 
 ```
 
@@ -279,7 +289,7 @@ Oops, we just overwrote our changes with the old text! This isn't a
 problem. We can fix that glitch by "unstaging" `A.rst` and putting
 `A.rst` back in the index:
 
-```
+```bash
 git reset HEAD A.rst
 git add A.rst
 dtags replicate -- A.rst
@@ -292,7 +302,7 @@ The final step is to make sure all of the tagged regions are
 consistent and commit our changes and push them to the repo used for
 the project.
 
-```
+```bash
 dtags check
 git add B.rst
 git commit -m "Changed foo_summary per VP of Marketing"


### PR DESCRIPTION
I have an artifactory instance that I need to use in my build pipeline. I am using Policyfiles, and in my research, I discovered [this Pull Request](https://github.com/chef/chef-dk/pull/1252) on the chef-dk repository. I was able to get it to work and decided to help the next guy who needed this by adding it to the documentation. I've already done the `dtags replicate` to propagate my change to everywhere it is needed.

The changes in the dtags markdown files was just some formatting that was brought to my attention by markdownlint.

Thanks!