### PR TITLE
Call it the Chef install script

### DIFF
--- a/chef_master/source/about_chefdk.rst
+++ b/chef_master/source/about_chefdk.rst
@@ -70,7 +70,7 @@ The most important tools included in the Chef development kit are:
    * - Cookstyle
      - A Rubocop-based style-checking tool for writing clean cookbooks.
    * - Delivery CLI
-     - A command-line tool for continuous delivery workflow. Is used to setup and execute phase jobs on an Chef Automate server.
+     - A command-line tool for continuous delivery workflow. Is used to setup and execute phase jobs on a Chef Automate server.
    * - Fauxhai
      - A gem for mocking Ohai data in ChefSpec tests.
    * - Foodcritic

--- a/chef_master/source/chef_client_overview.rst
+++ b/chef_master/source/chef_client_overview.rst
@@ -394,9 +394,9 @@ Bootstrap Operations
 
 The ``knife bootstrap`` command is a common way to install the chef-client on a node. The default for this approach assumes that a node can access the Chef website so that it may download the chef-client package from that location.
 
-The omnibus installer will detect the version of the operating system, and then install the appropriate version of the chef-client using a single command to install the chef-client and all of its dependencies, including an embedded version of Ruby, RubyGems, OpenSSL, key-value stores, parsers, libraries, and command line utilities.
+The Chef installer will detect the version of the operating system, and then install the appropriate version of the chef-client using a single command to install the chef-client and all of its dependencies, including an embedded version of Ruby, RubyGems, OpenSSL, key-value stores, parsers, libraries, and command line utilities.
 
-The omnibus installer puts everything into a unique directory (``/opt/chef/``) so that the chef-client will not interfere with other applications that may be running on the target machine. Once installed, the chef-client requires a few more configuration steps before it can perform its first chef-client run on a node.
+The Chef installer puts everything into a unique directory (``/opt/chef/``) so that the chef-client will not interfere with other applications that may be running on the target machine. Once installed, the chef-client requires a few more configuration steps before it can perform its first chef-client run on a node.
 
 .. end_tag
 
@@ -404,7 +404,7 @@ The omnibus installer puts everything into a unique directory (``/opt/chef/``) s
 
 A node is any physical, virtual, or cloud machine that is configured to be maintained by a chef-client. In order to bootstrap a node, you will first need a working installation of the `Chef software package </packages.html>`__. A bootstrap is a process that installs the chef-client on a target system so that it can run as a chef-client and communicate with a Chef server. There are two ways to do this:
 
-* Use the ``knife bootstrap`` subcommand to `bootstrap a node using the omnibus installer </install_bootstrap.html>`__
+* Use the ``knife bootstrap`` subcommand to `bootstrap a node using the Chef installer </install_bootstrap.html>`__
 * Use an unattended install to bootstrap a node from itself, without using SSH or WinRM
 
 .. end_tag

--- a/chef_master/source/community_contributions.rst
+++ b/chef_master/source/community_contributions.rst
@@ -112,7 +112,7 @@ The DCO is an attestation attached to every contribution made by every developer
         consistent with this project or the open source license(s)
         involved.
 
