### PR TITLE
Add missing resources from Chef 14.0 / 14.3

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -775,6 +775,11 @@
                 "url": "/resource_chocolatey_package.html"
               },
               {
+                "title": "chocolatey_source",
+                "hasSubItems": false,
+                "url": "/resource_chocolatey_source.html"
+              },
+              {
                 "title": "cookbook_file",
                 "hasSubItems": false,
                 "url": "/resource_cookbook_file.html"
@@ -893,6 +898,11 @@
                 "title": "ips_package",
                 "hasSubItems": false,
                 "url": "/resource_ips_package.html"
+              },
+              {
+                "title": "kernel_module",
+                "hasSubItems": false,
+                "url": "/resource_kernel_module.html"
               },
               {
                 "title": "ksh",
@@ -1030,6 +1040,11 @@
                 "url": "/resource_powershell_package.html"
               },
               {
+                "title": "powershell_package_source",
+                "hasSubItems": false,
+                "url": "/resource_powershell_package_source.html"
+              },
+              {
                 "title": "powershell_script",
                 "hasSubItems": false,
                 "url": "/resource_powershell_script.html"
@@ -1123,6 +1138,11 @@
                 "title": "solaris_package",
                 "hasSubItems": false,
                 "url": "/resource_solaris_package.html"
+              },
+              {
+                "title": "ssh_known_hosts_entry",
+                "hasSubItems": false,
+                "url": "/resource_ssh_known_hosts_entry.html"
               },
               {
                 "title": "subversion",

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -161,6 +161,7 @@ Cookbook Reference
 `chef_user </resource_chef_user.html>`__ |
 `chocolatey_config </resource_chocolatey_config.html>`__
 `chocolatey_package </resource_chocolatey_package.html>`__
+`chocolatey_source </resource_chocolatey_source.html>`__
 `cookbook_file </resource_cookbook_file.html>`__ |
 `cron </resource_cron.html>`__ |
 `cron_d </resource_cron_d.html>`__ |
@@ -187,6 +188,7 @@ Cookbook Reference
 `http_request </resource_http_request.html>`__ |
 `ifconfig </resource_ifconfig.html>`__ |
 `ips_package </resource_ips_package.html>`__ |
+`kernel_module </resource_kernel_module.html>`__ |
 `ksh </resource_ksh.html>`__ |
 `launchd </resource_launchd.html>`__ |
 `link </resource_link.html>`__ |
@@ -213,6 +215,7 @@ Cookbook Reference
 `perl </resource_perl.html>`__ |
 `portage_package </resource_portage_package.html>`__ |
 `powershell_package </resource_powershell_package.html>`__ |
+`powershell_package_source </resource_powershell_package_source.html>`__ |
 `powershell_script </resource_powershell_script.html>`__ |
 `private_key </resource_private_key.html>`__ |
 `public_key </resource_public_key.html>`__ |
@@ -234,6 +237,7 @@ Cookbook Reference
 `service </resource_service.html>`__ |
 `smartos_package </resource_smartos_package.html>`__ |
 `solaris_package </resource_solaris_package.html>`__ |
+`ssh_known_hosts_entry </resource_ssh_known_hosts_entry.html>`__ |
 `subversion </resource_subversion.html>`__ |
 `sudo </resource_sudo.html>`__ |
 `swap_file </resource_swap_file.html>`__ |

--- a/chef_master/source/resource_chocolatey_config.rst
+++ b/chef_master/source/resource_chocolatey_config.rst
@@ -14,8 +14,10 @@ This resource has the following syntax:
 .. code-block:: ruby
 
    chocolatey_config 'name' do
+     notifies                   # see description
      config_key                 String # default value: 'name'
      value                      String
+     subscribes                 # see description
      action                     Symbol # defaults to :set if not specified
    end
 

--- a/chef_master/source/resource_chocolatey_source.rst
+++ b/chef_master/source/resource_chocolatey_source.rst
@@ -1,0 +1,151 @@
+=====================================================
+chocolatey_source
+=====================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chocolatey_source.rst>`__
+
+Use the **chocolatey_source** resource to add or remove Chocolatey sources.
+
+**New in Chef Client 14.3.**
+
+Syntax
+=====================================================
+This resource has the following syntax:
+
+.. code-block:: ruby
+
+   chocolatey_source 'name' do
+     bypass_proxy               true, false # defaults to false
+     notifies                   # see description
+     priority                   Integer # defaults to 0
+     source                     String
+     source_name                String # default value: 'name'
+     subscribes                 # see description
+     action                     Symbol # defaults to :add if not specified
+   end
+
+where:
+
+* ``chocolatey_source`` is the name of the resource
+* ``bypass_proxy``, ``priority``, and ``source`` are the properties available to this resource
+
+Actions
+=====================================================
+
+``:add``
+   Default. Adds a Chocolatey source.
+
+``:remove``
+   Removes a Chocolatey source.
+
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+
+   .. end_tag
+
+Properties
+=====================================================
+
+``bypass_proxy``
+   **Ruby Type:** true, false | **Default Value:** ``false``
+
+   Whether or not to bypass the system's proxy settings to access the source.
+
+``notifies``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_notifies
+
+   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_notifies_syntax
+
+   The syntax for ``notifies`` is:
+
+   .. code-block:: ruby
+
+      notifies :action, 'resource[name]', :timer
+
+   .. end_tag
+
+``priority``
+   **Ruby Type:** Integer | **Default Value:** ``0``
+
+   The priority level of the source.
+
+``source``
+   **Ruby Type:** String
+
+   The source URL.
+
+``source_name``
+   **Ruby Type:** String
+
+   The name of the source to add. The resource's name will be used if this isn't provided.
+
+``subscribes``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_subscribes
+
+   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+   .. code-block:: ruby
+
+     file '/etc/nginx/ssl/example.crt' do
+        mode '0600'
+        owner 'root'
+     end
+
+     service 'nginx' do
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+     end
+
+   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_subscribes_syntax
+
+   The syntax for ``subscribes`` is:
+
+   .. code-block:: ruby
+
+      subscribes :action, 'resource[name]', :timer
+
+   .. end_tag

--- a/chef_master/source/resource_kernel_module.rst
+++ b/chef_master/source/resource_kernel_module.rst
@@ -1,0 +1,154 @@
+=====================================================
+kernel_module
+=====================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_kernel_module.rst>`__
+
+Use the **kernel_module** resource to manage kernel modules on Linux systems. This resource can load, unload, blacklist, install, and uninstall modules.
+
+**New in Chef Client 14.3.**
+
+Syntax
+=====================================================
+This resource has the following syntax:
+
+.. code-block:: ruby
+
+   kernel_module 'name' do
+     load_dir              String # defaults to /etc/modules-load.d
+     modname               String
+     notifies              # see description
+     unload_dir            String # defaults to /etc/modprobe.d
+     subscribes            # see description
+     action                Symbol # defaults to :install if not specified
+   end
+
+where:
+
+* ``kernel_module`` is the name of the resource
+* ``load_dir``, ``modname`` are the properties available to this resource.
+
+Actions
+=====================================================
+
+``:blacklist``
+   Blacklist a kernel module.
+
+``:install``
+   Default. Load kernel module, and ensure it loads on reboot.
+
+``:load``
+   Load a kernel module.
+
+``:uninstall``
+   Unload a kernel module and remove module config, so it doesn't load on reboot.
+
+``:unload``
+   Unload kernel module.
+
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+
+   .. end_tag
+
+Properties
+=====================================================
+
+``load_dir``
+   **Ruby Type:** String | **Default Value:** ``/etc/modules-load.d``
+
+   The directory to load modules from.
+
+``modname``
+   **Ruby Type:** String
+
+   The name of the kernel module.
+
+``notifies``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_notifies
+
+   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_notifies_syntax
+
+   The syntax for ``notifies`` is:
+
+   .. code-block:: ruby
+
+      notifies :action, 'resource[name]', :timer
+
+   .. end_tag
+
+``subscribes``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_subscribes
+
+   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+   .. code-block:: ruby
+
+     file '/etc/nginx/ssl/example.crt' do
+        mode '0600'
+        owner 'root'
+     end
+
+     service 'nginx' do
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+     end
+
+   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_subscribes_syntax
+
+   The syntax for ``subscribes`` is:
+
+   .. code-block:: ruby
+
+      subscribes :action, 'resource[name]', :timer
+
+   .. end_tag
+
+``unload_dir``
+   **Ruby Type:** String | **Default Value:** ``/etc/modprobe.d``
+
+   The modprobe.d directory.

--- a/chef_master/source/resource_macos_userdefaults.rst
+++ b/chef_master/source/resource_macos_userdefaults.rst
@@ -17,11 +17,14 @@ This resource has the following Syntax:
      domain                String # required
      global                True, False # default value: 'false'
      key                   String
+     notifies              # see description
+     subscribes            # see description
      sudo                  True, False # default value: 'false'
      type                  String # default value: ""
      user                  String
-     value                 # required - see description
-     action                Symbol # default to :write if not specified
+     value                 # required - see description     
+     action                Symbol # defaults to :write if not specified
+   end
 
 where:
 
@@ -38,7 +41,11 @@ This resource has the following actions:
    Default. Writes the setting to the specified domain. 
 
 ``:nothing``
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, the resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   .. tag resources_common_actions_nothing
+
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+
+   .. end_tag
 
 Properties
 =====================================================
@@ -58,6 +65,90 @@ This resource has the following properties:
    **Ruby Type:** String
 
    The preference key. 
+   
+``notifies``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_notifies
+
+   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_notifies_syntax
+
+   The syntax for ``notifies`` is:
+
+   .. code-block:: ruby
+
+      notifies :action, 'resource[name]', :timer
+
+   .. end_tag
+
+
+``subscribes``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_subscribes
+
+   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+   .. code-block:: ruby
+
+     file '/etc/nginx/ssl/example.crt' do
+        mode '0600'
+        owner 'root'
+     end
+
+     service 'nginx' do
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+     end
+
+   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_subscribes_syntax
+
+   The syntax for ``subscribes`` is:
+
+   .. code-block:: ruby
+
+      subscribes :action, 'resource[name]', :timer
+
+   .. end_tag
 
 ``sudo``
    **Ruby Type:** True, False | **Default Value:** ``false``

--- a/chef_master/source/resource_mdadm.rst
+++ b/chef_master/source/resource_mdadm.rst
@@ -86,7 +86,7 @@ This resource has the following properties:
    The devices to be part of a RAID array.
 
 ``exists``
-   **Ruby Type:** TrueClass, FalseClass | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
 
    Indicates whether the RAID array exists.
 

--- a/chef_master/source/resource_powershell_package_source.rst
+++ b/chef_master/source/resource_powershell_package_source.rst
@@ -1,0 +1,165 @@
+=====================================================
+powershell_package_source
+=====================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_powershell_package_source.rst>`__
+
+Use the **powershell_package_source** resource to register a PowerShell package repository.
+
+**New in Chef Client 14.3.**
+
+Syntax
+=====================================================
+This resource has the following syntax:
+
+.. code-block:: ruby
+
+   powershell_package_source 'name' do
+     notifies                    # see description
+     provider_name               String # defaults to NuGet
+     publish_location            String
+     script_publish_location     String
+     script_source_location      String
+     source_name                 String
+     subscribes                  # see description
+     trusted                     true, false # defaults to false
+     url                         String
+     action                      Symbol # defaults to :register if not specified
+   end
+
+where:
+
+* ``powershell_package_source`` is the name of the resource
+* ``provider_name``, ``publish_location``, ``script_publish_location``, ``script_source_location``, ``source_name``, and ``trusted`` are the properties available to this resource
+
+Actions
+=====================================================
+
+``register``
+   Default. Registers and updates the PowerShell package source.
+
+``unregister``
+   Unregisters the PowerShell package source.
+
+``:nothing``
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+
+Properties
+=====================================================
+
+``notifies``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_notifies
+
+   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_notifies_syntax
+
+   The syntax for ``notifies`` is:
+
+   .. code-block:: ruby
+
+      notifies :action, 'resource[name]', :timer
+
+   .. end_tag
+
+``provider_name``
+   **Ruby Type:** String | **Default Value:** ``NuGet``
+
+   The package management provider for the source. It supports the following providers: 'Programs', 'msi', 'NuGet', 'msu', 'PowerShellGet', 'psl' and 'chocolatey'.
+
+``publish_location``
+   **Ruby Type:** String
+
+   The url where modules will be published to for this source. Only valid if the provider is 'PowerShellGet'.
+
+``script_publish_location``
+   **Ruby Type:** String
+
+   The location where scripts will be published to for this source. Only valid if the provider is 'PowerShellGet'.
+
+``script_source_location``
+   **Ruby Type:** String
+
+   The url where scripts are located for this source. Only valid if the provider is 'PowerShellGet'.
+
+``source_name``
+   **Ruby Type:** String
+
+   The name of the package source.
+
+``subscribes``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_subscribes
+
+   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+   .. code-block:: ruby
+
+     file '/etc/nginx/ssl/example.crt' do
+        mode '0600'
+        owner 'root'
+     end
+
+     service 'nginx' do
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+     end
+
+   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_subscribes_syntax
+
+   The syntax for ``subscribes`` is:
+
+   .. code-block:: ruby
+
+      subscribes :action, 'resource[name]', :timer
+
+   .. end_tag
+
+``trusted``
+   **Ruby Type:** true, false | **Default Value:** ``false``
+
+   Whether or not to trust packages from this source.
+
+``url``
+   **Ruby Type:** String
+
+   The url to the package source.

--- a/chef_master/source/resource_reference.rst
+++ b/chef_master/source/resource_reference.rst
@@ -1128,6 +1128,8 @@ The following resources are built into the Chef Client:
 
 .. include:: resource_chocolatey_package.rst
 
+.. include:: resource_chocolatey_source.rst
+
 .. include:: resource_cookbook_file.rst
 
 .. include:: resource_cron.rst
@@ -1175,6 +1177,8 @@ The following resources are built into the Chef Client:
 .. include:: resource_ifconfig.rst
 
 .. include:: resource_ips_package.rst
+
+.. include:: resource_kernel_module.rst
 
 .. include:: resource_ksh.rst
 
@@ -1230,6 +1234,8 @@ The following resources are built into the Chef Client:
 
 .. include:: resource_powershell_package.rst
 
+.. include:: resource_powershell_package_source.rst
+
 .. include:: resource_powershell_script.rst
 
 .. include:: resource_python.rst
@@ -1267,6 +1273,8 @@ The following resources are built into the Chef Client:
 .. include:: resource_smartos_package.rst
 
 .. include:: resource_solaris_package.rst
+
+.. include:: resource_ssh_known_hosts_entry.rst
 
 .. include:: resource_subversion.rst
 

--- a/chef_master/source/resource_ssh_known_hosts_entry.rst
+++ b/chef_master/source/resource_ssh_known_hosts_entry.rst
@@ -1,0 +1,187 @@
+=====================================================
+ssh_known_hosts_entry
+=====================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_ssh_known_hosts_entry.rst>`__
+
+Use the **ssh_known_hosts_entry** resource to add an entry for the specified host in /etc/ssh/ssh_known_hosts or a user's known hosts file if specified.
+
+**New in Chef Client 14.3.**
+
+Syntax
+=====================================================
+This resource has the following syntax:
+
+.. code-block:: ruby
+
+   ssh_known_hosts_entry 'name' do
+     file_location             String # defaults to /etc/ssh/ssh_known_hosts
+     group                     String # defaults to the root_group on the system
+     hash_entries              true, false # defaults to false
+     host                      String
+     key                       String
+     key_type                  String # defaults to rsa
+     mode                      String # defaults to 0644
+     notifies                  # see description
+     owner                     String # defaults to root
+     port                      Integer # defaults to 22
+     subscribes                # see description
+     timeout                   Integer # defaults to 30
+     action                    Symbol # defaults to :create if not specified
+   end
+
+where:
+
+* ``ssh_known_hosts_entry`` is the name of the resource
+* ``file_location``, ``group``, ``hash_entries``, ``host``, ``key``, ``key_type``, ``mode``, ``owner``, and ``port`` are the properties available to this resource
+
+Actions
+=====================================================
+
+``:create``
+   Default. Create an entry in the ssh_known_hosts file.
+
+``:flush``
+   Immediately flush the entries to the config file. Without this the actual writing of the file is delayed in the Chef run so all entries can be accumulated before writing the file out.
+
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+
+   .. end_tag
+Properties
+=====================================================
+
+``file_location``
+   **Ruby Type:** String | **Default Value:** ``/etc/ssh/ssh_known_hosts``
+
+   The location of the ssh known hosts file. Change this to set a known host file for a particular user.
+
+``group``
+   **Ruby Type:** String
+
+   The file group for the ssh_known_hosts file.
+
+``hash_entries``
+   **Ruby Type:** true, false | **Default Value:** ``false``
+
+   Hash the hostname and addresses in the ssh_known_hosts file for privacy.
+
+``host``
+   **Ruby Type:** String
+
+   The host to add to the known hosts file.
+
+``key``
+   **Ruby Type:** String
+
+   An optional key for the host. If not provided this will be automatically determined.
+
+``key_type``
+   **Ruby Type:** String | **Default Value:** ``rsa``
+
+   The type of key to store.
+
+``mode``
+   **Ruby Type:** String | **Default Value:** ``0644``
+
+   The file mode for the ssh_known_hosts file.
+
+``notifies``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_notifies
+
+   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_notifies_syntax
+
+   The syntax for ``notifies`` is:
+
+   .. code-block:: ruby
+
+      notifies :action, 'resource[name]', :timer
+
+   .. end_tag
+
+``owner``
+   **Ruby Type:** String | **Default Value:** ``root``
+
+   The file owner for the ssh_known_hosts file.
+
+``port``
+   **Ruby Type:** Integer | **Default Value:** ``22``
+
+   The server port that the ssh-keyscan command will use to gather the public key.
+
+
+``subscribes``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   .. tag resources_common_notification_subscribes
+
+   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+   .. code-block:: ruby
+
+     file '/etc/nginx/ssl/example.crt' do
+        mode '0600'
+        owner 'root'
+     end
+
+     service 'nginx' do
+        subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+     end
+
+   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+   .. end_tag
+
+   .. tag resources_common_notification_timers
+
+   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+   ``:before``
+      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+   ``:delayed``
+      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+   ``:immediate``, ``:immediately``
+      Specifies that a notification should be run immediately, per resource notified.
+
+   .. end_tag
+
+   .. tag resources_common_notification_subscribes_syntax
+
+   The syntax for ``subscribes`` is:
+
+   .. code-block:: ruby
+
+      subscribes :action, 'resource[name]', :timer
+
+   .. end_tag
+
+``timeout``
+   **Ruby Type:** Integer | **Default Value:** ``30``
+
+   The timeout in seconds for ssh-keyscan.

--- a/chef_master/source/resource_ssh_known_hosts_entry.rst
+++ b/chef_master/source/resource_ssh_known_hosts_entry.rst
@@ -49,6 +49,7 @@ Actions
    Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
 
    .. end_tag
+
 Properties
 =====================================================
 

--- a/chef_master/source/resource_windows_printer_port.rst
+++ b/chef_master/source/resource_windows_printer_port.rst
@@ -35,24 +35,24 @@ Actions
 =====================================================
 ``:create``
    Default. Create the printer port, if one doesn't already exist.
-   
+
 ``:delete``
    Delete an existing printer port.
-   
+
 ``:nothing``
    .. tag resources_common_actions_nothing
 
    Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
 
    .. end_tag
-   
+
 Properties
 =====================================================
 ``ipv4_address``
    **Ruby Type:** String | **Default Value:** ``'name'``
-   
+
    The IPv4 address of the printer, if it differs from the resource block name.
-   
+
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
@@ -86,31 +86,31 @@ Properties
       notifies :action, 'resource[name]', :timer
 
    .. end_tag
-   
+
 ``port_description``
    **Ruby Type:** String
-   
-   A description of the port.
+
+   The description of the port.
 
 ``port_name``
    **Ruby Type:** String
-   
+
    The port name.
-             
+
 ``port_number``
    **Ruby Type:** Integer | **Default Value:** ``9100``
-   
+
    The port number.
 
 ``port_protocol``
    **Ruby Type:** Integer | **Default Value:** ``1``
-   
+
    The printer port protocol; ``1`` (RAW) or ``2`` (LPR).
 
 ``snmp_enabled``
    **Ruby Type:** True, False | **Default Value:** ``false``
-   
-   Determines ig SNMP is enabled on the port.
+
+   Determines if SNMP is enabled on the port
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_windows_printer_port.rst
+++ b/chef_master/source/resource_windows_printer_port.rst
@@ -29,7 +29,7 @@ where:
 
 * ``windows_printer_port`` is the resource
 * ``'name'`` is the IP address of the printer, or the name of the resource block
-*  and ``subscribes`` are the properties available to this resource
+* ``exists``, ``ipv4_address``, ``port_description``, ``port_name``, ``port_number``, and ``port_protocol`` are the properties available to this resource.
 
 Actions
 =====================================================

--- a/chef_master/source/resource_windows_task.rst
+++ b/chef_master/source/resource_windows_task.rst
@@ -5,7 +5,7 @@ windows_task
 
 Use the **windows_task** resource to create, delete or run a Windows scheduled task. Requires Windows Server 2008 or later due to API usage.
 
-**New in Chef Client 13**
+**New in Chef Client 13.0.**
 
 .. note:: The ``windows_task`` resource that was provided as part of the ``windows`` cookbook included the ``:change`` action, which has been removed from ``windows_task`` in Chef client. The ``:create`` action can be used instead to update an existing task.
 
@@ -16,34 +16,41 @@ A **windows_task** resource creates, deletes or runs a Windows scheduled task.
 .. code-block:: ruby
 
    windows_task 'name' do
-     task_name                   String
-     command                     String
-     cwd                         String
-     user                        String # defaults to SYSTEM
-     password                    String
-     run_level                   Symbol # defaults to :limited
-     force                       True, False # defaults to false
-     interactive_enabled         True, False # defaults to false
-     frequency                   Symbol
-     frequency_modifier          Integer, String # defaults to 1
-     start_day                   String
-     start_time                  String
-     day                         String, Integer
-     months                      String
-     idle_time                   Integer
-     random_delay                String, Integer
-     execution_time_limit        String, Integer
-     action                      Symbol #defaults to :create
+     command                            String
+     cwd                                String
+     day                                String, Integer
+     disallow_start_if_on_batteries     true, false # defaults to false
+     execution_time_limit               String, Integer # defaults to PT72H
+     force                              true, false # defaults to false
+     frequency                          Symbol
+     frequency_modifier                 Integer, String # defaults to 1
+     idle_time                          Integer
+     interactive_enabled                true, false # defaults to false
+     minutes_duration                   String, Integer
+     minutes_interval                   String, Integer
+     months                             String
+     notifies                           # see description
+     password                           String
+     priority                           Integer # defaults to 7
+     random_delay                       String, Integer
+     run_level                          Symbol # defaults to limited
+     start_day                          String
+     start_time                         String
+     stop_if_going_on_batteries         true, false # defaults to false
+     task_name                          String
+     subscribes                         # see description
+     user                               String # defaults to SYSTEM
+     action                             Symbol # defaults to :create if not specified
    end
 
-where
+where:
 
 * ``windows_task`` is the resource.
 * ``name`` is the name of the resource block.
 * ``task_name`` is the name of the task.
 * ``command`` is the command to be executed by the windows scheduled task.
 * ``action`` identifies which steps the chef-client will take to bring the node into the desired state
-* ``cwd``, ``day``, ``disallow_start_if_on_batteries``, ``execution_time_limit``, ``force``, ``frequency``, ``frequency_modifier``, ``idle_time``, ``interactive_enabled``, ``minutes_duration``, ``minutes_interval``, ``months``, ``password``, ``priority``, ``random_delay``, ``run_level``, ``start_day``, ``start_time``, and ``stop_if_going_on_batteries`` are the properties available to this resource.
+* ``command``, ``cwd``, ``day``, ``disallow_start_if_on_batteries``, ``execution_time_limit``, ``force``, ``frequency``, ``frequency_modifier``, ``idle_time``, ``interactive_enabled``, ``minutes_duration``, ``minutes_interval``, ``months``, ``password``, ``priority``, ``random_delay``, ``run_level``, ``start_day``, ``start_time``, ``stop_if_going_on_batteries``, and ``task_name`` are the properties available to this resource.
 
 Actions
 =====================================================


### PR DESCRIPTION
chocolatey_source
kernel_module
powershell_package_source
ssh_known_hosts_entry

Signed-off-by: Tim Smith <tsmith@chef.io>