### PR TITLE
Update our platform support for Amazon Linux 2.0

### DIFF
--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -39,7 +39,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``7.1`` (TL0 SP3 or higher, recommended), ``7.2``
    * - Amazon Linux
      -
-     - current version
+     - 2013+ and 2.0
    * - CentOS
      - ``x86_64``
      - ``6``, ``7``


### PR DESCRIPTION
"current version" doesn't mean much now that they have 2 versions. In reality we support all version of 1.x aka 2013-2018 and 2.0+