### PR TITLE
update "lazy" example

### DIFF
--- a/chef_master/source/resource_common.rst
+++ b/chef_master/source/resource_common.rst
@@ -456,7 +456,9 @@ The following example shows how to use lazy evaluation with template variables:
    template '/tmp/canvey_island.txt' do
      source 'canvey_island.txt.erb'
      variables(
-       canvey_island: lazy { node.run_state['sea_power'] }
+       lazy {
+         { canvey_island: node.run_state['sea_power'] }
+       }
      )
    end
 

--- a/chef_master/source/resource_reference.rst
+++ b/chef_master/source/resource_reference.rst
@@ -445,7 +445,9 @@ The following example shows how to use lazy evaluation with template variables:
    template '/tmp/canvey_island.txt' do
      source 'canvey_island.txt.erb'
      variables(
-       canvey_island: lazy { node.run_state['sea_power'] }
+       lazy {
+         { canvey_island: node.run_state['sea_power'] }
+       }
      )
    end
 


### PR DESCRIPTION
The existing "lazy" example for template variables does not work - it passes the lazy object to the template rather than evaluating lazily and passing the result to the template.