### PR TITLE
Add cron_d and cron_access resources for Chef 14.4

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -785,6 +785,16 @@
                 "url": "/resource_cron.html"
               },
               {
+                "title": "cron_d",
+                "hasSubItems": false,
+                "url": "/resource_cron_d.html"
+              },
+              {
+                "title": "cron_access",
+                "hasSubItems": false,
+                "url": "/resource_cron_access.html"
+              },
+              {
                 "title": "csh",
                 "hasSubItems": false,
                 "url": "/resource_csh.html"

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -163,6 +163,8 @@ Cookbook Reference
 `chocolatey_package </resource_chocolatey_package.html>`__
 `cookbook_file </resource_cookbook_file.html>`__ |
 `cron </resource_cron.html>`__ |
+`cron_d </resource_cron_d.html>`__ |
+`cron_access </resource_cron_access.html>`__ |
 `csh </resource_csh.html>`__ |
 `deploy </resource_deploy.html>`__ |
 `directory </resource_directory.html>`__ |

--- a/chef_master/source/resource_cron_access.rst
+++ b/chef_master/source/resource_cron_access.rst
@@ -1,0 +1,180 @@
+=====================================================
+cron_access
+=====================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_cron_access.rst>`__
+
+Use the **cron_access** resource to manage the /etc/cron.allow and /etc/cron.deny files. Note: This resource previously shipped in the ``cron`` cookbook as ``cron_manage``, which it can still be used as for backwards compatibility with existing chef-client releases.
+
+**New in Chef Client 14.4.**
+
+Syntax
+=====================================================
+
+This resource has the following syntax:
+
+.. code-block:: ruby
+
+   cron_access 'name' do
+     user                       String
+     notifies                   # see description
+     subscribes                 # see description
+     action                     Symbol # defaults to :create if not specified
+   end
+
+where
+
+* ``cron_access`` is the resource
+* ``name`` is the name of the resource block
+* ``user`` is the command to user to add to /etc/cron.allow or /etc/cron.deny. If not provided the resource uses the ``name``.
+* ``action`` identifies the steps the chef-client will take to bring the node into the desired state
+
+Actions
+=====================================================
+This resource has the following actions:
+
+``:allow``
+   Default. Add the user to the cron.allow file.
+
+``:deny``
+   Add the user to the cron.deny file.
+
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+
+   .. end_tag
+
+Properties
+=====================================================
+This resource has the following properties:
+
+``user``
+   **Ruby Type:** String
+
+   The user to allow or deny. If not provided we'll use the resource name.
+
+``ignore_failure``
+   **Ruby Types:** True, False
+
+   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+
+``notifies``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_notifies
+
+   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_notifies_syntax
+
+   The syntax for ``notifies`` is:
+
+   .. code-block:: ruby
+
+      notifies :action, 'resource[name]', :timer
+
+   .. end_tag
+
+``retries``
+   **Ruby Type:** Integer
+
+   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+
+``retry_delay``
+   **Ruby Type:** Integer
+
+   The retry delay (in seconds). Default value: ``2``.
+
+``subscribes``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_subscribes
+
+   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+   .. code-block:: ruby
+
+     file '/etc/nginx/ssl/example.crt' do
+        mode '0600'
+        owner 'root'
+     end
+
+     service 'nginx' do
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+     end
+
+   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_subscribes_syntax
+
+   The syntax for ``subscribes`` is:
+
+   .. code-block:: ruby
+
+      subscribes :action, 'resource[name]', :timer
+
+   .. end_tag
+
+Examples
+=====================================================
+The following examples demonstrate various approaches for using resources in recipes:
+
+**Add the mike user to cron.allow**
+
+.. code-block:: ruby
+
+  cron_access 'mike'
+
+**Add the mike user to cron.deny**
+
+.. code-block:: ruby
+
+  cron_access 'mike' do
+    action :deny
+  end
+
+**Specify the username with the user property**
+
+.. code-block:: ruby
+
+  cron_access 'Deny the tomcat access to cron for security purposes' do
+    user 'jenkins'
+    action :deny
+  end

--- a/chef_master/source/resource_examples.rst
+++ b/chef_master/source/resource_examples.rst
@@ -1391,9 +1391,9 @@ cron
 =====================================================
 .. tag resource_cron_summary
 
-Use the **cron** resource to manage cron entries for time-based job scheduling. Properties for a schedule will default to ``*`` if not provided. The **cron** resource requires access to a crontab program, typically cron.
+Use the **cron** resource to manage cron entries for time-based job scheduling.
 
-.. warning:: The **cron** resource should only be used to modify an entry in a crontab file. Use the **cookbook_file** or **template** resources to add a crontab file to the cron.d directory. The ``cron_d`` resource (found in the `cron <https://github.com/chef-cookbooks/cron>`__ cookbook) is another option for managing crontab files.
+.. warning:: The **cron** resource should only be used to modify an entry in a crontab file. The ``cron_d`` resource directly manages cron.d files. This resource ships in Chef 14.4 or later and can also be found in the `cron <https://github.com/chef-cookbooks/cron>`__ cookbook) for previous chef-client releases.
 
 .. end_tag
 

--- a/chef_master/source/resource_execute.rst
+++ b/chef_master/source/resource_execute.rst
@@ -346,7 +346,7 @@ The following arguments can be used with the ``not_if`` or ``only_if`` guard pro
 
 Examples
 =====================================================
-The following examples demonstrate various approaches for using resources in recipes. If you want to see examples of how Chef uses resources in recipes, take a closer look at the cookbooks that Chef authors and maintains: https://github.com/chef-cookbooks.
+The following examples demonstrate various approaches for using resources in recipes:
 
 **Run a command upon notification**
 

--- a/chef_master/source/resource_reference.rst
+++ b/chef_master/source/resource_reference.rst
@@ -1132,6 +1132,10 @@ The following resources are built into the Chef Client:
 
 .. include:: resource_cron.rst
 
+.. include:: resource_cron_d.rst
+
+.. include:: resource_cron_access.rst
+
 .. include:: resource_csh.rst
 
 .. include:: resource_directory.rst


### PR DESCRIPTION
These are new resources in Chef 14.4

Signed-off-by: Tim Smith <tsmith@chef.io>