### PR TITLE
Changing ChefDK references to Chef Workstation

### DIFF
--- a/chef_master/source/about_chefdk.rst
+++ b/chef_master/source/about_chefdk.rst
@@ -31,7 +31,7 @@ Chef is a systems and cloud infrastructure automation framework that makes it ea
 * `Install the ChefDK </install_dk.html>`_
 * `Ruby Guide </ruby.html>`_
 
-.. note:: See this blog post by Irving Popovetsky about running the ChefDK on Windows: https://www.chef.io/blog/2014/11/04/the-chefdk-on-windows-survival-guide/.
+.. note:: See this `blog post by Irving Popovetsky about running the ChefDK on Windows. <https://www.chef.io/blog/2014/11/04/the-chefdk-on-windows-survival-guide/>`__
 
 About Workflow
 -----------------------------------------------------

--- a/chef_master/source/about_chefdk.rst
+++ b/chef_master/source/about_chefdk.rst
@@ -1,7 +1,9 @@
 =====================================================
-About the Chef DK
+About the ChefDK
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/about_chefdk.rst>`__
+
+.. note:: `Chef Workstation <https://downloads.chef.io/chef-workstation/>`__ gives you everything you need to get started with Chef — ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software — all in one easy-to-install package. Chef Workstation replaces ChefDK, combining all the existing features with new features, such as ad-hoc task support and the new Chef Workstation desktop application. Chef will continue to maintain ChefDK, but new development will take place in Chef Workstation without backporting features.
 
 .. tag chef_dk
 
@@ -26,10 +28,10 @@ Chef is a systems and cloud infrastructure automation framework that makes it ea
 .. end_tag
 
 * `An Overview of Chef </chef_overview.html>`_
-* `Install the Chef DK </install_dk.html>`_
+* `Install the ChefDK </install_dk.html>`_
 * `Ruby Guide </ruby.html>`_
 
-.. note:: See this blog post by Irving Popovetsky about running the Chef DK on Windows: https://www.chef.io/blog/2014/11/04/the-chefdk-on-windows-survival-guide/.
+.. note:: See this blog post by Irving Popovetsky about running the ChefDK on Windows: https://www.chef.io/blog/2014/11/04/the-chefdk-on-windows-survival-guide/.
 
 About Workflow
 -----------------------------------------------------
@@ -86,7 +88,7 @@ The most important tools included in the Chef development kit are:
    * - Ruby
      - The reference language for Chef.
 
-Chef DK Tools
+ChefDK Tools
 -----------------------------------------------------
 The following tools are available only in the Chef development kit:
 

--- a/chef_master/source/aws_marketplace.rst
+++ b/chef_master/source/aws_marketplace.rst
@@ -149,9 +149,9 @@ Launch the BYOL AMI
 #. Associate the IAM role for backup access.
 #. Run the CloudFormation template to create the Chef Automate instance.
 
-Install the Chef DK
+Install the ChefDK
 -----------------------------------------------------
-While the Amazon Machine Images (AMI) for Chef Automate is provisioning, download and install the `Chef development kit </install_dk.html>`__.  The Chef development kit is a collection of tools and libraries that are packaged together to make it easy to develop cookbooks and resources for a Chef / Chef Automate environment. You'll need this to interact with Chef Automate and Chef server from the command line.
+While the Amazon Machine Images (AMI) for Chef Automate is provisioning, download and install the `Chef Development Kit </install_dk.html>`__.  The Chef Development Kit is a collection of tools and libraries that are packaged together to make it easy to develop cookbooks and resources for a Chef / Chef Automate environment. You'll need this to interact with Chef Automate and Chef server from the command line.
 
 Configure Chef Automate
 -----------------------------------------------------

--- a/chef_master/source/aws_marketplace.rst
+++ b/chef_master/source/aws_marketplace.rst
@@ -71,7 +71,7 @@ Launch the Metered AMI
 #. Configure the Amazon EC2 instance type, Amazon Virtual Private Cloud (VPC) settings, SSH key pair, IAM Role and assign `a public IP address <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-public-addresses>`__.
 #. Increase the root volume size to a minimum of 30GB. You might consider even larger if you have hundreds of nodes or need to maintain months of node visibility data.
 #. Launch the Amazon Machine Image (AMI).
-#. `Install the ChefDK <aws_marketplace.html#install-the-chef-dk>`__.
+#. `Install Chef Workstation <aws_marketplace.html#install-chef-workstation>`__.
 
 Bring Your Own License (BYOL) AMI
 -----------------------------------------------------
@@ -149,9 +149,9 @@ Launch the BYOL AMI
 #. Associate the IAM role for backup access.
 #. Run the CloudFormation template to create the Chef Automate instance.
 
