### PR TITLE
[MSYS-814] - Doc update for cron resource

### DIFF
--- a/chef_master/source/resource_cron.rst
+++ b/chef_master/source/resource_cron.rst
@@ -81,6 +81,16 @@ This resource has the following actions:
 
    .. end_tag
 
+.. note:: Chef can only reliably manage crontab entries that it creates. To remove existing system entries we may use **execute** resource with a guard like:
+  
+  .. code-block:: ruby
+
+    execute "remove foo_daemon from crontab" do
+      command "sed -i '/foo_daemon/d' /etc/crontab"
+      only_if "grep 'foo_daemon' /etc/crontab 2>&1 >/dev/null"
+    end
+
+
 Properties
 =====================================================
 This resource has the following properties:


### PR DESCRIPTION
Delete action can only be performed on cron entries created by chef.
As a part of workaround, we may use other resources like `execute`.

Signed-off-by: [Nimesh](<nimesh.patni@msystechnologies.com>)