### PR TITLE
Remove the option to install chef-client as a windows service

### DIFF
--- a/chef_master/source/install_windows.rst
+++ b/chef_master/source/install_windows.rst
@@ -61,48 +61,20 @@ The ``ADDLOCAL`` parameter adds two setup options that are specific to the chef-
      - Use to install the chef-client.
    * - ``ChefSchTaskFeature``
      - Use to configure the chef-client as a scheduled task in Microsoft Windows.
-   * - ``ChefServiceFeature``
-     - Use to configure the chef-client as a service in Microsoft Windows.
    * - ``ChefPSModuleFeature``
      - Used to install the chef PowerShell module. This will enable chef command line utilities within PowerShell.
 
-First install the chef-client, and then enable it to run as a scheduled task (recommended) or as a service. For example:
+First install the chef-client, and then enable it to run as a scheduled task. For example:
 
 .. code-block:: bash
 
-   $ msiexec /qn /i C:\inst\chef-client-12.4.3-1.windows.msi ADDLOCAL="ChefClientFeature,ChefSchTaskFeature,ChefPSModuleFeature"
-
-OR
-
-.. code-block:: bash
-
-   $ msiexec /qn /i C:\inst\chef-client-12.4.3-1.windows.msi ADDLOCAL="ChefClientFeature,ChefServiceFeature,ChefPSModuleFeature"
+   $ msiexec /qn /i C:\inst\chef-client-14.5.27-1-x64.msi ADDLOCAL="ChefClientFeature,ChefSchTaskFeature,ChefPSModuleFeature"
 
 .. end_tag
 
 Use MSI Installer
 =====================================================
 A Microsoft Installer Package (MSI) is available for installing the chef-client on a Microsoft Windows machine at `Chef Downloads <https://downloads.chef.io/>`__
-
-Run as a Service
------------------------------------------------------
-.. tag install_chef_client_windows_as_service
-
-To run the chef-client at periodic intervals (so that it can check in with the Chef server automatically), configure the chef-client to run as a service. This can be done via the MSI, by selecting the **Chef Unattended Execution Options** --> **Chef Client Service** option on the **Custom Setup** page or by running the following command after the chef-client is installed:
-
-.. code-block:: bash
-
-   $ chef-service-manager -a install
-
-and then start the chef-client as a service:
-
-.. code-block:: bash
-
-   $ chef-service-manager -a start
-
-After the chef-client is configured to run as a service, the default file path is: ``c:\chef\chef-client.log``.
-
-.. end_tag
 
 Run as a Scheduled Task
 -----------------------------------------------------
@@ -125,11 +97,9 @@ For example:
 
    $ SCHTASKS.EXE /CREATE /TN ChefClientSchTask /SC MINUTE /MO 30 /F /RU "System" /RP /RL HIGHEST /TR "cmd /c \"C:\opscode\chef\embedded\bin\ruby.exe C:\opscode\chef\bin\chef-client -L C:\chef\chef-client.log -c C:\chef\client.rb\""
 
-Refer `Schedule a Task <https://technet.microsoft.com/en-us/library/cc748993%28v=ws.11%29.aspx>`_ for more details.
+Refer `Schedule a Task <https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc748993(v=ws.11)>`_ for more details.
 
 After the chef-client is configured to run as a scheduled task, the default file path is: ``c:\chef\chef-client.log``.
-
-Using a scheduled task is a recommended approach. Refer to `Should I run chef-client on Windows as a 'service' or a 'scheduled task'? <https://getchef.zendesk.com/hc/en-us/articles/205233360-Should-I-run-chef-client-on-Windows-as-a-service-or-a-scheduled-task->`_ for additional information on the differences between the two approaches.
 
 .. end_tag
 

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -129,22 +129,14 @@ The ``ADDLOCAL`` parameter adds two setup options that are specific to the chef-
      - Use to install the chef-client.
    * - ``ChefSchTaskFeature``
      - Use to configure the chef-client as a scheduled task in Microsoft Windows.
-   * - ``ChefServiceFeature``
-     - Use to configure the chef-client as a service in Microsoft Windows.
    * - ``ChefPSModuleFeature``
      - Used to install the chef PowerShell module. This will enable chef command line utilities within PowerShell.
 
-First install the chef-client, and then enable it to run as a scheduled task (recommended) or as a service. For example:
+First install the chef-client, and then enable it to run as a scheduled task. For example:
 
 .. code-block:: bash
 
-   $ msiexec /qn /i C:\inst\chef-client-12.4.3-1.windows.msi ADDLOCAL="ChefClientFeature,ChefSchTaskFeature,ChefPSModuleFeature"
-
-OR
-
-.. code-block:: bash
-
-   $ msiexec /qn /i C:\inst\chef-client-12.4.3-1.windows.msi ADDLOCAL="ChefClientFeature,ChefServiceFeature,ChefPSModuleFeature"
+   $ msiexec /qn /i C:\inst\chef-client-14.5.27-1-x64.msi ADDLOCAL="ChefClientFeature,ChefSchTaskFeature,ChefPSModuleFeature"
 
 .. end_tag
 
@@ -164,11 +156,9 @@ For example:
 
    $ SCHTASKS.EXE /CREATE /TN ChefClientSchTask /SC MINUTE /MO 30 /F /RU "System" /RP /RL HIGHEST /TR "cmd /c \"C:\opscode\chef\embedded\bin\ruby.exe C:\opscode\chef\bin\chef-client -L C:\chef\chef-client.log -c C:\chef\client.rb\""
 
-Refer `Schedule a Task <https://technet.microsoft.com/en-us/library/cc748993%28v=ws.11%29.aspx>`_ for more details.
+Refer `Schedule a Task <https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc748993(v=ws.11)>`_ for more details.
 
 After the chef-client is configured to run as a scheduled task, the default file path is: ``c:\chef\chef-client.log``.
-
-Using a scheduled task is a recommended approach. Refer to `Should I run chef-client on Windows as a 'service' or a 'scheduled task'? <https://getchef.zendesk.com/hc/en-us/articles/205233360-Should-I-run-chef-client-on-Windows-as-a-service-or-a-scheduled-task->`_ for additional information on the differences between the two approaches.
 
 .. end_tag
 
@@ -3603,7 +3593,7 @@ The full syntax for all of the properties that are available to the **registry_k
     architecture      Symbol # default value: machine
     key               String # default value: 'name' unless specified
     recursive         true, false # default value: false
-    values            
+    values
     action            Symbol # defaults to :create if not specified
   end
 
@@ -3978,12 +3968,12 @@ This resource has the following properties:
 
 ``retries``
    **Ruby Type:** Integer | **Default Value:** ``0``
-  
+
    The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
    **Ruby Type:** Integer | **Default Value:** ``2``
-  
+
    The retry delay (in seconds).
 
 ``sensitive``


### PR DESCRIPTION
This isn't a thing anymore and isn't a thing in any supported release of Chef.