-Install the ChefDK
+Install Chef Workstation
 -----------------------------------------------------
-While the Amazon Machine Images (AMI) for Chef Automate is provisioning, download and install the `Chef Development Kit </install_dk.html>`__.  The Chef Development Kit is a collection of tools and libraries that are packaged together to make it easy to develop cookbooks and resources for a Chef / Chef Automate environment. You'll need this to interact with Chef Automate and Chef server from the command line.
+While the Amazon Machine Images (AMI) for Chef Automate is provisioning, download and install Chef Workstation. Chef Workstation is a collection of tools and libraries that are packaged together to make it easy to develop cookbooks and resources for a Chef / Chef Automate environment. You'll need this to interact with Chef Automate and Chef server from the command line.
 
 Configure Chef Automate
 -----------------------------------------------------

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -15,7 +15,7 @@ This diagram shows how you develop, test, and deploy your Chef code.
 
 .. end_tag
 
-* **Chef workstation** is the location where users interact with Chef. Users author and test `cookbooks </cookbooks.html>`__ using tools such as `Test Kitchen </kitchen.html>`__ and interact with the Chef server using the `knife </knife.html>`__ and `chef </ctl_chef.html>`__ command line tools.
+* **Chef workstation** is the location where users interact with Chef. With Chef Workstation, users can author and test `cookbooks </cookbooks.html>`__ using tools such as `Test Kitchen </kitchen.html>`__ and interact with the Chef server using the `knife </knife.html>`__ and `chef </ctl_chef.html>`__ command line tools.
 * **Chef client nodes** are the machines that are managed by Chef. The Chef client is installed on each node and is used to configure the node to its desired state.
 * **Chef server** acts as `a hub for configuration data </server_components.html>`__. Chef server stores cookbooks, the policies that are applied to nodes, and metadata that describes each registered node that is being managed by Chef. Nodes use the Chef client to ask the Chef server for configuration details, such as recipes, templates, and file distributions.
 

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -3,6 +3,8 @@ An Overview of Chef
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/chef_overview.rst>`__
 
+.. note:: `Chef Workstation <https://downloads.chef.io/chef-workstation/>`__ gives you everything you need to get started with Chef — ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software — all in one easy-to-install package. Chef Workstation replaces ChefDK, combining all the existing features with new features, such as ad-hoc task support and the new Chef Workstation desktop application. Chef will continue to maintain ChefDK, but new development will take place in Chef Workstation without backporting features.
+
 .. tag chef
 
 Chef is a powerful automation platform that transforms infrastructure into code. Whether you’re operating in the cloud, on-premises, or in a hybrid environment, Chef automates how infrastructure is configured, deployed, and managed across your network, no matter its size.
@@ -18,8 +20,6 @@ This diagram shows how you develop, test, and deploy your Chef code.
 * **Chef workstation** is the location where users interact with Chef. With Chef Workstation, users can author and test `cookbooks </cookbooks.html>`__ using tools such as `Test Kitchen </kitchen.html>`__ and interact with the Chef server using the `knife </knife.html>`__ and `chef </ctl_chef.html>`__ command line tools.
 * **Chef client nodes** are the machines that are managed by Chef. The Chef client is installed on each node and is used to configure the node to its desired state.
 * **Chef server** acts as `a hub for configuration data </server_components.html>`__. Chef server stores cookbooks, the policies that are applied to nodes, and metadata that describes each registered node that is being managed by Chef. Nodes use the Chef client to ask the Chef server for configuration details, such as recipes, templates, and file distributions.
-
-.. note:: `Chef Workstation <https://downloads.chef.io/chef-workstation/>`__ gives you everything you need to get started with Chef — ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software — all in one easy-to-install package. Chef Workstation replaces ChefDK, combining all the existing features with new features, such as ad-hoc task support and the new Chef Workstation desktop application. Chef will continue to maintain ChefDK, but new development will take place in Chef Workstation without backporting features.
 
 Chef Components
 =====================================================
@@ -93,7 +93,7 @@ Workstations
 =====================================================
 .. tag workstation_summary
 
-A workstation is a computer running the `Chef Development Kit </about_chefdk.html>`__ (ChefDK) that is used to author cookbooks, interact with the Chef server, and interact with nodes.
+A workstation is a computer running Chef Workstation that is used to author cookbooks, interact with the Chef server, and interact with nodes.
 
 The workstation is where users do most of their work, including:
 

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -15,9 +15,9 @@ This diagram shows how you develop, test, and deploy your Chef code.
 
 .. end_tag
 
