### PR TITLE
Automatically deploy using Workflow following merges

### DIFF
--- a/.delivery/build-cookbook/recipes/syntax.rb
+++ b/.delivery/build-cookbook/recipes/syntax.rb
@@ -1,1 +1,0 @@
-cia_delivery_verify_json File.join(node['delivery']['workspace']['repo'], 'config', 'redirects.json')

--- a/.delivery/config.json
+++ b/.delivery/config.json
@@ -1,16 +1,5 @@
 {
   "version": "2",
-  "build_cookbook": {
-      "name": "build-cookbook",
-      "path": ".delivery/build-cookbook"
-  },
-  "skip_phases": [
-    "unit",
-    "lint",
-    "quality",
-    "security",
-    "functional"
-  ],
   "job_dispatch": {
     "version": "v2",
     "filters": {
@@ -21,9 +10,16 @@
       }
     }
   },
-  "delivery-truck":{
-    "publish": {
-      "github": "chef/chef-web-docs"
-    }
-  }
+  "build_cookbook": {
+      "name": "build-cookbook",
+      "path": ".delivery/build-cookbook"
+  },
+  "skip_phases": [
+    "functional"
+    "lint",
+    "quality",
+    "security",
+    "syntax",
+    "unit"
+  ]
 }

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,9 +1,19 @@
 slack:
   notify_channel: releng-notify
 
+automate:
+  organization: tech-content
+  project: chef-web-docs
+
 github:
   delete_branch_on_merge: true
 
 pipelines:
   - verify:
       description: Pull Request validation tests
+
+merge_actions:
+  - built_in:update_acc:
+      ignore_labels:
+        - "ACC: Skip Update"
+        - "Expeditor: Skip All"


### PR DESCRIPTION
This removes the manual `delivery review` step that was previously needed to deploy changes to acceptance. Now each time a PR merge happens on GitHub, Expeditor will then trigger the proper Workflow pipeline and automatically deploy changes to acceptance.

The auto-deploy to Workflow can be skipped by applying one of the following labels to the GitHub PR:

- `ACC: Skip Update`
- `Expeditor: Skip All`

These are configured in the `.expeditor/config.yml` file. The `ignore_labels` action filter is documented here:
https://expeditor.chef.io/docs/reference/action-filters/#ignore-labels

Signed-off-by: Seth Chisamore <schisamo@chef.io>
