### PR TITLE
Move around the nav menu a bit more

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -154,6 +154,11 @@
                 "url": "/data_bags.html"
               },
               {
+                "title": "Run-lists",
+                "hasSubItems": false,
+                "url": "/run_lists.html"
+              },
+              {
                 "title": "Environments",
                 "hasSubItems": false,
                 "url": "/environments.html"
@@ -223,11 +228,6 @@
             "url": "/push_jobs.html"
           },
           {
-            "title": "Run-lists",
-            "hasSubItems": false,
-            "url": "/run_lists.html"
-          },
-          {
             "title": "Search",
             "hasSubItems": false,
            "url": "/chef_search.html"
@@ -236,14 +236,8 @@
     },
     {
       "title": "Troubleshooting",
-      "hasSubItems": true,
-      "subItems": [
-        {
-          "title": "Errors",
-          "hasSubItems": false,
-          "url": "/errors.html"
-        }
-      ]
+      "hasSubItems": false,
+      "url": "/errors.html"
     },
       {
         "title": "Setup",


### PR DESCRIPTION
Collapse the troubleshooting section that only had 1 sub menu item. Move
run lists into policy since it lines up with environments and all that
fun stuff.

Signed-off-by: Tim Smith <tsmith@chef.io>