### PR TITLE
Massive copyediting for true, false, and Default Values

### DIFF
--- a/chef_master/source/debug.rst
+++ b/chef_master/source/debug.rst
@@ -120,7 +120,7 @@ Attributes
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False | **Default Value:** ``false``
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
    Continue running a recipe if a resource fails for any reason.
 

--- a/chef_master/source/provisioning.rst
+++ b/chef_master/source/provisioning.rst
@@ -197,9 +197,9 @@ This resource has the following properties:
    Use to specify the driver to be used for provisioning.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``load_balancer_options``
    ...
@@ -247,14 +247,14 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -394,12 +394,12 @@ Properties
 This resource has the following properties:
 
 ``admin``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Use to specify whether the chef-client is an API client.
 
 ``allow_overwrite_keys``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Use to overwrite the key on a machine when it is different from the key specified by ``source_key``.
 
@@ -460,7 +460,7 @@ This resource has the following properties:
       end
 
 ``converge``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Use to manage convergence when used with the ``:create`` action. Set to ``false`` to prevent convergence. Set to ``true`` to force convergence. When ``nil``, the machine will converge only if something changes. Default value: ``nil``.
 
@@ -500,9 +500,9 @@ This resource has the following properties:
    Use to specify an image created by the **machine_image** resource.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``machine_options``
    **Ruby Type:** Hash
@@ -559,9 +559,9 @@ This resource has the following properties:
    Use to generate a private key of the desired size, type, and so on.
 
 ``public_key_format``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``pem``
 
-   Use to specify the format of a public key. Possible values: ``pem`` and ``der``. Default value: ``pem``.
+   Use to specify the format of a public key. Possible values: ``pem`` and ``der``.
 
 ``public_key_path``
    **Ruby Type:** String
@@ -605,14 +605,14 @@ This resource has the following properties:
    Use to remove a tag.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``role``
    Use to add a role to the run-list for the machine. Use this property multiple times to add multiple roles to a run-list. Use this property along with ``recipe`` to define a run-list. The order in which the ``recipe`` and ``role`` properties are specified will determine the order in which they are added to the run-list. This property should not be used in the same recipe as ``run_list``. For example:
@@ -699,7 +699,7 @@ This resource has the following properties:
    Use to add one (or more) tags. This will remove any tag currently associated with the machine. For example: ``tags :a, :b, :c``.
 
 ``validator``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Use to specify if the chef-client is a chef-validator.
 
@@ -931,9 +931,9 @@ This resource has the following attributes:
    ...
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``machine_options``
    ...
@@ -979,14 +979,14 @@ This resource has the following attributes:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -1201,14 +1201,12 @@ This resource has the following properties:
    Use to specify the driver to be used for provisioning.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``live_stream``
-   **Ruby Types:** True, False
-
-   Default value: ``false``.
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
 ``machine``
    **Ruby Type:** String
@@ -1250,14 +1248,14 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -1401,9 +1399,9 @@ This resource has the following properties:
    A string or ID that identifies the group owner by group name, including fully qualified group names such as ``domain\group`` or ``group@domain``. If this value is not specified, existing groups remain unchanged and new group assignments use the default ``POSIX`` group (if available).
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``local_path``
    **Ruby Type:** String
@@ -1473,14 +1471,14 @@ This resource has the following properties:
    Microsoft Windows: A path that begins with a forward slash (``/``) will point to the root of the current working directory of the chef-client process. This path can vary from system to system. Therefore, using a path that begins with a forward slash (``/``) is not recommended.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -1643,9 +1641,9 @@ This resource has the following properties:
    Use to specify if all of the attributes specified in ``attributes`` represent a complete specification for the machine image. When true, any attributes not specified in ``attributes`` will be reset to their default values.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``image_options``
    **Ruby Type:** Hash
@@ -1708,14 +1706,14 @@ This resource has the following properties:
    Use to remove a role from the run-list for the machine image.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``role``
    Use to add a role to the run-list for the machine image.

--- a/chef_master/source/provisioning_aws.rst
+++ b/chef_master/source/provisioning_aws.rst
@@ -491,7 +491,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - Property
      - Description
    * - ``automatic_failover``
-     - **Ruby Type:** True, False
+     - **Ruby Type:** true, false
 
        Use to specify if a read-only replica is automatically promoted to read/write primary if the existing primary fails. Set to ``true`` to enable automatic failover for this cache replication group.
    * - ``aws_tags``
@@ -794,9 +794,9 @@ This Chef provisioning driver-specific resource has the following properties:
 
        The managed entry store. For example: ``Chef::Provisioning.chef_managed_entry_store(self.chef_server)``.
    * - ``multi_az``
-     - **Ruby Type:** True, False
+     - **Ruby Type:** true, false | **Default Value:** ``false``
 
-       Specifies if the Amazon CloudSearch domain is deployed to multiple availability zones. Default value: ``false``.
+       Specifies if the Amazon CloudSearch domain is deployed to multiple availability zones.
    * - ``name``
      - **Ruby Type:** String
 
@@ -939,7 +939,7 @@ This Chef provisioning driver-specific resource has the following properties:
 
        The actions to execute when this alarm transitions to the ``ALARM`` state from any other state. Each action is specified as an Amazon Resource Name (ARN).
    * - ``actions_enabled``
-     - **Ruby Type:** True, False
+     - **Ruby Type:** true, false
 
        Indicates whether actions should be executed during any changes to the alarm state.
    * - ``alarm_description``
@@ -1192,7 +1192,7 @@ This Chef provisioning driver-specific resource has the following properties:
 
        The Chef provisioning driver.
    * - ``encrypted``
-     - **Ruby Type:** True, False
+     - **Ruby Type:** true, false
 
        Use to specify that a block-level storage device should be encrypted.
    * - ``iops``
@@ -1377,7 +1377,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - Property
      - Description
    * - ``associate_to_vpc``
-     - **Ruby Type:** True, False
+     - **Ruby Type:** true, false
 
        Use to associate an elastic IP address to a virtual network that is defined in Amazon Virtual Private Cloud (VPC).
    * - ``chef_server``
@@ -1508,7 +1508,7 @@ This Chef provisioning driver-specific resource has the following properties:
 
        The Chef provisioning driver.
    * - ``ebs_enabled``
-     - **Ruby Type:** True, False
+     - **Ruby Type:** true, false
 
        Use to specify the elastic block size enable/disable.
    * - ``managed_entry_store``
@@ -2179,7 +2179,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - Property
      - Description
    * - ``allow_overwrite``
-     - **Ruby Type:** True, False
+     - **Ruby Type:** true, false
 
        Use to allow a public or private key to be overwritten.
    * - ``aws_tags``
@@ -3242,9 +3242,9 @@ This Chef provisioning driver-specific resource has the following properties:
 
        The username for the database super user.
    * - ``multi_az``
-     - **Ruby Type:** True, False
+     - **Ruby Type:** true, false | **Default Value:** ``false``
 
-       Use to specify if the database instance is deployed to multiple availability zones. Default value: ``false``.
+       Use to specify if the database instance is deployed to multiple availability zones.
    * - ``name``
      - **Ruby Type:** String
 
@@ -3254,9 +3254,9 @@ This Chef provisioning driver-specific resource has the following properties:
 
        The port number on which the database accepts connections.
    * - ``publicly_accessible``
-     - **Ruby Type:** True, False
+     - **Ruby Type:** true, false | **Default Value:** ``false``
 
-       Use to specify that a relational database instance has DNS name that resolves to a routable public IP address. Default value: ``false``.
+       Use to specify that a relational database instance has DNS name that resolves to a routable public IP address.
 
 Examples
 -----------------------------------------------------
@@ -3846,9 +3846,9 @@ This Chef provisioning driver-specific resource has the following properties:
 
        The Chef provisioning driver.
    * - ``enable_website_hosting``
-     - **Ruby Type:** True, False
+     - **Ruby Type:** true, false | **Default Value:** ``false``
 
-       Use to specify if an Amazon Simple Storage Service (S3) bucket is configured for for static website hosting. Default value: ``false``.
+       Use to specify if an Amazon Simple Storage Service (S3) bucket is configured for for static website hosting.
    * - ``managed_entry_store``
      - **Ruby Type:** Chef::Provisioning::ManagedEntryStore
 
@@ -4780,9 +4780,9 @@ This Chef provisioning driver-specific resource has the following properties:
 
        The managed entry store. For example: ``Chef::Provisioning.chef_managed_entry_store(self.chef_server)``.
    * - ``map_public_ip_on_launch``
-     - **Ruby Type:** True, False
+     - **Ruby Type:** true, false | **Default Value:** ``false``
 
-       Use to specify if public IP addresses are assigned to new instances in this subnet by default. Default value: ``false``.
+       Use to specify if public IP addresses are assigned to new instances in this subnet by default.
    * - ``name``
      - **Ruby Type:** String
 

--- a/chef_master/source/provisioning_aws.rst
+++ b/chef_master/source/provisioning_aws.rst
@@ -462,7 +462,7 @@ The full syntax for all of the properties that are available to the ``aws_cache_
 
    aws_cache_replication_group 'name' do
      az_mode                       String
-     automatic_failover            True, False
+     automatic_failover            true, false
      description                   String
      engine                        String
      engine_version                String
@@ -748,7 +748,7 @@ The full syntax for all of the properties that are available to the ``aws_clouds
      access_policies               String
      index_fields                  Array
      instance_type                 String
-     multi_az                      True, False
+     multi_az                      true, false
      partition_count               Integer
      replication_count             Integer
    end
@@ -861,7 +861,7 @@ The full syntax for all of the properties that are available to the ``aws_cloudw
      insufficient_data_actions    Array
      ok_actions                   Array
      alarm_actions                Array
-     actions_enabled              True, False
+     actions_enabled              true, false
      alarm_description            String
      unit                         String
    end
@@ -1131,7 +1131,7 @@ The full syntax for all of the properties that are available to the ``aws_ebs_vo
    aws_ebs_volume 'name' do
      availability_zone             String
      device                        String
-     encrypted                     True, False
+     encrypted                     true, false
      iops                          Integer
      machine                       String
      size                          Integer
@@ -1200,7 +1200,7 @@ This Chef provisioning driver-specific resource has the following properties:
 
        Required for provisioned volumes. Use to specify the maximum number of input/output operations per second (IOPS) that the block-level storage device will support.
    * - ``machine``
-     - **Ruby Type:** String, False, AwsInstance, AWS::EC2::Instance
+     - **Ruby Type:** String, false, AwsInstance, AWS::EC2::Instance
 
        Use to specify the machine to be provisioned.
    * - ``managed_entry_store``
@@ -1355,8 +1355,8 @@ The full syntax for all of the properties that are available to the ``aws_eip_ad
 .. code-block:: ruby
 
    aws_eip_address 'name' do
-     associate_to_vpc              True, False
-     machine                       String, False
+     associate_to_vpc              true, false
+     machine                       String, false
      public_ip                     String
    end
 
@@ -1389,7 +1389,7 @@ This Chef provisioning driver-specific resource has the following properties:
 
        The Chef provisioning driver.
    * - ``machine``
-     - **Ruby Type:** String, False
+     - **Ruby Type:** String, false
 
        Use to specify the machine to be provisioned.
    * - ``managed_entry_store``
@@ -1473,7 +1473,7 @@ The full syntax for all of the properties that are available to the ``aws_elasti
 
    aws_elasticsearch_domain 'name' do
      instance_type                     String
-     ebs_enabled                       True, False
+     ebs_enabled                       true, false
      volume_size                       Integer
      automated_snapshot_start_hour     Integer
      elasticsearch_version             String, Integer
@@ -2156,7 +2156,7 @@ The full syntax for all of the properties that are available to the ``aws_key_pa
 .. code-block:: ruby
 
    aws_key_pair 'name' do
-     allow_overwrite               True, False
+     allow_overwrite               true, false
      private_key_options()         Hash
      private_key_path              String
      public_key_path               String
@@ -3024,7 +3024,7 @@ The full syntax for all of the properties that are available to the ``aws_networ
    aws_network_interface 'name' do
      description                   String
      device_index                  Integer
-     machine                       String, False
+     machine                       String, false
      network_interface_id          String
      private_ip_address            String
      subnet                        String
@@ -3083,7 +3083,7 @@ This Chef provisioning driver-specific resource has the following properties:
 
        The Chef provisioning driver.
    * - ``machine``
-     - **Ruby Type:** String, False, AwsInstance, AWS::EC2::Instance
+     - **Ruby Type:** String, false, AwsInstance, AWS::EC2::Instance
 
        Use to specify the name of the Amazon Web Services (AWS) instance that this network interface is associated with.
    * - ``managed_entry_store``
@@ -3164,9 +3164,9 @@ The full syntax for all of the properties that are available to the ``aws_rds_in
      iops                          Integer
      master_user_password          String
      master_username               String
-     multi_az                      True, False
+     multi_az                      true, false
      port                          Integer
-     publicly_accessible           True, False
+     publicly_accessible           true, false
    end
 
 where
@@ -3797,7 +3797,7 @@ The full syntax for all of the properties that are available to the ``aws_s3_buc
 .. code-block:: ruby
 
    aws_s3_bucket 'name' do
-     enable_website_hosting        True, False
+     enable_website_hosting        true, false
      options                       Hash
      website_options               Hash
    end
@@ -4718,7 +4718,7 @@ The full syntax for all of the properties that are available to the ``aws_subnet
    aws_subnet 'name' do
      availability_zone             String
      cidr_block                    String
-     map_public_ip_on_launch       True, False
+     map_public_ip_on_launch       true, false
      route_table                   String
      subnet_id                     String
      vpc                           String
@@ -4970,9 +4970,9 @@ The full syntax for all of the properties that are available to the ``aws_vpc`` 
    aws_vpc 'name' do
      cidr_block                    String
      dhcp_options                  String
