### PR TITLE
Update resource name typo in windows_feature_powershell docs

### DIFF
--- a/chef_master/source/resource_windows_feature_powershell.rst
+++ b/chef_master/source/resource_windows_feature_powershell.rst
@@ -26,7 +26,7 @@ This resource has the following syntax:
 
 where:
 
-* ``windows_feature_dism`` is the resource
+* ``windows_feature_powershell`` is the resource
 * ``'name'`` is the name of the feature / role, or the name of the resource block
 * ``all``, ``feature_name``, ``management_tools``, ``notifies``, ``source``, ``subscribes``, and ``timeout`` are the properties available to this resource
 


### PR DESCRIPTION
Wrong resource name was given under `where:`