### PR TITLE
Add missing redirect for the old knife.rb page

### DIFF
--- a/config/redirects.json
+++ b/config/redirects.json
@@ -1,4 +1,5 @@
 {
+  "config_rb_knife.html": "/config_rb.html",
   "config_rb_knife_optional_settings.html": "/config_rb_optional_settings.html",
   "workstation.html": "/chefdk_setup.html",
   "resource_env.html": "/resource_windows_env.html",


### PR DESCRIPTION
I missed this and the current search links point to it.

Signed-off-by: Tim Smith <tsmith@chef.io>