### PR TITLE
Remove references to definitions

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -503,11 +503,6 @@
             "url": "/attributes.html"
           },
           {
-            "title": "Definitions",
-            "hasSubItems": false,
-            "url": "/definitions.html"
-          },
-          {
             "title": "Files",
             "hasSubItems": false,
             "url": "/files.html"

--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -152,7 +152,7 @@ This configuration file has the following settings:
       license 'Proprietary - All Rights Reserved'
 
 ``long_description``
-   A longer description that ideally contains full instructions on the proper use of a cookbook, including definitions, libraries, dependencies, and so on. There are two ways to use this field: with the contents embedded in the field itself or with the contents pulled from a file at a specified path, such as a README.rdoc located at the top of a cookbook directory.
+   A longer description that ideally contains full instructions on the proper use of a cookbook, including resources, libraries, dependencies, and so on. There are two ways to use this field: with the contents embedded in the field itself or with the contents pulled from a file at a specified path, such as a README.rdoc located at the top of a cookbook directory.
 
    For example, to embed the long description within the field itself:
 
@@ -244,12 +244,6 @@ This configuration file has the following settings:
 
       provides 'cats::sleep'
       provides 'cats::eat'
-
-   For definitions:
-
-   .. code-block:: ruby
-
-      provides 'here(:kitty, :time_to_eat)'
 
    And for resources:
 

--- a/chef_master/source/cookbook_repo.rst
+++ b/chef_master/source/cookbook_repo.rst
@@ -190,7 +190,7 @@ This configuration file has the following settings:
       license 'Proprietary - All Rights Reserved'
 
 ``long_description``
-   A longer description that ideally contains full instructions on the proper use of a cookbook, including definitions, libraries, dependencies, and so on. There are two ways to use this field: with the contents embedded in the field itself or with the contents pulled from a file at a specified path, such as a README.rdoc located at the top of a cookbook directory.
+   A longer description that ideally contains full instructions on the proper use of a cookbook, including resources, libraries, dependencies, and so on. There are two ways to use this field: with the contents embedded in the field itself or with the contents pulled from a file at a specified path, such as a README.rdoc located at the top of a cookbook directory.
 
    For example, to embed the long description within the field itself:
 
@@ -282,12 +282,6 @@ This configuration file has the following settings:
 
       provides 'cats::sleep'
       provides 'cats::eat'
-
-   For definitions:
-
-   .. code-block:: ruby
-
-      provides 'here(:kitty, :time_to_eat)'
 
    And for resources:
 

--- a/chef_master/source/cookbooks.rst
+++ b/chef_master/source/cookbooks.rst
@@ -62,8 +62,6 @@ In addition to attributes and recipes, the following items are also part of cook
 
    * - Components
      - Description
-   * - `Definitions </definitions.html>`__
-     - A definition is used to create new resources by stringing together one (or more) existing resources.
    * - `Files </files.html>`__
      - A file distribution is a specific type of resource that tells a cookbook how to distribute files, including by node, by platform, or by file version.
    * - `Libraries </libraries.html>`__

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -116,7 +116,6 @@ Cookbook Reference
 -----------------------------------------------------
 `About Cookbooks </cookbooks.html>`__ |
 `Attributes </attributes.html>`__ |
-`Definitions </definitions.html>`__ |
 `Files </files.html>`__ |
 `Libraries </libraries.html>`__
 

--- a/chef_master/source/server_manage_cookbooks.rst
+++ b/chef_master/source/server_manage_cookbooks.rst
@@ -58,25 +58,6 @@ A cookbook can contain the following types of files:
 
        .. end_tag
 
-   * - Definitions
-     - .. tag 4
-
-       A definition is code that is reused across recipes, similar to a compile-time macro. A definition is created using arbitrary code wrapped around built-in chef-client resources---**file**, **execute**, **template**, and so on---by declaring those resources into the definition as if they were declared in a recipe. A definition is then used in one (or more) recipes as if it were a resource.
-
-       Though a definition behaves like a resource, some key differences exist. A definition:
-
-       * Is not a resource or a custom resource
-       * Is defined from within the ``/definitions`` directory of a cookbook
-       * Is loaded before resources during the chef-client run; this ensures the definition is available to all of the resources that may need it
-       * May not notify resources in the resource collection because a definition is loaded **before** the resource collection itself is created; however, a resource in a definition **may** notify a resource that exists within the same definition
-       * Automatically supports why-run mode, unlike custom resources
-
-       Use a definition when repeating patterns exist across resources and/or when a simple, direct approach is desired. There is no limit to the number of resources that may be included in a definition: use as many built-in chef-client resources as necessary.
-
-       .. end_tag
-
-       .. warning:: Starting with chef-client 12.5, it is recommended to `build custom resources </custom_resources.html>`__ instead of definitions and to `migrate existing definitions to be custom resources </definitions.html>`__.
-
    * - Files
      - .. tag resource_cookbook_file_summary
 
@@ -222,4 +203,3 @@ To view permissions for a cookbook object:
 #. Select a cookbook.
 #. Click the **Permissions** tab.
 #. Set the appropriate permissions: **Delete**, **Grant**, **Read**, and/or **Update**.
-


### PR DESCRIPTION
This is one of those features that causes people to have a really bad time with Chef. We've been warning for many years to not use this feature in Foodcritic and we've had a warning on the docs site since mid Chef 12. This is the next step in our deprecation of this feature: Hide it unless someone has it bookmarked.

In the near future we'll begin throwing formal deprecation warnings in the chef-client and then we'll remove the feature altogether.

Signed-off-by: Tim Smith <tsmith@chef.io>