### PR TITLE
Remove metadata.rb documentation regarding chef 12 and attributes

### DIFF
--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -22,8 +22,6 @@ A metadata.rb file is:
 
 .. note:: A metadata.json file can be edited directly, should temporary changes be required. Any subsequent upload or action that generates metadata will cause the existing metadata.json file to be overwritten with the newly generated metadata. Therefore, any permanent changes to cookbook metadata should be done in the metadata.rb file, and then re-uploaded to the Chef server.
 
- New in 12.8, ``gem`` allows the specification of gem dependency installation via ``chef_gem``. New in 12.6, ``chef_version`` for supporting a range of chef-client versions in a cookbooks, ``ohai_version`` for supporting a range of Ohai versions in a cookbook.  Changed in Chef Client 12.0 to support version constraints, requires ``name``.  New in 12.0, ``issues_url`` to capture issues tracking, ``provides`` method for mapping a custom resource or provider to an existing resource or provider, and ``source_url`` to capture source capture.
-
 Version Constraints
 ====================
 
@@ -50,8 +48,6 @@ Many fields in a cookbook's metadata allow the user to constrain versions. There
   * - Less than or equal to
     - ``<=``
 
-Changed in Chef Client 12.0 to support version constraints.
-
 .. note:: Pessimistic locking is enabled by proper `semantic versioning <https://semver.org>`__ of cookbooks. If we're on version 2.2.3 of a cookbook, we know that the API will be stable until the 3.0.0 release. Using traditional operators, we'd write this as ``>= 2.2.0, < 3.0``. Instead, we can write this by combining a tilde "~" and right angle bracket ">"--often called a tilde-rocket or "twiddle-wakka"--followed by the major and minor version numbers.  For example: ``~> 2.2``
 
 
@@ -61,34 +57,7 @@ Settings
 
 This configuration file has the following settings:
 
