### PR TITLE
Remove a leftover mention of downloading the chef-repo

### DIFF
--- a/chef_master/source/chef_repo.rst
+++ b/chef_master/source/chef_repo.rst
@@ -173,15 +173,7 @@ Example config.rb:
 
 Create the chef-repo
 =====================================================
-There are two ways to create a chef-repo when using the Chef boilerplate repository as a base:
 
-* Clone the chef-repo from GitHub
-* Download the chef-repo as a tar.gz file and place it into local version source control.
-
-.. note:: Chef strongly recommends using some type of version control tool to manage the source code in the chef-repo. Chef uses git for everything, including for cookbooks. git and/or GitHub is not required to use Chef. If another version source control system is preferred over git (such as Subversion, Mercurial, or Bazaar) that is just fine.
-
-Generate
------------------------------------------------------
 To create a chef-repo, run the following command:
 
 .. code-block:: bash


### PR DESCRIPTION
No point in an empty examples block