### PR TITLE
Rename the proxy doc and move it

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -318,11 +318,6 @@
         "hasSubItems": true,
         "subItems": [
           {
-            "title": "Proxies",
-            "hasSubItems": false,
-            "url": "/proxies.html"
-          },
-          {
             "title": "Workstation",
             "hasSubItems": false,
             "url": "/install_dk.html"
@@ -393,6 +388,11 @@
                 "url": "/install_server_ha.html"
               }
             ]
+          },
+          {
+            "title": "Working with Proxies",
+            "hasSubItems": false,
+            "url": "/proxies.html"
           },
           {
             "title": "Air-gapped Installation",

--- a/chef_master/source/install_chef_automate.rst
+++ b/chef_master/source/install_chef_automate.rst
@@ -391,7 +391,7 @@ to complete successfully. These can be set in the environment directly, or added
 Any host that needs to make outgoing http or https connections will require these settings as well. For example, the Chef Automate server
 (which makes knife calls to Chef server) and Chef server (for push jobs) should have these configured. To update the Chef Automate server, update ``/etc/delivery/delivery.rb`` on your Chef Automate server with the values specified in `Proxy Settings </config_rb_delivery.html#proxy-settings>`_. After you have configured your settings, run ``sudo automate-ctl reconfigure``.
 
-For general information on proxy settings, please see `About Proxies </proxies.html>`__.
+For general information on proxy settings, please see `Working with Proxies </proxies.html>`__.
 
 Compliance
 ===================================================================

--- a/chef_master/source/proxies.rst
+++ b/chef_master/source/proxies.rst
@@ -1,5 +1,5 @@
 =====================================================
-About Proxies
+Working with Proxies
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/proxies.rst>`__
 
@@ -152,4 +152,3 @@ will be set to:
    ENV['http_proxy'] = 'http://myself:Password1@proxy.example.org:8080'
 
 .. end_tag
-


### PR DESCRIPTION
Name it what it actually is. Also don't make it the first item in our
setup menu. Stick it next to airgapped installs since it's a similar,
but different thing.

Signed-off-by: Tim Smith <tsmith@chef.io>