-``attribute``
-   Deprecated in Chef Client 13.0, pending removal in 14.0.
-
-   .. warning:: ``attribute`` in cookbook configuration is deprecated and will be removed. ``attribute`` often requires frequent updating in the code, in the README.md file, and in the metadata, which may lead to extensive technical debt. When used, the current version of foodcritic will throw a warning.
-
-   The list of attributes that are required to configure a cookbook. An attribute name is required, followed by any of these options: ``display_name`` (the name that appears in the user interface), ``description`` (a short description), ``choice`` (an array of choices that are presented to a user), ``calculated`` (the default value is calculated by the recipe), ``type`` (the type of value, either ``string``, ``array``, or ``hash``), ``required`` (the level of user input, either ``required``, ``recommended``, or ``optional``), ``recipes`` (an array of recipes), or ``default`` (the attribute's default value).
-
-    For example:
-
-    .. code-block:: ruby
-
-       attribute 'pets/cat/name',
-         :display_name => 'Cat Name',
-         :description => 'The name of your cat',
-         :choice => \[
-           'kitty kitty',
-           'peanut',
-           'einstein',
-           'honey' \],
-         :type => 'string',
-         :required => 'recommended',
-         :recipes => \[ 'cats::eat' \],
-         :default => 'kitty kitty'
-
 ``chef_version``
-   New in Chef Client 12.6.
-
-   .. note:: This setting is not visible in Chef Supermarket.
 
    A range of chef-client versions that are supported by this cookbook. All `version constraint operators </config_rb_metadata.html#cookbook-version-constraints>`__ are applicable to this field.
 
@@ -99,7 +68,7 @@ This configuration file has the following settings:
 
    .. code-block:: ruby
 
-      chef_version '~> 12'
+      chef_version '~> 14'
 
    A more complex example where you set both a lower and upper bound of the chef-client version:
 
@@ -144,8 +113,6 @@ This configuration file has the following settings:
       gem "chef-sugar"
       gem "chef-provisioning"
 
-   New in Chef Client 12.8.
-
    .. end_tag
 
 ``issues_url``
@@ -156,8 +123,6 @@ This configuration file has the following settings:
    .. code-block:: ruby
 
       issues_url 'https://github.com/chef-cookbooks/chef-client/issues'
-
-   New in Chef Client 12.0.
 
 ``license``
    The type of license under which a cookbook is distributed: ``Apache v2.0``, ``GPL v2``, ``GPL v3``, ``MIT``, or ``license 'Proprietary - All Rights Reserved`` (default). Please be aware of the licenses for files inside of a cookbook and be sure to follow any restrictions they describe.
@@ -259,17 +224,15 @@ This configuration file has the following settings:
 
    .. tag config_rb_metadata_settings_example_ohai_version
 
-   For example, to match any 8.x version of Ohai, but not 7.x or 9.x:
+   For example, to match any 14.x version of Ohai, but not 13.x or 15.x:
 
    .. code-block:: ruby
 
-      ohai_version "~> 8"
+      ohai_version "~> 14"
 
    .. end_tag
 
    .. note:: This setting is not visible in Chef Supermarket.
-
-   New in Chef Client 12.6.
 
 ``privacy``
    Specify that a cookbook is private.
@@ -296,8 +259,6 @@ This configuration file has the following settings:
 
       provides 'service[snuggle]'
 
-   New in Chef Client 12.0.
-
 ``recipe``
    A description for a recipe, mostly for cosmetic value within the Chef server user interface.
 
@@ -321,8 +282,6 @@ This configuration file has the following settings:
    .. code-block:: ruby
 
       source_url 'https://github.com/chef-cookbooks/chef-client'
-
-   New in Chef Client 12.0.
 
 ``supports``
    Show that a cookbook has a supported platform. Use a version constraint to define dependencies for platform versions: ``<`` (less than), ``<=`` (less than or equal to), ``=`` (equal to), ``>=`` (greater than or equal to), ``~>`` (approximately greater than), or ``>`` (greater than). To specify more than one platform, use more than one ``supports`` field, once for each platform.

--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -57,7 +57,34 @@ Settings
 
 This configuration file has the following settings:
 
+``attribute``
+   Deprecated in Chef Client 13.0, pending removal in 14.0.
+
+   .. warning:: ``attribute`` in cookbook configuration is deprecated and will be removed. ``attribute`` often requires frequent updating in the code, in the README.md file, and in the metadata, which may lead to extensive technical debt. When used, the current version of foodcritic will throw a warning.
+
+   The list of attributes that are required to configure a cookbook. An attribute name is required, followed by any of these options: ``display_name`` (the name that appears in the user interface), ``description`` (a short description), ``choice`` (an array of choices that are presented to a user), ``calculated`` (the default value is calculated by the recipe), ``type`` (the type of value, either ``string``, ``array``, or ``hash``), ``required`` (the level of user input, either ``required``, ``recommended``, or ``optional``), ``recipes`` (an array of recipes), or ``default`` (the attribute's default value).
+
+    For example:
+
+    .. code-block:: ruby
+
+       attribute 'pets/cat/name',
+         :display_name => 'Cat Name',
+         :description => 'The name of your cat',
+         :choice => \[
+           'kitty kitty',
+           'peanut',
+           'einstein',
+           'honey' \],
+         :type => 'string',
+         :required => 'recommended',
+         :recipes => \[ 'cats::eat' \],
+         :default => 'kitty kitty'
+
 ``chef_version``
+   New in Chef Client 12.6.
+
+   .. note:: This setting is not visible in Chef Supermarket.
 
    A range of chef-client versions that are supported by this cookbook. All `version constraint operators </config_rb_metadata.html#cookbook-version-constraints>`__ are applicable to this field.
 
@@ -68,7 +95,7 @@ This configuration file has the following settings:
 
    .. code-block:: ruby
 
-      chef_version '~> 14'
+      chef_version '~> 12'
 
    A more complex example where you set both a lower and upper bound of the chef-client version:
 
@@ -113,6 +140,8 @@ This configuration file has the following settings:
       gem "chef-sugar"
       gem "chef-provisioning"
 
+   New in Chef Client 12.8.
+
    .. end_tag
 
 ``issues_url``
@@ -123,6 +152,8 @@ This configuration file has the following settings:
    .. code-block:: ruby
 
       issues_url 'https://github.com/chef-cookbooks/chef-client/issues'
+
+   New in Chef Client 12.0.
 
 ``license``
    The type of license under which a cookbook is distributed: ``Apache v2.0``, ``GPL v2``, ``GPL v3``, ``MIT``, or ``license 'Proprietary - All Rights Reserved`` (default). Please be aware of the licenses for files inside of a cookbook and be sure to follow any restrictions they describe.
@@ -224,15 +255,17 @@ This configuration file has the following settings:
 
    .. tag config_rb_metadata_settings_example_ohai_version
 
-   For example, to match any 14.x version of Ohai, but not 13.x or 15.x:
+   For example, to match any 8.x version of Ohai, but not 7.x or 9.x:
 
    .. code-block:: ruby
 
-      ohai_version "~> 14"
+      ohai_version "~> 8"
 
    .. end_tag
 
    .. note:: This setting is not visible in Chef Supermarket.
+
+   New in Chef Client 12.6.
 
 ``privacy``
    Specify that a cookbook is private.
@@ -259,6 +292,8 @@ This configuration file has the following settings:
 
       provides 'service[snuggle]'
 
+   New in Chef Client 12.0.
+
 ``recipe``
    A description for a recipe, mostly for cosmetic value within the Chef server user interface.
 
@@ -282,6 +317,8 @@ This configuration file has the following settings:
    .. code-block:: ruby
 
       source_url 'https://github.com/chef-cookbooks/chef-client'
+
+   New in Chef Client 12.0.
 
 ``supports``
    Show that a cookbook has a supported platform. Use a version constraint to define dependencies for platform versions: ``<`` (less than), ``<=`` (less than or equal to), ``=`` (equal to), ``>=`` (greater than or equal to), ``~>`` (approximately greater than), or ``>`` (greater than). To specify more than one platform, use more than one ``supports`` field, once for each platform.


### PR DESCRIPTION
If we introduced it in early Chef 12 releases we really don't need to mention that anymore. It's fair game for everyone. Also remove the attributes stuff which no one should ever use.