### PR TITLE
Changed vSphere link

### DIFF
--- a/chef_master/source/provisioning.rst
+++ b/chef_master/source/provisioning.rst
@@ -117,7 +117,7 @@ The following drivers are available for Chef provisioning:
      - A Chef provisioning driver for SSH.
    * - `Vagrant <https://github.com/chef/chef-provisioning-vagrant>`__
      - A Chef provisioning driver for Vagrant.
-   * - `vSphere <https://github.com/CenturyLinkCloud/chef-provisioning-vsphere>`__
+   * - `vSphere <https://github.com/chef-partners/chef-provisioning-vsphere>`__
      - A Chef provisioning driver for VMware vSphere.
 
 Driver-specific Resources


### PR DESCRIPTION
Obvious fix,
old link goes to page which says use: https://github.com/chef-partners/chef-provisioning-vsphere

### Description

[Please describe what this change achieves]

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [x] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