-     enable_dns_hostnames          True, False
-     enable_dns_support            True, False
-     internet_gateway              True, False
+     enable_dns_hostnames          true, false
+     enable_dns_support            true, false
+     internet_gateway              true, false
      instance_tenancy              Symbol
      main_route_table              String
      main_routes                   Hash
@@ -5031,11 +5031,11 @@ This Chef provisioning driver-specific resource has the following properties:
 
        The Chef provisioning driver.
    * - ``enable_dns_hostnames``
-     - **Ruby Type:** True
+     - **Ruby Type:** true
 
        Use to specify if instances launched in a defined virtual network are assigned DNS hostnames. Possible values: ``true`` or ``false``. When ``true``, ``enable_dns_support`` must also be set to ``true``.
    * - ``enable_dns_support``
-     - **Ruby Type:** True
+     - **Ruby Type:** true
 
        Use to specify if DNS resolution is supported for a defined virtual network. When ``false``, resolution of public DNS hostnames to IP addresses is disabled. When ``true``, queries made to either the DNS server provided by Amazon Web Services (AWS) (and located at the 169.254.169.253 IP address) or the reserved IP address at the base of the defined virtual network range (plus two) will be resolved successfully. For example, a reserved IP address of ``10.0.0.0/16`` is located at ``10.0.0.2``.
    * - ``instance_tenancy``

--- a/chef_master/source/provisioning_fog.rst
+++ b/chef_master/source/provisioning_fog.rst
@@ -77,7 +77,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - Property
      - Description
    * - ``allow_overwrite``
-     - **Ruby Type:** True, False
+     - **Ruby Type:** true, false
 
        Use to allow overwriting an existing key pair.
    * - ``driver``

--- a/chef_master/source/provisioning_fog.rst
+++ b/chef_master/source/provisioning_fog.rst
@@ -53,7 +53,7 @@ The full syntax for all of the properties that are available to the ``fog_key_pa
 .. code-block:: ruby
 
    fog_key_pair 'name' do
-     allow_overwrite         True, False
+     allow_overwrite         true, false
      driver                  Chef::Provisioning::Driver
      private_key_options     Hash
      private_key_path        String

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -2744,33 +2744,33 @@ The full syntax for all of the properties that are available to the **launchd** 
 .. code-block:: ruby
 
    launchd 'name' do
-     abandon_process_group      True, False
-     backup                     Integer, False
+     abandon_process_group      true, false
+     backup                     Integer, false
      cookbook                   String
-     debug                      True, False
-     disabled                   True, False
-     enable_globbing            True, False
-     enable_transactions        True, False
+     debug                      true, false
+     disabled                   true, false
+     enable_globbing            true, false
+     enable_transactions        true, false
      environment_variables      Hash
      exit_timeout               Integer
      group                      String, Integer
      hard_resource_limits       Hash
      hash                       Hash
-     ignore_failure             True, False
+     ignore_failure             true, false
      inetd_compatibility        Hash
-     init_groups                True, False
-     keep_alive                 True, False
+     init_groups                true, false
+     keep_alive                 true, false
      label                      String
-     launch_only_once           True, False
+     launch_only_once           true, false
      limit_load_from_hosts      Array
      limit_load_to_hosts        Array
      limit_load_to_session_type String
-     low_priority_io            True, False
+     low_priority_io            true, false
      mach_services              Hash
      mode                       Integer, String
      nice                       Integer
      notifies                   # see description
-     on_demand                  True, False
+     on_demand                  true, false
      owner                      Integer, String
      path                       String
      process_type               String
@@ -2781,7 +2781,7 @@ The full syntax for all of the properties that are available to the **launchd** 
      retries                    Integer
      retry_delay                Integer
      root_directory             String
-     run_at_load                True, False
+     run_at_load                true, false
      sockets                    Hash
      soft_resource_limits       Array
      standard_error_path        String
@@ -2789,14 +2789,14 @@ The full syntax for all of the properties that are available to the **launchd** 
      standard_out_path          String
      start_calendar_interval    Hash
      start_interval             Integer
-     start_on_mount             True, False
+     start_on_mount             true, false
      subscribes                 # see description
      throttle_interval          Integer
      time_out                   Integer
      type                       String
      umask                      Integer
      username                   String
-     wait_for_debugger          True, False
+     wait_for_debugger          true, false
      watch_paths                Array
      working_directory          String
      action                     Symbol # defaults to :create if not specified
@@ -2844,7 +2844,7 @@ Properties
 This resource has the following properties:
 
 ``backup``
-   **Ruby Types:** Integer, False
+   **Ruby Types:** Integer, false
 
    The number of backups to be kept in ``/var/chef/backup``. Set to ``false`` to prevent backups from being kept.
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -2278,14 +2278,14 @@ This resource has the following properties:
    A string or hash that contains a systemd `unit file <https://www.freedesktop.org/software/systemd/man/systemd.unit.html>`_ definition that describes the properties of systemd-managed entities, such as services, sockets, devices, and so on.
 
 ``triggers_reload``
-   **Ruby Type:** True, False
+   **Ruby Type:** true, false | **Default Value:** ``true``
 
-   Specifies whether to trigger a daemon reload when creating or deleting a unit. Default is true.
+   Specifies whether to trigger a daemon reload when creating or deleting a unit.
 
 ``verify``
-   **Ruby Type:** True, False
+   **Ruby Type:** true, false | **Default Value:** ``true``
 
-   Specifies if the unit will be verified before installation. Systemd can be overly strict when verifying units, so in certain cases it is preferable not to verify the unit. Defaults to true.
+   Specifies if the unit will be verified before installation. Systemd can be overly strict when verifying units, so in certain cases it is preferable not to verify the unit.
 
 
 What's New in 12.10
@@ -2864,9 +2864,9 @@ This resource has the following properties:
    A Hash of key value pairs used to create the launchd property list.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``label``
    **Ruby Type:** String
@@ -3010,27 +3010,27 @@ This resource has the following properties:
 The following resource properties may be used to define keys in the XML property list for a daemon or agent. Please refer to the Apple man page documentation for launchd for more information about these keys:
 
 ``abandon_process_group``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    If a job dies, all remaining processes with the same process ID may be kept running. Set to ``true`` to kill all remaining processes.
 
 ``debug``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Sets the log mask to ``LOG_DEBUG`` for this job.
 
 ``disabled``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Hints to ``launchctl`` to not submit this job to launchd. Default value: ``false``.
+   Hints to ``launchctl`` to not submit this job to launchd.
 
 ``enable_globbing``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Update program arguments before invocation.
 
 ``enable_transactions``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Track in-progress transactions; if none, then send the ``SIGKILL`` signal.
 
@@ -3040,9 +3040,9 @@ The following resource properties may be used to define keys in the XML property
    Additional environment variables to set before running a job.
 
 ``exit_timeout``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``20``
 
-   The amount of time (in seconds) launchd waits before sending a ``SIGKILL`` signal. Default value: ``20``.
+   The amount of time (in seconds) launchd waits before sending a ``SIGKILL`` signal.
 
 ``hard_resource_limits``
    **Ruby Type:** Hash
@@ -3055,19 +3055,19 @@ The following resource properties may be used to define keys in the XML property
    Specifies if a daemon expects to be run as if it were launched from ``inetd``. Set to ``wait => true`` to pass standard input, output, and error file descriptors. Set to ``wait => false`` to call the ``accept`` system call on behalf of the job, and then pass standard input, output, and error file descriptors.
 
 ``init_groups``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Specify if ``initgroups`` is called before running a job. Default value: ``true`` (starting with macOS 10.5).
 
 ``keep_alive``
-   **Ruby Types:** True, False, Hash
+   **Ruby Types:** true, false, Hash | **Default Value:** ``false``
 
-   Keep a job running continuously (``true``) or allow demand and conditions on the node to determine if the job keeps running (``false``). Default value: ``false``.
+   Keep a job running continuously (``true``) or allow demand and conditions on the node to determine if the job keeps running (``false``).
 
    Hash type was added in Chef client 12.14.
 
 ``launch_only_once``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Specify if a job can be run only one time. Set this value to ``true`` if a job cannot be restarted without a full machine reboot.
 
@@ -3087,7 +3087,7 @@ The following resource properties may be used to define keys in the XML property
    The session type to which this configuration file applies.
 
 ``low_priority_io``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Specify if the kernel on the node should consider this daemon to be low priority during file system I/O.
 
@@ -3102,7 +3102,7 @@ The following resource properties may be used to define keys in the XML property
    The program scheduling priority value in the range ``-20`` to ``20``.
 
 ``on_demand``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Keep a job alive. Only applies to macOS version 10.4 (and earlier); use ``keep_alive`` instead for newer versions.
 
@@ -3132,9 +3132,9 @@ The following resource properties may be used to define keys in the XML property
    ``chroot`` to this directory, and then run the job.
 
 ``run_at_load``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Launch a job once (at the time it is loaded). Default value: ``false``.
+   Launch a job once (at the time it is loaded).
 
 ``sockets``
    **Ruby Type:** Hash
@@ -3171,14 +3171,14 @@ The following resource properties may be used to define keys in the XML property
    The frequency (in seconds) at which a job is started.
 
 ``start_on_mount``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Start a job every time a file system is mounted.
 
 ``throttle_interval``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``10``
 
-   The frequency (in seconds) at which jobs are allowed to spawn. Default value: ``10``.
+   The frequency (in seconds) at which jobs are allowed to spawn.
 
 ``time_out``
    **Ruby Type:** Integer
@@ -3196,7 +3196,7 @@ The following resource properties may be used to define keys in the XML property
    When launchd is run as the root user, the user to run the job as.
 
 ``wait_for_debugger``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Specify if launchd has a job wait for a debugger to attach before executing code.
 
@@ -3378,9 +3378,9 @@ Properties
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -3604,9 +3604,9 @@ This resource has the following properties:
    Use to specify the identifier for the profile, such as ``com.company.screensaver``.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -3873,14 +3873,14 @@ Properties
 This resource has the following properties:
 
 ``frequency``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``86400``
 
-   Determines how frequently (in seconds) APT repository updates are made. Use this property when the ``:periodic`` action is specified. Default value: ``86400``.
+   Determines how frequently (in seconds) APT repository updates are made. Use this property when the ``:periodic`` action is specified.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -4154,9 +4154,9 @@ This resource has the following properties:
    The group name or group ID that must be changed before running a command.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -4212,19 +4212,19 @@ This resource has the following properties:
          end
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``returns``
-   **Ruby Types:** Integer, Array
+   **Ruby Types:** Integer, Array | **Default Value:** ``0``
 
-   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match. Default value: ``0``.
+   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match.
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -4276,9 +4276,9 @@ This resource has the following properties:
    .. end_tag
 
 ``timeout``
-   **Ruby Types:** Integer, Float
+   **Ruby Types:** Integer, Float | **Default Value:** ``3600``
 
-   The amount of time (in seconds) a command is to wait before timing out. Default value: ``3600``.
+   The amount of time (in seconds) a command is to wait before timing out.
 
 ``user``
    **Ruby Types:** String, Integer
@@ -6173,9 +6173,9 @@ Attributes
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``module_name``
    **Ruby Type:** String
@@ -6296,14 +6296,14 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -7696,9 +7696,9 @@ Attributes
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -7742,14 +7742,14 @@ This resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String
@@ -7901,7 +7901,7 @@ Attributes
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
    Continue running a recipe if a resource fails for any reason. Default value: ``false``.
 
@@ -7947,14 +7947,14 @@ This resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String
@@ -8912,9 +8912,9 @@ Properties
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -9161,9 +9161,9 @@ This resource has the following properties:
    .. end_tag
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -9207,14 +9207,14 @@ This resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String
@@ -9413,9 +9413,9 @@ This resource has the following properties:
    The amount of time (in minutes) to delay a reboot request.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -9441,14 +9441,14 @@ This resource has the following properties:
    A string that describes the reboot action.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -9629,9 +9629,9 @@ Properties
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``init_command``
    **Ruby Type:** String
@@ -9685,14 +9685,14 @@ This resource has the following properties:
    The command used to restart a service.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``run_as_password``
    **Ruby Type:** String

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -7903,7 +7903,7 @@ This resource has the following properties:
 ``ignore_failure``
    **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -3653,14 +3653,14 @@ This resource has the following properties:
    Use to specify the name of the profile, if different from the name of the resource block.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -3917,14 +3917,14 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_apt_package.rst
+++ b/chef_master/source/resource_apt_package.rst
@@ -94,9 +94,9 @@ The apt_package resource has the following properties:
    The default release. For example: ``stable``.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_apt_package.rst
+++ b/chef_master/source/resource_apt_package.rst
@@ -33,7 +33,7 @@ The full syntax for all of the properties that are available to the **apt_packag
      default_release            String
      notifies                   # see description
      options                    String, Array
-     overwrite_config_files     True, False # default value: 'false'
+     overwrite_config_files     true, false # default value: 'false'
      package_name               String, Array # defaults to 'name' if not specified
      response_file              String
      response_file_variables    Hash

--- a/chef_master/source/resource_apt_repository.rst
+++ b/chef_master/source/resource_apt_repository.rst
@@ -117,7 +117,7 @@ This resource has the following properties:
    The name of the repository to configure, if it differs from the name of the resource block. The value of this setting must not contain spaces.
 
 ``sensitive``
-   **Ruby Type:** True, False | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
 
    Determines whether sensitive resource data (such as key information) is not logged by the chef-client.
 

--- a/chef_master/source/resource_apt_repository.rst
+++ b/chef_master/source/resource_apt_repository.rst
@@ -33,14 +33,14 @@ The full syntax for all of the properties that are available to the **apt_reposi
       distribution          String
       components            Array
       arch                  String
-      trusted               True, False
-      deb_src               True, False
+      trusted               true, false
+      deb_src               true, false
       keyserver             String
       key                   String, Array
       key_proxy             String
       cookbook              String
-      cache_rebuild         True, False
-      sensitive             True, False
+      cache_rebuild         true, false
+      sensitive             true, false
       action                Symbol # defaults to :add if not specified
    end
 

