### PR TITLE
Add current Chef + ChefDK GA releases to the supported platforms

### DIFF
--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -493,21 +493,29 @@ Versions and Status
      - Lifecycle Status
      - EOL Date
    * - Chef Client
+     - 14.x
+     - GA
+     - n/a
+   * - Chef Client
+     - 13.x
+     - Deprecated
+     - n/a
+   * - Chef Client
      - 12.x
      - `EOL <https://www.chef.io/eol-chef12-and-chefdk1/>`__
      - April 30, 2018
-   * - Chef Client
-     - 13.x
+   * - Chef DK
+     - 3.x
+     - GA
+     - n/a
+   * - Chef DK
+     - 2.x
      - Deprecated
      - n/a
    * - Chef DK
      - 1.x
      - `EOL <https://www.chef.io/eol-chef12-and-chefdk1/>`__
      - April 30, 2018
-   * - Chef DK
-     - 2.x
-     - GA
-     - n/a
    * - Chef Server
      - 12.x
      - GA


### PR DESCRIPTION
Added Chef 14, ChefDK 3, Marked Chef 13 and ChefDK 2 deprecated. This is per our N and N-1 support policy around these projects.

The diff here isn't great. It's easier to just look at the table: https://github.com/chef/chef-web-docs/blob/dcc21e41554316f7c9635629bb18e96d061c8803/chef_master/source/platforms.rst#versions-and-status