### PR TITLE
 Re-enable basic verification testing in Buildkite

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -8,9 +8,9 @@ automate:
 github:
   delete_branch_on_merge: true
 
-# pipelines:
-#   - verify:
-#       description: Pull Request validation tests
+pipelines:
+  - verify:
+      description: Validate PRs for chef/chef-web-docs
 
 merge_actions:
   - built_in:update_acc:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,7 +1,12 @@
-- label: "build"
-  command:
-    - pip install -r requirements
-    - make docs
-  plugins:
-    docker#v1.1.1:
-      image: "chefes/buildkite"
+steps:
+
+  # Make sure that Sphinx builds successfully
+  - label: Sphinx
+    command:
+      - make docs
+    retry:
+      automatic:
+        limit: 1
+    plugins:
+      docker#v1.1.1:
+        image: "chefes/buildkite"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM python:2.7.14
-RUN curl -L https://omnitruck.chef.io/install.sh | bash -s -- -c current -P chefdk
-ENV PATH /opt/chefdk/embedded/bin:$PATH
-WORKDIR /build_dir
-ENTRYPOINT [ "doctools/docker_build.sh" ]

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -1,2 +1,0 @@
-FROM nginx:latest
-COPY build /usr/share/nginx/html

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BUILD_COMMAND = sphinx-build -a -W
 BUILD_COMMAND_AND_ARGS = $(BUILD_COMMAND)
 
 docs:
+	pip install -r requirements.txt --install-option="--install-scripts=/usr/local/bin"
 	mkdir -p $(BUILDDIR)
 	cp -r misc/robots.txt build/
 	cp -r misc/sitemap.xml build/
@@ -13,9 +14,7 @@ clean:
 	@rm -rf $(BUILDDIR)
 
 docker-build:
-	docker build . -t docsbuild
-	docker run -v $(shell pwd):/build_dir -it docsbuild:latest
+	docker run -v $(shell pwd):/chef-web-docs -w /chef-web-docs chefes/buildkite make docs
 
-docker-preview:
-	docker build -f Dockerfile.runner -t docsrunner .
-	docker run -p 8080:80 -it docsrunner:latest
+docker-preview: docker-build
+	docker run -it -v $(shell pwd):/chef-web-docs -w /chef-web-docs/build -p 8000:8000 chefes/buildkite python -m SimpleHTTPServer

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ To build the docs:
 
 - Run `make docker-build`
 
-To preview locally:
+To (build and) preview locally:
 
 - Run `make docker-preview`
-- go to http://localhost:8080
+- go to http://localhost:8000
 
 To clean your local development environment:
 

--- a/doctools/docker_build.sh
+++ b/doctools/docker_build.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-cd /build_dir
-# We explicitly install our requirements on every local build to make sure we're
-# up to date. This takes a little longer than building it into the docker image
-# but ensures we don't run into stale dependencies.
-pip install -r requirements.txt
-make docs


### PR DESCRIPTION
- Make local Docker build/preview work
- Re-enable basic verification testing in Buildkite

Signed-off-by: Seth Chisamore <schisamo@chef.io>
