### PR TITLE
Fixing nil references in docs

### DIFF
--- a/chef_master/source/provisioning.rst
+++ b/chef_master/source/provisioning.rst
@@ -462,7 +462,7 @@ This resource has the following properties:
 ``converge``
    **Ruby Types:** true, false
 
-   Use to manage convergence when used with the ``:create`` action. Set to ``false`` to prevent convergence. Set to ``true`` to force convergence. When ``nil``, the machine will converge only if something changes. Default value: ``nil``.
+   Use to manage convergence when used with the ``:create`` action. Set to ``false`` to prevent convergence. Set to ``true`` to force convergence. When ``nil``, the machine will converge only if something changes.
 
 ``driver``
    **Ruby Type:** Chef::Provisioning::Driver

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -1711,15 +1711,15 @@ The following properties are new or updated for the ``execute``, ``script``, ``b
 
 ``user``
   **Ruby types:** String
-  The user name of the user identity with which to launch the new process. Default value: ``nil``. The user name may optionally be specified with a domain, i.e. ``domain\user`` or ``user@my.dns.domain.com`` via Universal Principal Name (UPN) format. It can also be specified without a domain simply as ``user`` if the domain is instead specified using the ``domain`` attribute. On Windows only, if this property is specified, the ``password`` property **must** be specified.
+  The user name of the user identity with which to launch the new process. The user name may optionally be specified with a domain, i.e. ``domain\user`` or ``user@my.dns.domain.com`` via Universal Principal Name (UPN) format. It can also be specified without a domain simply as ``user`` if the domain is instead specified using the ``domain`` attribute. On Windows only, if this property is specified, the ``password`` property **must** be specified.
 
 ``password``
   **Ruby types** String
-  _Windows only:_ The password of the user specified by the ``user`` property. Default value: ``nil``. This property is mandatory if ``user`` is specified on Windows and may only be specified if ``user`` is specified. The ``sensitive`` property for this resource will automatically be set to ``true`` if ``password`` is specified.
+  _Windows only:_ The password of the user specified by the ``user`` property. This property is mandatory if ``user`` is specified on Windows and may only be specified if ``user`` is specified. The ``sensitive`` property for this resource will automatically be set to ``true`` if ``password`` is specified.
 
 ``domain``
   **Ruby types** String
-  _Windows only:_ The domain of the user specified by the ``user`` property. Default value: ``nil``. If not specified, the user name and password specified by the ``user`` and ``password`` properties will be used to resolve that user against the domain in which the system running Chef client is joined, or if that system is not joined to a domain it will resolve the user as a local account on that system. An alternative way to specify the domain is to leave this property unspecified and specify the domain as part of the ``user`` property.
+  _Windows only:_ The domain of the user specified by the ``user`` property. If not specified, the user name and password specified by the ``user`` and ``password`` properties will be used to resolve that user against the domain in which the system running Chef client is joined, or if that system is not joined to a domain it will resolve the user as a local account on that system. An alternative way to specify the domain is to leave this property unspecified and specify the domain as part of the ``user`` property.
 
 Usage
 -----------------------------------------------------
@@ -9636,7 +9636,7 @@ This resource has the following properties:
 ``init_command``
    **Ruby Type:** String
 
-   The path to the init script that is associated with the service. This is typically ``/etc/init.d/SERVICE_NAME``. The ``init_command`` property can be used to prevent the need to specify  overrides for the ``start_command``, ``stop_command``, and ``restart_command`` attributes. Default value: ``nil``.
+   The path to the init script that is associated with the service. This is typically ``/etc/init.d/SERVICE_NAME``. The ``init_command`` property can be used to prevent the need to specify  overrides for the ``start_command``, ``stop_command``, and ``restart_command`` attributes.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'

--- a/chef_master/source/resource_machine.rst
+++ b/chef_master/source/resource_machine.rst
@@ -223,7 +223,7 @@ This resource has the following properties:
 ``converge``
    **Ruby Types:** true, false
 
-   Use to manage convergence when used with the ``:create`` action. Set to ``false`` to prevent convergence. Set to ``true`` to force convergence. When ``nil``, the machine will converge only if something changes. Default value: ``nil``.
+   Use to manage convergence when used with the ``:create`` action. Set to ``false`` to prevent convergence. Set to ``true`` to force convergence. When ``nil``, the machine will converge only if something changes.
 
 ``driver``
    **Ruby Type:** Chef::Provisioning::Driver

--- a/chef_master/source/resource_remote_file.rst
+++ b/chef_master/source/resource_remote_file.rst
@@ -229,21 +229,21 @@ This resource has the following properties:
 ``remote_user``
    **Ruby Types:** String
 
-   **Windows only** The name of a user with access to the remote file specified by the ``source`` property. Default value: ``nil``. The user name may optionally be specified with a domain, such as: ``domain\user`` or ``user@my.dns.domain.com`` via Universal Principal Name (UPN) format. The domain may also be set using the ``remote_domain`` property. Note that this property is ignored if ``source`` is not a UNC path. If this property is specified, the ``remote_password`` property is required.
+   **Windows only** The name of a user with access to the remote file specified by the ``source`` property. The user name may optionally be specified with a domain, such as: ``domain\user`` or ``user@my.dns.domain.com`` via Universal Principal Name (UPN) format. The domain may also be set using the ``remote_domain`` property. Note that this property is ignored if ``source`` is not a UNC path. If this property is specified, the ``remote_password`` property is required.
 
    New in Chef client 13.4
 
 ``remote_password``
    **Ruby Types:** String
 
-   **Windows only** The password of the user specified by the ``remote_user`` property. Default value: ``nil``. This property is required if `remote_user` is specified and may only be specified if ``remote_user`` is specified. The ``sensitive`` property for this resource will automatically be set to ``true`` if ``remote_password`` is specified.
+   **Windows only** The password of the user specified by the ``remote_user`` property. This property is required if `remote_user` is specified and may only be specified if ``remote_user`` is specified. The ``sensitive`` property for this resource will automatically be set to ``true`` if ``remote_password`` is specified.
 
    New in Chef client 13.4
 
 ``remote_domain``
    **Ruby Types:** String
 
-   **Windows only** The domain of the user specified by the ``remote_user`` property. Default value: ``nil``. By default the resource will authenticate against the domain of the remote system, or as a local account if the remote system is not joined to a domain. If the remote system is not part of a domain, it is necessary to authenticate as a local user on the remote system by setting the domain to ``.``, for example: ``remote_domain "."``. The domain may also be specified as part of the ``remote_user`` property.
+   **Windows only** The domain of the user specified by the ``remote_user`` property. By default the resource will authenticate against the domain of the remote system, or as a local account if the remote system is not joined to a domain. If the remote system is not part of a domain, it is necessary to authenticate as a local user on the remote system by setting the domain to ``.``, for example: ``remote_domain "."``. The domain may also be specified as part of the ``remote_user`` property.
 
    New in Chef client 13.4
 


### PR DESCRIPTION
Signed-off-by: Mary Jinglewski <mjinglewski@chef.io>

### Description

Removes mentions of ``nil`` as default values in documentation, per discussion in https://github.com/chef/chef-web-docs/pull/1697

### Definition of Done

When dtags are okay and this PR is approved.

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
