### PR TITLE
The `new_resource.property` syntax isn't used in part of the docs

### DIFF
--- a/chef_master/source/custom_resources.rst
+++ b/chef_master/source/custom_resources.rst
@@ -69,7 +69,7 @@ This example ``site`` utilizes Chef's built in ``file``, ``service`` and ``packa
      end
 
      file '/var/www/html/index.html' do
-       content homepage
+       content new_resource.homepage
      end
    end
 
@@ -147,7 +147,7 @@ For example, the ``httpd.rb`` file in the ``website`` cookbook could be assigned
      end
 
      file '/var/www/html/index.html' do
-       content homepage
+       content new_resource.homepage
      end
    end
 

--- a/chef_master/source/dsl_custom_resource.rst
+++ b/chef_master/source/dsl_custom_resource.rst
@@ -646,7 +646,7 @@ For example, the ``httpd.rb`` file in the ``website`` cookbook could be assigned
      end
 
      file '/var/www/html/index.html' do
-       content homepage
+       content new_resource.homepage
      end
    end
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -4051,8 +4051,6 @@ where the first action listed is the default action.
 
 .. end_tag
 
-.. tag custom_resources_syntax_example
-
 This example ``site`` utilizes Chef's built in ``file``, ``service`` and ``package`` resources, and includes ``:create`` and ``:delete`` actions. Since it uses built in Chef resources, besides defining the property and actions, the code is very similar to that of a recipe.
 
 .. code-block:: ruby
@@ -4098,8 +4096,6 @@ and to delete the exampleco website, do the following:
    exampleco_site 'httpd' do
      action :delete
    end
-
-.. end_tag
 
 Custom Resource DSL
 -----------------------------------------------------


### PR DESCRIPTION
Its used later, just not in the beginning examples.