--- a/chef_master/source/resource_apt_update.rst
+++ b/chef_master/source/resource_apt_update.rst
@@ -74,14 +74,14 @@ Properties
 This resource has the following properties:
 
 ``frequency``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``86400``
 
-   Determines how frequently (in seconds) APT repository updates are made. Use this property when the ``:periodic`` action is specified. Default value: ``86400``.
+   Determines how frequently (in seconds) APT repository updates are made. Use this property when the ``:periodic`` action is specified.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -118,14 +118,14 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_bash.rst
+++ b/chef_master/source/resource_bash.rst
@@ -106,9 +106,9 @@ This resource has the following properties:
    The group name or group ID that must be changed before running a command.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -164,19 +164,19 @@ This resource has the following properties:
          end
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``returns``
-   **Ruby Types:** Integer, Array
+   **Ruby Types:** Integer, Array | **Default Value:** ``0``
 
-   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match. Default value: ``0``.
+   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match.
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -228,9 +228,9 @@ This resource has the following properties:
    .. end_tag
 
 ``timeout``
-   **Ruby Types:** Integer, Float
+   **Ruby Types:** Integer, Float | **Default Value:** ``3600``
 
-   The amount of time (in seconds) a command is to wait before timing out. Default value: ``3600``.
+   The amount of time (in seconds) a command is to wait before timing out.
 
 ``user``
    **Ruby Types:** String, Integer

--- a/chef_master/source/resource_bff_package.rst
+++ b/chef_master/source/resource_bff_package.rst
@@ -82,9 +82,9 @@ Properties
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -131,14 +131,14 @@ This resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_build_essential.rst
+++ b/chef_master/source/resource_build_essential.rst
@@ -43,7 +43,7 @@ The build_essential resource has the following actions:
 Properties
 =====================================================
 ``compile_time``
-   **Ruby Type:** True, False | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
    
    Install the build essential packages at compile time.
    

--- a/chef_master/source/resource_chef_acl.rst
+++ b/chef_master/source/resource_chef_acl.rst
@@ -68,9 +68,9 @@ This resource has the following properties:
    Use to specify if this resource defines a chef-client completely. When ``true``, any property not specified by this resource will be reset to default property values.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -149,14 +149,14 @@ This resource has the following properties:
       remove_rights :all, :users => [ 'jkeiser', 'adam' ]
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``rights``
    Use to add rights. Syntax: ``:right, :right => 'user', :groups => [ 'group', 'group']``. For example:

--- a/chef_master/source/resource_chef_client.rst
+++ b/chef_master/source/resource_chef_client.rst
@@ -77,9 +77,9 @@ This resource has the following properties:
    Use to specify if this resource defines a chef-client completely. When ``true``, any property not specified by this resource will be reset to default property values.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``name``
    The name of the chef-client.
@@ -142,14 +142,14 @@ This resource has the following properties:
       }
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source_key``
    Use to copy a public or private key, but apply a different ``format`` and ``password``. Use in conjunction with ``source_key_pass_phrase``` and ``source_key_path``.

--- a/chef_master/source/resource_chef_container.rst
+++ b/chef_master/source/resource_chef_container.rst
@@ -67,9 +67,9 @@ This resource has the following properties:
    The URL for the Chef server.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``name``
    The name of the container.
@@ -109,14 +109,14 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_chef_data_bag.rst
+++ b/chef_master/source/resource_chef_data_bag.rst
@@ -61,9 +61,9 @@ This resource has the following properties:
    The URL for the Chef server.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``name``
    The name of the data bag.
@@ -103,14 +103,14 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_chef_data_bag_item.rst
+++ b/chef_master/source/resource_chef_data_bag_item.rst
@@ -84,9 +84,9 @@ This resource has the following properties:
    The minimum required version of data bag encryption. Possible values: ``0``, ``1``, and ``2``. When all of the machines in an organization are running chef-client version 11.6 (or higher), it is recommended that this value be set to ``2``.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -136,14 +136,14 @@ This resource has the following properties:
       }
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_chef_environment.rst
+++ b/chef_master/source/resource_chef_environment.rst
@@ -79,9 +79,9 @@ This resource has the following properties:
    The description of the environment. This value populates the description field for the environment on the Chef server.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``name``
    The name of the environment.
@@ -145,14 +145,14 @@ This resource has the following properties:
       }
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_chef_gem.rst
+++ b/chef_master/source/resource_chef_gem.rst
@@ -35,10 +35,10 @@ The full syntax for all of the properties that are available to the **chef_gem**
 .. code-block:: ruby
 
    chef_gem 'name' do
-     clear_sources              True, False
-     compile_time               True, False
+     clear_sources              true, false
+     compile_time               true, false
      gem_binary                 String
-     include_default_source     True, False
+     include_default_source     true, false
      notifies                   # see description
      options                    String
      package_name               String # defaults to 'name' if not specified

--- a/chef_master/source/resource_chef_gem.rst
+++ b/chef_master/source/resource_chef_gem.rst
@@ -87,9 +87,9 @@ Properties
 This resource has the following properties:
 
 ``clear_sources``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Set to ``true`` to download a gem from the path specified by the ``source`` property (and not from RubyGems). Default value: ``false``.
+   Set to ``true`` to download a gem from the path specified by the ``source`` property (and not from RubyGems).
 
    .. note:: Another approach is to use the **gem_package** resource, and then specify the ``gem_binary`` location to the RubyGems directory that is used by Chef. For example:
 
@@ -101,7 +101,7 @@ This resource has the following properties:
                 end
 
 ``compile_time``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Controls the phase during which a gem is installed on a node. Set to ``true`` to install a gem while the resource collection is being built (the "compile phase"). Set to ``false`` to install a gem while the chef-client is configuring the node (the "converge phase"). Possible values: ``nil`` (for verbose warnings), ``true`` (to warn once per chef-client run), or ``false`` (to remove all warnings). Recommended value: ``false``.
 
@@ -111,16 +111,16 @@ This resource has the following properties:
    The path of a gem binary to use for the installation. By default, the same version of Ruby that is used by the chef-client will be installed.
 
 ``include_default_source``
-   **Ruby Types:** True, False | **Default Value:** ``true``
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
    Set to ``false`` to not include ``Chef::Config[:rubygems_url]`` in the sources.
 
    New in Chef Client 13.0
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -168,14 +168,14 @@ This resource has the following properties:
    The name of the gem. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:**  ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String, Array

--- a/chef_master/source/resource_chef_group.rst
+++ b/chef_master/source/resource_chef_group.rst
@@ -76,9 +76,9 @@ This resource has the following properties:
    ...
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``name``
 
@@ -135,14 +135,14 @@ This resource has the following properties:
    ...
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:**  ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_chef_handler.rst
+++ b/chef_master/source/resource_chef_handler.rst
@@ -184,9 +184,9 @@ Properties
 This resource has the following properties:
 
 ``arguments``
-   **Ruby Type:** Array
+   **Ruby Type:** Array | **Default Value:** ``[]``
 
-   An array of arguments that are passed to the initializer for the handler class. Default value: ``[]``. For example:
+   An array of arguments that are passed to the initializer for the handler class. For example:
 
    .. code-block:: ruby
 
@@ -204,9 +204,9 @@ This resource has the following properties:
    The name of the handler class. This can be module name-spaced.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -243,14 +243,14 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String
@@ -310,15 +310,15 @@ This resource has the following properties:
 
    .. warning:: This property has been deprecated, and will be removed in the future. Use the ``type`` property instead.
 
-   **Ruby Type:** Hash
+   **Ruby Type:** Hash | **Default Value:** ``{ report: true, exception: true }``.
 
-   The type of handler. Possible values: ``:exception``, ``:report``, or ``:start``. Default value: ``{ report: true, exception: true }``.
+   The type of handler. Possible values: ``:exception``, ``:report``, or ``:start``. 
 
 ``type``
 
-  **Ruby Type:** Hash
+  **Ruby Type:** Hash | **Default Value:** ``{ report: true, exception: true }``.
 
-   The type of handler. Possible values: ``:exception``, ``:report``, or ``:start``. Default value: ``{ report: true, exception: true }``.
+   The type of handler. Possible values: ``:exception``, ``:report``, or ``:start``. 
 
 
 

--- a/chef_master/source/resource_chef_mirror.rst
+++ b/chef_master/source/resource_chef_mirror.rst
@@ -75,9 +75,9 @@ This resource has the following properties:
    Use to freeze cookbooks upon upload to the mirrored location. When ``true`` (default), cookbooks are frozen.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``no_diff``
    Use to upload only new files.
@@ -123,14 +123,14 @@ This resource has the following properties:
    Use to remove objects that have been deleted locally from the mirrored location. For example, when used with the ``:upload`` action, cookbooks that exist in the mirrored location, but do not exist locally, will be deleted.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_chef_node.rst
+++ b/chef_master/source/resource_chef_node.rst
@@ -85,9 +85,9 @@ This resource has the following properties:
    Default value: ``{}``.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``name``
    The name of the node.
@@ -164,14 +164,14 @@ This resource has the following properties:
       }
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``run_list``
    A comma-separated list of roles and/or recipes to be applied. Default value: ``[]``. For example: ``["recipe[default]","recipe[apache2]"]``

--- a/chef_master/source/resource_chef_organization.rst
+++ b/chef_master/source/resource_chef_organization.rst
@@ -73,9 +73,9 @@ This resource has the following properties:
    The full name must begin with a non-white space character and must be between 1 and 1023 characters. For example: ``Chef Software, Inc.``.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``invites``
    Use to specify a list of users to be invited to the organization. An invitation is sent to any user in this list who is not already a member of the organization.
@@ -139,14 +139,14 @@ This resource has the following properties:
    Use to remove the specified users from an organization. Invitations that have not been accepted will be cancelled.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_chef_role.rst
+++ b/chef_master/source/resource_chef_role.rst
@@ -79,9 +79,9 @@ This resource has the following properties:
    The environment-specific run-list for a role. Default value: ``[]``. For example: ``["env_run_lists[webserver]"]``
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``name``
    The name of the role.
@@ -147,14 +147,14 @@ This resource has the following properties:
      }
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``run_list``
    A comma-separated list of roles and/or recipes to be applied. Default value: ``[]``. For example: ``["recipe[default]","recipe[apache2]"]``

--- a/chef_master/source/resource_chef_user.rst
+++ b/chef_master/source/resource_chef_user.rst
@@ -66,9 +66,9 @@ This resource has the following properties:
    ...
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``name``
    The name of the user.
@@ -126,14 +126,14 @@ This resource has the following properties:
    ...
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source_key``
    Use to copy a public or private key, but apply a different ``format`` and ``password``. Use in conjunction with ``source_key_pass_phrase``` and ``source_key_path``.

--- a/chef_master/source/resource_chocolatey_package.rst
+++ b/chef_master/source/resource_chocolatey_package.rst
@@ -95,9 +95,9 @@ Properties
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -141,17 +141,17 @@ This resource has the following properties:
 ``package_name``
    **Ruby Types:** String, Array
 
-   The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
+   The name of the package. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_common.rst
+++ b/chef_master/source/resource_common.rst
@@ -53,24 +53,24 @@ Properties
 The following properties are common to every resource:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``sensitive``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Ensure that sensitive resource data is not logged by the chef-client. Default value: ``false``.
+   Ensure that sensitive resource data is not logged by the chef-client.
 
 
 .. end_tag

--- a/chef_master/source/resource_cookbook_file.rst
+++ b/chef_master/source/resource_cookbook_file.rst
@@ -89,14 +89,14 @@ Properties
 This resource has the following properties:
 
 ``atomic_update``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file. Default value: ``true``.
+   Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file.
 
 ``backup``
-   **Ruby Types:** False, Integer
+   **Ruby Types:** False, Integer | **Default Value:** ``5``
 
-   The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept. Default value: ``5``.
+   The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept.
 
 ``cookbook``
    **Ruby Type:** String
@@ -104,9 +104,9 @@ This resource has the following properties:
    The cookbook in which a file is located (if it is not located in the current cookbook). The default value is the current cookbook.
 
 ``force_unlink``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   How the chef-client handles certain situations when the target file turns out not to be a file. For example, when a target file is actually a symlink. Set to ``true`` for the chef-client delete the non-file target and replace it with the specified file. Set to ``false`` for the chef-client to raise an error. Default value: ``false``.
+   How the chef-client handles certain situations when the target file turns out not to be a file. For example, when a target file is actually a symlink. Set to ``true`` for the chef-client delete the non-file target and replace it with the specified file. Set to ``false`` for the chef-client to raise an error.
 
 ``group``
    **Ruby Types:** Integer, String
@@ -114,17 +114,17 @@ This resource has the following properties:
    A string or ID that identifies the group owner by group name, including fully qualified group names such as ``domain\group`` or ``group@domain``. If this value is not specified, existing groups remain unchanged and new group assignments use the default ``POSIX`` group (if available).
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``inherits``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Microsoft Windows only. Whether a file inherits rights from its parent directory. Default value: ``true``.
+   Microsoft Windows only. Whether a file inherits rights from its parent directory.
 
 ``manage_symlink_source``
-   **Ruby Types:** True, False | **Default Value:** ``true`` (with warning)
+   **Ruby Types:** true, false | **Default Value:** ``true`` (with warning)
 
    Change the behavior of the file resource if it is pointed at a symlink. When this value is set to ``true``, the Chef client will manage the symlink's permissions or will replace the symlink with a normal file if the resource has content. When this value is set to ``false``, Chef will follow the symlink and will manage the permissions and content of the symlink's target file.
 
@@ -188,14 +188,14 @@ This resource has the following properties:
    Microsoft Windows: A path that begins with a forward slash (``/``) will point to the root of the current working directory of the chef-client process. This path can vary from system to system. Therefore, using a path that begins with a forward slash (``/``) is not recommended.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``rights``
    **Ruby Types:** Integer, String

