### PR TITLE
Update resource_package so not installing in loop.

### DIFF
--- a/chef_master/source/resource_package.rst
+++ b/chef_master/source/resource_package.rst
@@ -858,13 +858,9 @@ and the next uses a single **package** resource and a whitespace array (``%w``):
 
 .. code-block:: ruby
 
-   %w{package-a package-b package-c package-d}.each do |pkg|
-     package pkg do
-       action :upgrade
-     end
+   package %w{package-a package-b package-c package-d} do
+     action :upgrade
    end
-
-where ``|pkg|`` is used to define the name of the resource, but also to ensure that each item in the whitespace array has its own name.
 
 .. end_tag
 


### PR DESCRIPTION
Installing packages in a loop, like this:

```
   package %w{package-a package-b package-c package-d} do
     action :upgrade
   end
```

Causes unique package resources to be generated.  This increases the overall node object size and causes node runs to take much longer (O*n).  As such, I would argue that defining a list of packages then iterating over that list is an anti-pattern, especially considering the package resource takes an array.

Additionally, this is false:

    and the next uses a single **package** resource and a whitespace array (``%w``):

As iterating over the loop dynamically creates package resources equal to the number of packages.

Perhaps this would be more clear?

    pkgs = %w{package-a package-b package-c package-d}
    package pkgs do
      action :upgrade
    end

Thanks,
-Q

### Description

I don't think we should be promoting the pattern of installing packages in a loop.  While you need a package list of more than 50 packages to push your node object over the default 1MB limit, 50 packages isn't really that many.

I think it's a much better pattern to use the `package` resource as designed and pass it an array.

### Definition of Done

### Issues Resolved

N/A just happened to be showing someone the package doc and noticed this.

### Check List

- [x] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass

(uhh, how do I build the docs locally?)