### PR TITLE
Custom Resource Props and Keywords

### DIFF
--- a/chef_master/source/custom_resources.rst
+++ b/chef_master/source/custom_resources.rst
@@ -49,7 +49,9 @@ The syntax for a custom resource is. For example:
 
 where the first action listed is the default action.
 
-.. warning:: There are certain keywords in the chef-client resource system, like "name", which may not be used as a ``property :property_name`` in a custom resource. For example, the following is invalid syntax, and will result in difficult to debug errors ``property :name, String, default: 'thename'``. The rule of thumb is avoid existing keywords when coming up with property names for custom resources.
+.. warning:: 
+   Do not use existing keywords from the chef-client resource system in a custom resource, like "name". For example, ``property :property_name``  in the following invalid syntax: 
+   ``property :name, String, default: 'thename'``. 
 
 .. end_tag
 

--- a/chef_master/source/custom_resources.rst
+++ b/chef_master/source/custom_resources.rst
@@ -50,7 +50,7 @@ The syntax for a custom resource is. For example:
 where the first action listed is the default action.
 
 .. warning:: 
-   Do not use existing keywords from the chef-client resource system in a custom resource, like "name". For example, ``property :property_name``  in the following invalid syntax: 
+   Do not use existing keywords from the chef-client resource system in a custom resource, like "name". For example, ``property :property_name`` in the following invalid syntax: 
    ``property :name, String, default: 'thename'``. 
 
 .. end_tag

--- a/chef_master/source/custom_resources.rst
+++ b/chef_master/source/custom_resources.rst
@@ -49,6 +49,8 @@ The syntax for a custom resource is. For example:
 
 where the first action listed is the default action.
 
+.. warning:: There are certain keywords in the chef-client resource system, like "name", which may not be used as a ``property :property_name`` in a custom resource. For example, the following is invalid syntax, and will result in difficult to debug errors ``property :name, String, default: 'thename'``. The rule of thumb is avoid existing keywords when coming up with property names for custom resources.
+
 .. end_tag
 
 Example

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -4439,6 +4439,8 @@ The syntax for a custom resource is. For example:
 
 where the first action listed is the default action.
 
+.. warning:: There are certain keywords in the chef-client resource system, like "name", which may not be used as a ``property :property_name`` in a custom resource. For example, the following is invalid syntax, and will result in difficult to debug errors ``property :name, String, default: 'thename'``. The rule of thumb is avoid existing keywords when coming up with property names for custom resources.
+
 .. end_tag
 
 This example ``site`` utilizes Chef's built in ``file``, ``service`` and ``package`` resources, and includes ``:create`` and ``:delete`` actions. Since it uses built in Chef resources, besides defining the property and actions, the code is very similar to that of a recipe.

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -4439,7 +4439,9 @@ The syntax for a custom resource is. For example:
 
 where the first action listed is the default action.
 
-.. warning:: There are certain keywords in the chef-client resource system, like "name", which may not be used as a ``property :property_name`` in a custom resource. For example, the following is invalid syntax, and will result in difficult to debug errors ``property :name, String, default: 'thename'``. The rule of thumb is avoid existing keywords when coming up with property names for custom resources.
+.. warning:: 
+   Do not use existing keywords from the chef-client resource system in a custom resource, like "name". For example, ``property :property_name``  in the following invalid syntax: 
+   ``property :name, String, default: 'thename'``. 
 
 .. end_tag
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -4440,7 +4440,7 @@ The syntax for a custom resource is. For example:
 where the first action listed is the default action.
 
 .. warning:: 
-   Do not use existing keywords from the chef-client resource system in a custom resource, like "name". For example, ``property :property_name``  in the following invalid syntax: 
+   Do not use existing keywords from the chef-client resource system in a custom resource, like "name". For example, ``property :property_name`` in the following invalid syntax: 
    ``property :name, String, default: 'thename'``. 
 
 .. end_tag


### PR DESCRIPTION
Conflicts between custom resource properties and existing keywords in the resource system, like ":name" result in difficult to debug errors with no indication from the system that the use of ":name" will cause an issue. We'll clarify with a warning here.