### PR TITLE
Add page for erl_call deprecation

### DIFF
--- a/chef_master/source/chef_deprecations_client.rst
+++ b/chef_master/source/chef_deprecations_client.rst
@@ -147,7 +147,7 @@ All Deprecations
     - Deprecation of the ``:uninstall`` action in the ``chocolatey_package`` resource.
     - 13.7
     - 14.0
-  * - CHEF-22
+  * - `CHEF-22  </deprecations_erl_call_resource.html>`__
     - Deprecation of the ``erl_call`` resource.
     - 13.7
     - 14.0

--- a/chef_master/source/deprecations_erl_call_resource.rst
+++ b/chef_master/source/deprecations_erl_call_resource.rst
@@ -1,0 +1,11 @@
+=====================================================
+Deprecation: Deprecation of the erl_call resource (CHEF-22)
+=====================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_erl_call_resource.rst>`__
+
+The erl_call resource was deprecated in Chef 13.7 and removed from the chef-client in 14.0 (April 2018).
+
+Remediation
+=============
+
+Remove usage of the erl_call resource from all cookbooks.

--- a/chef_master/source/deprecations_erl_call_resource.rst
+++ b/chef_master/source/deprecations_erl_call_resource.rst
@@ -1,6 +1,6 @@
-=====================================================
+=================================================================
 Deprecation: Deprecation of the erl_call resource (CHEF-22)
-=====================================================
+=================================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_erl_call_resource.rst>`__
 
 The erl_call resource was deprecated in Chef 13.7 and removed from the chef-client in 14.0 (April 2018).

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -557,6 +557,7 @@ Addenda
    deprecations_deploy_resource
    deprecations_dnf_package_allow_downgrade
    deprecations_easy_install
+   deprecations_erl_call_resource
    deprecations_exit_code
    deprecations_internal_api
    deprecations_json_auto_inflate


### PR DESCRIPTION
This was an easy one to add. There's a few more missing.

Signed-off-by: Tim Smith <tsmith@chef.io>