### PR TITLE
Remove documentation for long ago deprecated features

### DIFF
--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -839,32 +839,6 @@ This argument has the following options:
 ``--cert-path PATH``
    The path to the location of the SSL certificate.
 
-``-d DISTRO``, ``--distro DISTRO``
-   .. tag knife_bootstrap_distro
-
-   The template file to be used during a bootstrap operation. The following distributions are supported:
-
-   * ``chef-full`` (the default bootstrap)
-   * ``centos5-gems``
-   * ``fedora13-gems``
-   * ``ubuntu10.04-gems``
-   * ``ubuntu10.04-apt``
-   * ``ubuntu12.04-gems``
-   * The name of a custom bootstrap template file.
-
-   When this option is used, knife searches for the template file in the following order:
-
-   #. The ``bootstrap/`` folder in the current working directory
-   #. The ``bootstrap/`` folder in the chef-repo
-   #. The ``bootstrap/`` folder in the ``~/.chef/`` directory
-   #. A default bootstrap file.
-
-   Do not use the ``--template-file`` option when ``--distro`` is specified.
-
-   .. end_tag
-
-   Deprecated in Chef Client 12.0,
-
 ``-H HOST_NAME``, ``--azure_host_name HOST_NAME``
    The host name for the virtual machine.
 


### PR DESCRIPTION
We deprecated this many years ago and it's since been removed from Chef.

Signed-off-by: Tim Smith <tsmith@chef.io>