### PR TITLE
Remove Chef 11 note about partial_search

### DIFF
--- a/chef_master/source/chef_search.rst
+++ b/chef_master/source/chef_search.rst
@@ -222,12 +222,6 @@ Filter Search Results
 
 Use ``:filter_result`` as part of a search query to filter the search output based on the pattern specified by a Hash. Only attributes in the Hash will be returned.
 
-.. note:: .. tag notes_filter_search_vs_partial_search
-
-          Prior to chef-client 12.0, this functionality was available from the ``partial_search`` cookbook and was referred to as "partial search".
-
-          .. end_tag
-
 The syntax for the ``search`` method that uses ``:filter_result`` is as follows:
 
 .. code-block:: ruby

--- a/chef_master/source/dsl_recipe.rst
+++ b/chef_master/source/dsl_recipe.rst
@@ -835,12 +835,6 @@ and then using the results of that query to populate a template:
 
 Use ``:filter_result`` as part of a search query to filter the search output based on the pattern specified by a Hash. Only attributes in the Hash will be returned.
 
-.. note:: .. tag notes_filter_search_vs_partial_search
-
-          Prior to chef-client 12.0, this functionality was available from the ``partial_search`` cookbook and was referred to as "partial search".
-
-          .. end_tag
-
 The syntax for the ``search`` method that uses ``:filter_result`` is as follows:
 
 .. code-block:: ruby

--- a/chef_master/source/knife_search.rst
+++ b/chef_master/source/knife_search.rst
@@ -689,12 +689,6 @@ This subcommand has the following options:
 ``-f FILTER``, ``--filter-result FILTER``
    Use to filter the search output based on the pattern that matches the specified ``FILTER``. Only attributes in the ``FILTER`` will be returned. For example: ``\"ServerName=name, Kernel=kernel.version\``.
 
-   .. note:: .. tag notes_filter_search_vs_partial_search
-
-             Prior to chef-client 12.0, this functionality was available from the ``partial_search`` cookbook and was referred to as "partial search".
-
-             .. end_tag
-
 ``-i``, ``--id-only``
    Show only matching object IDs.
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -9974,15 +9974,12 @@ The following configuration settings are updated for the client.rb file and now 
 
 Filter Search Results
 -----------------------------------------------------
-.. tag dsl_recipe_method_search_filter_result
 
 Use ``:filter_result`` as part of a search query to filter the search output based on the pattern specified by a Hash. Only attributes in the Hash will be returned.
 
 .. note:: .. tag notes_filter_search_vs_partial_search
 
           Prior to chef-client 12.0, this functionality was available from the ``partial_search`` cookbook and was referred to as "partial search".
-
-          .. end_tag
 
 The syntax for the ``search`` method that uses ``:filter_result`` is as follows:
 
@@ -10019,8 +10016,6 @@ For example:
      puts result['ip']
      puts result['kernel_version']
    end
-
-.. end_tag
 
 knife search
 +++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -9977,7 +9977,7 @@ Filter Search Results
 
 Use ``:filter_result`` as part of a search query to filter the search output based on the pattern specified by a Hash. Only attributes in the Hash will be returned.
 
-.. note:: .. tag notes_filter_search_vs_partial_search
+.. note:: ..
 
           Prior to chef-client 12.0, this functionality was available from the ``partial_search`` cookbook and was referred to as "partial search".
 


### PR DESCRIPTION
We can 100% assume everyone is on Chef 12 now and we have a Foodcritic warning for this anyways.

Signed-off-by: Tim Smith <tsmith@chef.io>