### PR TITLE
Simplify the libraries page

### DIFF
--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -244,7 +244,7 @@ Cookbooks are comprised of the following components:
 
      - .. tag libraries_summary
 
-       A library allows arbitrary Ruby code to be included in a cookbook, either as a way of extending the classes that are built-in to the chef-client---``Chef::Recipe``, for example---or for implementing entirely new functionality, similar to a mixin in Ruby. A library file is a Ruby file that is located within a cookbook's ``/libraries`` directory. Because a library is built using Ruby, anything that can be done with Ruby can be done in a library file.
+       A library allows arbitrary Ruby code to be included in a cookbook. The most common use for libraries is to write helpers that are used throughout recipes and custom resources. A library file is a Ruby file that is located within a cookbook's ``/libraries`` directory. Because a library is built using Ruby, anything that can be done with Ruby can be done in a library file, including advanced functionality such as extending built in Chef classes.
 
        .. end_tag
 

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -244,7 +244,7 @@ Cookbooks are comprised of the following components:
 
      - .. tag libraries_summary
 
-       A library allows arbitrary Ruby code to be included in a cookbook. The most common use for libraries is to write helpers that are used throughout recipes and custom resources. A library file is a Ruby file that is located within a cookbook's ``/libraries`` directory. Because a library is built using Ruby, anything that can be done with Ruby can be done in a library file, including advanced functionality such as extending built in Chef classes.
+       A library allows arbitrary Ruby code to be included in a cookbook. The most common use for libraries is to write helpers that are used throughout recipes and custom resources. A library file is a Ruby file that is located within a cookbook's ``/libraries`` directory. Because a library is built using Ruby, anything that can be done with Ruby can be done in a library file, including advanced functionality such as extending built-in Chef classes.
 
        .. end_tag
 

--- a/chef_master/source/libraries.rst
+++ b/chef_master/source/libraries.rst
@@ -5,13 +5,12 @@ About Libraries
 
 .. tag libraries_summary
 
-A library allows arbitrary Ruby code to be included in a cookbook, either as a way of extending the classes that are built-in to the chef-client---``Chef::Recipe``, for example---or for implementing entirely new functionality, similar to a mixin in Ruby. A library file is a Ruby file that is located within a cookbook's ``/libraries`` directory. Because a library is built using Ruby, anything that can be done with Ruby can be done in a library file.
+A library allows arbitrary Ruby code to be included in a cookbook. The most common use for libraries is to write helpers that are used throughout recipes and custom resources. A library file is a Ruby file that is located within a cookbook's ``/libraries`` directory. Because a library is built using Ruby, anything that can be done with Ruby can be done in a library file, including advanced functionality such as extending built in Chef classes.
 
 .. end_tag
 
 Use a library to:
 
-* Create a custom class or module; for example, create a subclass of ``Chef::Recipe``
 * Connect to a database
 * Talk to an LDAP provider
 * Do anything that can be done with Ruby

--- a/chef_master/source/libraries.rst
+++ b/chef_master/source/libraries.rst
@@ -5,7 +5,7 @@ About Libraries
 
 .. tag libraries_summary
 
-A library allows arbitrary Ruby code to be included in a cookbook. The most common use for libraries is to write helpers that are used throughout recipes and custom resources. A library file is a Ruby file that is located within a cookbook's ``/libraries`` directory. Because a library is built using Ruby, anything that can be done with Ruby can be done in a library file, including advanced functionality such as extending built in Chef classes.
+A library allows arbitrary Ruby code to be included in a cookbook. The most common use for libraries is to write helpers that are used throughout recipes and custom resources. A library file is a Ruby file that is located within a cookbook's ``/libraries`` directory. Because a library is built using Ruby, anything that can be done with Ruby can be done in a library file, including advanced functionality such as extending built-in Chef classes.
 
 .. end_tag
 

--- a/chef_master/source/server_manage_cookbooks.rst
+++ b/chef_master/source/server_manage_cookbooks.rst
@@ -68,7 +68,7 @@ A cookbook can contain the following types of files:
    * - Libraries
      - .. tag libraries_summary
 
-       A library allows arbitrary Ruby code to be included in a cookbook, either as a way of extending the classes that are built-in to the chef-client---``Chef::Recipe``, for example---or for implementing entirely new functionality, similar to a mixin in Ruby. A library file is a Ruby file that is located within a cookbook's ``/libraries`` directory. Because a library is built using Ruby, anything that can be done with Ruby can be done in a library file.
+       A library allows arbitrary Ruby code to be included in a cookbook. The most common use for libraries is to write helpers that are used throughout recipes and custom resources. A library file is a Ruby file that is located within a cookbook's ``/libraries`` directory. Because a library is built using Ruby, anything that can be done with Ruby can be done in a library file, including advanced functionality such as extending built in Chef classes.
 
        .. end_tag
 

--- a/chef_master/source/server_manage_cookbooks.rst
+++ b/chef_master/source/server_manage_cookbooks.rst
@@ -68,7 +68,7 @@ A cookbook can contain the following types of files:
    * - Libraries
      - .. tag libraries_summary
 
-       A library allows arbitrary Ruby code to be included in a cookbook. The most common use for libraries is to write helpers that are used throughout recipes and custom resources. A library file is a Ruby file that is located within a cookbook's ``/libraries`` directory. Because a library is built using Ruby, anything that can be done with Ruby can be done in a library file, including advanced functionality such as extending built in Chef classes.
+       A library allows arbitrary Ruby code to be included in a cookbook. The most common use for libraries is to write helpers that are used throughout recipes and custom resources. A library file is a Ruby file that is located within a cookbook's ``/libraries`` directory. Because a library is built using Ruby, anything that can be done with Ruby can be done in a library file, including advanced functionality such as extending built-in Chef classes.
 
        .. end_tag
 


### PR DESCRIPTION
Remove more advanced concepts. If you know Ruby you already know all the horrible things you can do. Let's explain to new users why they might want a library.