### PR TITLE
There is no 'rhel' platform

### DIFF
--- a/chef_master/source/dsl_recipe.rst
+++ b/chef_master/source/dsl_recipe.rst
@@ -624,7 +624,7 @@ or:
 
 .. code-block:: ruby
 
-   platform?('rhel', 'debian')
+   platform?('redhat', 'debian')
 
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
That's a platform family. These docs are all kinds of screwed up. This is the first part in fixing it.