-Chef does not merge any pull requests made against an Chef-managed open source repository until each commit has been signed for the DCO, with three exceptions:
+Chef does not merge any pull requests made against a Chef-managed open source repository until each commit has been signed for the DCO, with three exceptions:
 
 * "Obvious Fixes" (as described below)
 * Pull requests made against the docs.chef.io documentation repository (https://github.com/chef/chef-web-docs)

--- a/chef_master/source/config_rb_delivery_optional_settings.rst
+++ b/chef_master/source/config_rb_delivery_optional_settings.rst
@@ -358,7 +358,7 @@ This configuration file has the following settings for ``delivery``:
    Default value: ``"/var/opt/delivery/delivery/etc"``.
 
 ``delivery['git_repo_template']``
-   Where to look for the delivery git repo template must remain consistent with where omnibus-delivery's 'delivery' software definition puts it. Default value:
+   Where to look for the delivery git repo template must remain consistent with where Chef-delivery's 'delivery' software definition puts it. Default value:
 
    .. code-block:: ruby
 

--- a/chef_master/source/config_rb_delivery_optional_settings.rst
+++ b/chef_master/source/config_rb_delivery_optional_settings.rst
@@ -358,7 +358,7 @@ This configuration file has the following settings for ``delivery``:
    Default value: ``"/var/opt/delivery/delivery/etc"``.
 
 ``delivery['git_repo_template']``
-   Where to look for the delivery git repo template must remain consistent with where Chef-delivery's 'delivery' software definition puts it. Default value:
+   Where to look for the delivery git repo template must remain consistent with where omnibus-delivery's 'delivery' software definition puts it. Default value:
 
    .. code-block:: ruby
 

--- a/chef_master/source/config_yml_kitchen.rst
+++ b/chef_master/source/config_yml_kitchen.rst
@@ -356,7 +356,7 @@ Kitchen also supports ``http_proxy`` and ```https_proxy`` in the ``.kitchen.yml`
 
 chef-client Settings
 ==========================================================================
-A .kitchen.yml file may define chef-client-specific settings, such as whether to require the omnibus installer or the URL from which the chef-client is downloaded, or to override settings in the client.rb file:
+A .kitchen.yml file may define chef-client-specific settings, such as whether to require the Chef installer or the URL from which the chef-client is downloaded, or to override settings in the client.rb file:
 
 .. code-block:: yaml
 
@@ -387,7 +387,7 @@ A .kitchen.yml file may define chef-client-specific settings, such as whether to
 
 where:
 
-* ``require_chef_omnibus`` is used to ensure that the omnibus installer will be used to install the chef-client to all platform instances; ``require_chef_omnibus`` may also be set to ``latest``, which means the newest version of the chef-client for that platform will be used for cookbook testing
+* ``require_chef_omnibus`` is used to ensure that the Chef installer will be used to install the chef-client to all platform instances; ``require_chef_omnibus`` may also be set to ``latest``, which means the newest version of the chef-client for that platform will be used for cookbook testing
 * ``chef_omnibus_url`` is used to specify the URL from which the chef-client is downloaded
 * All of the ``attributes`` for the ``config`` test suite contain specific client.rb settings for use with this test suite
 

--- a/chef_master/source/ctl_analytics.rst
+++ b/chef_master/source/ctl_analytics.rst
@@ -12,7 +12,7 @@ opscode-analytics-ctl (executable)
 
 .. end_tag
 
-The Chef Analytics installations that are done using the omnibus installer include a command-line utility named opscode-analytics-ctl. This command-line tool is used to start and stop individual services, reconfigure the Chef Analytics server, run smoke tests, and tail the Chef Analytics log files.
+The Chef Analytics installations that are done using the Chef installer include a command-line utility named opscode-analytics-ctl. This command-line tool is used to start and stop individual services, reconfigure the Chef Analytics server, run smoke tests, and tail the Chef Analytics log files.
 
 .. note:: .. tag chef_subscriptions
 

--- a/chef_master/source/ctl_kitchen.rst
+++ b/chef_master/source/ctl_kitchen.rst
@@ -80,7 +80,7 @@ will return something similar to:
 
 kitchen converge
 =====================================================
-Use the ``converge`` subcommand to converge one (or more) instances. Instances are based on the list of platforms in the .kitchen.yml file. This process will install the chef-client on an instance using the omnibus installer, upload cookbook files and minimal configuration to the instance, and then start a chef-client run using the run-list and attributes specified in the .kitchen.yml file.
+Use the ``converge`` subcommand to converge one (or more) instances. Instances are based on the list of platforms in the .kitchen.yml file. This process will install the chef-client on an instance using the Chef installer, upload cookbook files and minimal configuration to the instance, and then start a chef-client run using the run-list and attributes specified in the .kitchen.yml file.
 
 Kitchen will skip unnecessary steps. For example, if the chef-client is already installed to the instance, Kitchen will not re-install the chef-client. That said, Kitchen will always upload the cookbook files and minimal configuration. This ensures that cookbook testing is being done correctly.
 

--- a/chef_master/source/ctl_supermarket.rst
+++ b/chef_master/source/ctl_supermarket.rst
@@ -5,7 +5,7 @@ supermarket-ctl (executable)
 
 .. tag ctl_supermarket_summary
 
-The Chef Supermarket installations that are done using the omnibus installer include a command-line utility named supermarket-ctl. This command-line tool is used to start and stop individual services, reconfigure the Chef Supermarket server, run smoke tests, and tail the Chef Supermarket log files.
+The Chef Supermarket installations that are done using the Chef installer include a command-line utility named supermarket-ctl. This command-line tool is used to start and stop individual services, reconfigure the Chef Supermarket server, run smoke tests, and tail the Chef Supermarket log files.
 
 .. end_tag
 
@@ -19,7 +19,7 @@ This subcommand has the following syntax:
 
    $ sudo -u supermarket supermarket-ctl make-admin USER_NAME
 
-where ``USER_NAME`` represents the name of the user to be granted administrator priviliges.
+where ``USER_NAME`` represents the name of the user to be granted administrator privileges.
 
 Quality Metrics
 =====================================================

--- a/chef_master/source/fips.rst
+++ b/chef_master/source/fips.rst
@@ -174,7 +174,7 @@ If you ever stop using FIPS mode on the Chef Automate server, simply delete the 
 
 For more information on configuring the Chef Automate server, see `Delivery CLI </delivery_cli.html>`_.
 
-.. note:: If you set up any runners using an Chef Automate server version ``0.7.61`` or earlier, then you will need to re-run `automate-ctl install-runner </ctl_automate_server.html#install-runner>`_ on every existing runner after upgrading your Chef Automate server. Your runners will not work with FIPS enabled without re-running the installer.
+.. note:: If you set up any runners using a Chef Automate server version ``0.7.61`` or earlier, then you will need to re-run `automate-ctl install-runner </ctl_automate_server.html#install-runner>`_ on every existing runner after upgrading your Chef Automate server. Your runners will not work with FIPS enabled without re-running the installer.
 
 
 

--- a/chef_master/source/install_bootstrap.rst
+++ b/chef_master/source/install_bootstrap.rst
@@ -7,7 +7,7 @@ Bootstrap a Node
 
 A node is any physical, virtual, or cloud machine that is configured to be maintained by a chef-client. In order to bootstrap a node, you will first need a working installation of the `Chef software package </packages.html>`__. A bootstrap is a process that installs the chef-client on a target system so that it can run as a chef-client and communicate with a Chef server. There are two ways to do this:
 
-* Use the ``knife bootstrap`` subcommand to `bootstrap a node using the omnibus installer </install_bootstrap.html>`__
+* Use the ``knife bootstrap`` subcommand to `bootstrap a node using the Chef installer </install_bootstrap.html>`__
 * Use an unattended install to bootstrap a node from itself, without using SSH or WinRM
 
 .. end_tag
@@ -18,9 +18,9 @@ knife bootstrap
 
 The ``knife bootstrap`` command is a common way to install the chef-client on a node. The default for this approach assumes that a node can access the Chef website so that it may download the chef-client package from that location.
 
-The omnibus installer will detect the version of the operating system, and then install the appropriate version of the chef-client using a single command to install the chef-client and all of its dependencies, including an embedded version of Ruby, RubyGems, OpenSSL, key-value stores, parsers, libraries, and command line utilities.
+The Chef installer will detect the version of the operating system, and then install the appropriate version of the chef-client using a single command to install the chef-client and all of its dependencies, including an embedded version of Ruby, RubyGems, OpenSSL, key-value stores, parsers, libraries, and command line utilities.
 
-The omnibus installer puts everything into a unique directory (``/opt/chef/``) so that the chef-client will not interfere with other applications that may be running on the target machine. Once installed, the chef-client requires a few more configuration steps before it can perform its first chef-client run on a node.
+The Chef installer puts everything into a unique directory (``/opt/chef/``) so that the chef-client will not interfere with other applications that may be running on the target machine. Once installed, the chef-client requires a few more configuration steps before it can perform its first chef-client run on a node.
 
 .. end_tag
 

--- a/chef_master/source/install_chef_air_gap.rst
+++ b/chef_master/source/install_chef_air_gap.rst
@@ -170,7 +170,7 @@ Install Chef DK
 
 Create a bootstrap template
 -----------------------------------------------------
-By default, ``knife bootstrap`` uses the ``chef-full`` template to bootstrap a node. This template contains a number of useful features, but it also attempts to pull an installation script from ``omnitruck.chef.io``. In this section, you'll copy the contents of the ``chef-full`` template to a custom template, and then modify the package and Ruby gem sources.
+By default, ``knife bootstrap`` uses the ``chef-full`` template to bootstrap a node. This template contains a number of useful features, but it also attempts to pull an installation script from ``downloads.chef.io``. In this section, you'll copy the contents of the ``chef-full`` template to a custom template, and then modify the package and Ruby gem sources.
 
 #. Navigate to the ``.chef`` directory, and create a ``bootstrap`` directory within it:
 

--- a/chef_master/source/install_chef_air_gap.rst
+++ b/chef_master/source/install_chef_air_gap.rst
@@ -66,7 +66,7 @@ In this section you'll install the Chef server, and create your organization and
 
 .. note:: If you intend to use Chef Automate, create the ``delivery`` user and add it to your organization during this step.
 
-#. Download the package from https://omnitruck.chef.io/chef-server/.
+#. Download the package from https://downloads.chef.io/chef-server/.
 #. Upload the package to the machine that will run the Chef server, and then record its location on the file system. The rest of these steps assume this location is in the ``/tmp`` directory.
 
 #. .. tag install_chef_server_install_package

--- a/chef_master/source/install_chef_air_gap.rst
+++ b/chef_master/source/install_chef_air_gap.rst
@@ -66,7 +66,7 @@ In this section you'll install the Chef server, and create your organization and
 
 .. note:: If you intend to use Chef Automate, create the ``delivery`` user and add it to your organization during this step.
 
-#. Download the package from https://downloads.chef.io/chef-server/.
+#. Download the package from https://omnitruck.chef.io/chef-server/.
 #. Upload the package to the machine that will run the Chef server, and then record its location on the file system. The rest of these steps assume this location is in the ``/tmp`` directory.
 
 #. .. tag install_chef_server_install_package

--- a/chef_master/source/install_dk.rst
+++ b/chef_master/source/install_dk.rst
@@ -3,9 +3,9 @@ Install the Chef DK
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/install_dk.rst>`__
 
-The Chef DK installer is used to set up the Chef development kit on a workstation, including the chef-client itself, an embedded version of Ruby, RubyGems, OpenSSL, key-value stores, parsers, libraries, command line utilities, and community tools such as Kitchen, Berkshelf, and ChefSpec. The omnibus installer puts everything into a unique directory (``/opt/chefdk/`` on macOS / Linux and ``C:\opscode\chefdk\`` on Windows) so that these components will not interfere with other applications that may be running on the target machine.
+The Chef DK installer is used to set up the Chef development kit on a workstation, including the chef-client itself, an embedded version of Ruby, RubyGems, OpenSSL, key-value stores, parsers, libraries, command line utilities, and community tools such as Kitchen, Berkshelf, and ChefSpec. The Chef installer puts everything into a unique directory (``/opt/chefdk/`` on macOS / Linux and ``C:\opscode\chefdk\`` on Windows) so that these components will not interfere with other applications that may be running on the target machine.
 
