### PR TITLE
Remove references to the old old web UI

### DIFF
--- a/chef_master/source/runbook.rst
+++ b/chef_master/source/runbook.rst
@@ -34,12 +34,6 @@ The following diagram shows the various components that are part of a Chef serve
        .. end_tag
 
        All cookbooks are stored in a dedicated repository.
-   * - WebUI
-     - .. tag chef_server_component_webui
-
-       chef-server-webui is a Ruby on Rails application that hosts the web interface for the Chef server.
-
-       .. end_tag
 
    * - Erchef
      - .. tag chef_server_component_erchef
@@ -101,4 +95,3 @@ The following sections detail how to monitor the server, manage log files, manag
 .. include:: server_tuning.rst
 
 .. include:: server_backup_restore.rst
-

--- a/chef_master/source/server_components.rst
+++ b/chef_master/source/server_components.rst
@@ -40,13 +40,8 @@ The following diagram shows the various components that are part of a Chef serve
        .. end_tag
 
    * - Chef Manage
-     - .. tag chef_server_component_webui
+     - Chef Manage is the web interface for the Chef server, which uses the Chef server API for all communication to the Chef server.
 
-       chef-server-webui is a Ruby on Rails application that hosts the web interface for the Chef server.
-
-       .. end_tag
-
-       The Chef management console uses the Chef server API for all communication to the Chef server.
    * - Chef Server
      - .. tag chef_server_component_erchef
 


### PR DESCRIPTION
Manage is the old UI. The old web UI is the old old one.

Signed-off-by: Tim Smith <tsmith@chef.io>