### PR TITLE
Corrected policyfile typo #1435

### DIFF
--- a/chef_master/source/config_rb_policyfile.rst
+++ b/chef_master/source/config_rb_policyfile.rst
@@ -62,7 +62,7 @@ A ``Policyfile.rb`` file may contain the following settings:
 
    ``default_source :chef_repo, "path/to/repo"`` pulls cookbooks from a monolithic cookbook repository. This may be a path to the top-level of a cookbook repository or to the ``/cookbooks`` directory within that repository.
 
-   ``default_source :artifactory, "https://artifactory.example/api/chef/my-supermarket" pulls cookbooks from an Artifactory server. Requires either ``artifactory_api_key`` to be set in ``knife.rb`` or ``ARTIFACTORY_API_KEY`` to be set in your environment.
+   ``default_source :artifactory, "https://artifactory.example/api/chef/my-supermarket"`` pulls cookbooks from an Artifactory server. Requires either ``artifactory_api_key`` to be set in ``knife.rb`` or ``ARTIFACTORY_API_KEY`` to be set in your environment.
 
    Multiple cookbook sources may be specified. For example from the public Chef Supermarket and a monolithic repository:
 

--- a/chef_master/source/policyfile.rst
+++ b/chef_master/source/policyfile.rst
@@ -148,7 +148,7 @@ A ``Policyfile.rb`` file may contain the following settings:
 
    ``default_source :chef_repo, "path/to/repo"`` pulls cookbooks from a monolithic cookbook repository. This may be a path to the top-level of a cookbook repository or to the ``/cookbooks`` directory within that repository.
 
-   ``default_source :artifactory, "https://artifactory.example/api/chef/my-supermarket" pulls cookbooks from an Artifactory server. Requires either ``artifactory_api_key`` to be set in ``knife.rb`` or ``ARTIFACTORY_API_KEY`` to be set in your environment.
+   ``default_source :artifactory, "https://artifactory.example/api/chef/my-supermarket"`` pulls cookbooks from an Artifactory server. Requires either ``artifactory_api_key`` to be set in ``knife.rb`` or ``ARTIFACTORY_API_KEY`` to be set in your environment.
 
    Multiple cookbook sources may be specified. For example from the public Chef Supermarket and a monolithic repository:
 


### PR DESCRIPTION
In #1435, I forgot to close a pair of backticks, but since I made sure I did everything else correctly, it slipped past us all until I noticed it in the live docs (which I had to refer to since I already forgot how to use the feature I documented). This one should be equally smooth with the added bonus of being correct!