-* The **Chef workstation** is the location where users interact with Chef. On the workstation, users author and test `cookbooks </cookbooks.html>`__ using tools such as `Test Kitchen </kitchen.html>`__ and interact with the Chef server using the `knife </knife.html>`__ and `chef </ctl_chef.html>`__ command line tools.
+* **Chef workstation** is the location where users interact with Chef. Users author and test `cookbooks </cookbooks.html>`__ using tools such as `Test Kitchen </kitchen.html>`__ and interact with the Chef server using the `knife </knife.html>`__ and `chef </ctl_chef.html>`__ command line tools.
 * **Chef client nodes** are the machines that are managed by Chef. The Chef client is installed on each node and is used to configure the node to its desired state.
-* The **Chef server** acts as `a hub for configuration data </server_components.html>`__. The Chef server stores cookbooks, the policies that are applied to nodes, and metadata that describes each registered node that is being managed by Chef. Nodes use the Chef client to ask the Chef server for configuration details, such as recipes, templates, and file distributions.
+* **Chef server** acts as `a hub for configuration data </server_components.html>`__. Chef server stores cookbooks, the policies that are applied to nodes, and metadata that describes each registered node that is being managed by Chef. Nodes use the Chef client to ask the Chef server for configuration details, such as recipes, templates, and file distributions.
 
 .. note:: `Chef Workstation <https://downloads.chef.io/chef-workstation/>`__ gives you everything you need to get started with Chef — ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software — all in one easy-to-install package. Chef Workstation replaces ChefDK, combining all the existing features with new features, such as ad-hoc task support and the new Chef Workstation desktop application. Chef will continue to maintain ChefDK, but new development will take place in Chef Workstation without backporting features.
 

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -15,9 +15,11 @@ This diagram shows how you develop, test, and deploy your Chef code.
 
 .. end_tag
 
-* The **Chef DK workstation** is the location where users interact with Chef. On the workstation users author and test `cookbooks </cookbooks.html>`__ using tools such as `Test Kitchen </kitchen.html>`__ and interact with the Chef server using the `knife </knife.html>`__ and `chef </ctl_chef.html>`__ command line tools.
+* The **Chef Workstation** is the location where users interact with Chef. On the workstation users author and test `cookbooks </cookbooks.html>`__ using tools such as `Test Kitchen </kitchen.html>`__ and interact with the Chef server using the `knife </knife.html>`__ and `chef </ctl_chef.html>`__ command line tools.
 * **Chef client nodes** are the machines that are managed by Chef. The Chef client is installed on each node and is used to configure the node to its desired state.
 * The **Chef server** acts as `a hub for configuration data </server_components.html>`__. The Chef server stores cookbooks, the policies that are applied to nodes, and metadata that describes each registered node that is being managed by Chef. Nodes use the Chef client to ask the Chef server for configuration details, such as recipes, templates, and file distributions.
+
+.. note:: `Chef Workstation <https://downloads.chef.io/chef-workstation/>`__ gives you everything you need to get started with Chef — ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software — all in one easy-to-install package. Chef Workstation replaces ChefDK, combining all the existing features with new features, such as ad-hoc task support and the new Chef Workstation desktop application. Chef will continue to maintain ChefDK, but new development will take place in Chef Workstation without backporting features.
 
 Chef Components
 =====================================================
@@ -91,7 +93,7 @@ Workstations
 =====================================================
 .. tag workstation_summary
 
-A workstation is a computer running the `Chef Development Kit </about_chefdk.html>`__ (Chef DK) that is used to author cookbooks, interact with the Chef server, and interact with nodes.
+A workstation is a computer running the `Chef Development Kit </about_chefdk.html>`__ (ChefDK) that is used to author cookbooks, interact with the Chef server, and interact with nodes.
 
 The workstation is where users do most of their work, including:
 
@@ -103,7 +105,7 @@ The workstation is where users do most of their work, including:
 
 .. end_tag
 
-The Chef Development Kit tooling encourages integration and unit testing, and defines workflow around cookbook authoring and policy, but it's important to note that you know best about how your infrastructure should be put together. Therefore, Chef makes as few decisions on its own as possible. When a decision must be made tools uses a reasonable default setting that can be easily changed. While Chef encourages the use of the tooling packaged in the Chef DK, none of these tools should be seen as a requirement or pre-requisite for being successful using Chef.
+The Chef Development Kit tooling encourages integration and unit testing, and defines workflow around cookbook authoring and policy, but it's important to note that you know best about how your infrastructure should be put together. Therefore, Chef makes as few decisions on its own as possible. When a decision must be made tools uses a reasonable default setting that can be easily changed. While Chef encourages the use of the tooling packaged in the ChefDK, none of these tools should be seen as a requirement or pre-requisite for being successful using Chef.
 
 Workstation Components and Tools
 -----------------------------------------------------
@@ -139,10 +141,16 @@ Some important tools and components of Chef workstations include:
           :width: 100px
           :align: center
 
