### PR TITLE
Remove ohai from the list of things in DK

### DIFF
--- a/chef_master/source/about_chefdk.rst
+++ b/chef_master/source/about_chefdk.rst
@@ -7,7 +7,7 @@ About the Chef DK
 
 The Chef Development Kit is a package that contains everything that is needed to start using Chef:
 
-* chef-client and ohai
+* chef-client
 * chef and knife command line tools
 * Testing tools such as Test Kitchen, ChefSpec, Cookstyle, and Foodcritic
 * InSpec

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -123,7 +123,7 @@ Some important tools and components of Chef workstations include:
 
        The Chef Development Kit is a package that contains everything that is needed to start using Chef:
 
-       * chef-client and ohai
+       * chef-client
        * chef and knife command line tools
        * Testing tools such as Test Kitchen, ChefSpec, Cookstyle, and Foodcritic
        * InSpec


### PR DESCRIPTION
No one actually cares about Ohai. As the maintainer I can say that. It silently does it's still and makes Chef work, but doesn't need to get called out here.