### PR TITLE
Generate build output to `public/`

### DIFF
--- a/.delivery/build-cookbook/recipes/publish.rb
+++ b/.delivery/build-cookbook/recipes/publish.rb
@@ -9,5 +9,5 @@ execute 'make docs' do
 end
 
 cia_delivery_publish_artifact node['delivery']['change']['project'] do
-  build_path 'build'
+  build_path 'public'
 end

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.doctree
 *.pickle
 
-build/
+public/
 
 **/.sass-cache
 **/.sass-cache/*

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-BUILDDIR = build
+BUILDDIR = public
 BUILD_COMMAND = sphinx-build -a -W
 BUILD_COMMAND_AND_ARGS = $(BUILD_COMMAND)
 
 docs:
 	pip install -r requirements.txt --install-option="--install-scripts=/usr/local/bin"
 	mkdir -p $(BUILDDIR)
-	cp -r misc/robots.txt build/
-	cp -r misc/sitemap.xml build/
+	cp -r misc/robots.txt public/
+	cp -r misc/sitemap.xml public/
 	$(BUILD_COMMAND_AND_ARGS) chef_master/source $(BUILDDIR)
 	bash doctools/rundtags.sh
 
@@ -17,4 +17,4 @@ docker-build:
 	docker run -v $(shell pwd):/chef-web-docs -w /chef-web-docs chefes/buildkite make docs
 
 docker-preview: docker-build
-	docker run -it -v $(shell pwd):/chef-web-docs -w /chef-web-docs/build -p 8000:8000 chefes/buildkite python -m SimpleHTTPServer
+	docker run -it -v $(shell pwd):/chef-web-docs -w /chef-web-docs/public -p 8000:8000 chefes/buildkite python -m SimpleHTTPServer

--- a/README.md
+++ b/README.md
@@ -75,17 +75,17 @@ install Sphinx, the documentation generator, possibly using `sudo`:
   pip install -r requirements.txt
 ```
 
-> Note: The default `make` target is `docs`. This is the target that creates the appropriate `build` directory on your local machine and references in the source files in the `chef_master/source` directory of your local repo.
+> Note: The default `make` target is `docs`. This is the target that creates the appropriate `public` directory on your local machine and references in the source files in the `chef_master/source` directory of your local repo.
 
 The docs build in a minute or two. To
 view the local version you built, you have two options:
 
-- Open the file `build/<filename>` in your browser
+- Open the file `public/<filename>` in your browser
 - Use a local web server like the `SimpleHTTPServer` python module
 
 Viewing your content using the `SimpleHTTPServer` module allows you to navigate through the documentation as if you were browsing it on https://docs.chef.io. To use the `SimpleHTTPServer` module:
 
-1. Navigate to the `build` directory.
+1. Navigate to the `public` directory.
 2. Run `python -m SimpleHTTPServer`. After the server starts up, connect to your docs through your loopback IP address (http://127.0.0.1:8000).
 
 If you need tips on the source language for the docs, check out the

--- a/terraform/www.tf
+++ b/terraform/www.tf
@@ -3,7 +3,7 @@
 module "hugo_site" {
   source        = "git@github.com:chef/es-terraform.git//modules/cd_hugo_static_site"
   subdomain     = "${var.www_dns}"
-  site_dir      = "../build"
+  site_dir      = "../"
   build_command = "make docs"
   fastly_fqdn   = "${var.fastly_fqdn}"
 }


### PR DESCRIPTION
This matches what we do for Hugo and ensures this repo works as expected with our existing Terraform modules we use for deployment.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