-     - ChefDK includes two important command-line tools:
+     - Chef Workstation includes important command-line tools:
 
        * Chef: Use the chef command-line tool to work with items in a chef-repo, which is the primary location in which cookbooks are authored, tested, and maintained, and from which policy is uploaded to the Chef server
        * Knife: Use the knife command-line tool to interact with nodes or work with objects on the Chef server
+       * chef-client: an agent that configures your nodes
+       * Ohai: a tool for collecting system profiling data 
+       * Test Kitchen: a testing harness for rapid validation of Chef code
+       * InSpec: Chef's open source security & compliance automation framework
+       * chef-run: a tool for running ad-hoc tasks
+       * Chef Workstation App: for updating and managing your chef tools
 
    * - .. image:: ../../images/icon_repository.svg
           :width: 100px

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -3,8 +3,6 @@ An Overview of Chef
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/chef_overview.rst>`__
 
-.. note:: `Chef Workstation <https://downloads.chef.io/chef-workstation/>`__ gives you everything you need to get started with Chef — ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software — all in one easy-to-install package. Chef Workstation replaces ChefDK, combining all the existing features with new features, such as ad-hoc task support and the new Chef Workstation desktop application. Chef will continue to maintain ChefDK, but new development will take place in Chef Workstation without backporting features.
-
 .. tag chef
 
 Chef is a powerful automation platform that transforms infrastructure into code. Whether you’re operating in the cloud, on-premises, or in a hybrid environment, Chef automates how infrastructure is configured, deployed, and managed across your network, no matter its size.
@@ -105,7 +103,7 @@ The workstation is where users do most of their work, including:
 
 .. end_tag
 
-The Chef Development Kit tooling encourages integration and unit testing, and defines workflow around cookbook authoring and policy, but it's important to note that you know best about how your infrastructure should be put together. Therefore, Chef makes as few decisions on its own as possible. When a decision must be made tools uses a reasonable default setting that can be easily changed. While Chef encourages the use of the tooling packaged in the ChefDK, none of these tools should be seen as a requirement or pre-requisite for being successful using Chef.
+`Chef Workstation <https://downloads.chef.io/chef-workstation/>`__ gives you everything you need to get started with Chef — ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software — all in one easy-to-install package. Chef Workstation replaces ChefDK, combining all the existing features with new features, such as ad-hoc task support and the new Chef Workstation desktop application. Chef will continue to maintain ChefDK, but new development will take place in Chef Workstation without backporting features.
 
 Workstation Components and Tools
 -----------------------------------------------------

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -15,7 +15,7 @@ This diagram shows how you develop, test, and deploy your Chef code.
 
 .. end_tag
 
-* The **Chef Workstation** is the location where users interact with Chef. On the workstation users author and test `cookbooks </cookbooks.html>`__ using tools such as `Test Kitchen </kitchen.html>`__ and interact with the Chef server using the `knife </knife.html>`__ and `chef </ctl_chef.html>`__ command line tools.
+* The **Chef workstation** is the location where users interact with Chef. On the workstation, users author and test `cookbooks </cookbooks.html>`__ using tools such as `Test Kitchen </kitchen.html>`__ and interact with the Chef server using the `knife </knife.html>`__ and `chef </ctl_chef.html>`__ command line tools.
 * **Chef client nodes** are the machines that are managed by Chef. The Chef client is installed on each node and is used to configure the node to its desired state.
 * The **Chef server** acts as `a hub for configuration data </server_components.html>`__. The Chef server stores cookbooks, the policies that are applied to nodes, and metadata that describes each registered node that is being managed by Chef. Nodes use the Chef client to ask the Chef server for configuration details, such as recipes, templates, and file distributions.
 

--- a/chef_master/source/chef_quick_overview.rst
+++ b/chef_master/source/chef_quick_overview.rst
@@ -37,7 +37,7 @@ Workstations
 =====================================================
 .. tag workstation_summary
 
-A workstation is a computer running the `Chef Development Kit </about_chefdk.html>`__ (ChefDK) that is used to author cookbooks, interact with the Chef server, and interact with nodes.
+A workstation is a computer running Chef Workstation that is used to author cookbooks, interact with the Chef server, and interact with nodes.
 
 The workstation is where users do most of their work, including:
 

--- a/chef_master/source/chef_quick_overview.rst
+++ b/chef_master/source/chef_quick_overview.rst
@@ -37,7 +37,7 @@ Workstations
 =====================================================
 .. tag workstation_summary
 
-A workstation is a computer running the `Chef Development Kit </about_chefdk.html>`__ (Chef DK) that is used to author cookbooks, interact with the Chef server, and interact with nodes.
+A workstation is a computer running the `Chef Development Kit </about_chefdk.html>`__ (ChefDK) that is used to author cookbooks, interact with the Chef server, and interact with nodes.
 
 The workstation is where users do most of their work, including:
 