--- a/chef_master/source/resource_cookbook_file.rst
+++ b/chef_master/source/resource_cookbook_file.rst
@@ -36,13 +36,13 @@ The full syntax for all of the properties that are available to the **cookbook_f
 .. code-block:: ruby
 
    cookbook_file 'name' do
-     atomic_update              True, False
-     backup                     False, Integer
+     atomic_update              true, false
+     backup                     false, Integer
      cookbook                   String
-     force_unlink               True, False
+     force_unlink               true, false
      group                      String, Integer
-     inherits                   True, False
-     manage_symlink_source      True, False
+     inherits                   true, false
+     manage_symlink_source      true, false
      mode                       String, Integer
      notifies                   # see description
      owner                      String, Integer
@@ -94,7 +94,7 @@ This resource has the following properties:
    Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file.
 
 ``backup``
-   **Ruby Types:** False, Integer | **Default Value:** ``5``
+   **Ruby Types:** false, Integer | **Default Value:** ``5``
 
    The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept.
 

--- a/chef_master/source/resource_cron.rst
+++ b/chef_master/source/resource_cron.rst
@@ -144,7 +144,7 @@ The cron resource has the following properties:
    The hour at which the cron entry is to run (0 - 23).
 
 ``ignore_failure``
-   **Ruby Types:** True, False | **Default Value:** ``false``
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
    Continue running a recipe if a resource fails for any reason.
 

--- a/chef_master/source/resource_cron_access.rst
+++ b/chef_master/source/resource_cron_access.rst
@@ -54,9 +54,9 @@ The cron_access resource has the following properties:
    The user to allow or deny. If not provided we'll use the resource name.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -93,14 +93,14 @@ The cron_access resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_cron_d.rst
+++ b/chef_master/source/resource_cron_d.rst
@@ -146,7 +146,7 @@ The cron_d resource has the following properties:
    The hour at which the cron entry is to run (0 - 23).
 
 ``ignore_failure``
-   **Ruby Types:** True, False | **Default Value:** ``false``
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
    Continue running a recipe if a resource fails for any reason.
 

--- a/chef_master/source/resource_csh.rst
+++ b/chef_master/source/resource_csh.rst
@@ -101,9 +101,9 @@ This resource has the following properties:
    The group name or group ID that must be changed before running a command.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -159,19 +159,19 @@ This resource has the following properties:
          end
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``returns``
-   **Ruby Types:** Integer, Array
+   **Ruby Types:** Integer, Array | **Default Value:** ``0``
 
-   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match. Default value: ``0``.
+   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match.
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -223,9 +223,9 @@ This resource has the following properties:
    .. end_tag
 
 ``timeout``
-   **Ruby Types:** Integer, Float
+   **Ruby Types:** Integer, Float | **Default Value:** ``3600``
 
-   The amount of time (in seconds) a command is to wait before timing out. Default value: ``3600``.
+   The amount of time (in seconds) a command is to wait before timing out.
 
 ``user``
    **Ruby Types:** String, Integer

--- a/chef_master/source/resource_deploy.rst
+++ b/chef_master/source/resource_deploy.rst
@@ -70,12 +70,12 @@ The full syntax for all of the properties that are available to the **deploy** w
      create_dirs_before_symlink Array
      deploy_to                  String # defaults to 'name' if not specified
      depth                      Integer
-     enable_submodules          True, False
+     enable_submodules          true, false
      environment                Hash
      git_ssh_wrapper            String
      group                      String
      keep_releases              Integer
-     migrate                    True, False
+     migrate                    true, false
      migration_command          String
      notifies                   # see description
      purge_before_symlink       Array
@@ -85,9 +85,9 @@ The full syntax for all of the properties that are available to the **deploy** w
      repository_cache           String
      restart_command            Proc, String
      revision                   String
-     rollback_on_error          True, False
+     rollback_on_error          true, false
      scm_provider               Chef::Provider::Git
-     shallow_clone              True, False
+     shallow_clone              true, false
      ssh_wrapper                String
      symlinks                   Hash
      symlink_before_migrate     Hash
@@ -111,7 +111,7 @@ and the full syntax for all of the properties that are available to the **deploy
      environment                Hash
      group                      String
      keep_releases              Integer
-     migrate                    True, False
+     migrate                    true, false
      migration_command          String
      notifies                   # see description
      purge_before_symlink       Array
@@ -120,7 +120,7 @@ and the full syntax for all of the properties that are available to the **deploy
      repository_cache           String
      restart_command            Proc, String
      revision                   String
-     rollback_on_error          True, False
+     rollback_on_error          true, false
      scm_provider               Chef::Provider::Subversion
      subscribes                 # see description
      svn_arguments              String

--- a/chef_master/source/resource_deploy.rst
+++ b/chef_master/source/resource_deploy.rst
@@ -330,19 +330,19 @@ This resource has the following properties:
    The system group that is responsible for the checked-out code.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``keep_releases``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``5``
 
-   The number of releases for which a backup is kept. Default value: ``5``.
+   The number of releases for which a backup is kept.
 
 ``migrate``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Run a migration command. Default value: ``false``.
+   Run a migration command.
 
 ``migration_command``
    **Ruby Type:** String
@@ -399,9 +399,9 @@ This resource has the following properties:
    The URI for the repository.
 
 ``repository_cache``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``cached-copy``
 
-   The name of the sub-directory in which the pristine copy of an application's source is kept. Default value: ``cached-copy``.
+   The name of the sub-directory in which the pristine copy of an application's source is kept.
 
 ``restart_command``
    **Ruby Types:** String, Proc
@@ -409,29 +409,29 @@ This resource has the following properties:
    A string that contains a shell command that can be executed to run a restart operation.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``revision``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``HEAD``
 
-   A branch, tag, or commit to be synchronized with git. This can be symbolic, like ``HEAD`` or it can be a source control management-specific revision identifier. Default value: ``HEAD``.
+   A branch, tag, or commit to be synchronized with git. This can be symbolic, like ``HEAD`` or it can be a source control management-specific revision identifier.
 
 ``rollback_on_error``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Roll a resource back to a previously-deployed release if an error occurs when deploying a new release. Default value: ``false``.
+   Roll a resource back to a previously-deployed release if an error occurs when deploying a new release.
 
 ``scm_provider``
-   **Ruby Type:** Chef Class
+   **Ruby Type:** Chef Class | **Default Value:** ``Chef::Provider::Git``
 
-   The name of the source control management provider. Default value: ``Chef::Provider::Git``. Optional values: ``Chef::Provider::Subversion``.
+   The name of the source control management provider. Optional values: ``Chef::Provider::Subversion``.
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -510,9 +510,9 @@ The following properties are for use with git only:
    The depth of a git repository, truncated to the specified number of revisions. See ``shallow_clone``.
 
 ``enable_submodules``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Perform a sub-module initialization and update. Default value: ``false``.
+   Perform a sub-module initialization and update.
 
 ``git_ssh_wrapper``
    **Ruby Type:** String
@@ -520,14 +520,14 @@ The following properties are for use with git only:
    The alias for the ``ssh_wrapper``.
 
 ``remote``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``origin``
 
-   The remote repository to use when synchronizing an existing clone. Default value: ``origin``.
+   The remote repository to use when synchronizing an existing clone.
 
 ``shallow_clone``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Set the clone depth to ``5``. If a depth other than ``5`` is required, use the ``depth`` property instead of ``shallow_clone``. Default value: ``false``.
+   Set the clone depth to ``5``. If a depth other than ``5`` is required, use the ``depth`` property instead of ``shallow_clone``.
 
 ``ssh_wrapper``
    **Ruby Type:** String

--- a/chef_master/source/resource_directory.rst
+++ b/chef_master/source/resource_directory.rst
@@ -78,14 +78,14 @@ This resource has the following properties:
    A string or ID that identifies the group owner by group name, including fully qualified group names such as ``domain\group`` or ``group@domain``. If this value is not specified, existing groups remain unchanged and new group assignments use the default ``POSIX`` group (if available).
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``inherits``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Microsoft Windows only. Whether a file inherits rights from its parent directory. Default value: ``true``.
+   Microsoft Windows only. Whether a file inherits rights from its parent directory.
 
 ``mode``
    **Ruby Types:** Integer, String
@@ -143,19 +143,19 @@ This resource has the following properties:
    The path to the directory. Using a fully qualified path is recommended, but is not always required. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``recursive``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Create or delete parent directories recursively. For the ``owner``, ``group``, and ``mode`` properties, the value of this attribute applies only to the leaf directory. Default value: ``false``.
+   Create or delete parent directories recursively. For the ``owner``, ``group``, and ``mode`` properties, the value of this attribute applies only to the leaf directory.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``rights``
    **Ruby Types:** Integer, String

--- a/chef_master/source/resource_directory.rst
+++ b/chef_master/source/resource_directory.rst
@@ -33,12 +33,12 @@ The full syntax for all of the properties that are available to the **directory*
 
    directory 'name' do
      group                      String, Integer
-     inherits                   True, False
+     inherits                   true, false
      mode                       String, Integer
      notifies                   # see description
      owner                      String, Integer
      path                       String # defaults to 'name' if not specified
-     recursive                  True, False
+     recursive                  true, false
      rights                     Hash
      subscribes                 # see description
      action                     Symbol # defaults to :create if not specified

--- a/chef_master/source/resource_dmg_package.rst
+++ b/chef_master/source/resource_dmg_package.rst
@@ -14,8 +14,8 @@ This resource has the following syntax:
 .. code-block:: ruby
 
    dmg_package 'name' do
-     accept_eula                True, False # default value: 'false'
-     allow_untrusted            True, False # default value: 'false'
+     accept_eula                true, false # default value: 'false'
+     allow_untrusted            true, false # default value: 'false'
      app                        String # default value: 'name'
      checksum                   String
      destination                String # default value: '/Applications'

--- a/chef_master/source/resource_dmg_package.rst
+++ b/chef_master/source/resource_dmg_package.rst
@@ -54,12 +54,12 @@ Actions
 Properties
 =====================================================
 ``accept_eula``
-   **Ruby Type:** True, False | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
    
    Specify if the application's EULA should be accepted, if applicable.
 
 ``allow_untrusted``
-   **Ruby Type:** True, False | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
    
    Allow installation of packages that do not have trusted certificates.
 

--- a/chef_master/source/resource_dnf_package.rst
+++ b/chef_master/source/resource_dnf_package.rst
@@ -125,9 +125,9 @@ This resource has the following properties:
    .. note:: The ``flush_cache`` property does not flush the local DNF cache! Use dnf tools---``dnf clean metadata``, ``dnf clean packages``, ``dnf clean all``---to clean the local DNF cache.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -174,19 +174,19 @@ This resource has the following properties:
    One of the following: the name of a package, the name of a package and its architecture, the name of a dependency. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``sensitive``
-  **Ruby Type** True, False
+  **Ruby Type** true, false | **Default Value:** ``false``
 
-   Ensure that sensitive resource data is not logged by the chef-client. Default value: ``false``.
+   Ensure that sensitive resource data is not logged by the chef-client.
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_dnf_package.rst
+++ b/chef_master/source/resource_dnf_package.rst
@@ -32,13 +32,13 @@ The full syntax for all of the properties that are available to the **dnf_packag
    dnf_package 'name' do
      arch                       String, Array
      flush_cache                Array
-     ignore_failure             True, False # defaults to ``false``
+     ignore_failure             true, false # defaults to ``false``
      notifies                   # see description
      options                    String
      package_name               String, Array # defaults to 'name' if not specified
      retries                    Integer
      retry_delay                Integer
-     sensitive                  True, False # defaults to ``false``
+     sensitive                  true, false # defaults to ``false``
      source                     String
      subscribes                 # see description
      timeout                    String, Integer

--- a/chef_master/source/resource_dpkg_package.rst
+++ b/chef_master/source/resource_dpkg_package.rst
@@ -72,9 +72,9 @@ Properties
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -121,14 +121,14 @@ This resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_erlang_call.rst
+++ b/chef_master/source/resource_erlang_call.rst
@@ -32,7 +32,7 @@ The full syntax for all of the properties that are available to the **erl_call**
    erl_call 'name' do
      code                       String
      cookie                     String
-     distributed                True, False
+     distributed                true, false
      name_type                  String
      node_name                  String
      notifies                   # see description

--- a/chef_master/source/resource_erlang_call.rst
+++ b/chef_master/source/resource_erlang_call.rst
@@ -72,14 +72,14 @@ This resource has the following properties:
    The magic cookie for the node to which a connection is made.
 
 ``distributed``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   The node is a distributed Erlang node. Default value: ``false``.
+   The node is a distributed Erlang node.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``name_type``
    **Ruby Type:** String
@@ -126,14 +126,14 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_execute.rst
+++ b/chef_master/source/resource_execute.rst
@@ -57,10 +57,10 @@ The full syntax for all of the properties that are available to the **execute** 
      cwd                        String
      environment                Hash # env is an alias for environment
      group                      String, Integer
-     live_stream                True, False
+     live_stream                true, false
      notifies                   # see description
      returns                    Integer, Array
-     sensitive                  True, False
+     sensitive                  true, false
      subscribes                 # see description
      timeout                    Integer, Float
      umask                      String, Integer

--- a/chef_master/source/resource_execute.rst
+++ b/chef_master/source/resource_execute.rst
@@ -95,7 +95,7 @@ This resource has the following properties:
 ``command``
    **Ruby Types:** String, Array
 
-   The name of the command to be executed. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
+   The name of the command to be executed. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 
    .. note:: Use the **execute** resource to run a single command. Use multiple **execute** resource blocks to run multiple commands.
 
@@ -120,14 +120,14 @@ This resource has the following properties:
    The group name or group ID that must be changed before running a command.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``live_stream``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Send the output of the command run by this **execute** resource block to the chef-client event stream. Default value: ``false``.
+   Send the output of the command run by this **execute** resource block to the chef-client event stream.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -164,22 +164,22 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``returns``
-   **Ruby Types:** Integer, Array
+   **Ruby Types:** Integer, Array | **Default Value:** ``0``
 
