### PR TITLE
Remove require rubygems from all our examples

### DIFF
--- a/chef_master/source/auth.rst
+++ b/chef_master/source/auth.rst
@@ -240,7 +240,6 @@ On a system with the chef-client installed, use Ruby to make an authenticated re
 
 .. code-block:: ruby
 
-   require 'rubygems'
    require 'chef/config'
    require 'chef/log'
    require 'chef/rest'
@@ -256,7 +255,6 @@ or:
 
 .. code-block:: ruby
 
-   require 'rubygems'
    require 'mixlib/cli'
    require 'chef'
    require 'chef/node'
@@ -506,7 +504,6 @@ Use the following code to set the correct permissions:
 .. code-block:: ruby
 
    #!/usr/bin/env ruby
-   require 'rubygems'
    require 'chef/knife'
    require 'chef/rest'
 

--- a/chef_master/source/handlers.rst
+++ b/chef_master/source/handlers.rst
@@ -99,7 +99,6 @@ For example:
 
 .. code-block:: ruby
 
-   require 'rubygems'
    require '/var/chef/handlers/email_me'         # the installation path
 
    email_handler = MyOrg::EmailMe.new            # a simple handler
@@ -913,7 +912,6 @@ After it has run, the run status data can be loaded and inspected via Interactiv
 
 .. code-block:: ruby
 
-   irb(main):001:0> require 'rubygems' => true
    irb(main):002:0> require 'json' => true
    irb(main):003:0> require 'chef' => true
    irb(main):004:0> r = JSON.parse(IO.read('/var/chef/reports/chef-run-report-20110322060731.json')) => ... output truncated

--- a/chef_master/source/resource_chef_handler.rst
+++ b/chef_master/source/resource_chef_handler.rst
@@ -319,7 +319,7 @@ This resource has the following properties:
 
    The type of handler. Possible values: ``:exception``, ``:report``, or ``:start``. Default value: ``{ report: true, exception: true }``.
 
-  
+
 
 Custom Handlers
 =====================================================
@@ -706,7 +706,6 @@ After it has run, the run status data can be loaded and inspected via Interactiv
 
 .. code-block:: ruby
 
-   irb(main):001:0> require 'rubygems' => true
    irb(main):002:0> require 'json' => true
    irb(main):003:0> require 'chef' => true
    irb(main):004:0> r = JSON.parse(IO.read('/var/chef/reports/chef-run-report-20110322060731.json')) => ... output truncated
@@ -755,4 +754,3 @@ By using the `chef_handler </resource_chef_handler.html>`__ resource in a recipe
    end
 
 .. end_tag
-

--- a/chef_master/source/resource_examples.rst
+++ b/chef_master/source/resource_examples.rst
@@ -1160,7 +1160,6 @@ After it has run, the run status data can be loaded and inspected via Interactiv
 
 .. code-block:: ruby
 
-   irb(main):001:0> require 'rubygems' => true
    irb(main):002:0> require 'json' => true
    irb(main):003:0> require 'chef' => true
    irb(main):004:0> r = JSON.parse(IO.read('/var/chef/reports/chef-run-report-20110322060731.json')) => ... output truncated

--- a/chef_master/source/server_orgs.rst
+++ b/chef_master/source/server_orgs.rst
@@ -161,7 +161,6 @@ Use the following code to set the correct permissions:
 .. code-block:: ruby
 
    #!/usr/bin/env ruby
-   require 'rubygems'
    require 'chef/knife'
    require 'chef/rest'
 
@@ -907,4 +906,3 @@ This subcommand has the following syntax:
    $ chef-server-ctl org-user-remove ORG_NAME USER_NAME (options)
 
 .. end_tag
-


### PR DESCRIPTION
This is a Ruby 1.8 thing

Signed-off-by: Tim Smith <tsmith@chef.io>