--- a/chef_master/source/delivery_truck.rst
+++ b/chef_master/source/delivery_truck.rst
@@ -541,7 +541,7 @@ To use ``delivery-truck`` and its dependency, ``delivery-sugar``, you must first
 Generate a cookbook
 -----------------------------------------------------
 
-#. On your workstation, use Chef Workstation's `cookbook generator command </ctl_chef.html#chef-generate-cookbook>`__ to create a default cookbook directory structure called ``my_cookbook``.
+#. Use Chef Workstation's `cookbook generator command </ctl_chef.html#chef-generate-cookbook>`__ to create a default cookbook directory structure called ``my_cookbook``.
 
    .. code-block:: bash
 

--- a/chef_master/source/delivery_truck.rst
+++ b/chef_master/source/delivery_truck.rst
@@ -497,7 +497,7 @@ Prerequisites
 * Ensure you have a private Supermarket installed, setup, and running. See `Install Private Supermarket </install_supermarket.html>`__ for more information.
 * Ensure you have a Chef server with the Chef Identity authentication/authorization service configured, a Chef Automate server setup that references your private Supermarket, and at least one Chef Automate build node/runner installed, setup, and running. See `Install Chef Automate </install_chef_automate.html>`__ and `Chef Identity </install_supermarket.html#chef-identity.html>`__ for more information.
 * Ensure you have created a project in Chef Automate. Follow these instructions to `Set Up Projects </delivery_build_cookbook.html#set-up-projects>`__.
-* Ensure you have `ChefDK <https://downloads.chef.io/chefdk/.html>`__ installed on your `workstation </workstation.html>`__.
+* Ensure you have `Chef Workstation <https://downloads.chef.io/chef-workstation/>`__ installed on your `workstation </workstation.html>`__.
 
 Share cookbooks with your private Supermarket
 -----------------------------------------------------
@@ -541,7 +541,7 @@ To use ``delivery-truck`` and its dependency, ``delivery-sugar``, you must first
 Generate a cookbook
 -----------------------------------------------------
 
-#. On your workstation, use ChefDK's `cookbook generator command </ctl_chef.html#chef-generate-cookbook>`__ to create a default cookbook directory structure called ``my_cookbook``.
+#. On your workstation, use Chef Workstation's `cookbook generator command </ctl_chef.html#chef-generate-cookbook>`__ to create a default cookbook directory structure called ``my_cookbook``.
 
    .. code-block:: bash
 

--- a/chef_master/source/dk_windows.rst
+++ b/chef_master/source/dk_windows.rst
@@ -11,7 +11,7 @@ Workstations
 =====================================================
 .. tag workstation_summary
 
-A workstation is a computer running the `Chef Development Kit </about_chefdk.html>`__ (ChefDK) that is used to author cookbooks, interact with the Chef server, and interact with nodes.
+A workstation is a computer running Chef Workstation that is used to author cookbooks, interact with the Chef server, and interact with nodes.
 
 The workstation is where users do most of their work, including:
 

--- a/chef_master/source/dk_windows.rst
+++ b/chef_master/source/dk_windows.rst
@@ -5,6 +5,8 @@ ChefDK on Windows Workstations
 
 This guide details some of the common considerations that come into play when using the Chef Development Kit on Windows. Download the ChefDK by following the installation instructions on `Installing the ChefDK </install_dk.html>`_.
 
+.. note:: `Chef Workstation <https://downloads.chef.io/chef-workstation/>`__ gives you everything you need to get started with Chef — ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software — all in one easy-to-install package. Chef Workstation replaces ChefDK, combining all the existing features with new features, such as ad-hoc task support and the new Chef Workstation desktop application. Chef will continue to maintain ChefDK, but new development will take place in Chef Workstation without backporting features.
+
 Workstations
 =====================================================
 .. tag workstation_summary

--- a/chef_master/source/dk_windows.rst
+++ b/chef_master/source/dk_windows.rst
@@ -11,7 +11,7 @@ Workstations
 =====================================================
 .. tag workstation_summary
 
-A workstation is a computer running the `Chef Development Kit </about_chefdk.html>`__ (Chef DK) that is used to author cookbooks, interact with the Chef server, and interact with nodes.
+A workstation is a computer running the `Chef Development Kit </about_chefdk.html>`__ (ChefDK) that is used to author cookbooks, interact with the Chef server, and interact with nodes.
 
 The workstation is where users do most of their work, including:
 

--- a/chef_master/source/install_dk.rst
+++ b/chef_master/source/install_dk.rst
@@ -52,4 +52,4 @@ Linux
 
 Next Steps
 =====================================================
