### PR TITLE
Add new openssl resources and update types / examples on existing resources

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -26,7 +26,7 @@ merge_actions:
         - "Expeditor: Skip All"
 
 promote:
-  action:
+  actions:
     - trigger_pipeline:deploy/production:
         only_if_conditions:
           - value_one: "{{target_channel}}"

--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -970,6 +970,16 @@
                 "url": "/resource_openssl_rsa_public_key.html"
               },
               {
+                "title": "openssl_x509_crl",
+                "hasSubItems": false,
+                "url": "/resource_openssl_x509_crl.html"
+              },
+              {
+                "title": "openssl_x509_request",
+                "hasSubItems": false,
+                "url": "/resource_openssl_x509_request.html"
+              },
+              {
                 "title": "osx_profile",
                 "hasSubItems": false,
                 "url": "/resource_osx_profile.html"

--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -950,6 +950,16 @@
                 "url": "/resource_openssl_dhparam.html"
               },
               {
+                "title": "openssl_ec_private_key",
+                "hasSubItems": false,
+                "url": "/resource_openssl_ec_private_key.html"
+              },
+              {
+                "title": "openssl_ec_public_key",
+                "hasSubItems": false,
+                "url": "/resource_openssl_ec_public_key.html"
+              },
+              {
                 "title": "openssl_rsa_private_key",
                 "hasSubItems": false,
                 "url": "/resource_openssl_rsa_private_key.html"

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -201,6 +201,8 @@ Cookbook Reference
 `openssl_ec_public_key </resource_openssl_ec_public_key.html>`__ |
 `openssl_rsa_private_key </resource_openssl_rsa_private_key.html>`__ |
 `openssl_rsa_public_key </resource_openssl_rsa_public_key.html>`__ |
+`openssl_x509_crl </resource_openssl_x509_crl.html>`__ |
+`openssl_x509_request </resource_openssl_x509_request.html>`__ |
 `osx_profile </resource_osx_profile.html>`__ |
 `package </resource_package.html>`__ |
 `pacman_package </resource_pacman_package.html>`__ |
@@ -871,9 +873,13 @@ Addenda
    resource_ohai
    resource_ohai_hint
    resource_openbsd_package
+   resource_openssl_dhparam
+   resource_openssl_ec_private_key
+   resource_openssl_ec_public_key
    resource_openssl_rsa_private_key
    resource_openssl_rsa_public_key
-   resource_openssl_dhparam
+   resource_openssl_x509_crl
+   resource_openssl_x509_request
    resource_osx_profile
    resource_package
    resource_pacman_package

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -197,6 +197,8 @@ Cookbook Reference
 `ohai_hint </resource_ohai_hint.html>`__ |
 `openbsd_package </resource_openbsd_package.html>`__ |
 `openssl_dhparam </resource_openssl_dhparam.html>`__ |
+`openssl_ec_private_key </resource_openssl_ec_private_key.html>`__ |
+`openssl_ec_public_key </resource_openssl_ec_public_key.html>`__ |
 `openssl_rsa_private_key </resource_openssl_rsa_private_key.html>`__ |
 `openssl_rsa_public_key </resource_openssl_rsa_public_key.html>`__ |
 `osx_profile </resource_osx_profile.html>`__ |

--- a/chef_master/source/resource_openssl_dhparam.rst
+++ b/chef_master/source/resource_openssl_dhparam.rst
@@ -28,7 +28,7 @@ where:
 
 * ``openssl_dhparam`` is the name of the resource
 * ``'name'`` is the path where the dhparam file will be written, or the name of the resource block
-* ``generator``, ``group``, ``key_length``, ``mode``, ``notifies``, ``owner``, and ``path``, and ``subscribes`` are the properties available to this resource
+* ``generator``, ``group``, ``key_length``, ``mode``, ``notifies``, ``owner``, ``path``, and ``subscribes`` are the properties available to this resource
 
 Actions
 =====================================================

--- a/chef_master/source/resource_openssl_dhparam.rst
+++ b/chef_master/source/resource_openssl_dhparam.rst
@@ -15,11 +15,11 @@ This resource has the following syntax:
 
    openssl_dhparam 'name' do
      generator                  Integer # default value: '2'
-     group                      String, nil
+     group                      String
      key_length                 Integer # default value: '2048'
      mode                       Integer, String # default value: '0640'
      notifies                   # see description
-     owner                      String, nil
+     owner                      String
      path                       String # default value: 'name'
      subscribes                 # see description
      action                     Symbol # defaults to :create if not specified
@@ -50,7 +50,7 @@ Properties
    The desired Diffie-Hellmann generator; available options are ``2`` and ``5``.
 
 ``group``
-   **Ruby Types:** String, nil
+   **Ruby Types:** String
 
    The system group of all files created by the resource.
 
@@ -99,7 +99,7 @@ Properties
    .. end_tag
 
 ``owner``
-   **Ruby Types:** String, nil
+   **Ruby Types:** String
 
    The owner of all files created by the resource.
 

--- a/chef_master/source/resource_openssl_dhparam.rst
+++ b/chef_master/source/resource_openssl_dhparam.rst
@@ -5,6 +5,8 @@ openssl_dhparam
 
 Use the **openssl_dhparam** resource to generate ``dhparam.pem`` files. If a valid ``dhparam.pem`` file is found at the specified location, no new file will be created. If a file is found at the specified location, but it is not a valid dhparam file, it will be overwritten.
 
+New in Chef Client 14.0.
+
 Syntax
 =====================================================
 This resource has the following syntax:
@@ -45,12 +47,12 @@ Properties
 ``generator``
    **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The desired Diffie-Hellmann generator; available options are ``2`` and ``5``. 
+   The desired Diffie-Hellmann generator; available options are ``2`` and ``5``.
 
 ``group``
    **Ruby Types:** String, nil
 
-   The system group of all files created by the resource. 
+   The system group of all files created by the resource.
 
 ``key_length``
    **Ruby Type:** Integer | **Default Value:** ``2048``
@@ -94,12 +96,12 @@ Properties
 
       notifies :action, 'resource[name]', :timer
 
-   .. end_tag 
+   .. end_tag
 
 ``owner``
    **Ruby Types:** String, nil
 
-   The owner of all files created by the resource. 
+   The owner of all files created by the resource.
 
 ``path``
    **Ruby Type:** String
@@ -173,8 +175,8 @@ Examples
 
 **Create a dhparam file with specific user/group ownership**
 
-.. code-block:: ruby 
-   
+.. code-block:: ruby
+
    openssl_dhparam '/etc/httpd/ssl/dhparam.pem' do
      owner 'www-data'
      group 'www-data'

--- a/chef_master/source/resource_openssl_ec_private_key.rst
+++ b/chef_master/source/resource_openssl_ec_private_key.rst
@@ -1,13 +1,13 @@
 =====================================================
-openssl_rsa_private_key
+openssl_ec_private_key
 =====================================================
-`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_openssl_rsa_private_key>`__
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_openssl_ec_private_key>`__
 
-Use the **openssl_rsa_private_key** resource to generate RSA private key files. If a valid RSA key file can be opened at the specified location, no new file will be created. If the RSA key file cannot be opened or does not exist, it will be overwritten.
+Use the **openssl_ec_private_key** resource to generate elliptic curve (EC) private key files. If a valid EC key file can be opened at the specified location, no new file will be created. If the EC key file cannot be opened or does not exist, it will be overwritten.
 
-.. note:: If the password to your RSA key file does not match the password in the recipe, it cannot be opened, and will be overwritten.
+.. note:: If the password to your EC key file does not match the password in the recipe, it cannot be opened, and will be overwritten.
 
-New in Chef Client 14.0.
+New in Chef Client 14.5.
 
 Syntax
 =====================================================
@@ -15,11 +15,11 @@ This resource has the following syntax:
 
 .. code-block:: ruby
 
-   openssl_rsa_private_key_file 'name' do
+   openssl_ec_private_key_file 'name' do
      force                      True, False # default value: 'false'
      group                      String, nil
      key_cipher                 String # default value: 'des3'
-     key_length                 Integer # default value: '2048'
+     key_curve                  String # default value: 'prime256v1'
      key_pass                   String
      mode                       Integer, String # default value: '0640'
      notifies                   # see description
@@ -31,14 +31,14 @@ This resource has the following syntax:
 
 where:
 
-* ``openssl_rsa_private_key_file`` is the name of the resource
+* ``openssl_ec_private_key_file`` is the name of the resource
 * ``'name'`` is the path to the private key file that is to be created, or the name of the resource block
-* ``force``, ``group``, ``key_cipher``, ``key_length``, ``key_pass``, ``mode``, ``notifies``, ``owner``, ``path``, and ``subscribes`` are the properties available to this resource
+* ``force``, ``group``, ``key_cipher``, ``key_curve``, ``key_pass``, ``mode``, ``notifies``, ``owner``, ``path``, and ``subscribes`` are the properties available to this resource
 
 Actions
 =====================================================
 ``:create``
-   Default. Create the RSA private key file.
+   Default. Create the EC private key file.
 
 ``:nothing``
    .. tag resources_common_actions_nothing
@@ -64,10 +64,10 @@ Properties
 
    The designed cipher to use when generating your key; run ``openssl list-cipher-algorithms`` to see available options.
 
-``key_length``
-   **Ruby Type:** Integer | **Default Value:** ``2048``
+``key_curve``
+   **Ruby Type:** String | **Default Value:** ``prime256v1``
 
-   The desired bit length of the generated key; available options are ``1024``, ``2048``, ``4096``, and ``8192``.
+   The desired curve of the generated key; run ``openssl ecparam -list_curves`` to see available options
 
 ``key_pass``
    **Ruby Type:** String

--- a/chef_master/source/resource_openssl_ec_private_key.rst
+++ b/chef_master/source/resource_openssl_ec_private_key.rst
@@ -17,13 +17,13 @@ This resource has the following syntax:
 
    openssl_ec_private_key_file 'name' do
      force                      True, False # default value: 'false'
-     group                      String, nil
+     group                      String
      key_cipher                 String # default value: 'des3'
      key_curve                  String # default value: 'prime256v1'
      key_pass                   String
      mode                       Integer, String # default value: '0640'
      notifies                   # see description
-     owner                      String, nil
+     owner                      String
      path                       String # default value: 'name'
      subscribes                 # see description
      action                     Symbol # defaults to :create if not specified
@@ -55,7 +55,7 @@ Properties
    Force creation of the key even if the same key already exists on the node.
 
 ``group``
-   **Ruby Types:** String, nil
+   **Ruby Types:** String
 
    The system group of all files created by the resource.
 
@@ -114,7 +114,7 @@ Properties
    .. end_tag
 
 ``owner``
-   **Ruby Types:** String, nil
+   **Ruby Types:** String
 
    The system user that owns all files created by the resource.
 

--- a/chef_master/source/resource_openssl_ec_public_key.rst
+++ b/chef_master/source/resource_openssl_ec_public_key.rst
@@ -14,10 +14,10 @@ This resource has the following syntax:
 .. code-block:: ruby
 
    openssl_ec_public_key 'name' do
-     group                      String, nil
+     group                      String
      mode                       Integer, String # default value: '0640'
      notifies                   # see description
-     owner                      String, nil
+     owner                      String
      path                       String
      private_key_content        String
      private_key_pass           String
@@ -47,7 +47,7 @@ Actions
 Properties
 =====================================================
 ``group``
-   **Ruby Types:** String, nil
+   **Ruby Types:** String
 
    The system group of all files created by the resource.
 
@@ -91,7 +91,7 @@ Properties
    .. end_tag
 
 ``owner``
-   **Ruby Types:** String, nil
+   **Ruby Types:** String
 
    The system user that owns all files created by the resource.
 

--- a/chef_master/source/resource_openssl_ec_public_key.rst
+++ b/chef_master/source/resource_openssl_ec_public_key.rst
@@ -1,11 +1,11 @@
 =====================================================
-openssl_rsa_public_key
+openssl_ec_public_key
 =====================================================
-`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_openssl_rsa_public_key.rst>`__
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_openssl_ec_public_key.rst>`__
 
-Use the **openssl_rsa_public_key** resource to generate RSA public key files for a given RSA private key.
+Use the **openssl_ec_public_key** resource to generate elliptic curve (EC) public key files from a given EC private key.
 
-New in Chef Client 14.0.
+New in Chef Client 14.5.
 
 Syntax
 =====================================================
@@ -13,7 +13,7 @@ This resource has the following syntax:
 
 .. code-block:: ruby
 
-   openssl_rsa_public_key 'name' do
+   openssl_ec_public_key 'name' do
      group                      String, nil
      mode                       Integer, String # default value: '0640'
      notifies                   # see description
@@ -28,14 +28,14 @@ This resource has the following syntax:
 
 where:
 
-* ``openssl_rsa_public_key`` is the name of the resource
+* ``openssl_ec_public_key`` is the name of the resource
 * ``name`` is the path to the public key file that is to be created, or the name of the resource block
 * ``group``, ``mode``, ``notifies``, ``owner``, ``path``, ``private_key_content``, ``private_key_pass``, ``private_key_path``, and ``subscribes`` are the properties available to this resource
 
 Actions
 =====================================================
 ``:create``
-   Default. Create the RSA public key.
+   Default. Generate the EC public key from a private key.
 
 ``:nothing``
    .. tag resources_common_actions_nothing
@@ -170,16 +170,16 @@ Examples
 
 .. code-block:: ruby
 
-   openssl_rsa_public_key '/etc/example/key.pub' do
+   openssl_ec_public_key '/etc/example/key.pub' do
      private_key_path '/etc/example/key.pem'
    end
 
 **Create a public key from a private key, without writing the private key to disk**
 
-You can provide the private key content as a string to the openssl_rsa_public_key resource. In this example we just pass a string, but this content could be loaded from an encrypted data bag or other secure storage.
+You can provide the private key content as a string to the openssl_ec_public_key resource. In this example we just pass a string, but this content could be loaded from an encrypted data bag or other secure storage.
 
 .. code-block:: ruby
 
-   openssl_rsa_public_key '/etc/example/key.pub' do
+   openssl_ec_public_key '/etc/example/key.pub' do
      private_key_content 'KEY_CONTENT_HERE_AS_A_STRING'
    end

--- a/chef_master/source/resource_openssl_rsa_private_key.rst
+++ b/chef_master/source/resource_openssl_rsa_private_key.rst
@@ -17,13 +17,13 @@ This resource has the following syntax:
 
    openssl_rsa_private_key_file 'name' do
      force                      True, False # default value: 'false'
-     group                      String, nil
+     group                      String
      key_cipher                 String # default value: 'des3'
      key_length                 Integer # default value: '2048'
      key_pass                   String
      mode                       Integer, String # default value: '0640'
      notifies                   # see description
-     owner                      String, nil
+     owner                      String
      path                       String # default value: 'name'
      subscribes                 # see description
      action                     Symbol # defaults to :create if not specified
@@ -55,7 +55,7 @@ Properties
    Force creation of the key even if the same key already exists on the node.
 
 ``group``
-   **Ruby Types:** String, nil
+   **Ruby Types:** String
 
    The system group of all files created by the resource.
 
@@ -114,7 +114,7 @@ Properties
    .. end_tag
 
 ``owner``
-   **Ruby Types:** String, nil
+   **Ruby Types:** String
 
    The system user that owns all files created by the resource.
 

--- a/chef_master/source/resource_openssl_rsa_public_key.rst
+++ b/chef_master/source/resource_openssl_rsa_public_key.rst
@@ -14,10 +14,10 @@ This resource has the following syntax:
 .. code-block:: ruby
 
    openssl_rsa_public_key 'name' do
-     group                      String, nil
+     group                      String
      mode                       Integer, String # default value: '0640'
      notifies                   # see description
-     owner                      String, nil
+     owner                      String
      path                       String
      private_key_content        String
      private_key_pass           String
@@ -47,7 +47,7 @@ Actions
 Properties
 =====================================================
 ``group``
-   **Ruby Types:** String, nil
+   **Ruby Types:** String
 
    The system group of all files created by the resource.
 
@@ -91,7 +91,7 @@ Properties
    .. end_tag
 
 ``owner``
-   **Ruby Types:** String, nil
+   **Ruby Types:** String
 
    The system user that owns all files created by the resource.
 

--- a/chef_master/source/resource_openssl_x509_crl.rst
+++ b/chef_master/source/resource_openssl_x509_crl.rst
@@ -1,0 +1,209 @@
+=====================================================
+openssl_x509_crl
+=====================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_openssl_x509_crl.rst>`__
+
+Use the **openssl_x509_crl** resource to generate PEM-formatted x509 certificate revocation list (CRL) files.
+
+New in Chef Client 14.5.
+
+Syntax
+=====================================================
+This resource has the following syntax:
+
+.. code-block:: ruby
+
+   openssl_x509_crl 'name' do
+     ca_cert_file               String # required
+     ca_key_file                String # required
+     ca_key_pass                String
+     expire                     Integer # default value: 8
+     group                      String
+     mode                       Integer, String # default value: '0640'
+     notifies                   # see description
+     owner                      String
+     path                       String # default value: 'name'
+     renewal_threshold          Integer # default value: 1
+     revocation_reason          Integer # default value: 0
+     serial_to_revoke           Integer, String
+     subscribes                 # see description
+     action                     Symbol # defaults to :create if not specified
+
+where:
+
+* ``openssl_x509_crl`` is the name of the resource
+* ``'name'`` is the path where the crl file will be written, or the name of the resource block
+* ``ca_cert_file``, ``ca_key_file``, ``ca_key_pass``, ``expire``, ``group``, ``mode``, ``notifies``, ``owner``, ``path``, ``renewal_threshold``, ``revocation_reason``, ``serial_to_revoke``, and ``subscribes`` are the properties available to this resource
+
+Actions
+=====================================================
+``:create``
+   Default. Create the certificate revocation list file.
+
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+
+   .. end_tag
+
+Properties
+=====================================================
+``ca_cert_file``
+   **Ruby Types:** Integer
+
+   Required. The path to the CA X509 Certificate on the filesystem.
+
+``ca_key_file``
+   **Ruby Types:** Integer
+
+   Required. The path to the CA private key on the filesystem.
+
+``ca_key_pass``
+   **Ruby Types:** Integer
+
+   The passphrase for CA private key's passphrase
+
+``expire``
+   **Ruby Types:** Integer | **Default Value:** ``8``
+
+   Value representing the number of days from now through which the issued CRL will remain valid. The CRL will expire after this period.
+
+``group``
+   **Ruby Types:** String
+
+   The system group of all files created by the resource.
+
+``mode``
+   **Ruby Types:** Integer, String | **Default Value:** ``0640``
+
+   The permission mode applied to all files created by the resource.
+
+``notifies``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_notifies
+
+   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_notifies_syntax
+
+   The syntax for ``notifies`` is:
+
+   .. code-block:: ruby
+
+      notifies :action, 'resource[name]', :timer
+
+   .. end_tag
+
+``owner``
+   **Ruby Types:** String
+
+   The owner of all files created by the resource.
+
+``path``
+   **Ruby Type:** String
+
+   The path to write the file to, if it differs from the resource name.
+
+``renewal_threshold``
+   **Ruby Types:** Integer | **Default Value:** ``1``
+
+   Number of days before the expiration. It this threshold is reached, the CRL will be renewed
+
+``revocation_reason``
+   **Ruby Types:** Integer | **Default Value:** ``0``
+
+   Reason for the revokation.
+
+``serial_to_revoke``
+   **Ruby Types:** Integer, String
+
+   Serial of the X509 Certificate to revoke.
+
+``subscribes``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_subscribes
+
+   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+   .. code-block:: ruby
+
+     file '/etc/nginx/ssl/example.crt' do
+        mode '0600'
+        owner 'root'
+     end
+
+     service 'nginx' do
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+     end
+
+   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_subscribes_syntax
+
+   The syntax for ``subscribes`` is:
+
+   .. code-block:: ruby
+
+      subscribes :action, 'resource[name]', :timer
+
+   .. end_tag
+
+Examples
+=====================================================
+**Create a certificate revocation file**
+
+.. code-block:: ruby
+
+  openssl_x509_crl '/etc/ssl_test/my_ca.crl' do
+    ca_cert_file '/etc/ssl_test/my_ca.crt'
+    ca_key_file '/etc/ssl_test/my_ca.key'
+  end
+
+**Create a certificate revocation file for a particular serial**
+
+.. code-block:: ruby
+
+  openssl_x509_crl '/etc/ssl_test/my_ca.crl' do
+    ca_cert_file '/etc/ssl_test/my_ca.crt'
+    ca_key_file '/etc/ssl_test/my_ca.key'
+    serial_to_revoke C7BCB6602A2E4251EF4E2827A228CB52BC0CEA2F
+  end

--- a/chef_master/source/resource_openssl_x509_request.rst
+++ b/chef_master/source/resource_openssl_x509_request.rst
@@ -1,0 +1,218 @@
+=====================================================
+openssl_x509_request
+=====================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_openssl_x509_request.rst>`__
+
+Use the **openssl_x509_request** resource to generate PEM-formatted x509 certificates requests. If no existing key is specified, the resource will automatically generate a passwordless key with the certificate.
+
+New in Chef Client 14.5.
+
+Syntax
+=====================================================
+This resource has the following syntax:
+
+.. code-block:: ruby
+
+   openssl_x509_request 'name' do
+     city                       String
+     email                      String
+     common_name                String
+     country                    String
+     group                      String
+     key_curve                  String # default value: 'prime256v1'
+     key_file                   String
+     key_length                 Integer # default value: '2048'
+     key_type                   String # default value: 'ec'
+     mode                       Integer, String # default value: '0640'
+     notifies                   # see description
+     owner                      String
+     path                       String # default value: 'name'
+     state                      String
+     subscribes                 # see description
+     action                     Symbol # defaults to :create if not specified
+
+where:
+
+* ``openssl_x509_request`` is the name of the resource
+* ``'name'`` is the path where the certificate file will be written, or the name of the resource block
+* ``city``, ``email``, ``common_name``, ``country``, ``group``, ``key_curve``, ``key_file``, ``key_length``, ``key_type``, ``mode``, ``notifies``, ``owner``, ``path``, ``state``, and ``subscribes`` are the properties available to this resource
+
+Actions
+=====================================================
+``:create``
+   Default. Create the certificate request file.
+
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+
+   .. end_tag
+
+Properties
+=====================================================
+``city``
+   **Ruby Type:** String
+
+   Value for the ``L`` certificate field.
+
+``email``
+   **Ruby Type:** String
+
+   Value for the ``email`` ssl field.
+
+``common_name``
+   **Ruby Type:** String
+
+   Value for the ``CN`` certificate field.
+
+``country``
+   **Ruby Type:** String
+
+   Value for the ``C`` certificate field.
+
+``group``
+   **Ruby Types:** String
+
+   The system group of all files created by the resource.
+
+``key_curve``
+   **Ruby Types:** String | **Default Value:** ``prime256v1``
+
+   The desired curve of the generated key (if key_type is equal to 'ec'). Run ``openssl ecparam -list_curves`` to see available options.
+
+``key_file``
+   **Ruby Types:** String
+
+   The path to a certificate key file on the filesystem. If the key_file property is specified, the resource will attempt to source a key from this location. If no key file is found, the resource will generate a new key file at this location. If the key_file property is not specified, the resource will generate a key file in the same directory as the generated certificate, with the same name as the generated certificate.
+
+``key_length``
+   **Ruby Type:** Integer | **Default Value:** ``2048``
+
+   The desired bit length of the generated key (if key_type is equal to 'rsa'). Available options are ``1024``, ``2048``, ``4096``, and ``8192``.
+
+``key_pass``
+   **Ruby Types:** String
+
+   The passphrase for an existing key's passphrase
+
+``key_type``
+   **Ruby Types:** String | **Default Value:** ``ec``
+
+   The desired type of the generated key (rsa or ec).
+
+``mode``
+   **Ruby Types:** Integer, String | **Default Value:** ``0640``
+
+   The permission mode applied to all files created by the resource.
+
+``notifies``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_notifies
+
+   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_notifies_syntax
+
+   The syntax for ``notifies`` is:
+
+   .. code-block:: ruby
+
+      notifies :action, 'resource[name]', :timer
+
+   .. end_tag
+
+``owner``
+   **Ruby Types:** String
+
+   The owner of all files created by the resource.
+
+``path``
+   **Ruby Type:** String
+
+   The path to write the file to, if it differs from the resource name.
+
+``state``
+   **Ruby Types:** String
+
+   Value for the ``ST`` certificate field.
+
+``subscribes``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_subscribes
+
+   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+   .. code-block:: ruby
+
+     file '/etc/nginx/ssl/example.crt' do
+        mode '0600'
+        owner 'root'
+     end
+
+     service 'nginx' do
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+     end
+
+   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_subscribes_syntax
+
+   The syntax for ``subscribes`` is:
+
+   .. code-block:: ruby
+
+      subscribes :action, 'resource[name]', :timer
+
+   .. end_tag
+
+Examples
+=====================================================
+**Create a certificate request file**
+
+.. code-block:: ruby
+
+  openssl_x509_request '/etc/ssl_test/my_ec_request.csr' do
+    common_name 'myecrequest.example.com'
+    org 'Test Kitchen Example'
+    org_unit 'Kitchens'
+    country 'UK'
+  end

--- a/chef_master/source/resource_reference.rst
+++ b/chef_master/source/resource_reference.rst
@@ -1204,6 +1204,10 @@ The following resources are built into the Chef Client:
 
 .. include:: resource_openssl_rsa_private_key.rst
 
+.. include:: resource_openssl_x509_crl.rst
+
+.. include:: resource_openssl_x509_request.rst
+
 .. include:: resource_osx_profile.rst
 
 .. include:: resource_package.rst

--- a/chef_master/source/resource_reference.rst
+++ b/chef_master/source/resource_reference.rst
@@ -1196,6 +1196,10 @@ The following resources are built into the Chef Client:
 
 .. include:: resource_openssl_dhparam.rst
 
+.. include:: resource_openssl_ec_public_key.rst
+
+.. include:: resource_openssl_ec_private_key.rst
+
 .. include:: resource_openssl_rsa_public_key.rst
 
 .. include:: resource_openssl_rsa_private_key.rst


### PR DESCRIPTION
This adds 2 new resources we're shipping in Chef 14.5 (today maybe).