### PR TITLE
Remove aws marketplace link from getting started

### DIFF
--- a/chef_master/source/quick_start.rst
+++ b/chef_master/source/quick_start.rst
@@ -40,5 +40,4 @@ This will create a file named ``test.txt`` at the home path on your machine. Ope
 There's a lot more that Chef can do, obviously, but that was super easy!
 
 * See https://learn.chef.io/ for more detailed setup scenarios.
-* Try `running Chef in the AWS Marketplace </aws_marketplace.html>`__.
 * Keep reading  for more information about setting up a workstation, configuring Kitchen to run virtual environments, setting up a more detailed cookbook, resources, and more.


### PR DESCRIPTION
If you're brand new to Chef this isn't going to help you out.