### PR TITLE
Reinstate Windows 7 and 8.1 as supported for ChefDK and Client

### DIFF
--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -66,7 +66,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``14.04``, ``16.04``, ``18.04``
    * - Microsoft Windows
      - ``x86``, ``x86_64``
-     - ``2008 R2``, ``2012``, ``2012 R2``, ``2016``, ``10``
+     - ``7``, ``8.1``, ``2008``, ``2008 R2``, ``2012``, ``2012 R2``, ``2016``, ``10``
 
 Community Support
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -134,7 +134,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``14.04``, ``16.04``, ``18.04``
    * - Microsoft Windows
      -
-     - ``2008 R2``, ``2012``, ``2012 R2``, ``2016``, ``10``
+     - - ``7``, ``8.1``, ``2008``, ``2008 R2``, ``2012``, ``2012 R2``, ``2016``, ``10``
 
 Community Support
 ++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -66,7 +66,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``14.04``, ``16.04``, ``18.04``
    * - Microsoft Windows
      - ``x86``, ``x86_64``
-     - ``7``, ``8.1``, ``2008``, ``2008 R2``, ``2012``, ``2012 R2``, ``2016``, ``10``
+     - ``7``, ``8.1``, ``2008 R2``, ``2012``, ``2012 R2``, ``2016``, ``10``
 
 Community Support
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -134,7 +134,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``14.04``, ``16.04``, ``18.04``
    * - Microsoft Windows
      -
-     - - ``7``, ``8.1``, ``2008``, ``2008 R2``, ``2012``, ``2012 R2``, ``2016``, ``10``
+     - ``7``, ``8.1``, ``2008 R2``, ``2012``, ``2012 R2``, ``2016``, ``10``
 
 Community Support
 ++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Reinstates Windows 7 and 8.1 as supported platforms for Chef Client and ChefDK in accordance with our policy to follow the Microsoft "end of extended support" dates for these Chef products.

**Windows 7 (with Service Pack 1)** end of extended support date: **January 14, 2020**
**Windows 8.1**, end of extended support date: **January 10, 2023**

Await approval from @krasnow before merging.

### Check List

- [x] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