-Now that you've installed the ChefDK, proceed to the `ChefDK Setup </chefdk_setup.html>`__ guide to configure your ChefDK installation.
+Now that you've installed ChefDK, proceed to the `ChefDK Setup </chefdk_setup.html>`__ guide to configure your ChefDK installation.

--- a/chef_master/source/install_dk.rst
+++ b/chef_master/source/install_dk.rst
@@ -1,11 +1,13 @@
 =====================================================
-Install the Chef DK
+Install the ChefDK
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/install_dk.rst>`__
 
-Use the Chef Development Kit installer to set up the Chef DK on a workstation. Chef DK includes the chef-client, an embedded version of Ruby, RubyGems, and OpenSSL, as well as our tools: Test Kitchen, Cookstyle, Foodcritic and ChefSpec. The Chef installer puts everything into a unique directory (``/opt/chefdk/`` on macOS / Linux and ``C:\opscode\chefdk\`` on Windows) so that these components will not interfere with other applications that may be running on the target machine.
+Use the Chef Development Kit installer to set up the ChefDK on a workstation. ChefDK includes the chef-client, an embedded version of Ruby, RubyGems, and OpenSSL, as well as our tools: Test Kitchen, Cookstyle, Foodcritic and ChefSpec. The Chef installer puts everything into a unique directory (``/opt/chefdk/`` on macOS / Linux and ``C:\opscode\chefdk\`` on Windows) so that these components will not interfere with other applications that may be running on the target machine.
 
 .. note:: The Chef installer must run as a privileged user.
+
+.. note:: `Chef Workstation <https://downloads.chef.io/chef-workstation/>`__ gives you everything you need to get started with Chef — ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software — all in one easy-to-install package. Chef Workstation replaces ChefDK, combining all the existing features with new features, such as ad-hoc task support and the new Chef Workstation desktop application. Chef will continue to maintain ChefDK, but new development will take place in Chef Workstation without backporting features.
 
 Install
 =====================================================
@@ -15,20 +17,20 @@ macOS
 
 .. note:: ChefDK works without installing Xcode, but Xcode is required for native Ruby Gem installation. Run ``xcode-select --install`` from the terminal to install Xcode.
 
-#. Visit the `Chef DK downloads page <https://downloads.chef.io/chefdk#mac_os_x>`__ and select the appropriate package for your macOS version. Click on the **Download** button.
+#. Visit the `ChefDK downloads page <https://downloads.chef.io/chefdk#mac_os_x>`__ and select the appropriate package for your macOS version. Click on the **Download** button.
 #. Follow the steps to accept the license and install the Chef development kit. You will have the option to change your install location; by default the installer uses the ``/opt/chefdk/`` directory.
 
 Windows
 -----------------------------------------------------
-#. Visit the `Chef DK downloads page <https://downloads.chef.io/chefdk#windows>`__ and select the appropriate package for your Windows version. Click on the **Download** button.
+#. Visit the `ChefDK downloads page <https://downloads.chef.io/chefdk#windows>`__ and select the appropriate package for your Windows version. Click on the **Download** button.
 #. Follow the steps to accept the license and install the Chef development kit. You will have the option to change your install location; by default the installer uses the ``C:\opscode\chefdk\`` directory.
 #. **Optional:** Set the default shell. On Microsoft Windows it is strongly recommended to use Windows PowerShell and ``cmd.exe``.
 
-See the `Chef DK on Windows </dk_windows.html>`__ guide for additional caveats and configuration options specific to Windows.
+See the `ChefDK on Windows </dk_windows.html>`__ guide for additional caveats and configuration options specific to Windows.
 
 Linux
 -----------------------------------------------------
-#. Visit the `Chef DK downloads page <https://downloads.chef.io/chefdk>`__ and download the appropriate package for your distribution:
+#. Visit the `ChefDK downloads page <https://downloads.chef.io/chefdk>`__ and download the appropriate package for your distribution:
 
    .. code-block:: bash
 
@@ -50,4 +52,4 @@ Linux
 
 Next Steps
 =====================================================
-Now that you've installed the Chef DK, proceed to the `Chef DK Setup </chefdk_setup.html>`__ guide to configure your ChefDK installation.
+Now that you've installed the ChefDK, proceed to the `ChefDK Setup </chefdk_setup.html>`__ guide to configure your ChefDK installation.

--- a/chef_master/source/knife.rst
+++ b/chef_master/source/knife.rst
@@ -340,7 +340,7 @@ Knife functionality can be extended with plugins, which work the same as built-i
 Plugin Installation
 -----------------------------------------------------
 
-Knife plugins ship as Rubygems and are installed into the ChefDK installation using the ``chef`` command:
+Knife plugins ship as Rubygems and are installed into the Chef Workstation installation using the ``chef`` command:
 
 .. code-block:: bash
 
