### PR TITLE
Rename the changelog link

### DIFF
--- a/chef_master/source/release_notes_chefdk.rst
+++ b/chef_master/source/release_notes_chefdk.rst
@@ -3,7 +3,7 @@ Release Notes: Chef Development Kit 0.19 - 3.1
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/release_notes_chefdk.rst>`__
 
-Chef Development Kit is released on a monthly schedule with new releases the third Monday of every month. Below are the major changes for each release. For a detailed list of changes see the `Chef DK on GitHub <https://github.com/chef/chef-dk/blob/master/CHANGELOG.md>`__
+Chef Development Kit is released on a monthly schedule with new releases the third Monday of every month. Below are the major changes for each release. For a detailed list of changes see the `Chef DK Changelog on GitHub <https://github.com/chef/chef-dk/blob/master/CHANGELOG.md>`__
 
 What's New in 3.1
 =====================================================


### PR DESCRIPTION
The name of this link seemed odd considering it was the changelog not the DK project main page.