-   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match. Default value: ``0``.
+   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match.
 
 ``sensitive``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
    Ensure that sensitive resource data is not logged by the chef-client. Default value: ``false``.
 

--- a/chef_master/source/resource_file.rst
+++ b/chef_master/source/resource_file.rst
@@ -89,14 +89,14 @@ Properties
 This resource has the following properties:
 
 ``atomic_update``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file. Default value: ``true``.
+   Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file.
 
 ``backup``
-   **Ruby Types:** False, Integer
+   **Ruby Types:** False, Integer | **Default Value:** ``5``
 
-   The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept. Default value: ``5``.
+   The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept.
 
 ``checksum``
    **Ruby Types:** String
@@ -109,9 +109,9 @@ This resource has the following properties:
    A string that is written to the file. The contents of this property replace any previous content when this property has something other than the default value. The default behavior will not modify content.
 
 ``force_unlink``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   How the chef-client handles certain situations when the target file turns out not to be a file. For example, when a target file is actually a symlink. Set to ``true`` for the chef-client delete the non-file target and replace it with the specified file. Set to ``false`` for the chef-client to raise an error. Default value: ``false``.
+   How the chef-client handles certain situations when the target file turns out not to be a file. For example, when a target file is actually a symlink. Set to ``true`` for the chef-client delete the non-file target and replace it with the specified file. Set to ``false`` for the chef-client to raise an error.
 
 ``group``
    **Ruby Types:** Integer, String
@@ -119,17 +119,17 @@ This resource has the following properties:
    A string or ID that identifies the group owner by group name, including fully qualified group names such as ``domain\group`` or ``group@domain``. If this value is not specified, existing groups remain unchanged and new group assignments use the default ``POSIX`` group (if available).
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``inherits``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Microsoft Windows only. Whether a file inherits rights from its parent directory. Default value: ``true``.
+   Microsoft Windows only. Whether a file inherits rights from its parent directory.
 
 ``manage_symlink_source``
-   **Ruby Types:** True, False | **Default Value:** ``true`` (with warning)
+   **Ruby Types:** true, false | **Default Value:** ``true`` (with warning)
 
    Change the behavior of the file resource if it is pointed at a symlink. When this value is set to ``true``, the Chef client will manage the symlink's permissions or will replace the symlink with a normal file if the resource has content. When this value is set to ``false``, Chef will follow the symlink and will manage the permissions and content of symlink's target file.
 
@@ -193,14 +193,14 @@ This resource has the following properties:
    Microsoft Windows: A path that begins with a forward slash (``/``) will point to the root of the current working directory of the chef-client process. This path can vary from system to system. Therefore, using a path that begins with a forward slash (``/``) is not recommended.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``rights``
    **Ruby Types:** Integer, String
@@ -208,9 +208,9 @@ This resource has the following properties:
    Microsoft Windows only. The permissions for users and groups in a Microsoft Windows environment. For example: ``rights <permissions>, <principal>, <options>`` where ``<permissions>`` specifies the rights granted to the principal, ``<principal>`` is the group or user name, and ``<options>`` is a Hash with one (or more) advanced rights options.
 
 ``sensitive``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Ensure that sensitive resource data is not logged by the chef-client. Default value: ``false``.
+   Ensure that sensitive resource data is not logged by the chef-client.
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_file.rst
+++ b/chef_master/source/resource_file.rst
@@ -34,20 +34,20 @@ The full syntax for all of the properties that are available to the **file** res
 .. code-block:: ruby
 
    file 'name' do
-     atomic_update              True, False
-     backup                     False, Integer
+     atomic_update              true, false
+     backup                     false, Integer
      checksum                   String
      content                    String
-     force_unlink               True, False
+     force_unlink               true, false
      group                      String, Integer
-     inherits                   True, False
-     manage_symlink_source      True, False
+     inherits                   true, false
+     manage_symlink_source      true, false
      mode                       String, Integer
      notifies                   # see description
      owner                      String, Integer
      path                       String # defaults to 'name' if not specified
      rights                     Hash
-     sensitive                  True, False
+     sensitive                  true, false
      subscribes                 # see description
      verify                     String, Block
      action                     Symbol # defaults to :create if not specified
@@ -94,7 +94,7 @@ This resource has the following properties:
    Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file.
 
 ``backup``
-   **Ruby Types:** False, Integer | **Default Value:** ``5``
+   **Ruby Types:** false, Integer | **Default Value:** ``5``
 
    The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept.
 

--- a/chef_master/source/resource_freebsd_package.rst
+++ b/chef_master/source/resource_freebsd_package.rst
@@ -69,9 +69,9 @@ Properties
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -118,14 +118,14 @@ This resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_gem_package.rst
+++ b/chef_master/source/resource_gem_package.rst
@@ -36,8 +36,8 @@ The full syntax for all of the properties that are available to the **gem_packag
 .. code-block:: ruby
 
    gem_package 'name' do
-     clear_sources              True, False
-     include_default_source     True, False
+     clear_sources              true, false
+     include_default_source     true, false
      gem_binary                 String
      notifies                   # see description
      options                    String

--- a/chef_master/source/resource_gem_package.rst
+++ b/chef_master/source/resource_gem_package.rst
@@ -206,14 +206,14 @@ Properties
 This resource has the following properties:
 
 ``clear_sources``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Set to ``true`` to download a gem from the path specified by the ``source`` property (and not from RubyGems). Default value: ``false``.
+   Set to ``true`` to download a gem from the path specified by the ``source`` property (and not from RubyGems).
 
 ``include_default_source``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Set to ``false`` to not include ``Chef::Config[:rubygems_url]`` in the sources. Default value: ``true``.
+   Set to ``false`` to not include ``Chef::Config[:rubygems_url]`` in the sources.
 
    New in Chef Client 13.0
 
@@ -223,9 +223,9 @@ This resource has the following properties:
    A property for the ``gem_package`` provider that is used to specify a gems binary. By default, the same version of Ruby that is used by the chef-client will be installed.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -269,17 +269,17 @@ This resource has the following properties:
 ``package_name``
    **Ruby Types:** String, Array
 
-   The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
+   The name of the package. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String, Array

--- a/chef_master/source/resource_git.rst
+++ b/chef_master/source/resource_git.rst
@@ -82,9 +82,9 @@ The git resource has the following properties:
    A Hash of additional remotes that are added to the git repository configuration.
 
 ``checkout_branch``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``deploy``
 
-   Do a one-time checkout from git **or** use when a branch in the upstream repository is named ``deploy``. To prevent the **git** resource from attempting to check out master from master, set ``enable_checkout`` to ``false`` when using the ``checkout_branch`` property. See ``revision``. Default value: ``deploy``.
+   Do a one-time checkout from git **or** use when a branch in the upstream repository is named ``deploy``. To prevent the **git** resource from attempting to check out master from master, set ``enable_checkout`` to ``false`` when using the ``checkout_branch`` property. See ``revision``.
 
 ``depth``
    **Ruby Type:** Integer
@@ -97,14 +97,14 @@ The git resource has the following properties:
    The location path to which the source is to be cloned, checked out, or exported. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``enable_checkout``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Check out a repo from master. Set to ``false`` when using the ``checkout_branch`` attribute to prevent the **git** resource from attempting to check out master from master. Default value: ``true``.
+   Check out a repo from master. Set to ``false`` when using the ``checkout_branch`` attribute to prevent the **git** resource from attempting to check out master from master.
 
 ``enable_submodules``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Perform a sub-module initialization and update. Default value: ``false``.
+   Perform a sub-module initialization and update.
 
 ``environment``
    **Ruby Type:** Hash
@@ -119,9 +119,9 @@ The git resource has the following properties:
    The system group that is responsible for the checked-out code.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -173,19 +173,19 @@ The git resource has the following properties:
    The URI for the git repository.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``revision``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``HEAD``
 
-   A branch, tag, or commit to be synchronized with git. This can be symbolic, like ``HEAD`` or it can be a source control management-specific revision identifier. See ``checkout_branch``. Default value: ``HEAD``.
+   A branch, tag, or commit to be synchronized with git. This can be symbolic, like ``HEAD`` or it can be a source control management-specific revision identifier. See ``checkout_branch``.
 
    The value of the ``revision`` attribute may change over time. From one branch to another, to a tag, to a specific SHA for a commit, and then back to a branch. The ``revision`` attribute may even be changed in a way where history gets rewritten.
 

--- a/chef_master/source/resource_group.rst
+++ b/chef_master/source/resource_group.rst
@@ -83,9 +83,9 @@ The group resource has the following properties:
    The name of the group. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``members``
    **Ruby Type:** Array
@@ -93,9 +93,9 @@ The group resource has the following properties:
    Which users should be set or appended to a group. When more than one group member is identified, the list of members should be an array: ``members ['user1', 'user2']``.
 
 ``non_unique``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Allow ``gid`` duplication. May only be used with the ``Groupadd`` provider. Default value: ``false``.
+   Allow ``gid`` duplication. May only be used with the ``Groupadd`` provider.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -132,14 +132,14 @@ The group resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -191,7 +191,7 @@ The group resource has the following properties:
    .. end_tag
 
 ``system``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Show if a group belongs to a system group. Set to ``true`` if the group belongs to a system group.
 

--- a/chef_master/source/resource_homebrew_package.rst
+++ b/chef_master/source/resource_homebrew_package.rst
@@ -95,9 +95,9 @@ This resource has the following properties:
    .. end_tag
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -144,14 +144,14 @@ This resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_http_request.rst
+++ b/chef_master/source/resource_http_request.rst
@@ -85,9 +85,9 @@ The http_request resource has the following properties:
    A Hash of custom headers.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``message``
    **Ruby Type:** Object
@@ -129,14 +129,14 @@ The http_request resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_ifconfig.rst
+++ b/chef_master/source/resource_ifconfig.rst
@@ -131,9 +131,9 @@ The ifconfig resource has the following properties:
    The hardware address for the network interface.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``inet_addr``
    **Ruby Type:** String
@@ -212,14 +212,14 @@ The ifconfig resource has the following properties:
    Bring up the network interface when its parent interface is brought up.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_ips_package.rst
+++ b/chef_master/source/resource_ips_package.rst
@@ -30,7 +30,7 @@ The full syntax for all of the properties that are available to the **ips_packag
 .. code-block:: ruby
 
    ips_package 'name' do
-     accept_license             True, False
+     accept_license             true, false
      notifies                   # see description
      options                    String
      package_name               String, Array # defaults to 'name' if not specified

--- a/chef_master/source/resource_ips_package.rst
+++ b/chef_master/source/resource_ips_package.rst
@@ -75,14 +75,14 @@ Properties
 The ips_package resource has the following properties:
 
 ``accept_license``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Accept an end-user license agreement, automatically. Default value: ``false``.
+   Accept an end-user license agreement, automatically.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -129,14 +129,14 @@ The ips_package resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_ksh.rst
+++ b/chef_master/source/resource_ksh.rst
@@ -111,9 +111,9 @@ This resource has the following properties:
    The group name or group ID that must be changed before running a command.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -169,19 +169,19 @@ This resource has the following properties:
          end
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``returns``
-   **Ruby Types:** Integer, Array
+   **Ruby Types:** Integer, Array | **Default Value:** ``0``
 
-   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match. Default value: ``0``.
+   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match.
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -233,9 +233,9 @@ This resource has the following properties:
    .. end_tag
 
 ``timeout``
-   **Ruby Types:** Integer, Float
+   **Ruby Types:** Integer, Float | **Default Value:** ``3600``
 
-   The amount of time (in seconds) a command is to wait before timing out. Default value: ``3600``.
+   The amount of time (in seconds) a command is to wait before timing out.
 
 ``user``
    **Ruby Types:** String, Integer

--- a/chef_master/source/resource_link.rst
+++ b/chef_master/source/resource_link.rst
@@ -84,19 +84,19 @@ The link resource has the following properties:
    A string or ID that identifies the group associated with a symbolic link.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``link_type``
-   **Ruby Type:** Symbol
+   **Ruby Type:** Symbol | **Default Value:** ``:symbolic``
 
-   The type of link: ``:symbolic`` or ``:hard``. Default value: ``:symbolic``.
+   The type of link: ``:symbolic`` or ``:hard``.
 
 ``mode``
-   **Ruby Types:** Integer, String
+   **Ruby Types:** Integer, String | **Default Value:** ``777``
 
-   If ``mode`` is not specified and if the file already exists, the existing mode on the file is used. If ``mode`` is not specified, the file does not exist, and the ``:create`` action is specified, the chef-client assumes a mask value of ``'0777'`` and then applies the umask for the system on which the file is to be created to the ``mask`` value. For example, if the umask on a system is ``'022'``, the chef-client uses the default value of ``'0755'``. Default value: ``777``.
+   If ``mode`` is not specified and if the file already exists, the existing mode on the file is used. If ``mode`` is not specified, the file does not exist, and the ``:create`` action is specified, the chef-client assumes a mask value of ``'0777'`` and then applies the umask for the system on which the file is to be created to the ``mask`` value. For example, if the umask on a system is ``'022'``, the chef-client uses the default value of ``'0755'``. 
 
    The behavior is different depending on the platform.
 
@@ -144,14 +144,14 @@ The link resource has the following properties:
    The owner associated with a symbolic link.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_load_balancer.rst
+++ b/chef_master/source/resource_load_balancer.rst
@@ -70,9 +70,9 @@ This resource has the following properties:
    Use to specify the driver to be used for provisioning.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``load_balancer_options``
    ...
@@ -120,14 +120,14 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_log.rst
+++ b/chef_master/source/resource_log.rst
@@ -68,7 +68,7 @@ Properties
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False | **Default Value:** ``false``
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
    Continue running a recipe if a resource fails for any reason.
 

--- a/chef_master/source/resource_machine.rst
+++ b/chef_master/source/resource_machine.rst
@@ -155,12 +155,12 @@ Properties
 This resource has the following properties:
 
 ``admin``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Use to specify whether the chef-client is an API client.
 
 ``allow_overwrite_keys``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Use to overwrite the key on a machine when it is different from the key specified by ``source_key``.
 
