### PR TITLE
Update resource_systemd_unit.rst

### DIFF
--- a/chef_master/source/resource_systemd_unit.rst
+++ b/chef_master/source/resource_systemd_unit.rst
@@ -150,7 +150,7 @@ Examples
 .. code-block:: ruby
 
    systemd_unit 'etcd.service' do
-     content(Unit: {
+     content({Unit: {
                Description: 'Etcd',
                Documentation: 'https://coreos.com/etcd',
                After: 'network.target',
@@ -162,7 +162,7 @@ Examples
              },
              Install: {
                WantedBy: 'multi-user.target',
-             })
+             }})
      action :create
    end
 


### PR DESCRIPTION
Fix a bug in the "Create etcd systemd service unit file" example. Entire unit declaration within content() needs to be surrounded in braces to make it an object.