### PR TITLE
Property `freeze` changed to `freeze_on_upload` in `chef_mirror` resource

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -765,6 +765,11 @@
                 "url": "/resource_chef_handler.html"
               },
               {
+                "title": "chocolatey_config",
+                "hasSubItems": false,
+                "url": "/resource_chocolatey_config.html"
+              },
+              {
                 "title": "chocolatey_package",
                 "hasSubItems": false,
                 "url": "/resource_chocolatey_package.html"

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -51,7 +51,7 @@ Getting Started
 -----------------------------------------------------
 `Chef Overview </chef_overview.html>`__ |
 `Quick Start </quick_start.html>`__ |
-`System Requirements </chef_system_requirements.html>`__ 
+`System Requirements </chef_system_requirements.html>`__
 
 **Chef Workstation**:
 `Chef Workstation Beta <https://www.chef.sh/>`__ |
@@ -123,15 +123,15 @@ Cookbook Reference
 
 **Recipes**: `About Recipes </recipes.html>`__ | `Debug Recipes, Client Runs </debug.html>`__
 
-**Audit Mode DSL**: 
+**Audit Mode DSL**:
 `About the Audit Mode DSL </dsl_audit.html>`__ |
 `control </dsl_audit.html#control>`__ |
 `control_group </dsl_audit.html#control-group>`__ |
 
-**Resources**: 
-`About Resources </resource.html>`__ | 
+**Resources**:
+`About Resources </resource.html>`__ |
 `Common Functionality </resource_common.html>`__ |
-`Custom Resources </custom_resources.html>`__ | 
+`Custom Resources </custom_resources.html>`__ |
 `All Resources (Single Page) </resource_reference.html>`__ |
 `Examples (by Resource) </resource_examples.html>`__
 
@@ -140,116 +140,117 @@ Cookbook Reference
 `apt_repository </resource_apt_repository.html>`__ |
 `apt_update </resource_apt_update.html>`__ |
 `bash </resource_bash.html>`__ |
-`batch </resource_batch.html>`__ | 
-`bff_package </resource_bff_package.html>`__ | 
+`batch </resource_batch.html>`__ |
+`bff_package </resource_bff_package.html>`__ |
 `breakpoint </resource_breakpoint.html>`__ |
-`build_essential </resource_build_essential.html>`__ | 
-`cab_package </resource_cab_package.html>`__ | 
+`build_essential </resource_build_essential.html>`__ |
+`cab_package </resource_cab_package.html>`__ |
 `chef_acl </resource_chef_acl.html>`__ |
-`chef_client </resource_chef_client.html>`__ | 
-`chef_container </resource_chef_container.html>`__ | 
-`chef_data_bag </resource_chef_data_bag.html>`__ | 
-`chef_data_bag_item </resource_chef_data_bag_item.html>`__ | 
-`chef_environment </resource_chef_environment.html>`__ | 
-`chef_gem </resource_chef_gem.html>`__ | 
+`chef_client </resource_chef_client.html>`__ |
+`chef_container </resource_chef_container.html>`__ |
+`chef_data_bag </resource_chef_data_bag.html>`__ |
+`chef_data_bag_item </resource_chef_data_bag_item.html>`__ |
+`chef_environment </resource_chef_environment.html>`__ |
+`chef_gem </resource_chef_gem.html>`__ |
 `chef_group </resource_chef_group.html>`__ |
-`chef_handler </resource_chef_handler.html>`__ | 
-`chef_mirror </resource_chef_mirror.html>`__ | 
-`chef_node </resource_chef_node.html>`__ | 
-`chef_organization </resource_chef_organization.html>`__ | 
-`chef_role </resource_chef_role.html>`__ | 
-`chef_user </resource_chef_user.html>`__ |  
+`chef_handler </resource_chef_handler.html>`__ |
+`chef_mirror </resource_chef_mirror.html>`__ |
+`chef_node </resource_chef_node.html>`__ |
+`chef_organization </resource_chef_organization.html>`__ |
+`chef_role </resource_chef_role.html>`__ |
+`chef_user </resource_chef_user.html>`__ |
+`chocolatey_config </resource_chocolatey_config.html>`__
 `chocolatey_package </resource_chocolatey_package.html>`__
-`cookbook_file </resource_cookbook_file.html>`__ | 
-`cron </resource_cron.html>`__ | 
-`csh </resource_csh.html>`__ | 
-`deploy </resource_deploy.html>`__ | 
-`directory </resource_directory.html>`__ | 
-`dmg_package </resource_dmg_package.html>`__ | 
-`dpkg_package </resource_dpkg_package.html>`__ | 
-`dsc_resource </resource_dsc_resource.html>`__ | 
-`dsc_script </resource_dsc_script.html>`__ | 
-`windows_env </resource_windows_env.html>`__ | 
-`erl_call </resource_erlang_call.html>`__ | 
-`execute </resource_execute.html>`__ | 
-`file </resource_file.html>`__ | 
-`freebsd_package </resource_freebsd_package.html>`__ | 
-`gem_package </resource_gem_package.html>`__ | 
-`git </resource_git.html>`__ | 
-`group </resource_group.html>`__ | 
-`homebrew_cask </resource_homebrew_cask.html>`__ | 
-`homebrew_package </resource_homebrew_package.html>`__ | 
-`homebrew_tap </resource_homebrew_tap.html>`__ | 
-`hostname </resource_hostname.html>`__ | 
-`http_request </resource_http_request.html>`__ | 
-`ifconfig </resource_ifconfig.html>`__ | 
-`ips_package </resource_ips_package.html>`__ | 
+`cookbook_file </resource_cookbook_file.html>`__ |
+`cron </resource_cron.html>`__ |
+`csh </resource_csh.html>`__ |
+`deploy </resource_deploy.html>`__ |
+`directory </resource_directory.html>`__ |
+`dmg_package </resource_dmg_package.html>`__ |
+`dpkg_package </resource_dpkg_package.html>`__ |
+`dsc_resource </resource_dsc_resource.html>`__ |
+`dsc_script </resource_dsc_script.html>`__ |
+`windows_env </resource_windows_env.html>`__ |
+`erl_call </resource_erlang_call.html>`__ |
+`execute </resource_execute.html>`__ |
+`file </resource_file.html>`__ |
+`freebsd_package </resource_freebsd_package.html>`__ |
+`gem_package </resource_gem_package.html>`__ |
+`git </resource_git.html>`__ |
+`group </resource_group.html>`__ |
+`homebrew_cask </resource_homebrew_cask.html>`__ |
+`homebrew_package </resource_homebrew_package.html>`__ |
+`homebrew_tap </resource_homebrew_tap.html>`__ |
+`hostname </resource_hostname.html>`__ |
+`http_request </resource_http_request.html>`__ |
+`ifconfig </resource_ifconfig.html>`__ |
+`ips_package </resource_ips_package.html>`__ |
 `ksh </resource_ksh.html>`__ |
-`launchd </resource_launchd.html>`__ | 
-`link </resource_link.html>`__ | 
-`log </resource_log.html>`__ | 
-`macos_userdefaults </resource_macos_userdefaults.html>`__ | 
-`macports_package </resource_macports_package.html>`__ | 
-`mdadm </resource_mdadm.html>`__ | 
-`mount </resource_mount.html>`__ | 
-`ohai </resource_ohai.html>`__ | 
-`ohai_hint </resource_ohai_hint.html>`__ | 
-`openbsd_package </resource_openbsd_package.html>`__ | 
-`openssl_dhparam </resource_openssl_dhparam.html>`__ | 
-`openssl_rsa_private_key </resource_openssl_rsa_private_key.html>`__ | 
-`openssl_rsa_public_key </resource_openssl_rsa_public_key.html>`__ | 
-`osx_profile </resource_osx_profile.html>`__ | 
-`package </resource_package.html>`__ | 
-`pacman_package </resource_pacman_package.html>`__ | 
-`paludis_package </resource_paludis_package.html>`__ | 
-`perl </resource_perl.html>`__ | 
-`portage_package </resource_portage_package.html>`__ | 
-`powershell_package </resource_powershell_package.html>`__ | 
-`powershell_script </resource_powershell_script.html>`__ | 
-`private_key </resource_private_key.html>`__ | 
-`public_key </resource_public_key.html>`__ | 
-`python </resource_python.html>`__ | 
-`reboot </resource_reboot.html>`__ | 
-`registry_key </resource_registry_key.html>`__ | 
-`remote_directory </resource_remote_directory.html>`__ | 
-`remote_file </resource_remote_file.html>`__ | 
-`route </resource_route.html>`__ | 
-`rpm_package </resource_rpm_package.html>`__ | 
-`ruby </resource_ruby.html>`__ | 
-`ruby_block </resource_ruby_block.html>`__ | 
-`script </resource_script.html>`__ | 
-`rhsm_errata </resource_rhsm_errata.html>`__ | 
-`rhsm_errata_level </resource_rhsm_errata_level.html>`__ | 
-`rhsm_register </resource_rhsm_register.html>`__ | 
-`rhsm_repo </resource_rhsm_repo.html>`__ | 
-`rhsm_subscription </resource_rhsm_subscription.html>`__ | 
-`service </resource_service.html>`__ | 
-`smartos_package </resource_smartos_package.html>`__ | 
-`solaris_package </resource_solaris_package.html>`__ | 
-`subversion </resource_subversion.html>`__ | 
-`sudo </resource_sudo.html>`__ | 
-`swap_file </resource_swap_file.html>`__ | 
-`sysctl </resource_sysctl.html>`__ | 
-`systemd_unit </resource_systemd_unit.html>`__ | 
-`template </resource_template.html>`__ | 
-`user </resource_user.html>`__ | 
-`windows_ad_join </resource_windows_ad_join.html>`__ | 
-`windows_auto_run </resource_windows_auto_run.html>`__ | 
-`windows_feature </resource_windows_feature.html>`__ | 
-`windows_feature_dism </resource_windows_feature_dism.html>`__ | 
-`windows_feature_powershell.html </resource_windows_feature_powershell.html>`__ | 
-`windows_font </resource_windows_font.html>`__ | 
-`windows_package </resource_windows_package.html>`__ | 
-`windows_printer.html </resource_windows_printer.html>`__ | 
-`windows_printer_port </resource_windows_printer_port.html>`__ | 
-`windows_service </resource_windows_service.html>`__ | 
-`windows_shortcut </resource_windows_shortcut.html>`__ | 
-`windows_task </resource_windows_task.html>`__ | 
-`yum_package </resource_yum.html>`__ | 
-`yum_repository </resource_yum_repository.html>`__ | 
-`dnf_package </resource_dnf_package.html>`__ | 
-`zypper_package </resource_zypper_package.html>`__ | 
-`zypper_repository </resource_zypper_repository.html>`__  
+`launchd </resource_launchd.html>`__ |
+`link </resource_link.html>`__ |
+`log </resource_log.html>`__ |
+`macos_userdefaults </resource_macos_userdefaults.html>`__ |
+`macports_package </resource_macports_package.html>`__ |
+`mdadm </resource_mdadm.html>`__ |
+`mount </resource_mount.html>`__ |
+`ohai </resource_ohai.html>`__ |
+`ohai_hint </resource_ohai_hint.html>`__ |
+`openbsd_package </resource_openbsd_package.html>`__ |
+`openssl_dhparam </resource_openssl_dhparam.html>`__ |
+`openssl_rsa_private_key </resource_openssl_rsa_private_key.html>`__ |
+`openssl_rsa_public_key </resource_openssl_rsa_public_key.html>`__ |
+`osx_profile </resource_osx_profile.html>`__ |
+`package </resource_package.html>`__ |
+`pacman_package </resource_pacman_package.html>`__ |
+`paludis_package </resource_paludis_package.html>`__ |
+`perl </resource_perl.html>`__ |
+`portage_package </resource_portage_package.html>`__ |
+`powershell_package </resource_powershell_package.html>`__ |
+`powershell_script </resource_powershell_script.html>`__ |
+`private_key </resource_private_key.html>`__ |
+`public_key </resource_public_key.html>`__ |
+`python </resource_python.html>`__ |
+`reboot </resource_reboot.html>`__ |
+`registry_key </resource_registry_key.html>`__ |
+`remote_directory </resource_remote_directory.html>`__ |
+`remote_file </resource_remote_file.html>`__ |
+`route </resource_route.html>`__ |
+`rpm_package </resource_rpm_package.html>`__ |
+`ruby </resource_ruby.html>`__ |
+`ruby_block </resource_ruby_block.html>`__ |
+`script </resource_script.html>`__ |
+`rhsm_errata </resource_rhsm_errata.html>`__ |
+`rhsm_errata_level </resource_rhsm_errata_level.html>`__ |
+`rhsm_register </resource_rhsm_register.html>`__ |
+`rhsm_repo </resource_rhsm_repo.html>`__ |
+`rhsm_subscription </resource_rhsm_subscription.html>`__ |
+`service </resource_service.html>`__ |
+`smartos_package </resource_smartos_package.html>`__ |
+`solaris_package </resource_solaris_package.html>`__ |
+`subversion </resource_subversion.html>`__ |
+`sudo </resource_sudo.html>`__ |
+`swap_file </resource_swap_file.html>`__ |
+`sysctl </resource_sysctl.html>`__ |
+`systemd_unit </resource_systemd_unit.html>`__ |
+`template </resource_template.html>`__ |
+`user </resource_user.html>`__ |
+`windows_ad_join </resource_windows_ad_join.html>`__ |
+`windows_auto_run </resource_windows_auto_run.html>`__ |
+`windows_feature </resource_windows_feature.html>`__ |
+`windows_feature_dism </resource_windows_feature_dism.html>`__ |
+`windows_feature_powershell.html </resource_windows_feature_powershell.html>`__ |
+`windows_font </resource_windows_font.html>`__ |
+`windows_package </resource_windows_package.html>`__ |
+`windows_printer.html </resource_windows_printer.html>`__ |
+`windows_printer_port </resource_windows_printer_port.html>`__ |
+`windows_service </resource_windows_service.html>`__ |
+`windows_shortcut </resource_windows_shortcut.html>`__ |
+`windows_task </resource_windows_task.html>`__ |
+`yum_package </resource_yum.html>`__ |
+`yum_repository </resource_yum_repository.html>`__ |
+`dnf_package </resource_dnf_package.html>`__ |
+`zypper_package </resource_zypper_package.html>`__ |
+`zypper_repository </resource_zypper_repository.html>`__
 
 
 `Templates </templates.html>`__ |

--- a/chef_master/source/resource_chef_mirror.rst
+++ b/chef_master/source/resource_chef_mirror.rst
@@ -71,8 +71,8 @@ This resource has the following properties:
 ``concurrency``
    The number of threads to run in-parallel. Default value: ``10``.
 
-``freeze``
-   Use to freeze cookbooks upon upload to the mirrored location. When ``true``, cookbooks are frozen.
+``freeze_on_upload``
+   Use to freeze cookbooks upon upload to the mirrored location. When ``true`` (default), cookbooks are frozen.
 
 ``ignore_failure``
    **Ruby Types:** True, False

--- a/chef_master/source/resource_chocolatey_config.rst
+++ b/chef_master/source/resource_chocolatey_config.rst
@@ -1,0 +1,136 @@
+=====================================================
+chocolatey_config
+=====================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chocolatey_config.rst>`__
+
+Use the **chocolatey_config** resource to add or remove Chocolatey configuration keys.
+
+**New in Chef Client 14.3.**
+
+Syntax
+=====================================================
+This resource has the following syntax:
+
+.. code-block:: ruby
+
+   chocolatey_config 'name' do
+     config_key                 String # default value: 'name'
+     value                      String
+     action                     Symbol # defaults to :set if not specified
+   end
+
+where:
+
+* ``chocolatey_config`` is the resource
+* ``'name'`` is the name of the config key to set, or the name of the resource block
+* ``value`` is the value to set.
+
+Actions
+=====================================================
+``:set``
+   Default. Sets a Chocolatey config value.
+
+``:unset``
+   Unsets a Chocolatey config value.
+
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+
+   .. end_tag
+
+Properties
+=====================================================
+``config_key``
+   **Ruby Type:** String | **Default Value:** ``'name'``
+
+   The name of the config. The resource's name will be used if this isn't provided.
+
+``value``
+   **Ruby Type:** String
+
+   The value to set.
+
+``notifies``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_notifies
+
+   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_notifies_syntax
+
+   The syntax for ``notifies`` is:
+
+   .. code-block:: ruby
+
+      notifies :action, 'resource[name]', :timer
+
+   .. end_tag
+
+``subscribes``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_subscribes
+
+   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+   .. code-block:: ruby
+
+     file '/etc/nginx/ssl/example.crt' do
+        mode '0600'
+        owner 'root'
+     end
+
+     service 'nginx' do
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+     end
+
+   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_subscribes_syntax
+
+   The syntax for ``subscribes`` is:
+
+   .. code-block:: ruby
+
+      subscribes :action, 'resource[name]', :timer
+
+   .. end_tag

--- a/chef_master/source/resource_reference.rst
+++ b/chef_master/source/resource_reference.rst
@@ -1122,6 +1122,8 @@ The following resources are built into the Chef Client:
 
 .. include:: resource_chef_handler.rst
 
+.. include:: resource_chocolatey_config.rst
+
 .. include:: resource_chocolatey_package.rst
 
 .. include:: resource_cookbook_file.rst


### PR DESCRIPTION


### Description

Since Cheffish v5 this deprecation warning (and later fail) appears when trying to use freeze:
"Property `freeze` on the `chef_mirror` resource has changed to `freeze_on_upload`." \
"Please use `freeze_on_upload` instead. This will raise an exception in a future version of the cheffish gem."
[Please describe what this change achieves]

### Definition of Done
replace `freeze` with `freeze_on_upload`

### Issues Resolved
the documentation is incorrect