@@ -221,7 +221,7 @@ This resource has the following properties:
       end
 
 ``converge``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Use to manage convergence when used with the ``:create`` action. Set to ``false`` to prevent convergence. Set to ``true`` to force convergence. When ``nil``, the machine will converge only if something changes. Default value: ``nil``.
 
@@ -261,9 +261,9 @@ This resource has the following properties:
    Use to specify an image created by the **machine_image** resource.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``machine_options``
    **Ruby Type:** Hash
@@ -320,9 +320,9 @@ This resource has the following properties:
    Use to generate a private key of the desired size, type, and so on.
 
 ``public_key_format``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``pem``
 
-   Use to specify the format of a public key. Possible values: ``pem`` and ``der``. Default value: ``pem``.
+   Use to specify the format of a public key. Possible values: ``pem`` and ``der``.
 
 ``public_key_path``
    **Ruby Type:** String
@@ -366,14 +366,14 @@ This resource has the following properties:
    Use to remove a tag.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``role``
    Use to add a role to the run-list for the machine. Use this property multiple times to add multiple roles to a run-list. Use this property along with ``recipe`` to define a run-list. The order in which the ``recipe`` and ``role`` properties are specified will determine the order in which they are added to the run-list. This property should not be used in the same recipe as ``run_list``. For example:
@@ -460,7 +460,7 @@ This resource has the following properties:
    Use to add one (or more) tags. This will remove any tag currently associated with the machine. For example: ``tags :a, :b, :c``.
 
 ``validator``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Use to specify if the chef-client is a chef-validator.
 

--- a/chef_master/source/resource_machine_batch.rst
+++ b/chef_master/source/resource_machine_batch.rst
@@ -163,9 +163,9 @@ This resource has the following attributes:
    ...
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``machine_options``
    ...
@@ -211,14 +211,14 @@ This resource has the following attributes:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_machine_execute.rst
+++ b/chef_master/source/resource_machine_execute.rst
@@ -78,14 +78,12 @@ This resource has the following properties:
    Use to specify the driver to be used for provisioning.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``live_stream``
-   **Ruby Types:** True, False
-
-   Default value: ``false``.
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
 ``machine``
    **Ruby Type:** String
@@ -127,14 +125,14 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_machine_file.rst
+++ b/chef_master/source/resource_machine_file.rst
@@ -87,9 +87,9 @@ This resource has the following properties:
    A string or ID that identifies the group owner by group name, including fully qualified group names such as ``domain\group`` or ``group@domain``. If this value is not specified, existing groups remain unchanged and new group assignments use the default ``POSIX`` group (if available).
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``local_path``
    **Ruby Type:** String
@@ -159,14 +159,14 @@ This resource has the following properties:
    Microsoft Windows: A path that begins with a forward slash (``/``) will point to the root of the current working directory of the chef-client process. This path can vary from system to system. Therefore, using a path that begins with a forward slash (``/``) is not recommended.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_machine_image.rst
+++ b/chef_master/source/resource_machine_image.rst
@@ -78,9 +78,9 @@ This resource has the following properties:
    Use to specify if all of the attributes specified in ``attributes`` represent a complete specification for the machine image. When true, any attributes not specified in ``attributes`` will be reset to their default values.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``image_options``
    **Ruby Type:** Hash
@@ -143,14 +143,14 @@ This resource has the following properties:
    Use to remove a role from the run-list for the machine image.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``role``
    Use to add a role to the run-list for the machine image.

--- a/chef_master/source/resource_macos_userdefaults.rst
+++ b/chef_master/source/resource_macos_userdefaults.rst
@@ -153,7 +153,7 @@ The macos_userdefaults resource has the following properties:
    .. end_tag
 
 ``sudo``
-   **Ruby Type:** True, False | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
 
    Set to ``true`` if the setting you wish to modify requires privileged access.
 

--- a/chef_master/source/resource_macos_userdefaults.rst
+++ b/chef_master/source/resource_macos_userdefaults.rst
@@ -15,11 +15,11 @@ The macos_userdefaults resource has the following syntax:
 
    macos_userdefaults 'name' do
      domain                String # required
-     global                True, False # default value: 'false'
+     global                true, false # default value: 'false'
      key                   String
      notifies              # see description
      subscribes            # see description
-     sudo                  True, False # default value: 'false'
+     sudo                  true, false # default value: 'false'
      type                  String # default value: ""
      user                  String
      value                 Integer, Float, String, true, false, Hash, Array

--- a/chef_master/source/resource_macports_package.rst
+++ b/chef_master/source/resource_macports_package.rst
@@ -76,9 +76,9 @@ Properties
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -125,14 +125,14 @@ This resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_mdadm.rst
+++ b/chef_master/source/resource_mdadm.rst
@@ -77,9 +77,9 @@ The mdadm resource has the following properties:
    Indicates whether the RAID array exists.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``layout``
    **Ruby Type:** String
@@ -136,14 +136,14 @@ The mdadm resource has the following properties:
    The name of the RAID device. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_mount.rst
+++ b/chef_master/source/resource_mount.rst
@@ -111,9 +111,9 @@ The mount resource has the following properties:
    Required. The file system type (fstype) of the device.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``mount_point``
    **Ruby Type:** String
@@ -121,9 +121,9 @@ The mount resource has the following properties:
    The directory (or path) in which the device is to be mounted. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``mounted``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Use to specify if a file system is already mounted. Default value: ``false``.
+   Use to specify if a file system is already mounted.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -160,14 +160,14 @@ The mount resource has the following properties:
    .. end_tag
 
 ``options``
-   **Ruby Types:** Array, String
+   **Ruby Types:** Array, String | **Default Value:** ``defaults``
 
-   An array or string that contains mount options. If this value is a string, it is converted to an array. Default value: ``defaults``.
+   An array or string that contains mount options. If this value is a string, it is converted to an array.
 
 ``pass``
-   **Ruby Types:** Integer, False
+   **Ruby Types:** Integer, false | **Default Value:** ``2``
 
-   The pass number used by the file system check (``fsck``) command while creating a file systems table (``fstab``) entry. Default value: ``2``.
+   The pass number used by the file system check (``fsck``) command while creating a file systems table (``fstab``) entry.
 
 ``password``
    **Ruby Type:** String
@@ -175,14 +175,14 @@ The mount resource has the following properties:
    Microsoft Windows only. Use to specify the password for ``username``.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_ohai_hint.rst
+++ b/chef_master/source/resource_ohai_hint.rst
@@ -44,7 +44,7 @@ The ohai_hint resource has the following actions:
 Properties
 =====================================================
 ``compile_time``
-   **Ruby Type:** True, False | **Default Value:** ``true``
+   **Ruby Type:** true, false | **Default Value:** ``true``
 
    Determines whether or not the resource is executed during the compile time phase.
 

--- a/chef_master/source/resource_openbsd_package.rst
+++ b/chef_master/source/resource_openbsd_package.rst
@@ -77,9 +77,9 @@ Properties
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -126,14 +126,14 @@ This resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_osx_profile.rst
+++ b/chef_master/source/resource_osx_profile.rst
@@ -63,9 +63,9 @@ This resource has the following properties:
    Use to specify the identifier for the profile, such as ``com.company.screensaver``.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -112,14 +112,14 @@ This resource has the following properties:
    Use to specify the name of the profile, if different from the name of the resource block.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_package.rst
+++ b/chef_master/source/resource_package.rst
@@ -66,7 +66,7 @@ The full syntax for all of the properties that are available to the **package** 
 .. code-block:: ruby
 
    package 'name' do
-     allow_downgrade            True, False # Yum, RPM packages only
+     allow_downgrade            true, false # Yum, RPM packages only
      arch                       String, Array # Yum packages only
      default_release            String # Apt packages only
      flush_cache                Array

--- a/chef_master/source/resource_package.rst
+++ b/chef_master/source/resource_package.rst
@@ -240,9 +240,9 @@ Properties
 This resource has the following attributes:
 
 ``allow_downgrade``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   **yum_package** resource only. Downgrade a package to satisfy requested version requirements. Default value: ``false``.
+   **yum_package** resource only. Downgrade a package to satisfy requested version requirements.
 
 ``arch``
    **Ruby Types:** String, Array
@@ -298,9 +298,9 @@ This resource has the following attributes:
    **homebrew_package** resource only. The name of the Homebrew owner to be used by the chef-client when executing a command.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -357,14 +357,14 @@ This resource has the following attributes:
    **apt_package** and **dpkg_package** resources only. A Hash of response file variables in the form of ``{"VARIABLE" => "VALUE"}``.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_pacman_package.rst
+++ b/chef_master/source/resource_pacman_package.rst
@@ -75,9 +75,9 @@ Properties
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -124,14 +124,14 @@ This resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_paludis_package.rst
+++ b/chef_master/source/resource_paludis_package.rst
@@ -80,9 +80,9 @@ Properties
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -129,14 +129,14 @@ This resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_perl.rst
+++ b/chef_master/source/resource_perl.rst
@@ -101,9 +101,9 @@ This resource has the following properties:
    The group name or group ID that must be changed before running a command.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -159,19 +159,19 @@ This resource has the following properties:
          end
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``returns``
-   **Ruby Types:** Integer, Array
+   **Ruby Types:** Integer, Array | **Default Value:** ``0``
 
-   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match. Default value: ``0``.
+   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match.
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -223,9 +223,9 @@ This resource has the following properties:
    .. end_tag
 
 ``timeout``
-   **Ruby Types:** Integer, Float
+   **Ruby Types:** Integer, Float | **Default Value:** ``3600``
 
-   The amount of time (in seconds) a command is to wait before timing out. Default value: ``3600``.
+   The amount of time (in seconds) a command is to wait before timing out.
 
 ``user``
    **Ruby Types:** String, Integer

--- a/chef_master/source/resource_portage_package.rst
+++ b/chef_master/source/resource_portage_package.rst
@@ -74,9 +74,9 @@ Properties
 This resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -123,14 +123,14 @@ This resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_private_key.rst
+++ b/chef_master/source/resource_private_key.rst
@@ -64,9 +64,9 @@ This resource has the following properties:
    Use to specify the format of a private key. Possible values: ``pem`` and ``der``. Default value: ``pem``.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -118,14 +118,14 @@ This resource has the following properties:
    Use to regenerate a private key if it does not have the desired size, type, and so on. Default value: ``false``.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``size``
    Use to specify the size of an RSA or DSA private key. Default value: ``2048``.