@@ -355,7 +355,7 @@ Post installation you will also need to rehash the list of knife commands by run
 Chef Maintained Knife Plugins
 -----------------------------------------------------
 
-Chef maintains the following plugins which ship with Chef-DK:
+Chef maintains the following plugins which ship with Chef Workstation:
 
 * ``knife-acl``
 * ``knife-azure``

--- a/chef_master/source/knife.rst
+++ b/chef_master/source/knife.rst
@@ -340,7 +340,7 @@ Knife functionality can be extended with plugins, which work the same as built-i
 Plugin Installation
 -----------------------------------------------------
 
-Knife plugins ship as Rubygems and are installed into the Chef Workstation installation using the ``chef`` command:
+Knife plugins ship as RubyGems and are installed into the Chef Workstation installation using the ``chef`` command:
 
 .. code-block:: bash
 

--- a/chef_master/source/knife_azure.rst
+++ b/chef_master/source/knife_azure.rst
@@ -22,7 +22,7 @@ Install Chef Workstation
 
 Install the latest version of Chef Workstation from `Chef Downloads <https://downloads.chef.io/chef-workstation>`__
 
-For Windows versions older than 2012r2, download the `ChefDK <https://downloads.chef.io/chefdk/>`__.
+For Windows versions older than 2012r2, download the `ChefDK <https://downloads.chef.io/>`__.
 
 Install Knife Azure 
 ------------------------------------------------------

--- a/chef_master/source/knife_azure.rst
+++ b/chef_master/source/knife_azure.rst
@@ -22,7 +22,7 @@ Install Chef Workstation
 
 Install the latest version of Chef Workstation from `Chef Downloads <https://downloads.chef.io/chef-workstation>`__
 
-For Windows versions older than 2012r2, download the `ChefDK <https://downloads.chef.io/>`__.
+For Windows versions older than 2012r2, download `ChefDK <https://downloads.chef.io/chefdk/>`__.
 
 Install Knife Azure 
 ------------------------------------------------------

--- a/chef_master/source/knife_azurerm.rst
+++ b/chef_master/source/knife_azurerm.rst
@@ -22,7 +22,7 @@ Install Chef Workstation
 
 Install the latest version of Chef Workstation from `Chef Downloads <https://downloads.chef.io/chef-workstation>`__.
 
-For Windows versions older than 2012r2, download the `ChefDK <https://downloads.chef.io/chefdk/>`__.
+For Windows versions older than 2012r2, download the `ChefDK <https://downloads.chef.io/>`__.
 
 Install Knife Azure 
 ------------------------------------------------------

--- a/chef_master/source/knife_azurerm.rst
+++ b/chef_master/source/knife_azurerm.rst
@@ -22,7 +22,7 @@ Install Chef Workstation
 
 Install the latest version of Chef Workstation from `Chef Downloads <https://downloads.chef.io/chef-workstation>`__.
 
-For Windows versions older than 2012r2, download the `ChefDK <https://downloads.chef.io/>`__.
+For Windows versions older than 2012r2, download `ChefDK <https://downloads.chef.io/chefdk/>`__.
 
 Install Knife Azure 
 ------------------------------------------------------

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -1120,7 +1120,7 @@ What's New in 13.0/13.1
 =====================================================
 
 * **Blacklist attributes**
-* **Rubygems sources**
+* **RubyGems sources**
 * **windows_task resource**
 * **Chef client will now exit using the rfc062 defined exit codes**
 * **New default encrypted databag format**
@@ -1196,7 +1196,7 @@ For attributes that contain slashes (``/``) within the attribute value, such as 
 
 .. end_tag
 
-Rubygems provider sources behavior changed.
+RubyGems provider sources behavior changed.
 -----------------------------------------------------
 The behavior of ``gem_package`` and ``chef_gem`` is now to always apply the ``Chef::Config[:rubygems_uri]`` sources, which may be a string uri or an array of strings.  If additional sources are put on the resource with the ``source`` property those are added to the configured ``:rubygems_uri`` sources.
 
@@ -1626,7 +1626,7 @@ What's New in 12.21.4
 
 * **Improved Resource Reporting** Resource reporting for Chef Automate has been improved
 * **Ruby Upgrade** Ruby has been updated to 2.3.4
-* **Rubygems Upgrade** Rubygems has been updated to 2.6.12 to prevent a segfault on Windows
+* **RubyGems Upgrade** RubyGems has been updated to 2.6.12 to prevent a segfault on Windows
 * **Policyfile fix** Chef client now properly sends expanded run list events for policy file nodes
 
 What's New in 12.21.1

