### PR TITLE
Adds .github to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.github
 
 # ignore doctree files in translation folders
 *.doctree


### PR DESCRIPTION
### Description

`git pull --rebase origin master` keeps adding the `.github`  contents to PRs that I work on. This tells it not to do this. I am possibly wrong--not that the files won't be ignored, rather that the end result is something other than what I think it is.

### Definition of Done

That rebasing doesn't add these files to PRs, but also does not do anything else.

### Issues Resolved

#1503 

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