--- a/chef_master/source/resource_public_key.rst
+++ b/chef_master/source/resource_public_key.rst
@@ -55,9 +55,9 @@ This resource has the following properties:
    Use to specify the format of a public key. Possible values: ``pem`` and ``der``. Default value: ``pem``.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -97,14 +97,14 @@ This resource has the following properties:
    The path to a public key.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source_key``
    Use to copy a public key, but apply a different ``format`` and ``password``. Use in conjunction with ``source_key_pass_phrase``` and ``source_key_path``.

--- a/chef_master/source/resource_python.rst
+++ b/chef_master/source/resource_python.rst
@@ -107,9 +107,9 @@ The python resource has the following properties:
    The group name or group ID that must be changed before running a command.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -165,19 +165,19 @@ The python resource has the following properties:
          end
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``returns``
-   **Ruby Types:** Integer, Array
+   **Ruby Types:** Integer, Array | **Default Value:** ``0``
 
-   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match. Default value: ``0``.
+   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match.
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -229,9 +229,9 @@ The python resource has the following properties:
    .. end_tag
 
 ``timeout``
-   **Ruby Types:** Integer, Float
+   **Ruby Types:** Integer, Float | **Default Value:** ``3600``
 
-   The amount of time (in seconds) a command is to wait before timing out. Default value: ``3600``.
+   The amount of time (in seconds) a command is to wait before timing out.
 
 ``user``
    **Ruby Types:** String, Integer

--- a/chef_master/source/resource_reboot.rst
+++ b/chef_master/source/resource_reboot.rst
@@ -63,9 +63,9 @@ The reboot resource has the following properties:
    The amount of time (in minutes) to delay a reboot request.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -91,14 +91,14 @@ The reboot resource has the following properties:
    A string that describes the reboot action.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_reference.rst
+++ b/chef_master/source/resource_reference.rst
@@ -50,24 +50,24 @@ Properties
 The following properties are common to every resource:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``sensitive``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Ensure that sensitive resource data is not logged by the chef-client. Default value: ``false``.
+   Ensure that sensitive resource data is not logged by the chef-client.
 
 
 .. end_tag

--- a/chef_master/source/resource_remote_directory.rst
+++ b/chef_master/source/resource_remote_directory.rst
@@ -35,19 +35,19 @@ The full syntax for all of the properties that are available to the **remote_dir
 
    remote_directory 'name' do
      cookbook                   String
-     files_backup               Integer, False
+     files_backup               Integer, false
      files_group                String
      files_mode                 String
      files_owner                String
      group                      String, Integer
-     inherits                   True, False
+     inherits                   true, false
      mode                       String, Integer
      notifies                   # see description
-     overwrite                  True, False
+     overwrite                  true, false
      owner                      String, Integer
      path                       String # defaults to 'name' if not specified
-     purge                      True, False
-     recursive                  True, False
+     purge                      true, false
+     recursive                  true, false
      rights                     Hash
      source                     String
      subscribes                 # see description
@@ -93,7 +93,7 @@ The remote_directory resource has the following properties:
    The cookbook in which a file is located (if it is not located in the current cookbook). The default value is the current cookbook.
 
 ``files_backup``
-   **Ruby Types:** Integer, False | **Default Value:** ``5``
+   **Ruby Types:** Integer, false | **Default Value:** ``5``
 
    The number of backup copies to keep for files in the directory.
 

--- a/chef_master/source/resource_remote_directory.rst
+++ b/chef_master/source/resource_remote_directory.rst
@@ -93,9 +93,9 @@ The remote_directory resource has the following properties:
    The cookbook in which a file is located (if it is not located in the current cookbook). The default value is the current cookbook.
 
 ``files_backup``
-   **Ruby Types:** Integer, False
+   **Ruby Types:** Integer, False | **Default Value:** ``5``
 
-   The number of backup copies to keep for files in the directory. Default value: ``5``.
+   The number of backup copies to keep for files in the directory.
 
 ``files_group``
    **Ruby Type:** String
@@ -122,14 +122,14 @@ The remote_directory resource has the following properties:
    Use to configure permissions for directories. A string or ID that identifies the group owner by group name, including fully qualified group names such as ``domain\group`` or ``group@domain``. If this value is not specified, existing groups remain unchanged and new group assignments use the default ``POSIX`` group (if available).
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``inherits``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Microsoft Windows only. Whether a file inherits rights from its parent directory. Default value: ``true``.
+   Microsoft Windows only. Whether a file inherits rights from its parent directory.
 
 ``mode``
    **Ruby Types:** Integer, String
@@ -177,9 +177,9 @@ The remote_directory resource has the following properties:
    .. end_tag
 
 ``overwrite``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Overwrite a file when it is different. Default value: ``true``.
+   Overwrite a file when it is different.
 
 ``owner``
    **Ruby Types:** Integer, String
@@ -192,24 +192,24 @@ The remote_directory resource has the following properties:
    The path to the directory. Using a fully qualified path is recommended, but is not always required. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``purge``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Purge extra files found in the target directory. Default value: ``false``.
+   Purge extra files found in the target directory.
 
 ``recursive``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Create or delete directories recursively. Default value: ``true``; the chef-client must be able to create the directory structure, including parent directories (if missing), as defined in ``COOKBOOK_NAME/files/default/REMOTE_DIRECTORY``.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``rights``
    **Ruby Types:** Integer, String

--- a/chef_master/source/resource_remote_file.rst
+++ b/chef_master/source/resource_remote_file.rst
@@ -104,14 +104,14 @@ Properties
 This resource has the following properties:
 
 ``atomic_update``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file. Default value: ``true``.
+   Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file.
 
 ``backup``
-   **Ruby Types:** False, Integer
+   **Ruby Types:** False, Integer | **Default Value:** ``5``
 
-   The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept. Default value: ``5``.
+   The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept.
 
 ``checksum``
    **Ruby Type:** String
@@ -119,14 +119,14 @@ This resource has the following properties:
    Optional, see ``use_conditional_get``. The SHA-256 checksum of the file. Use to prevent a file from being re-downloaded. When the local file matches the checksum, the chef-client does not download it.
 
 ``force_unlink``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   How the chef-client handles certain situations when the target file turns out not to be a file. For example, when a target file is actually a symlink. Set to ``true`` for the chef-client delete the non-file target and replace it with the specified file. Set to ``false`` for the chef-client to raise an error. Default value: ``false``.
+   How the chef-client handles certain situations when the target file turns out not to be a file. For example, when a target file is actually a symlink. Set to ``true`` for the chef-client delete the non-file target and replace it with the specified file. Set to ``false`` for the chef-client to raise an error.
 
 ``ftp_active_mode``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Whether the chef-client uses active or passive FTP. Set to ``true`` to use active FTP. Default value: ``false``.
+   Whether the chef-client uses active or passive FTP. Set to ``true`` to use active FTP.
 
 ``group``
    **Ruby Types:** Integer, String
@@ -134,9 +134,9 @@ This resource has the following properties:
    A string or ID that identifies the group owner by group name, including fully qualified group names such as ``domain\group`` or ``group@domain``. If this value is not specified, existing groups remain unchanged and new group assignments use the default ``POSIX`` group (if available).
 
 ``headers()``
-   **Ruby Type:** Hash
+   **Ruby Type:** Hash | **Default Value:** ``{}``
 
-   A Hash of custom headers. Default value: ``{}``. For example:
+   A Hash of custom headers. For example:
 
    .. code-block:: ruby
 
@@ -155,17 +155,17 @@ This resource has the following properties:
       headers( "Authorization"=>"Basic #{ Base64.encode64("#{username}:#{password}").gsub("\n", "") }" )
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``inherits``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Microsoft Windows only. Whether a file inherits rights from its parent directory. Default value: ``true``.
+   Microsoft Windows only. Whether a file inherits rights from its parent directory.
 
 ``manage_symlink_source``
-   **Ruby Types:** True, False | **Default Value:** ``true`` (with warning)
+   **Ruby Types:** true, false | **Default Value:** ``true`` (with warning)
 
    Change the behavior of the file resource if it is pointed at a symlink. When this value is set to ``true``, the Chef client will manage the symlink's permissions or will replace the symlink with a normal file if the resource has content. When this value is set to ``false``, Chef will follow the symlink and will manage the permissions and content of the symlink's target file.
 
@@ -248,14 +248,14 @@ This resource has the following properties:
    New in Chef client 13.4
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``rights``
    **Ruby Types:** Integer, String
@@ -373,24 +373,24 @@ This resource has the following properties:
    .. end_tag
 
 ``use_conditional_get``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Enable conditional HTTP requests by using a conditional ``GET`` (with the If-Modified-Since header) or an opaque identifier (ETag). To use If-Modified-Since headers, ``use_last_modified`` must also be set to ``true``. To use ETag headers, ``use_etag`` must also be set to ``true``. Default value: ``true``.
+   Enable conditional HTTP requests by using a conditional ``GET`` (with the If-Modified-Since header) or an opaque identifier (ETag). To use If-Modified-Since headers, ``use_last_modified`` must also be set to ``true``. To use ETag headers, ``use_etag`` must also be set to ``true``.
 
 ``use_etag``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Enable ETag headers. Set to ``false`` to disable ETag headers. To use this setting, ``use_conditional_get`` must also be set to ``true``. Default value: ``true``.
+   Enable ETag headers. Set to ``false`` to disable ETag headers. To use this setting, ``use_conditional_get`` must also be set to ``true``.
 
 ``use_last_modified``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Enable If-Modified-Since headers. Set to ``false`` to disable If-Modified-Since headers. To use this setting, ``use_conditional_get`` must also be set to ``true``. Default value: ``true``.
+   Enable If-Modified-Since headers. Set to ``false`` to disable If-Modified-Since headers. To use this setting, ``use_conditional_get`` must also be set to ``true``.
 
 ``show_progess``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Displays the progress of the file download. Set to ``true`` to enable this feature. Default value: ``false``.
+   Displays the progress of the file download. Set to ``true`` to enable this feature.
 
 ``verify``
    **Ruby Types:** String, Block

--- a/chef_master/source/resource_remote_file.rst
+++ b/chef_master/source/resource_remote_file.rst
@@ -48,8 +48,8 @@ The full syntax for all of the properties that are available to the **remote_fil
      ftp_active_mode            true, false # default value: false
      group                      String, Integer
      headers                    Hash
-     inherits                   True, False
-     manage_symlink_source      True, False
+     inherits                   true, false
+     manage_symlink_source      true, false
      mode                       String, Integer
      notifies                   # see description
      owner                      String, Integer
@@ -57,7 +57,7 @@ The full syntax for all of the properties that are available to the **remote_fil
      rights                     Hash
      source                     String, Array
      subscribes                 # see description
-     use_conditional_get        True, False
+     use_conditional_get        true, false
      verify                     String, Block
      remote_domain              String
      remote_password            String
@@ -109,7 +109,7 @@ This resource has the following properties:
    Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file.
 
 ``backup``
-   **Ruby Types:** False, Integer | **Default Value:** ``5``
+   **Ruby Types:** false, Integer | **Default Value:** ``5``
 
    The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept.
 

--- a/chef_master/source/resource_rhsm_register.rst
+++ b/chef_master/source/resource_rhsm_register.rst
@@ -56,7 +56,7 @@ Properties
    A string or array of  activation keys to use when registering; you must also specify the ``organization`` property when using this.
 
 ``auto_attach``
-   **Ruby Type:** True, False | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
 
    If ``true``, RHSM will attempt to automatically attach the host to applicable subscriptions. It is generally better to use an activation key with the subscriptions predefined.
 
@@ -66,12 +66,12 @@ Properties
    The environment to use when registering; required when using the ``username`` and ``password`` properties.
 
 ``force``
-   **Ruby Type:** True, False | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
 
    If true, the system will be registered even if it is already registered. Normally, any register operations will fail if the machine has already been registered.
 
 ``install_katello_agent``
-   **Ruby Type:** True, False | **Default Value:** ``true``
+   **Ruby Type:** true, false | **Default Value:** ``true``
 
    If true, the ``katello-agent`` RPM will be installed.
 

--- a/chef_master/source/resource_route.rst
+++ b/chef_master/source/resource_route.rst
@@ -81,9 +81,9 @@ This resource has the following properties:
    The gateway for the route.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``netmask``
    **Ruby Type:** String
@@ -125,14 +125,14 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_rpm_package.rst
+++ b/chef_master/source/resource_rpm_package.rst
@@ -30,7 +30,7 @@ The full syntax for all of the properties that are available to the **rpm_packag
 .. code-block:: ruby
 
    rpm_package 'name' do
-     allow_downgrade            True, False
+     allow_downgrade            true, false
      notifies                   # see description
      options                    String
      package_name               String, Array # defaults to 'name' if not specified

--- a/chef_master/source/resource_rpm_package.rst
+++ b/chef_master/source/resource_rpm_package.rst
@@ -73,14 +73,14 @@ Properties
 This resource has the following properties:
 
 ``allow_downgrade``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Downgrade a package to satisfy requested version requirements.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -127,14 +127,14 @@ This resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_ruby.rst
+++ b/chef_master/source/resource_ruby.rst
@@ -106,9 +106,9 @@ This resource has the following properties:
    The group name or group ID that must be changed before running a command.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -164,19 +164,19 @@ This resource has the following properties:
          end
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``returns``
-   **Ruby Types:** Integer, Array
+   **Ruby Types:** Integer, Array | **Default Value:** ``0``
 
-   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match. Default value: ``0``.
+   The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match.
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -228,9 +228,9 @@ This resource has the following properties:
    .. end_tag
 
 ``timeout``
-   **Ruby Types:** Integer, Float
+   **Ruby Types:** Integer, Float | **Default Value:** ``3600``
 
-   The amount of time (in seconds) a command is to wait before timing out. Default value: ``3600``.
+   The amount of time (in seconds) a command is to wait before timing out.
 
 ``user``
    **Ruby Types:** String, Integer

--- a/chef_master/source/resource_ruby_block.rst
+++ b/chef_master/source/resource_ruby_block.rst
@@ -74,9 +74,9 @@ This resource has the following properties:
    The name of the Ruby block. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -113,14 +113,14 @@ This resource has the following properties:
    .. end_tag
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_script.rst
+++ b/chef_master/source/resource_script.rst
@@ -139,9 +139,9 @@ This resource has the following attributes:
    The group name or group ID that must be changed before running a command.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``interpreter``
    **Ruby Type:** String
@@ -202,14 +202,14 @@ This resource has the following attributes:
          end
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``returns``
    **Ruby Types:** Integer, Array
@@ -266,9 +266,9 @@ This resource has the following attributes:
    .. end_tag
 
 ``timeout``
-   **Ruby Types:** Integer, Float
+   **Ruby Types:** Integer, Float | **Default Value:**  ``3600``
 
-   The amount of time (in seconds) a command is to wait before timing out. Default value: ``3600``.
+   The amount of time (in seconds) a command is to wait before timing out.
 
 ``user``
    **Ruby Types:** String

--- a/chef_master/source/resource_service.rst
+++ b/chef_master/source/resource_service.rst
@@ -80,9 +80,9 @@ Properties
 The service resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``init_command``
    **Ruby Type:** String
@@ -129,9 +129,9 @@ The service resource has the following properties:
    Solaris platform only. Options to pass to the service command. See the ``svcadm`` manual for details of possible options.
 
 ``pattern``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``service_name``
 
-   The pattern to look for in the process table. Default value: ``service_name``.
+   The pattern to look for in the process table.
 
 ``priority``
    **Ruby Types:** Integer, String, Hash
@@ -149,14 +149,14 @@ The service resource has the following properties:
    The command used to restart a service.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``service_name``
    **Ruby Type:** String
@@ -233,9 +233,9 @@ The service resource has the following properties:
    A list of properties that controls how the chef-client is to attempt to manage a service: ``:restart``, ``:reload``, ``:status``. For ``:restart``, the init script or other service provider can use a restart command; if ``:restart`` is not specified, the chef-client attempts to stop and then start a service. For ``:reload``, the init script or other service provider can use a reload command. For ``:status``, the init script or other service provider can use a status command to determine if the service is running; if ``:status`` is not specified, the chef-client attempts to match the ``service_name`` against the process table as a regular expression, unless a pattern is specified as a parameter property. Default value: ``{ restart: false, reload: false, status: false }`` for all platforms (except for the Red Hat platform family, which defaults to ``{ restart: false, reload: false, status: true }``.)
 
 ``timeout``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``60``
 
-   Microsoft Windows platform only. The amount of time (in seconds) to wait before timing out. Default value: ``60``.
+   Microsoft Windows platform only. The amount of time (in seconds) to wait before timing out.
 
 Examples
 =====================================================

--- a/chef_master/source/resource_smartos_package.rst
+++ b/chef_master/source/resource_smartos_package.rst
@@ -74,9 +74,9 @@ Properties
 The smartos_package resource has the following properties:
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -123,14 +123,14 @@ The smartos_package resource has the following properties:
    The name of the package. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_solaris_package.rst
+++ b/chef_master/source/resource_solaris_package.rst
@@ -72,9 +72,9 @@ The solaris_package resource has the following properties:
    Required. The path to a package in the local file system.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_subversion.rst
+++ b/chef_master/source/resource_subversion.rst
@@ -82,9 +82,9 @@ The subversion resource has the following properties:
    The system group that is responsible for the checked-out code.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -126,19 +126,19 @@ The subversion resource has the following properties:
    The URI for the Subversion repository.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``revision``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``HEAD``
 
-   A branch, tag, or commit to be synchronized with git. This can be symbolic, like ``HEAD`` or it can be a source control management-specific revision identifier. Default value: ``HEAD``.
+   A branch, tag, or commit to be synchronized with git. This can be symbolic, like ``HEAD`` or it can be a source control management-specific revision identifier.
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_swap_file.rst
+++ b/chef_master/source/resource_swap_file.rst
@@ -92,7 +92,7 @@ The swap_file resource has the following properties:
    The path where the swap file will be created on the system, if it differs from the resource block name.
 
 ``persist``
-   **Ruby Type:** True, False | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
 
    Persist the swapon.
 

--- a/chef_master/source/resource_systemd_unit.rst
+++ b/chef_master/source/resource_systemd_unit.rst
@@ -125,12 +125,12 @@ The systemd_unit resource has the following properties:
    A string or hash that contains a systemd `unit file <https://www.freedesktop.org/software/systemd/man/systemd.unit.html>`_ definition that describes the properties of systemd-managed entities, such as services, sockets, devices, and so on. In Chef 14.4, repeatable options can be implemented with an array.
 
 ``triggers_reload``
