### PR TITLE
Clarify Standard Return Codes and Fork Usage

### DIFF
--- a/chef_master/source/config_rb_client.rst
+++ b/chef_master/source/config_rb_client.rst
@@ -71,7 +71,7 @@ This configuration file has the following settings:
    The port on which chef-zero is to listen. This value may be specified as a range; the chef-client will take the first available port in the range. For example ``10,20,30`` or ``10000-20000``. Default value: ``8889-9999``.
 
 ``client_fork``
-   Contain the chef-client run in a secondary process with dedicated RAM. When the chef-client run is complete, the RAM is returned to the master process. This setting helps ensure that a chef-client uses a steady amount of RAM over time because the master process does not run recipes. This setting also helps prevent memory leaks such as those that can be introduced by the code contained within a poorly designed cookbook. Set to ``false`` to disable running the chef-client in fork node. Default value: ``true``.
+   Contain the chef-client run in a secondary process with dedicated RAM. When the chef-client run is complete, the RAM is returned to the master process. This setting helps ensure that a chef-client uses a steady amount of RAM over time because the master process does not run recipes. This setting also helps prevent memory leaks such as those that can be introduced by the code contained within a poorly designed cookbook. Set to ``false`` to disable running the chef-client in fork node. Default value: ``true``. Must be set to false up to Chef Client 13.11.3 to gather the standard return code offered by ``exit_status true``. Chef Client 14.x behaves as expected, with no changes to the Chef Client configuration file necessary.
 
 ``client_key``
    The location of the file that contains the client key. Default value: ``/etc/chef/client.pem``.
@@ -156,8 +156,7 @@ This configuration file has the following settings:
 
    .. note:: The behavior with the default value consists of a warning on the use of deprecated and non-standard exit codes. In the 13.x release of Chef Client and beyond, using standardized exit codes is the default behavior and cannot be changed with this config item.
 
-   Changed in Chef Client 12.11 to support standard exit codes.
-   In Chef Client 13.x and above, you will also need to set ``client_fork false`` in the Chef Client config file in order to capture the standard return code. Otherwise, you will be gathering the exit status of the master process, and not that of the forked chef-client process that did the actual run.
+   In Chef Client 13.x, you will also need to set ``client_fork false`` in the Chef Client config file in order to capture the standard return code. Otherwise, you will be gathering the exit status of the master process, and not that of the forked chef-client process that did the actual run. Chef 14.x allows the standard return codes to be returned to the calling shell in both forking and non-forking mode.
 
 ``file_atomic_update``
    Apply atomic file updates to all resources. Set to ``true`` for global atomic file updates. Set to ``false`` for global non-atomic file updates. (Use the ``atomic_update`` setting on a per-resource basis to override this setting.) Default value: ``true``.

--- a/chef_master/source/config_rb_client.rst
+++ b/chef_master/source/config_rb_client.rst
@@ -154,9 +154,10 @@ This configuration file has the following settings:
 ``exit_status``
    When set to ``:enabled``, chef-client will use `standardized exit codes <https://github.com/chef/chef-rfc/blob/master/rfc062-exit-status.md#exit-codes-in-use>`_ for Chef client run status, and any non-standard exit codes will be converted to ``1`` or ``GENERIC_FAILURE``. This setting can also be set to ``:disabled`` which preserves the old behavior of using non-standardized exit codes and skips the deprecation warnings. Default value: ``nil``.
 
-   .. note:: The behavior with the default value consists of a warning on the use of deprecated and non-standard exit codes. In a future release of Chef client, using standardized exit codes will be the default behavior.
+   .. note:: The behavior with the default value consists of a warning on the use of deprecated and non-standard exit codes. In the 13.x release of Chef Client and beyond, using standardized exit codes is the default behavior and cannot be changed with this config item.
 
    Changed in Chef Client 12.11 to support standard exit codes.
+   In Chef Client 13.x and above, you will also need to set ``client_fork false`` in the Chef Client config file in order to capture the standard return code. Otherwise, you will be gathering the exit status of the master process, and not that of the forked chef-client process that did the actual run.
 
 ``file_atomic_update``
    Apply atomic file updates to all resources. Set to ``true`` for global atomic file updates. Set to ``false`` for global non-atomic file updates. (Use the ``atomic_update`` setting on a per-resource basis to override this setting.) Default value: ``true``.

--- a/chef_master/source/config_rb_client.rst
+++ b/chef_master/source/config_rb_client.rst
@@ -33,7 +33,7 @@ This configuration file has the following settings:
 
       knife[:authentication_protocol_version] = '1.3'
 
-   Note that authentication protocol 1.3 is only supported on Chef server versions 12.4.0 and above.
+   .. note:: Authentication protocol 1.3 is only supported on Chef server versions 12.4.0 and above.
 
 ``automatic_attribute_blacklist``
    A hash  that blacklists ``automatic`` attributes, preventing blacklisted attributes from being saved.
@@ -71,7 +71,9 @@ This configuration file has the following settings:
    The port on which chef-zero is to listen. This value may be specified as a range; the chef-client will take the first available port in the range. For example ``10,20,30`` or ``10000-20000``. Default value: ``8889-9999``.
 
 ``client_fork``
-   Contain the chef-client run in a secondary process with dedicated RAM. When the chef-client run is complete, the RAM is returned to the master process. This setting helps ensure that a chef-client uses a steady amount of RAM over time because the master process does not run recipes. This setting also helps prevent memory leaks such as those that can be introduced by the code contained within a poorly designed cookbook. Set to ``false`` to disable running the chef-client in fork node. Default value: ``true``. Must be set to false up to Chef Client 13.11.3 to gather the standard return code offered by ``exit_status true``. Chef Client 14.x behaves as expected, with no changes to the Chef Client configuration file necessary.
+   Contain the chef-client run in a secondary process with dedicated RAM. When the chef-client run is complete, the RAM is returned to the master process. This setting helps ensure that a chef-client uses a steady amount of RAM over time because the master process does not run recipes. This setting also helps prevent memory leaks such as those that can be introduced by the code contained within a poorly designed cookbook. Default value: ``true``.  Set to ``false`` to disable running the chef-client in fork node. 
+   
+   .. note:: Must be set to ``false`` up to Chef Client 13.11.3 to gather the standard return code offered by ``exit_status true``. Chef Client 14.x behaves as expected, with no changes to the Chef Client configuration file necessary.
 
 ``client_key``
    The location of the file that contains the client key. Default value: ``/etc/chef/client.pem``.


### PR DESCRIPTION
### Description
If you fork a child process, then a command line capture of the return code will be that from the parent, not the child that does the chef-client run.