### PR TITLE
Remove note about a now deprecated ChefDK release

### DIFF
--- a/chef_master/source/ctl_chef.rst
+++ b/chef_master/source/ctl_chef.rst
@@ -343,7 +343,6 @@ will return something similar to:
 
 chef generate cookbook
 =====================================================
-Changed in Chef DK 1.3, ``chef generate cookbook`` requires Chef client 12.1+, includes the chef_version metadata, and uses SPDX standard license strings.
 
 Use the ``chef generate cookbook`` subcommand to generate a cookbook.
 


### PR DESCRIPTION
We've actually changed this all a few times.