--- a/chef_master/source/release_notes_chef_automate.rst
+++ b/chef_master/source/release_notes_chef_automate.rst
@@ -108,7 +108,7 @@ Resolved Issues
 * Fixed a race condition preventing the ‘updates available’ notification for Compliance profiles from being displayed
 * Correctly displays platform versions in the Compliance nodes list
 * Fixed missing input validation on Compliance UI
-* Rubygems installed into Automate with an overly restrictive umask are now fixed when ``automate-ctl reconfigure`` is run
+* RubyGems installed into Automate with an overly restrictive umask are now fixed when ``automate-ctl reconfigure`` is run
 * Passwords and keys fields no longer display values when editing a credential
 * The Compliance UI now displays a spinner when loading pages
 * Scan jobs are now nested inside their parent job

--- a/chef_master/source/release_notes_push_jobs.rst
+++ b/chef_master/source/release_notes_push_jobs.rst
@@ -14,7 +14,7 @@ This release includes an important fix for a number of deadlock scenarios. We en
 
 This also includes a number of maintenance items, including:
 
-Ruby and Rubygems upgraded to 2.4.4 and 2.7.6, respectively, to include a number of security fixes.
+Ruby and RubyGems upgraded to 2.4.4 and 2.7.6, respectively, to include a number of security fixes.
 Chef Client (packaged as a library) upgraded to 14.0.202
 Other dependencies upgraded to latest
 

--- a/chef_master/source/ruby.rst
+++ b/chef_master/source/ruby.rst
@@ -768,9 +768,9 @@ Default and override attributes are cleared at the start of the chef-client run,
 
 ``node.set`` (and ``node.normal``) should only be used to do something like generate a password for a database on the first chef-client run, after which it's remembered (instead of persisted). Even this case should be avoided, as using a data bag is the recommended way to store this type of data.
 
-Cookbook Linting with ChefDK Tools
+Cookbook Linting with Chef Workstation Tools
 =====================================================
-ChefDK includes Foodcritic for linting the Chef specific portion of your cookbook code, and Cookstyle for linting the Ruby specific portion of your code.
+Chef Workstation includes Foodcritic for linting the Chef specific portion of your cookbook code, and Cookstyle for linting the Ruby specific portion of your code.
 
 Foodcritic Linting
 -----------------------------------------------------

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -239,7 +239,7 @@ Check your combined certificate's validity on the Chef Server:
 
    $ openssl verify -verbose -purpose sslserver -CAfile cacert.pem  /var/opt/opscode/nginx/ca/FQDN.crt 
 
-The cacert.pem should contain only your root CA's certificate file. This is not the usual treatment, but mimics how ChefDK behaves after a ``knife ssl fetch`` followed by a ``knife ssl verify``.
+The cacert.pem should contain only your root CA's certificate file. This is not the usual treatment, but mimics how Chef Workstation behaves after a ``knife ssl fetch`` followed by a ``knife ssl verify``.
 
 Intermediate Certificates
 -----------------------------------------------------

--- a/chef_master/source/setup_build_node.rst
+++ b/chef_master/source/setup_build_node.rst
@@ -9,7 +9,7 @@ The following steps should be performed on a Chef Automate server:
 
 #. If you have an on-premises Supermarket installation, copy the Supermarket certificate file to ``/etc/delivery/supermarket.crt``.
 
-#. Download the latest ChefDK from `<https://downloads.chef.io/chefdk/>`_. Version 0.15.16 or greater is required. The download location is referred to below as ``$CHEF_DK_PACKAGE_PATH``.
+#. Download the latest ChefDK from `<https://downloads.chef.io/>`_. Version 0.15.16 or greater is required. The download location is referred to below as ``$CHEF_DK_PACKAGE_PATH``.
 
 #. Run the ``install-build-node`` subcommand.
 

--- a/chef_master/source/setup_build_node.rst
+++ b/chef_master/source/setup_build_node.rst
@@ -9,7 +9,7 @@ The following steps should be performed on a Chef Automate server:
 
 #. If you have an on-premises Supermarket installation, copy the Supermarket certificate file to ``/etc/delivery/supermarket.crt``.
 
-#. Download the latest ChefDK from `<https://downloads.chef.io/>`_. Version 0.15.16 or greater is required. The download location is referred to below as ``$CHEF_DK_PACKAGE_PATH``.
+#. Download the latest ChefDK from `<https://downloads.chef.io/chefdk/>`_. Version 0.15.16 or greater is required. The download location is referred to below as ``$CHEF_DK_PACKAGE_PATH``.
 
 #. Run the ``install-build-node`` subcommand.
 


### PR DESCRIPTION
Signed-off-by: Mary Jinglewski <mjinglewski@chef.io>

### Description

ChefDK references are being changed to Chef Workstation.

### Definition of Done


### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