-.. note:: The omnibus installer must run as a root user.
+.. note:: The Chef installer must run as a root user.
 
 Install
 =====================================================

--- a/chef_master/source/install_omnibus.rst
+++ b/chef_master/source/install_omnibus.rst
@@ -5,7 +5,7 @@ Install via URL
 
 .. tag packages_install_script
 
-The Omnitruck install script does the following:
+The Chef install script does the following:
 
 * Detects the platform, version, and architecture of the machine on which the installer is to be executed
 * Fetches the appropriate package, for the requested product and version
@@ -18,7 +18,7 @@ Run the Install Script
 =====================================================
 .. tag packages_install_script_run
 
-The Omnitruck install script can be run on UNIX, Linux, and Microsoft Windows platforms.
+The Chef install script can be run on UNIX, Linux, and Microsoft Windows platforms.
 
 .. end_tag
 
@@ -26,7 +26,7 @@ UNIX and Linux
 -----------------------------------------------------
 .. tag packages_install_script_run_unix_linux
 
-On UNIX and Linux systems the Omnitruck install script is invoked with:
+On UNIX and Linux systems the Chef install script is invoked with:
 
 .. code-block:: bash
 
@@ -40,7 +40,7 @@ Microsoft Windows
 -----------------------------------------------------
 .. tag packages_install_script_run_windows
 
