### PR TITLE
correct "lazy" example for use with template variables

### DIFF
--- a/chef_master/source/resource_common.rst
+++ b/chef_master/source/resource_common.rst
@@ -456,7 +456,9 @@ The following example shows how to use lazy evaluation with template variables:
    template '/tmp/canvey_island.txt' do
      source 'canvey_island.txt.erb'
      variables(
-       canvey_island: lazy { node.run_state['sea_power'] }
+       lazy {
+       { canvey_island: node.run_state['sea_power'] }
+       }
      )
    end
 


### PR DESCRIPTION
The provided example doesn't work to access in a template. This update should help others with using lazy variables in conjunction with chef templates.