### PR TITLE
Fix the version of chef where new openssl_* resources land

### DIFF
--- a/chef_master/source/resource_openssl_ec_private_key.rst
+++ b/chef_master/source/resource_openssl_ec_private_key.rst
@@ -7,7 +7,7 @@ Use the **openssl_ec_private_key** resource to generate elliptic curve (EC) priv
 
 .. note:: If the password to your EC key file does not match the password in the recipe, it cannot be opened, and will be overwritten.
 
-New in Chef Client 14.5.
+New in Chef Client 14.4.
 
 Syntax
 =====================================================

--- a/chef_master/source/resource_openssl_ec_public_key.rst
+++ b/chef_master/source/resource_openssl_ec_public_key.rst
@@ -5,7 +5,7 @@ openssl_ec_public_key
 
 Use the **openssl_ec_public_key** resource to generate elliptic curve (EC) public key files from a given EC private key.
 
-New in Chef Client 14.5.
+New in Chef Client 14.4.
 
 Syntax
 =====================================================

--- a/chef_master/source/resource_openssl_x509_certificate.rst
+++ b/chef_master/source/resource_openssl_x509_certificate.rst
@@ -5,7 +5,7 @@ openssl_x509_certificate
 
 Use the **openssl_x509_certificate** resource to generate signed or self-signed, PEM-formatted x509 certificates. If no existing key is specified, the resource will automatically generate a passwordless key with the certificate. If a CA private key and certificate are provided, the certificate will be signed with them. Note: This resource was renamed from openssl_x509 to openssl_x509_certificate. The legacy name will continue to function, but cookbook code should be updated for the new resource name.
 
-New in Chef Client 14.5.
+New in Chef Client 14.4.
 
 Syntax
 =====================================================

--- a/chef_master/source/resource_openssl_x509_crl.rst
+++ b/chef_master/source/resource_openssl_x509_crl.rst
@@ -5,7 +5,7 @@ openssl_x509_crl
 
 Use the **openssl_x509_crl** resource to generate PEM-formatted x509 certificate revocation list (CRL) files.
 
-New in Chef Client 14.5.
+New in Chef Client 14.4.
 
 Syntax
 =====================================================

--- a/chef_master/source/resource_openssl_x509_request.rst
+++ b/chef_master/source/resource_openssl_x509_request.rst
@@ -5,7 +5,7 @@ openssl_x509_request
 
 Use the **openssl_x509_request** resource to generate PEM-formatted x509 certificates requests. If no existing key is specified, the resource will automatically generate a passwordless key with the certificate.
 
-New in Chef Client 14.5.
+New in Chef Client 14.4.
 
 Syntax
 =====================================================


### PR DESCRIPTION
I jumped the gun on our versions a bit. These ship in 14.4 not 14.5

Signed-off-by: Tim Smith <tsmith@chef.io>