### PR TITLE
Update how we suggest users share cookbooks

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -462,7 +462,7 @@
               {
                 "title": "knife supermarket",
                 "hasSubItems": false,
-                "url": "/plugin_knife_supermarket.html"
+                "url": "/knife_supermarket.html"
               },
               {
                 "title": "supermarket-ctl",

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -301,7 +301,7 @@ Chef DK
 
 `knife spork </plugin_knife_spork.html>`__
 
-**knife supermarket**: `supermarket download </plugin_knife_supermarket.html#download>`__ | `supermarket install </plugin_knife_supermarket.html#install>`__ | `supermarket list </plugin_knife_supermarket.html#list>`__ | `supermarket search </plugin_knife_supermarket.html#search>`__ | `supermarket share </plugin_knife_supermarket.html#share>`__ | `supermarket show </plugin_knife_supermarket.html#show>`__ | `supermarket unshare </plugin_knife_supermarket.html#unshare>`__
+**knife supermarket**: `supermarket download </knife_supermarket.html#download>`__ | `supermarket install </knife_supermarket.html#install>`__ | `supermarket list </plugin_knife_supermarket.html#list>`__ | `supermarket search </plugin_knife_supermarket.html#search>`__ | `supermarket share </plugin_knife_supermarket.html#share>`__ | `supermarket show </plugin_knife_supermarket.html#show>`__ | `supermarket unshare </plugin_knife_supermarket.html#unshare>`__
 
 **Ohai**: `About Ohai </ohai.html>`__ | `ohai (executable) </ctl_ohai.html>`__
 
@@ -765,6 +765,7 @@ Addenda
    knife_ssl_check
    knife_ssl_fetch
    knife_status
+   knife_supermarket
    knife_tag
    knife_upload
    knife_user
@@ -788,7 +789,6 @@ Addenda
    plugin_knife_push_jobs
    plugin_knife_reporting
    plugin_knife_spork
-   plugin_knife_supermarket
    plugin_knife_windows
    policy
    policyfile

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -301,7 +301,7 @@ Chef DK
 
 `knife spork </plugin_knife_spork.html>`__
 
-**knife supermarket**: `supermarket download </knife_supermarket.html#download>`__ | `supermarket install </knife_supermarket.html#install>`__ | `supermarket list </plugin_knife_supermarket.html#list>`__ | `supermarket search </plugin_knife_supermarket.html#search>`__ | `supermarket share </plugin_knife_supermarket.html#share>`__ | `supermarket show </plugin_knife_supermarket.html#show>`__ | `supermarket unshare </plugin_knife_supermarket.html#unshare>`__
+**knife supermarket**: `supermarket download </knife_supermarket.html#download>`__ | `supermarket install </knife_supermarket.html#install>`__ | `supermarket list </knife_supermarket.html#list>`__ | `supermarket search </knife_supermarket.html#search>`__ | `supermarket share </knife_supermarket.html#share>`__ | `supermarket show </knife_supermarket.html#show>`__ | `supermarket unshare </knife_supermarket.html#unshare>`__
 
 **Ohai**: `About Ohai </ohai.html>`__ | `ohai (executable) </ctl_ohai.html>`__
 
@@ -338,7 +338,7 @@ Managing the Server
 
 **Push Jobs**: `knife push jobs </plugin_knife_push_jobs.html>`__ | `push-jobs-client </ctl_push_jobs_client.html>`__ | `push-jobs-client.rb </config_rb_push_jobs_client.html>`__ | `push-jobs-server.rb </config_rb_push_jobs_server.html>`__ | `Push Jobs API </api_push_jobs.html>`__ | `Server Sent Events </server_sent_events.html>`__
 
-**Supermarket**: `Log Files </supermarket_logs.html>`__ | `Backup and Restore </supermarket_backup_restore.html>`__ | `Monitoring </supermarket_monitor.html>`__ | `supermarket.rb </config_rb_supermarket.html>`__ | `knife supermarket </plugin_knife_supermarket.html>`__ | `supermarket-ctl </ctl_supermarket.html>`__ | `Supermarket API </supermarket_api.html>`__
+**Supermarket**: `Log Files </supermarket_logs.html>`__ | `Backup and Restore </supermarket_backup_restore.html>`__ | `Monitoring </supermarket_monitor.html>`__ | `supermarket.rb </config_rb_supermarket.html>`__ | `knife supermarket </knife_supermarket.html>`__ | `supermarket-ctl </ctl_supermarket.html>`__ | `Supermarket API </supermarket_api.html>`__
 
 **Management Console**: `Configure SAML </server_configure_saml.html>`__ | `Clients </server_manage_clients.html>`__ | `Cookbooks </server_manage_cookbooks.html>`__ | `Data Bags </server_manage_data_bags.html>`__ | `Environments </server_manage_environments.html>`__ | `Nodes </server_manage_nodes.html>`__ | `Roles </server_manage_roles.html>`__ | `Users </server_users.html#chef-manage.html>`__ | `manage.rb </config_rb_manage.html>`__ | `chef-manage-ctl </ctl_manage.html>`__
 

--- a/chef_master/source/install_supermarket.rst
+++ b/chef_master/source/install_supermarket.rst
@@ -25,7 +25,6 @@ The private Chef Supermarket is installed behind the firewall on the internal ne
           The source code for Chef Supermarket is located at the following URLs:
 
           * The application itself: https://github.com/chef/supermarket. Report issues to: https://github.com/chef/supermarket/issues.
-          * The code that builds Chef Supermarket as a Chef package: https://github.com/chef/omnibus-supermarket. Use a Kitchen-based environment to build your own Chef packages.
           * The cookbook that is run by the ``supermarket-ctl reconfigure`` command: https://github.com/chef/supermarket/tree/master/omnibus/cookbooks/omnibus-supermarket
 
           .. end_tag
@@ -296,9 +295,9 @@ Install Supermarket Directly (without a cookbook)
 =====================================================
 While there are many benefits to using the cookbook method to install Supermarket, there are also cases where it's simpler to set up the Supermarket installation manually. These steps will walk you through the process of manually configuring your private Supermarket server.
 
-Before following these steps, be sure to complete the OAuth setup process detailed in the `Chef Identity </install_supermarket.html#chef-identity>`__ section of this guide.  
+Before following these steps, be sure to complete the OAuth setup process detailed in the `Chef Identity </install_supermarket.html#chef-identity>`__ section of this guide.
 
-#. `Download <https://downloads.chef.io/supermarket/>`__ the correct package for your operating system from ``downloads.chef.io``. 
+#. `Download <https://downloads.chef.io/supermarket/>`__ the correct package for your operating system from ``downloads.chef.io``.
 
 #. Install Supermarket using the appropriate package manager for your distribution:
 
@@ -340,7 +339,7 @@ Before following these steps, be sure to complete the OAuth setup process detail
    * ``chef_oauth2_verify_ssl`` is set to false, which is necessary when using a self-signed certificate without a properly configured certificate authority
    * ``fqdn`` should contain the desired URL that will be used to access your private Supermarket. If not specified, this default to the FQDN of the machine
 
- 
+
 #. Issue another ``reconfigure`` command to apply your changes:
 
    .. code-block:: none
@@ -395,4 +394,4 @@ Cookbook artifacts---tar.gz artifacts that are uploaded to Chef Supermarket when
    node.override['supermarket_omnibus']['config']['s3_region'] = 'some-place-3'
    node.override['supermarket_omnibus']['config']['s3_secret_access_key'] = 'yoursecretaccesskey'
 
-.. note:: Encrypted S3 buckets are currently not supported. 
+.. note:: Encrypted S3 buckets are currently not supported.

--- a/chef_master/source/knife_cookbook_site.rst
+++ b/chef_master/source/knife_cookbook_site.rst
@@ -17,7 +17,7 @@ The ``knife cookbook site`` subcommand is used to interact with cookbooks that a
 
 .. warning:: .. tag notes_knife_cookbook_site_use_devkit_berkshelf
 
-             Please consider managing community cookbooks using the version of Berkshelf that ships with the Chef development kit. For more information about the Chef development kit, see `About the Chef DK </about_chefdk.html>`__.
+             Please consider managing community cookbooks using the version of Berkshelf that ships with the Chef Development Kit. For more information about the Chef Development Kit, see `About the Chef DK </about_chefdk.html>`__.
 
              .. end_tag
 
@@ -31,11 +31,11 @@ Private Supermarket
 =====================================================
 To use the ``knife cookbook site`` command with a private Supermarket installation, you must first add the URL of your Supermarket to your ``knife.rb`` file:
 
-.. code-block:: ruby 
+.. code-block:: ruby
 
    knife[:supermarket_site] = 'https://supermarket.example.com'
 
-If this value is not specified, knife will use ``https://supermarket.chef.io`` by default. 
+If this value is not specified, knife will use ``https://supermarket.chef.io`` by default.
 
 download
 =====================================================

--- a/chef_master/source/knife_supermarket.rst
+++ b/chef_master/source/knife_supermarket.rst
@@ -207,6 +207,8 @@ To search for a cookbook, use a command similar to:
 
 where ``mysql`` is the search term. This will return something similar to:
 
+.. code-block:: bash
+
    mysql:
      cookbook:             https://supermarket.chef.io/api/v1/cookbooks/mysql
      cookbook_description: Provides mysql_service, mysql_config, and mysql_client resources

--- a/chef_master/source/knife_supermarket.rst
+++ b/chef_master/source/knife_supermarket.rst
@@ -16,7 +16,11 @@ The ``knife supermarket`` subcommand is used to interact with cookbooks that are
 
           .. end_tag
 
-.. note:: Review the list of `common options </knife_options>`_ available to this (and all) knife subcommands and plugins.
+.. note:: .. tag knife_common_see_common_options_link
+
+          Review the list of `common options </knife_options.html>`__ available to this (and all) knife subcommands and plugins.
+
+          .. end_tag
 
 download
 =====================================================

--- a/chef_master/source/knife_supermarket.rst
+++ b/chef_master/source/knife_supermarket.rst
@@ -3,12 +3,6 @@ knife supermarket
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/knife_supermarket.rst>`__
 
-.. tag supermarket_api_summary
-
-The Supermarket API is used to provide access to cookbooks, tools, and users on the `Chef Supermarket <https://supermarket.chef.io>`__. All of the cookbooks, tools, and users on the Supermarket are accessible through a RESTful API by accessing ``supermarket.chef.io/api/v1/`` via the supported endpoints. In most cases, knife is the best way to interact with the Supermarket; however in some cases, direct use of the Supermarket API is necessary.
-
-.. end_tag
-
 The ``knife supermarket`` subcommand is used to interact with cookbooks that are located in private Chef Supermarket configured inside the firewall. A user account is required for any community actions that write data to the Chef Supermarket; however, the following arguments do not require a user account: ``download``, ``search``, ``install``, and ``list``.
 
 .. note:: If you are interested in uploading to the supermarket as a company you might be interested

--- a/chef_master/source/knife_supermarket.rst
+++ b/chef_master/source/knife_supermarket.rst
@@ -1,7 +1,7 @@
 =====================================================
 knife supermarket
 =====================================================
-`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/plugin_knife_supermarket.rst>`__
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/knife_supermarket.rst>`__
 
 .. tag supermarket_api_summary
 

--- a/chef_master/source/knife_supermarket.rst
+++ b/chef_master/source/knife_supermarket.rst
@@ -3,7 +3,7 @@ knife supermarket
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/knife_supermarket.rst>`__
 
-The ``knife supermarket`` subcommand is used to interact with cookbooks that are located in private Chef Supermarket configured inside the firewall. A user account is required for any community actions that write data to the Chef Supermarket; however, the following arguments do not require a user account: ``download``, ``search``, ``install``, and ``list``.
+The ``knife supermarket`` subcommand is used to interact with cookbooks that are located in on the public Supermarket as well as private Chef Supermarket sites. A user account is required for any community actions that write data to the Chef Supermarket; however, the following arguments do not require a user account: ``download``, ``search``, ``install``, and ``list``.
 
 .. note:: If you are interested in uploading to the supermarket as a company you might be interested
           in looking at the `Chef Partner Cookbook Program <https://www.chef.io/partners/cookbooks/>`__

--- a/chef_master/source/plugin_knife_supermarket.rst
+++ b/chef_master/source/plugin_knife_supermarket.rst
@@ -3,8 +3,6 @@ knife supermarket
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/plugin_knife_supermarket.rst>`__
 
-.. warning:: Only use knife supermarket if you are using a Chef 12.12 or earlier. If you are using Chef 12.13 or later, you should use the `knife cookbook site </knife_cookbook_site.html>`__ commands.
-
 .. tag supermarket_api_summary
 
 The Supermarket API is used to provide access to cookbooks, tools, and users on the `Chef Supermarket <https://supermarket.chef.io>`__. All of the cookbooks, tools, and users on the Supermarket are accessible through a RESTful API by accessing ``supermarket.chef.io/api/v1/`` via the supported endpoints. In most cases, knife is the best way to interact with the Supermarket; however in some cases, direct use of the Supermarket API is necessary.
@@ -20,7 +18,7 @@ The ``knife supermarket`` subcommand is used to interact with cookbooks that are
 
 .. note:: .. tag notes_knife_cookbook_site_use_devkit_berkshelf
 
-          Please consider managing community cookbooks using the version of Berkshelf that ships with the Chef development kit. For more information about the Chef development kit, see `About the Chef DK </about_chefdk.html>`__.
+          Please consider managing community cookbooks using the version of Berkshelf that ships with the Chef Development Kit. For more information about the Chef Development Kit, see `About the Chef DK </about_chefdk.html>`__.
 
           .. end_tag
 
@@ -212,17 +210,17 @@ To search for a cookbook, use a command similar to:
 where ``mysql`` is the search term. This will return something similar to:
 
    mysql:
-     cookbook:             http://cookbooks.opscode.com/api/v1/cookbooks/mysql
+     cookbook:             https://supermarket.chef.io/api/v1/cookbooks/mysql
      cookbook_description: Provides mysql_service, mysql_config, and mysql_client resources
      cookbook_maintainer:  chef
      cookbook_name:        mysql
    mysql-apt-config:
-     cookbook:             http://cookbooks.opscode.com/api/v1/cookbooks/mysql-apt-config
+     cookbook:             https://supermarket.chef.io/api/v1/cookbooks/mysql-apt-config
      cookbook_description: Installs/Configures mysql-apt-config
      cookbook_maintainer:  tata
      cookbook_name:        mysql-apt-config
    mysql-multi:
-     cookbook:             http://cookbooks.opscode.com/api/v1/cookbooks/mysql-multi
+     cookbook:             https://supermarket.chef.io/api/v1/cookbooks/mysql-multi
      cookbook_description: MySQL replication wrapper cookbook
      cookbook_maintainer:  rackops
      cookbook_name:        mysql-multi
@@ -305,18 +303,18 @@ to return something similar to:
 .. code-block:: bash
 
    average_rating:
-   category:           Other
-   created_at:         2009-10-28T19:16:54.000Z
-   deprecated:         false
-   description:        Provides mysql_service, mysql_config, and mysql_client resources
-   external_url:       https://github.com/chef-cookbooks/mysql
-   foodcritic_failure: true
-   issues_url:
-   latest_version:     http://cookbooks.opscode.com/api/v1/cookbooks/mysql/versions/6.0.15
-   maintainer:         chef
+   category:        Other
+   created_at:      2009-10-28T19:16:54.000Z
+   deprecated:      false
+   description:     Provides mysql_service, mysql_config, and mysql_client resources
+   external_url:    https://github.com/chef-cookbooks/mysql
+   issues_url:      https://github.com/chef-cookbooks/mysql/issues
+   latest_version:  https://supermarket.chef.io/api/v1/cookbooks/mysql/versions/8.5.1
+   maintainer:      sous-chefs
    metrics:
+     collaborators: 2
      downloads:
-       total:    79275449
+       total:    128998032
      versions:
        0.10.0: 927561
        0.15.0: 927536
@@ -337,18 +335,64 @@ To show the details for a cookbook version, run a command similar to:
 
 .. code-block:: bash
 
-   $ knife supermarket show mysql 0.10.0
+   $ knife supermarket show mysql 8.5.1
 
-where ``mysql`` is the cookbook and ``0.10.0`` is the cookbook version. This will return something similar to:
+where ``mysql`` is the cookbook and ``8.5.1`` is the cookbook version. This will return something similar to:
 
 .. code-block:: bash
 
-   average_rating:
-   cookbook:          http://cookbooks.opscode.com/api/v1/cookbooks/mysql
-   file:              http://cookbooks.opscode.com/api/v1/cookbooks/mysql/versions/0.10.0/download
-   license:           Apache 2.0
-   tarball_file_size: 7010
-   version:           0.10.0
+    average_rating:
+    cookbook:          https://supermarket.chef.io/api/v1/cookbooks/mysql
+    file:              https://supermarket.chef.io/api/v1/cookbooks/mysql/versions/8.5.1/download
+    license:           Apache-2.0
+    published_at:      2017-08-23T19:01:28Z
+    quality_metrics:
+      failed:   false
+      feedback: passed the No Binaries metric. Contains no obvious binaries.
+      name:     No Binaries
+
+      failed:   false
+      feedback: mysql passed the publish metric
+      name:     Publish
+
+      failed:   false
+      feedback: mysql supports at least one platform.
+      name:     Supported Platforms
+
+      failed:   false
+      feedback: passed the Collaborators Metric with 2 collaborators.
+      name:     Collaborator Number
+
+      failed:   false
+      feedback:
+      Run with Foodcritic Version 14.0.0 with tags metadata,correctness ~FC031 ~FC045 and failure tags any
+      name:     Foodcritic
+
+      failed:   false
+      feedback: passed the CONTRIBUTING.md file metric.
+      name:     Contributing File
+
+      failed:   false
+      feedback: passed the version tag metric.
+      name:     Version Tag
+
+      failed:   false
+      feedback: passed the TESTING.md file metric.
+      name:     Testing File
+    supports:
+      amazon:       >= 0.0.0
+      centos:       >= 6.0
+      debian:       >= 7.0
+      fedora:       >= 0.0.0
+      opensuse:     >= 13.0
+      opensuseleap: >= 0.0.0
+      oracle:       >= 6.0
+      redhat:       >= 6.0
+      scientific:   >= 6.0
+      suse:         >= 12.0
+      ubuntu:       >= 12.04
+    tarball_file_size: 23763
+    version:           8.5.1
 
 unshare
 =====================================================

--- a/chef_master/source/supermarket.rst
+++ b/chef_master/source/supermarket.rst
@@ -37,7 +37,6 @@ The private Chef Supermarket is installed behind the firewall on the internal ne
           The source code for Chef Supermarket is located at the following URLs:
 
           * The application itself: https://github.com/chef/supermarket. Report issues to: https://github.com/chef/supermarket/issues.
-          * The code that builds Chef Supermarket as a Chef package: https://github.com/chef/omnibus-supermarket. Use a Kitchen-based environment to build your own Chef packages.
           * The cookbook that is run by the ``supermarket-ctl reconfigure`` command: https://github.com/chef/supermarket/tree/master/omnibus/cookbooks/omnibus-supermarket
 
           .. end_tag
@@ -71,35 +70,6 @@ To install a Private Supermarket, see the instructions `here </install_supermark
 
 Set up Workstation
 -----------------------------------------------------
-If you are using Chef 12.13 or higher, use the `knife cookbook site </knife_cookbook_site.html>`__ commands to work with cookbooks in both Public Chef Supermarket and a Private Chef Supermarket.
-
-If you are using Chef 12.12 or lower, use the ``knife supermarket`` plugin to work with cookbooks in a Private Chef Supermarket.
-
-knife
-+++++++++++++++++++++++++++++++++++++++++++++++++++++
-Chef 12.13 and higher
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you are using Chef 12.13 or higher, use the `knife cookbook site </knife_cookbook_site.html>`__ commands with BOTH Public Supermarket and Private Supermarket.
-
-Chef 12.12 and lower
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you are using Chef 12.12 or a previous version, you will need to use ``knife supermarket``.
-
-The ``knife supermarket`` command is a plugin that must be installed to the workstation.
-
-If using the Chef development kit, run the following command:
-
-.. code-block:: bash
-
-   $ chef gem install knife-supermarket
-
-and if not using the Chef development kit, run the following command:
-
-.. code-block:: bash
-
-   $ gem install knife-supermarket
 
 Configure knife.rb
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -118,7 +88,7 @@ To configure knife.rb for the private Chef Supermarket, do the following:
 
 Create a Cookbook
 -----------------------------------------------------
-The following examples show how to create a simple cookbook by using the chef command that is built into the the Chef development kit.
+The following examples show how to create a simple cookbook by using the chef command that is built into the the Chef Development Kit.
 
 **Generate a chef-repo**
 
@@ -184,16 +154,6 @@ Upload a Cookbook
 -----------------------------------------------------
 To upload a cookbook to Chef Supermarket, do the following:
 
-#. Determine which version of Chef you are using.
-
-   If you are using Chef 12.13 or later, you have everything you need in the knife cookbook site commands
-
-   If you are using Chef 12.12 or earlier, you need to install the ``knife supermarket`` plugin:
-
-   .. code-block:: bash
-
-      $ chef gem install knife-supermarket
-
 #. Add a setting for Chef Supermarket to the knife.rb file:
 
    .. code-block:: ruby
@@ -214,27 +174,12 @@ To upload a cookbook to Chef Supermarket, do the following:
 
 #. Upload the cookbook to Chef Supermarket:
 
-   If you are using Chef 12.13 or later:
-
-   .. code-block:: bash
-
-      $ knife cookbook site share mycookbook "Other"
-
-   If you are using Chef 12.12 or earlier:
-
    .. code-block:: bash
 
       $ knife supermarket share mycookbook "Other"
 
 Share a Cookbook
 -----------------------------------------------------
-If you are using Chef 12.13 or later, a cookbook may be shared to the private Chef Supermarket using the ``knife cookbook site``` commands.
-
-.. code-block:: bash
-
-   $ knife cookbook site share 'my_cookbook'
-
-If you are using Chef 12.12 or lower, a cookbook may be shared to the private Chef Supermarket using the ``knife supermarket`` command. Run the following command:
 
 .. code-block:: bash
 
@@ -303,8 +248,6 @@ For more information about the Supermarket API, see `Supermarket API </supermark
 fieri
 -----------------------------------------------------
 Fieri is an optional service what will check cookbook versions for certain metrics to determine the quality of the cookbook.
-
-As of Supermarket 2.7, Fieri now lives within the Supermarket code base.
 
 If you are using a private Chef Supermarket, you can activate the Fieri service like this:
 

--- a/config/redirects.json
+++ b/config/redirects.json
@@ -661,7 +661,7 @@
   "release/devkit/plugin_community.html": "/plugin_community.html",
   "release/devkit/plugin_kitchen_vagrant.html": "/plugin_kitchen_vagrant.html",
   "release/devkit/plugin_knife_spork.html": "/plugin_knife_spork.html",
-  "release/devkit/plugin_knife_supermarket.html": "/plugin_knife_supermarket.html",
+  "release/devkit/plugin_knife_supermarket.html": "/knife_supermarket.html",
   "release/devkit/policyfile.html": "/policyfile.html",
   "release/devkit/provisioning.html": "/provisioning.html",
   "release/devkit/provisioning_aws.html": "/provisioning_aws.html",
@@ -768,7 +768,7 @@
   "release/supermarket/ctl_supermarket.html": "/ctl_supermarket.html",
   "release/supermarket/index.html": "/supermarket.html",
   "release/supermarket/install_supermarket.html": "/install_supermarket.html",
-  "release/supermarket/plugin_knife_supermarket.html": "/plugin_knife_supermarket.html",
+  "release/supermarket/plugin_knife_supermarket.html": "/knife_supermarket.html",
   "release/supermarket/supermarket.html": "/supermarket.html",
   "release/supermarket/supermarket_logs.html": "/supermarket_logs.html",
   "release/supermarket/supermarket_monitor.html": "/supermarket_monitor.html",
@@ -780,5 +780,6 @@
   "integrate_compliance_chef_automate.html": "/perform_compliance_scan.html",
   "job_dispatch.html": "/runners.html",
   "audit_supported_configurations.html": "/audit_cookbook.html",
-  "setup_visibility_chef_automate.html": "/data_collection.html"
+  "setup_visibility_chef_automate.html": "/data_collection.html",
+  "plugin_knife_supermarket.html": "/knife_supermarket.html"
 }

--- a/misc/sitemap.xml
+++ b/misc/sitemap.xml
@@ -1162,7 +1162,7 @@
 
 
 <url>
-<loc>https://docs.chef.io/plugin_knife_supermarket.html</loc>
+<loc>https://docs.chef.io/knife_supermarket.html</loc>
 </url>
 
 


### PR DESCRIPTION
In Chef 13+ we ship both the knife cookbook site and knife supermarket commands. The cookbook site was the pre-2014 site and we decided that in Chef 15 we're going to deprecate the old cookbook site commands. The first step is updating our docs to suggest everyone use the supermarket commands.

Also fixes a few inaccurate statements about Supermarket

Signed-off-by: Tim Smith <tsmith@chef.io>