### PR TITLE
Apply legacy redirects in new S3 buckets

### DIFF
--- a/.expeditor/buildkite/apply_redirects.sh
+++ b/.expeditor/buildkite/apply_redirects.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+aws-configure chef-cd
+
+# Process the legacy redirects
+while IFS== read -r key value; do
+  aws s3api put-object \
+    --profile chef-cd \
+    --acl public-read \
+    --bucket "chef-web-docs-$ENVIRONMENT.cd.chef.co" \
+    --key $key \
+    --website-redirect-location $value
+done < <(jq -r 'to_entries | .[] | .key + "=" + .value ' config/redirects.json)

--- a/.expeditor/deploy.pipeline.yml
+++ b/.expeditor/deploy.pipeline.yml
@@ -13,3 +13,17 @@ steps:
           - CHEF_CD_AWS_ACCESS_KEY_ID
           - CHEF_CD_AWS_SECRET_ACCESS_KEY
           - CHEF_CI_GITHUB_TOKEN
+
+  - wait
+
+  - command: .expeditor/buildkite/apply_redirects.sh
+    label: ":amazon-s3:"
+    concurrency: 1
+    concurrency_group: chef-web-docs-master/deploy/$ENVIRONMENT
+    plugins:
+      docker#v1.1.1:
+        image: "chefes/buildkite"
+        environment:
+          - ENVIRONMENT
+          - CHEF_CD_AWS_ACCESS_KEY_ID
+          - CHEF_CD_AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
This was previously handled by the `cia_infra_static_site` resource which was part of the Workflow pipeline build cookbook.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
