### PR TITLE
Remove super dated Ruby 1.8 warning

### DIFF
--- a/chef_master/source/resource_user.rst
+++ b/chef_master/source/resource_user.rst
@@ -172,7 +172,7 @@ This resource has the following properties:
 ``password``
    **Ruby Type:** String
 
-   The password shadow hash. This property requires that ``ruby-shadow`` be installed. This is part of the Debian package: ``libshadow-ruby1.8``.
+   The password shadow hash
  
 ``retries``
    **Ruby Type:** Integer | **Default Value:** ``0``


### PR DESCRIPTION
Why is this still here...