-On Microsoft Windows systems the Omnitruck install script is invoked using Windows PowerShell:
+On Microsoft Windows systems the Chef install script is invoked using Windows PowerShell:
 
 .. code-block:: none
 
@@ -52,7 +52,7 @@ Install Script Options
 =====================================================
 .. tag packages_install_script_options
 
-In addition to the default install behavior, the Omnitruck install script supports the following options:
+In addition to the default install behavior, the Chef install script supports the following options:
 
 ``-c`` (``-channel`` on Microsoft Windows)
    The release channel from which a package is pulled. Possible values: ``current`` or ``stable``. Default value: ``stable``.

--- a/chef_master/source/install_server_ha.rst
+++ b/chef_master/source/install_server_ha.rst
@@ -454,7 +454,7 @@ The ``chef-backend-ctl gen-server-config`` command, which can be run as root fro
 Software Versions
 ----------------------------------------------------------------
 
-The backend HA cluster uses the Chef installer (https://github.com/chef/omnibus) to package all of the software
+The backend HA cluster uses the Chef installer to package all of the software
 necessary to run the services included in the backend cluster. For a full list of the software packages included (and their versions), see the file located at ``/opt/chef-backend/version-manifest.json``.
 
 Do not attempt to upgrade individual components of the Chef package. Due to the way Chef packages are built, modifying any of the individual components in the package will lead to cluster instability. If the latest version of the backend cluster is providing an out-of-date package, please bring it to the attention of Chef by filling out a ticket with support@chef.io.

--- a/chef_master/source/install_server_ha.rst
+++ b/chef_master/source/install_server_ha.rst
@@ -454,10 +454,10 @@ The ``chef-backend-ctl gen-server-config`` command, which can be run as root fro
 Software Versions
 ----------------------------------------------------------------
 
-The backend HA cluster uses the omnibus installer (https://github.com/chef/omnibus) to package all of the software
+The backend HA cluster uses the Chef installer (https://github.com/chef/omnibus) to package all of the software
 necessary to run the services included in the backend cluster. For a full list of the software packages included (and their versions), see the file located at ``/opt/chef-backend/version-manifest.json``.
 
-Do not attempt to upgrade individual components of the omnibus package. Due to the way omnibus packages are built, modifying any of the individual components in the package will lead to cluster instability. If the latest version of the backend cluster is providing an out-of-date package, please bring it to the attention of Chef by filling out a ticket with support@chef.io.
+Do not attempt to upgrade individual components of the Chef package. Due to the way Chef packages are built, modifying any of the individual components in the package will lead to cluster instability. If the latest version of the backend cluster is providing an out-of-date package, please bring it to the attention of Chef by filling out a ticket with support@chef.io.
 
 chef-backend.rb Options
 =====================================================

--- a/chef_master/source/install_supermarket.rst
+++ b/chef_master/source/install_supermarket.rst
@@ -25,7 +25,7 @@ The private Chef Supermarket is installed behind the firewall on the internal ne
           The source code for Chef Supermarket is located at the following URLs:
 
           * The application itself: https://github.com/chef/supermarket. Report issues to: https://github.com/chef/supermarket/issues.
-          * The code that builds Chef Supermarket as an omnibus package: https://github.com/chef/omnibus-supermarket. Use a Kitchen-based environment to build your own omnibus packages.
+          * The code that builds Chef Supermarket as a Chef package: https://github.com/chef/omnibus-supermarket. Use a Kitchen-based environment to build your own Chef packages.
           * The cookbook that is run by the ``supermarket-ctl reconfigure`` command: https://github.com/chef/supermarket/tree/master/omnibus/cookbooks/omnibus-supermarket
 
           .. end_tag

--- a/chef_master/source/knife_bootstrap.rst
+++ b/chef_master/source/knife_bootstrap.rst
@@ -7,7 +7,7 @@ knife bootstrap
 
 A node is any physical, virtual, or cloud machine that is configured to be maintained by a chef-client. In order to bootstrap a node, you will first need a working installation of the `Chef software package </packages.html>`__. A bootstrap is a process that installs the chef-client on a target system so that it can run as a chef-client and communicate with a Chef server. There are two ways to do this:
 
-* Use the ``knife bootstrap`` subcommand to `bootstrap a node using the omnibus installer </install_bootstrap.html>`__
+* Use the ``knife bootstrap`` subcommand to `bootstrap a node using the Chef installer </install_bootstrap.html>`__
 * Use an unattended install to bootstrap a node from itself, without using SSH or WinRM
 
 .. end_tag
@@ -198,7 +198,7 @@ This subcommand has the following options:
    New in Chef Client 12.6.
 
 ``-t TEMPLATE``, ``--bootstrap-template TEMPLATE``
-   The bootstrap template to use. This may be the name of a bootstrap template---``chef-full``, for example---or it may be the full path to an Embedded Ruby (ERB) template that defines a custom bootstrap. Default value: ``chef-full``, which installs the chef-client using the omnibus installer on all supported platforms.
+   The bootstrap template to use. This may be the name of a bootstrap template---``chef-full``, for example---or it may be the full path to an Embedded Ruby (ERB) template that defines a custom bootstrap. Default value: ``chef-full``, which installs the chef-client using the Chef installer on all supported platforms.
 
    New in Chef Client 12.0.
 
@@ -328,7 +328,7 @@ Custom Templates
 =====================================================
 .. tag knife_bootstrap_template
 
-The default ``chef-full`` template uses the omnibus installer. For most bootstrap operations, regardless of the platform on which the target node is running, using the ``chef-full`` distribution is the best approach for installing the chef-client on a target node. In some situations, a custom template may be required.
+The default ``chef-full`` template uses the Chef installer. For most bootstrap operations, regardless of the platform on which the target node is running, using the ``chef-full`` distribution is the best approach for installing the chef-client on a target node. In some situations, a custom template may be required.
 
 For example, the default bootstrap operation relies on an Internet connection to get the distribution to the target node. If a target node cannot access the Internet, then a custom template can be used to define a specific location for the distribution so that the target node may access it during the bootstrap operation. The example below will show you how to create a bootstrap template that uses a custom artifact store for Chef packages and installation scripts, as well as a RubyGem mirror:
 

--- a/chef_master/source/packages.rst
+++ b/chef_master/source/packages.rst
@@ -3,7 +3,7 @@ Chef Software Inc Packages
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/packages.rst>`__
 
-Packages for Chef Software Inc products may be installed using platform-native package repositories or the Omnitruck install script. Both installation methods support the following release channels:
+Packages for Chef Software Inc products may be installed using platform-native package repositories or the Chef install script. Both installation methods support the following release channels:
 
 .. list-table::
    :widths: 150 450
@@ -109,11 +109,11 @@ To set up a Yum package repository for Enterprise Linux platforms:
   		  
       $ sudo mv chef-stable.repo /etc/yum.repos.d/
 
-Omnitruck Install Scripts
+Chef Install Script
 =====================================================
 .. tag packages_install_script
 
-The Omnitruck install script does the following:
+The Chef install script does the following:
 
 * Detects the platform, version, and architecture of the machine on which the installer is to be executed
 * Fetches the appropriate package, for the requested product and version
@@ -122,11 +122,11 @@ The Omnitruck install script does the following:
 
 .. end_tag
 
-Run the Omnitruck Install Script
+Run the Chef Install Script
 -----------------------------------------------------
 .. tag packages_install_script_run
 
-The Omnitruck install script can be run on UNIX, Linux, and Microsoft Windows platforms.
+The Chef install script can be run on UNIX, Linux, and Microsoft Windows platforms.
 
 .. end_tag
 
@@ -134,7 +134,7 @@ UNIX and Linux
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. tag packages_install_script_run_unix_linux
 
-On UNIX and Linux systems the Omnitruck install script is invoked with:
+On UNIX and Linux systems the Chef install script is invoked with:
 
 .. code-block:: bash
 
@@ -148,7 +148,7 @@ Microsoft Windows
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. tag packages_install_script_run_windows
 
-On Microsoft Windows systems the Omnitruck install script is invoked using Windows PowerShell:
+On Microsoft Windows systems the Chef install script is invoked using Windows PowerShell:
 
 .. code-block:: none
 
@@ -156,11 +156,11 @@ On Microsoft Windows systems the Omnitruck install script is invoked using Windo
 
 .. end_tag
 
-Omnitruck Install Script Options
+Chef install Script Options
 -----------------------------------------------------
 .. tag packages_install_script_options
 
-In addition to the default install behavior, the Omnitruck install script supports the following options:
+In addition to the default install behavior, the Chef install script supports the following options:
 
 ``-c`` (``-channel`` on Microsoft Windows)
    The release channel from which a package is pulled. Possible values: ``current`` or ``stable``. Default value: ``stable``.

--- a/chef_master/source/resource_gem_package.rst
+++ b/chef_master/source/resource_gem_package.rst
@@ -64,7 +64,7 @@ The RubyGems package provider attempts to use the RubyGems API to install gems w
 
 * When a ``gem_binary`` property is specified (as a hash, a string, or by a .gemrc file), the chef-client will run that command to examine its environment settings and then again to install the gem.
 * When install options are specified as a string, the chef-client will span a gems command with those options when installing the gem.
-* The omnibus installer will search the ``PATH`` for a gem command rather than defaulting to the current gem environment. As part of ``enforce_path_sanity``, the ``bin`` directories area added to the ``PATH``, which means when there are no other proceeding RubyGems, the installation will still be operated against it.
+* The Chef installer will search the ``PATH`` for a gem command rather than defaulting to the current gem environment. As part of ``enforce_path_sanity``, the ``bin`` directories area added to the ``PATH``, which means when there are no other proceeding RubyGems, the installation will still be operated against it.
 
 .. end_tag
 

--- a/chef_master/source/resource_package.rst
+++ b/chef_master/source/resource_package.rst
@@ -99,7 +99,7 @@ The RubyGems package provider attempts to use the RubyGems API to install gems w
 
 * When a ``gem_binary`` property is specified (as a hash, a string, or by a .gemrc file), the chef-client will run that command to examine its environment settings and then again to install the gem.
 * When install options are specified as a string, the chef-client will span a gems command with those options when installing the gem.
-* The omnibus installer will search the ``PATH`` for a gem command rather than defaulting to the current gem environment. As part of ``enforce_path_sanity``, the ``bin`` directories area added to the ``PATH``, which means when there are no other proceeding RubyGems, the installation will still be operated against it.
+* The Chef installer will search the ``PATH`` for a gem command rather than defaulting to the current gem environment. As part of ``enforce_path_sanity``, the ``bin`` directories area added to the ``PATH``, which means when there are no other proceeding RubyGems, the installation will still be operated against it.
 
 .. end_tag
 

--- a/chef_master/source/run_lists.rst
+++ b/chef_master/source/run_lists.rst
@@ -543,9 +543,9 @@ Bootstrap Operations
 
 The ``knife bootstrap`` command is a common way to install the chef-client on a node. The default for this approach assumes that a node can access the Chef website so that it may download the chef-client package from that location.
 
-The omnibus installer will detect the version of the operating system, and then install the appropriate version of the chef-client using a single command to install the chef-client and all of its dependencies, including an embedded version of Ruby, RubyGems, OpenSSL, key-value stores, parsers, libraries, and command line utilities.
+The Chef installer will detect the version of the operating system, and then install the appropriate version of the chef-client using a single command to install the chef-client and all of its dependencies, including an embedded version of Ruby, RubyGems, OpenSSL, key-value stores, parsers, libraries, and command line utilities.
 
-The omnibus installer puts everything into a unique directory (``/opt/chef/``) so that the chef-client will not interfere with other applications that may be running on the target machine. Once installed, the chef-client requires a few more configuration steps before it can perform its first chef-client run on a node.
+The Chef installer puts everything into a unique directory (``/opt/chef/``) so that the chef-client will not interfere with other applications that may be running on the target machine. Once installed, the chef-client requires a few more configuration steps before it can perform its first chef-client run on a node.
 
 .. end_tag
 
@@ -553,7 +553,7 @@ The omnibus installer puts everything into a unique directory (``/opt/chef/``) s
 
 A node is any physical, virtual, or cloud machine that is configured to be maintained by a chef-client. In order to bootstrap a node, you will first need a working installation of the `Chef software package </packages.html>`__. A bootstrap is a process that installs the chef-client on a target system so that it can run as a chef-client and communicate with a Chef server. There are two ways to do this:
 
-* Use the ``knife bootstrap`` subcommand to `bootstrap a node using the omnibus installer </install_bootstrap.html>`__
+* Use the ``knife bootstrap`` subcommand to `bootstrap a node using the Chef installer </install_bootstrap.html>`__
 * Use an unattended install to bootstrap a node from itself, without using SSH or WinRM
 
 .. end_tag

--- a/chef_master/source/supermarket.rst
+++ b/chef_master/source/supermarket.rst
@@ -37,7 +37,7 @@ The private Chef Supermarket is installed behind the firewall on the internal ne
           The source code for Chef Supermarket is located at the following URLs:
 
           * The application itself: https://github.com/chef/supermarket. Report issues to: https://github.com/chef/supermarket/issues.
-          * The code that builds Chef Supermarket as an omnibus package: https://github.com/chef/omnibus-supermarket. Use a Kitchen-based environment to build your own omnibus packages.
+          * The code that builds Chef Supermarket as a Chef package: https://github.com/chef/omnibus-supermarket. Use a Kitchen-based environment to build your own Chef packages.
           * The cookbook that is run by the ``supermarket-ctl reconfigure`` command: https://github.com/chef/supermarket/tree/master/omnibus/cookbooks/omnibus-supermarket
 
           .. end_tag
@@ -274,7 +274,7 @@ supermarket-ctl (executable)
 -----------------------------------------------------
 .. tag ctl_supermarket_summary
 
-The Chef Supermarket installations that are done using the omnibus installer include a command-line utility named supermarket-ctl. This command-line tool is used to start and stop individual services, reconfigure the Chef Supermarket server, run smoke tests, and tail the Chef Supermarket log files.
+The Chef Supermarket installations that are done using the Chef installer include a command-line utility named supermarket-ctl. This command-line tool is used to start and stop individual services, reconfigure the Chef Supermarket server, run smoke tests, and tail the Chef Supermarket log files.
 
 .. end_tag
 

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -719,7 +719,7 @@ knife bootstrap
 
 A node is any physical, virtual, or cloud machine that is configured to be maintained by a chef-client. In order to bootstrap a node, you will first need a working installation of the `Chef software package </packages.html>`__. A bootstrap is a process that installs the chef-client on a target system so that it can run as a chef-client and communicate with a Chef server. There are two ways to do this:
 
-* Use the ``knife bootstrap`` subcommand to `bootstrap a node using the omnibus installer </install_bootstrap.html>`__
+* Use the ``knife bootstrap`` subcommand to `bootstrap a node using the Chef installer </install_bootstrap.html>`__
 * Use an unattended install to bootstrap a node from itself, without using SSH or WinRM
 
 .. end_tag
@@ -900,7 +900,7 @@ This subcommand has the following options:
    New in Chef Client 12.6.
 
 ``-t TEMPLATE``, ``--bootstrap-template TEMPLATE``
-   The bootstrap template to use. This may be the name of a bootstrap template---``chef-full``, for example---or it may be the full path to an Embedded Ruby (ERB) template that defines a custom bootstrap. Default value: ``chef-full``, which installs the chef-client using the omnibus installer on all supported platforms.
+   The bootstrap template to use. This may be the name of a bootstrap template---``chef-full``, for example---or it may be the full path to an Embedded Ruby (ERB) template that defines a custom bootstrap. Default value: ``chef-full``, which installs the chef-client using the Chef installer on all supported platforms.
 
    New in Chef Client 12.0.
 


### PR DESCRIPTION
If you're not collecting a paycheck from Chef you probably don't care that we call it the Omnitruck script. Just call it the Chef install script.