-   **Ruby Type:** True, False
+   **Ruby Type:** true, false | **Default Value:** ``true``
 
-   Specifies whether to trigger a daemon reload when creating or deleting a unit. Default is true.
+   Specifies whether to trigger a daemon reload when creating or deleting a unit.
 
 ``verify``
-   **Ruby Type:** True, False
+   **Ruby Type:** true, false
 
    Specifies if the unit will be verified before installation. Systemd can be overly strict when verifying units, so in certain cases it is preferable not to verify the unit. Defaults to true.
 

--- a/chef_master/source/resource_template.rst
+++ b/chef_master/source/resource_template.rst
@@ -45,22 +45,22 @@ The full syntax for all of the properties that are available to the **template**
 .. code-block:: ruby
 
    template 'name' do
-     atomic_update              True, False
-     backup                     False, Integer
+     atomic_update              true, false
+     backup                     false, Integer
      cookbook                   String
-     force_unlink               True, False
+     force_unlink               true, false
      group                      String, Integer
      helper(:method)            Method { String } # see Helpers below
      helpers(module)            Module # see Helpers below
-     inherits                   True, False
-     local                      True, False
-     manage_symlink_source      True, False
+     inherits                   true, false
+     local                      true, false
+     manage_symlink_source      true, false
      mode                       String, Integer
      notifies                   # see description
      owner                      String, Integer
      path                       String # defaults to 'name' if not specified
      rights                     Hash
-     sensitive                  True, False
+     sensitive                  true, false
      source                     String, Array
      subscribes                 # see description
      variables                  Hash
@@ -109,7 +109,7 @@ This resource has the following properties:
    Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file.
 
 ``backup``
-   **Ruby Types:** False, Integer | **Default Value:** ``5``
+   **Ruby Types:** false, Integer | **Default Value:** ``5``
 
    The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept.
 

--- a/chef_master/source/resource_template.rst
+++ b/chef_master/source/resource_template.rst
@@ -104,14 +104,14 @@ Properties
 This resource has the following properties:
 
 ``atomic_update``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file. Default value: ``true``.
+   Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file.
 
 ``backup``
-   **Ruby Types:** False, Integer
+   **Ruby Types:** False, Integer | **Default Value:** ``5``
 
-   The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept. Default value: ``5``.
+   The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept.
 
 ``cookbook``
    **Ruby Type:** String
@@ -119,9 +119,9 @@ This resource has the following properties:
    The cookbook in which a file is located (if it is not located in the current cookbook). The default value is the current cookbook.
 
 ``force_unlink``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   How the chef-client handles certain situations when the target file turns out not to be a file. For example, when a target file is actually a symlink. Set to ``true`` for the chef-client delete the non-file target and replace it with the specified file. Set to ``false`` for the chef-client to raise an error. Default value: ``false``.
+   How the chef-client handles certain situations when the target file turns out not to be a file. For example, when a target file is actually a symlink. Set to ``true`` for the chef-client delete the non-file target and replace it with the specified file. Set to ``false`` for the chef-client to raise an error.
 
 ``group``
    **Ruby Types:** Integer, String
@@ -129,32 +129,32 @@ This resource has the following properties:
    A string or ID that identifies the group owner by group name, including fully qualified group names such as ``domain\group`` or ``group@domain``. If this value is not specified, existing groups remain unchanged and new group assignments use the default ``POSIX`` group (if available).
 
 ``helper``
-   **Ruby Type:** Method
+   **Ruby Type:** Method | **Default Value:** ``{}``
 
-   Define a helper method inline. For example: ``helper(:hello_world) { "hello world" }`` or ``helper(:app) { node["app"] }`` or ``helper(:app_conf) { |setting| node["app"][setting] }``. Default value: ``{}``.
+   Define a helper method inline. For example: ``helper(:hello_world) { "hello world" }`` or ``helper(:app) { node["app"] }`` or ``helper(:app_conf) { |setting| node["app"][setting] }``.
 
 ``helpers``
-   **Ruby Type:** Module
+   **Ruby Type:** Module | **Default Value:** ``[]``
 
-   Define a helper module inline or in a library. For example, an inline module: ``helpers do``, which is then followed by a block of Ruby code. And for a library module: ``helpers(MyHelperModule)``. Default value: ``[]``.
+   Define a helper module inline or in a library. For example, an inline module: ``helpers do``, which is then followed by a block of Ruby code. And for a library module: ``helpers(MyHelperModule)``.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``inherits``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``true``
 
-   Microsoft Windows only. Whether a file inherits rights from its parent directory. Default value: ``true``.
+   Microsoft Windows only. Whether a file inherits rights from its parent directory.
 
 ``local``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Load a template from a local path. By default, the chef-client loads templates from a cookbook's ``/templates`` directory. When this property is set to ``true``, use the ``source`` property to specify the path to a template on the local node. Default value: ``false``.
+   Load a template from a local path. By default, the chef-client loads templates from a cookbook's ``/templates`` directory. When this property is set to ``true``, use the ``source`` property to specify the path to a template on the local node.
 
 ``manage_symlink_source``
-   **Ruby Types:** True, False | **Default Value:** ``true`` (with warning)
+   **Ruby Types:** true, false | **Default Value:** ``true`` (with warning)
 
    Change the behavior of the file resource if it is pointed at a symlink. When this value is set to ``true``, the Chef client will manage the symlink's permissions or will replace the symlink with a normal file if the resource has content. When this value is set to ``false``, Chef will follow the symlink and will manage the permissions and content of the symlink's target file.
 
@@ -218,14 +218,14 @@ This resource has the following properties:
    Microsoft Windows: A path that begins with a forward slash (``/``) will point to the root of the current working directory of the chef-client process. This path can vary from system to system. Therefore, using a path that begins with a forward slash (``/``) is not recommended.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``rights``
    **Ruby Types:** Integer, String
@@ -233,9 +233,9 @@ This resource has the following properties:
    Microsoft Windows only. The permissions for users and groups in a Microsoft Windows environment. For example: ``rights <permissions>, <principal>, <options>`` where ``<permissions>`` specifies the rights granted to the principal, ``<principal>`` is the group or user name, and ``<options>`` is a Hash with one (or more) advanced rights options.
 
 ``sensitive``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Ensure that sensitive resource data is not logged by the chef-client. Default value: ``false``.
+   Ensure that sensitive resource data is not logged by the chef-client.
 
 ``source``
    **Ruby Types:** String, Array

--- a/chef_master/source/resource_user.rst
+++ b/chef_master/source/resource_user.rst
@@ -32,18 +32,18 @@ The full syntax for all of the properties that are available to the **user** res
 
    user 'name' do
      comment                    String
-     force                      True, False # see description
+     force                      true, false # see description
      gid                        String, Integer
      home                       String
      iterations                 Integer
-     manage_home                True, False
-     non_unique                 True, False
+     manage_home                true, false
+     non_unique                 true, false
      notifies                   # see description
      password                   String
      salt                       String
      shell                      String
      subscribes                 # see description
-     system                     True, False
+     system                     true, false
      uid                        String, Integer
      username                   String # defaults to 'name' if not specified
      action                     Symbol # defaults to :create if not specified

--- a/chef_master/source/resource_user.rst
+++ b/chef_master/source/resource_user.rst
@@ -95,7 +95,7 @@ This resource has the following properties:
    One (or more) comments about the user.
 
 ``force``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Force the removal of a user. May be used only with the ``:remove`` action.
 
@@ -112,9 +112,9 @@ This resource has the following properties:
    The location of the home directory.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``iterations``
    **Ruby Type:** Integer
@@ -122,7 +122,7 @@ This resource has the following properties:
    macOS platform only. The number of iterations for a password with a SALTED-SHA512-PBKDF2 shadow hash.
 
 ``manage_home``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Manage a user's home directory.
 
@@ -131,7 +131,7 @@ This resource has the following properties:
    When used with the ``:modify`` action, a user's home directory is moved to ``HOME_DIR``. If the home directory is missing, it is created unless ``CREATE_HOME`` in ``/etc/login.defs`` is set to ``no``. The contents of the user's home directory are moved to the new location.
 
 ``non_unique``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Create a duplicate (non-unique) user account.
 
@@ -244,7 +244,7 @@ This resource has the following properties:
    .. end_tag
 
 ``system``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false
 
    Create a system user. This property may be used with ``useradd`` as the provider to create a system user which passes the ``-r`` flag to ``useradd``.
 

--- a/chef_master/source/resource_windows_feature.rst
+++ b/chef_master/source/resource_windows_feature.rst
@@ -51,7 +51,7 @@ Actions
 Properties
 =====================================================
 ``all``
-   **Ruby Type:** True, False | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
 
    Install all subfeatures.
 

--- a/chef_master/source/resource_windows_feature_dism.rst
+++ b/chef_master/source/resource_windows_feature_dism.rst
@@ -42,7 +42,7 @@ Actions
 Properties
 =====================================================
 ``all``
-   **Ruby Type:** True, False | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
    
    Install all sub-features. When set to ``true``, this is the equivalent of specifying the ``/All`` switch to ``dism.exe``.
    

--- a/chef_master/source/resource_windows_feature_powershell.rst
+++ b/chef_master/source/resource_windows_feature_powershell.rst
@@ -51,7 +51,7 @@ Actions
 Properties
 =====================================================
 ``all``
-   **Ruby Type:** True, False | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
 
    Install all subfeatures. When set to ``true``, this is the equivalent of specifying the ``-InstallAllSubFeatures`` switch with ``Add-WindowsFeature``.
 
@@ -61,7 +61,7 @@ Properties
    The name of the feature(s) or role(s) to install, if it differs from the resource block name.
 
 ``management_tools``
-   **Ruby Type:** True, False | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
 
    Install all applicable management tools for the roles, role services, or features.
 

--- a/chef_master/source/resource_windows_feature_powershell.rst
+++ b/chef_master/source/resource_windows_feature_powershell.rst
@@ -14,9 +14,9 @@ This resource has the following syntax:
 .. code-block:: ruby
 
    windows_feature_powershell 'name' do
-     all                        True, False # default value: 'false'
+     all                        true, false # default value: 'false'
      feature_name               Array, String # default value: 'name'
-     management_tools           True, False # default value: 'false'
+     management_tools           true, false # default value: 'false'
      notifies                   # see description
      source                     String
      subscribes                 # see description

--- a/chef_master/source/resource_windows_printer_port.rst
+++ b/chef_master/source/resource_windows_printer_port.rst
@@ -114,7 +114,7 @@ The windows_printer_port resource has the following properties:
    The printer port protocol; ``1`` (RAW) or ``2`` (LPR).
 
 ``snmp_enabled``
-   **Ruby Type:** True, False | **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
 
    Determines if SNMP is enabled on the port
 

--- a/chef_master/source/resource_yum_package.rst
+++ b/chef_master/source/resource_yum_package.rst
@@ -129,9 +129,9 @@ This resource has the following properties:
    .. note:: The ``flush_cache`` property does not flush the local Yum cache! Use Yum tools---``yum clean headers``, ``yum clean packages``, ``yum clean all``---to clean the local Yum cache.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -178,14 +178,14 @@ This resource has the following properties:
    One of the following: the name of a package, the name of a package and its architecture, the name of a dependency. Default value: the ``name`` of the resource block See "Syntax" section above for more information.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String

--- a/chef_master/source/resource_zypper_package.rst
+++ b/chef_master/source/resource_zypper_package.rst
@@ -96,14 +96,14 @@ The zypper_package resource has the following properties:
    New in Chef Client 13.6.
 
 ``gpg_check``
-   **Ruby Type:** true, false
+   **Ruby Type:** true, false | **Default Value:** ``true``
 
-   Verify the package's GPG signature. Default value: ``true``. Can also be controlled site-wide using the ``zypper_check_gpg`` config option.
+   Verify the package's GPG signature. Can also be controlled site-wide using the ``zypper_check_gpg`` config option.
 
 ``ignore_failure``
-   **Ruby Types:** True, False
+   **Ruby Types:** true, false | **Default Value:** ``false``
 
-   Continue running a recipe if a resource fails for any reason. Default value: ``false``.
+   Continue running a recipe if a resource fails for any reason.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
@@ -150,14 +150,14 @@ The zypper_package resource has the following properties:
    The name of the package. Defaults to the name of the resourse block unless specified.
 
 ``retries``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource. Default value: ``0``.
+   The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer
+   **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds). Default value: ``2``.
+   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String


### PR DESCRIPTION
Signed-off-by: Mary Jinglewski <mjinglewski@chef.io>

### Description

Cleans up "True, False" values to "true, false" and fixes formatting for various **Default Value:**

### Definition of Done

When the dtags are resolved.

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
