### PR TITLE
Shuffle around more things and remove some DK nav items

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -141,9 +141,9 @@
         "hasSubItems": true,
         "subItems": [
           {
-            "title": "Workstation",
+            "title": "Chef Development Kit",
             "hasSubItems": false,
-            "url": "/workstation.html"
+            "url": "/about_chefdk.html"
           },
           {
             "title": "Nodes",

--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -1346,7 +1346,7 @@
             "url": "/chefspec.html"
           },
           {
-            "title": "config.rb",
+            "title": "config.rb (knife.rb)",
             "hasSubItems": false,
             "url": "/config_rb.html"
           },

--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -1346,20 +1346,9 @@
             "url": "/chefspec.html"
           },
           {
-            "title": "Configuration",
-            "hasSubItems": true,
-            "subItems": [
-              {
-                "title": "config.rb",
-                "hasSubItems": false,
-                "url": "/config_rb.html"
-              },
-              {
-                "title": "Multiple Config Files",
-                "hasSubItems": false,
-                "url": "/config_rb_client.html#d-directories"
-              }
-            ]
+            "title": "config.rb",
+            "hasSubItems": false,
+            "url": "/config_rb.html"
           },
           {
             "title": "cookstyle",

--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -79,11 +79,6 @@
             "url": "/chef_overview.html"
           },
           {
-            "title": "Install ChefDK",
-            "hasSubItems": false,
-            "url": "/install_dk.html"
-          },
-          {
             "title": "Quick Start",
             "hasSubItems": false,
             "url": "/quick_start.html"

--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -1244,11 +1244,6 @@
             "url": "/berkshelf.html"
           },
           {
-            "title": "chef-apply (executable)",
-            "hasSubItems": false,
-            "url": "/ctl_chef_apply.html"
-          },
-          {
             "title": "chef-shell (executable)",
             "hasSubItems": false,
             "url": "/chef_shell.html"
@@ -1271,11 +1266,6 @@
                 "title": "chef gem",
                 "hasSubItems": false,
                 "url": "/ctl_chef.html#chef-gem"
-              },
-              {
-                "title": "chef generate app",
-                "hasSubItems": false,
-                "url": "/ctl_chef.html#chef-generate-app"
               },
               {
                 "title": "chef generate attribute",
@@ -1316,11 +1306,6 @@
                 "title": "chef generate template",
                 "hasSubItems": false,
                 "url": "/ctl_chef.html#chef-generate-template"
-              },
-              {
-                "title": "chef provision",
-                "hasSubItems": false,
-                "url": "/ctl_chef.html#chef-provision"
               },
               {
                 "title": "chef shell-init",

--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -89,37 +89,6 @@
             "url": "/chef_system_requirements.html"
           },
           {
-            "title": "Release Notes",
-            "hasSubItems": true,
-            "subItems": [
-              {
-                "title": "Chef Client",
-                "hasSubItems": false,
-                "url": "/release_notes.html"
-              },
-              {
-                "title": "Chef Development Kit",
-                "hasSubItems": false,
-                "url": "/release_notes_chefdk.html"
-              },
-              {
-                "title": "Chef Server",
-                "hasSubItems": false,
-                "url": "/release_notes_server.html"
-              },
-              {
-                "title": "Chef Push Jobs",
-                "hasSubItems": false,
-                "url": "/release_notes_push_jobs.html"
-              }
-            ]
-          },
-          {
-            "title": "Deprecations",
-            "hasSubItems": false,
-            "url": "/chef_deprecations_client.html"
-          },
-          {
             "title": "Microsoft Windows Guide",
             "hasSubItems": false,
             "url": "/windows.html"

--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -250,7 +250,7 @@
         "hasSubItems": true,
         "subItems": [
           {
-            "title": "Workstation",
+            "title": "Chef DK",
             "hasSubItems": false,
             "url": "/install_dk.html"
           },

--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -125,9 +125,9 @@
             "url": "/server_components.html"
           },
           {
-            "title": "Secrets",
+            "title": "chef-repo",
             "hasSubItems": false,
-            "url": "/secrets.html"
+            "url": "/chef_repo.html"
           },
           {
             "title": "Cookbooks",
@@ -166,6 +166,11 @@
             ]
           },
           {
+            "title": "Secrets",
+            "hasSubItems": false,
+            "url": "/secrets.html"
+          },
+          {
             "title": "Authentication",
             "hasSubItems": false,
             "url": "/auth.html#authentication"
@@ -197,11 +202,6 @@
         "title": "Features",
         "hasSubItems": true,
         "subItems": [
-          {
-            "title": "chef-repo",
-            "hasSubItems": false,
-            "url": "/chef_repo.html"
-          },
           {
             "title": "FIPS-mode",
             "hasSubItems": false,


### PR DESCRIPTION
Remove duplicate release notes and deprecation pages that happened with the nav shuffles
Don't name things workstation when we mean DK since that's already getting confusing
Yank more features we've deprecated from the nav bar
Remove a very funky configuration page that had nothing to do with DK
