### PR TITLE
Removing Spaces between Chef DK

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -113,7 +113,7 @@
                 "url": "/windows.html"
               },
               {
-                "title": "Chef DK on Windows",
+                "title": "ChefDK on Windows",
                 "hasSubItems": false,
                 "url": "/dk_windows.html"
               },
@@ -295,7 +295,7 @@
         "hasSubItems": true,
         "subItems": [
           {
-            "title": "Chef DK",
+            "title": "ChefDK",
             "hasSubItems": false,
             "url": "/install_dk.html"
           },
@@ -1270,11 +1270,11 @@
         ]
       },
       {
-        "title": "Chef DK",
+        "title": "ChefDK",
         "hasSubItems": true,
         "subItems": [
           {
-            "title": "About the ChefDK",
+            "title": "About ChefDK",
             "hasSubItems": false,
             "url": "/about_chefdk.html"
           },

--- a/chef_master/source/about_chefdk.rst
+++ b/chef_master/source/about_chefdk.rst
@@ -1,5 +1,5 @@
 =====================================================
-About the ChefDK
+About ChefDK
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/about_chefdk.rst>`__
 
@@ -28,10 +28,10 @@ Chef is a systems and cloud infrastructure automation framework that makes it ea
 .. end_tag
 
 * `An Overview of Chef </chef_overview.html>`_
-* `Install the ChefDK </install_dk.html>`_
+* `Install ChefDK </install_dk.html>`_
 * `Ruby Guide </ruby.html>`_
 
-.. note:: See this `blog post by Irving Popovetsky about running the ChefDK on Windows. <https://www.chef.io/blog/2014/11/04/the-chefdk-on-windows-survival-guide/>`__
+.. note:: See this `blog post by Irving Popovetsky about running ChefDK on Windows. <https://www.chef.io/blog/2014/11/04/the-chefdk-on-windows-survival-guide/>`__
 
 About Workflow
 -----------------------------------------------------

--- a/chef_master/source/berkshelf.rst
+++ b/chef_master/source/berkshelf.rst
@@ -233,7 +233,7 @@ Solver Keyword
 
 It is possible to configure which engine to use for the `solve <https://github.com/berkshelf/solve>`__ dependency resolution system.
 
-By default, the solver selection depends on your environment. When the ``dep_selector`` gem is installed, as in the case of Chef DK, the ``gecode`` solver is used. Otherwise, the ``ruby`` solver is utilized by default.
+By default, the solver selection depends on your environment. When the ``dep_selector`` gem is installed, as in the case of ChefDK, the ``gecode`` solver is used. Otherwise, the ``ruby`` solver is utilized by default.
 
 The ``gecode`` solver matches the engine used by the Chef Server, so will more closely reflect the behavior of the Chef Server in selecting cookbooks:
 

--- a/chef_master/source/chef_system_requirements.rst
+++ b/chef_master/source/chef_system_requirements.rst
@@ -97,6 +97,6 @@ Chef Client
 * The chef-client binaries are stored in the ``/opt/chef`` directory, which requires a minimum of 200MB of disk space. On Windows, the chef-client binaries can be found in ``C:\opscode\``, and they require a minimum of 600MB of disk space.
 * The chef-client caches to ``/var/chef/cache`` during the chef-client run. This is the location in which downloaded cookbooks, packages required by those cookbooks, and other large files are stored. This directory requires enough space to save all of this data and should be generously sized. 5GB is a safe number as a starting point, but tune the size of ``/var/chef/cache`` as necessary. This location is tunable in a node's `client.rb <https://docs.chef.io/config_rb_client.html>`__ file via the ``file_cache_path`` setting.
 
-Chef DK
+ChefDK
 =====================================================
 The Chef development kit has the same requirements as the chef-client.

--- a/chef_master/source/chefdk_setup.rst
+++ b/chef_master/source/chefdk_setup.rst
@@ -1,9 +1,9 @@
 =====================================================
-Configuring the ChefDK
+Configuring ChefDK
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/chefdk_setup.rst>`__
 
-This guide contains common configuration options used when setting up a new ChefDK installation. If you do not have the ChefDK installed, see its  `installation guide </install_dk.html>`__ before proceeding further.
+This guide contains common configuration options used when setting up a new ChefDK installation. If you do not have ChefDK installed, see its  `installation guide </install_dk.html>`__ before proceeding further.
 
 Configure Ruby Environment
 =====================================================
@@ -39,7 +39,7 @@ For many users of Chef, the version of Ruby that is included in the Chef develop
 
 Add Ruby to $PATH
 =====================================================
-The Chef Client includes a stable version of Ruby as part of its installer. The path to this version of Ruby must be added to the ``$PATH`` environment variable and saved in the configuration file for the command shell (Bash, csh, and so on) that is used on the machine running the ChefDK. In a command window, type the following:
+The Chef Client includes a stable version of Ruby as part of its installer. The path to this version of Ruby must be added to the ``$PATH`` environment variable and saved in the configuration file for the command shell (Bash, csh, and so on) that is used on the machine running ChefDK. In a command window, type the following:
 
 .. code-block:: bash
 
@@ -55,7 +55,7 @@ where ``configuration_file`` is the name of the configuration file for the speci
 
 Install Git
 =====================================================
-An open source distributed version control system called Git must be installed before the chef-repo can be cloned to the ChefDK machine from GitHub.
+An open source distributed version control system called Git must be installed before the chef-repo can be cloned to ChefDK machine from GitHub.
 
 To install Git:
 
@@ -86,7 +86,7 @@ The ``.chef`` directory is used to store three files:
 * ``ORGANIZATION-validator.pem``
 * ``USER.pem``
 
-Where ``ORGANIZATION`` and ``USER`` represent strings that are unique to each organization. These files must be present in the ``.chef`` directory in order for the ChefDK to be able to connect to a Chef server.
+Where ``ORGANIZATION`` and ``USER`` represent strings that are unique to each organization. These files must be present in the ``.chef`` directory in order for ChefDK to be able to connect to a Chef server.
 
 To create the ``.chef`` directory:
 
@@ -277,7 +277,7 @@ Verify Install
 =====================================================
 The ChefDK is installed correctly when it is able to use ``knife`` to communicate with the Chef server.
 
-To verify that the ChefDK can connect to the Chef server:
+To verify that ChefDK can connect to the Chef server:
 
 #. In a command window, navigate to the Chef repository:
 

--- a/chef_master/source/community_contributions.rst
+++ b/chef_master/source/community_contributions.rst
@@ -29,7 +29,7 @@ The following repositories are the preferred locations for the creation of issue
      - https://github.com/chef/ohai
    * - Chef Workstation
      - https://github.com/chef/chef-workstation
-   * - Chef DK
+   * - ChefDK
      - https://github.com/chef/chef-dk
    * - Chef Server
      - https://github.com/chef/chef-server

--- a/chef_master/source/config_rb.rst
+++ b/chef_master/source/config_rb.rst
@@ -168,7 +168,7 @@ This configuration file has the following settings:
       versioned_cookbooks true
 
 ``config_log_level``
-   New in Chef DK 1.2.
+   New in ChefDK 1.2.
    Sets the default value of ``log_level`` in the client.rb file of the node being bootstrapped. Possible values are ``:debug``, ``:info``, ``:warn``, ``:error`` and ``:fatal``. For example:
 
    .. code-block:: ruby
@@ -176,7 +176,7 @@ This configuration file has the following settings:
       config_log_level :debug
 
 ``config_log_location``
-   New in Chef DK 1.2.
+   New in ChefDK 1.2.
    Sets the default value of ``log_location`` in the client.rb file of the node being bootstrapped. Possible values are ``/path/to/log_location``, ``STDOUT``, ``STDERR``, ``:win_evt`` and ``:syslog``. For example:
 
    .. code-block:: ruby

--- a/chef_master/source/config_rb_policyfile.rst
+++ b/chef_master/source/config_rb_policyfile.rst
@@ -138,7 +138,7 @@ A ``Policyfile.rb`` file may contain the following settings:
       named_run_list :update_app, "my_app_cookbook::default"
 
 ``include_policy "NAME", *args``
-   **New in Chef DK 2.4** Specify a policyfile lock to be merged with this policy. Chef DK supports pulling this lock from a local file or from Chef server. When the policyfile lock is included, its run-lists will appear before the current policyfile's run-list. This setting requires that the solved cookbooks appear as-is from the included policyfile lock. If conflicting attributes or cookbooks are provided, an error will be presented. See `RFC097 <https://github.com/chef/chef-rfc/blob/master/rfc097-policyfile-includes.md>`__ for the full specifications of this feature.
+   **New in ChefDK 2.4** Specify a policyfile lock to be merged with this policy. ChefDK supports pulling this lock from a local file or from Chef server. When the policyfile lock is included, its run-lists will appear before the current policyfile's run-list. This setting requires that the solved cookbooks appear as-is from the included policyfile lock. If conflicting attributes or cookbooks are provided, an error will be presented. See `RFC097 <https://github.com/chef/chef-rfc/blob/master/rfc097-policyfile-includes.md>`__ for the full specifications of this feature.
 
 
   Pull the policyfile lock from ``./NAME.lock.json``:

--- a/chef_master/source/config_yml_kitchen.rst
+++ b/chef_master/source/config_yml_kitchen.rst
@@ -133,7 +133,7 @@ Kitchen can configure the chef-zero provisioner with the following Chef-specific
    * - ``chef_metadata_url``
      - **This will be deprecated in a future version.**
    * - ``chef_omnibus_install_options``
-     - Use to specify the package to be installed. Possible values: ``-P chef`` (for the Chef client) and ``-P chefdk`` (for the Chef client that is packaged as part of the ChefDK). Use ``-n`` to specify the nightly build. For example: ``-P chefdk`` or ``-n -P chefdk``. **This will be deprecated in a future version.** See the ``product_name``, ``product_version``, and ``channel`` settings instead.
+     - Use to specify the package to be installed. Possible values: ``-P chef`` (for the Chef client) and ``-P chefdk`` (for the Chef client that is packaged as part of ChefDK). Use ``-n`` to specify the nightly build. For example: ``-P chefdk`` or ``-n -P chefdk``. **This will be deprecated in a future version.** See the ``product_name``, ``product_version``, and ``channel`` settings instead.
 
    * - ``chef_omnibus_root``
      - Default value: ``/etc/opt`` for UNIX and Linux, ``$env:systemdrive\\opscode\\chef`` on Microsoft Windows.

--- a/chef_master/source/config_yml_kitchen.rst
+++ b/chef_master/source/config_yml_kitchen.rst
@@ -133,7 +133,7 @@ Kitchen can configure the chef-zero provisioner with the following Chef-specific
    * - ``chef_metadata_url``
      - **This will be deprecated in a future version.**
    * - ``chef_omnibus_install_options``
-     - Use to specify the package to be installed. Possible values: ``-P chef`` (for the Chef client) and ``-P chefdk`` (for the Chef client that is packaged as part of the Chef DK). Use ``-n`` to specify the nightly build. For example: ``-P chefdk`` or ``-n -P chefdk``. **This will be deprecated in a future version.** See the ``product_name``, ``product_version``, and ``channel`` settings instead.
+     - Use to specify the package to be installed. Possible values: ``-P chef`` (for the Chef client) and ``-P chefdk`` (for the Chef client that is packaged as part of the ChefDK). Use ``-n`` to specify the nightly build. For example: ``-P chefdk`` or ``-n -P chefdk``. **This will be deprecated in a future version.** See the ``product_name``, ``product_version``, and ``channel`` settings instead.
 
    * - ``chef_omnibus_root``
      - Default value: ``/etc/opt`` for UNIX and Linux, ``$env:systemdrive\\opscode\\chef`` on Microsoft Windows.
@@ -557,7 +557,7 @@ Examples
 ==========================================================================
 The following examples show actual kitchen.yml files used in Chef-maintained cookbooks.
 
-Chef, Chef DK
+Chef, ChefDK
 --------------------------------------------------------------------------
 The following example shows the provisioner settings needed to install the Chef development kit, and then use the version of Chef that is embedded in the Chef development kit to converge the node.
 

--- a/chef_master/source/ctl_automate_server.rst
+++ b/chef_master/source/ctl_automate_server.rst
@@ -562,7 +562,7 @@ The ``install-runner`` subcommand configures a remote node as a job runner, whic
                                             You can pass the password in directly or you will be prompted if you simply pass --password.
                                             If --ssh-identify-file is also passed, will only be used for sudo access
 
-      -v, --chefdk-version VERSION          Custom version of the ChefDK you wish to download and install.
+      -v, --chefdk-version VERSION          Custom version of ChefDK you wish to download and install.
                                             This option cannot be passed with --installer as that option specifies using a package local to this server.
                                             If neither are passed, the latest ChefDK will be downloaded remotely
 

--- a/chef_master/source/delivery_cli.rst
+++ b/chef_master/source/delivery_cli.rst
@@ -9,9 +9,9 @@ Install Delivery CLI
 =====================================================
 .. tag delivery_cli_install
 
-The Delivery CLI is required for the workstation and for many Chef Automate functions. It is included in the Chef DK and can be obtained by `installing the latest version </install_dk.html>`__.
+The Delivery CLI is required for the workstation and for many Chef Automate functions. It is included in the ChefDK and can be obtained by `installing the latest version </install_dk.html>`__.
 
-.. note:: You must delete your old Delivery CLI if you installed it prior to it being included in the Chef DK.
+.. note:: You must delete your old Delivery CLI if you installed it prior to it being included in the ChefDK.
 
 .. end_tag
 
@@ -716,7 +716,7 @@ delivery local
 =====================================================
 Use the ``local`` subcommand to run a phase or stage of Chef Automate locally, based on settings in the ``project.toml`` file located in the project's ``.delivery`` directory.
 
-.. note:: As of Chef DK 1.2, delivery local now supports options for functional phases, running stages, and specifying a remote ``project.toml``.
+.. note:: As of ChefDK 1.2, delivery local now supports options for functional phases, running stages, and specifying a remote ``project.toml``.
 
 Syntax
 -----------------------------------------------------

--- a/chef_master/source/delivery_cli.rst
+++ b/chef_master/source/delivery_cli.rst
@@ -9,9 +9,9 @@ Install Delivery CLI
 =====================================================
 .. tag delivery_cli_install
 
-The Delivery CLI is required for the workstation and for many Chef Automate functions. It is included in the ChefDK and can be obtained by `installing the latest version </install_dk.html>`__.
+The Delivery CLI is required for the workstation and for many Chef Automate functions. It is included in ChefDK and can be obtained by `installing the latest version </install_dk.html>`__.
 
-.. note:: You must delete your old Delivery CLI if you installed it prior to it being included in the ChefDK.
+.. note:: You must delete your old Delivery CLI if you installed it prior to it being included in ChefDK.
 
 .. end_tag
 

--- a/chef_master/source/delivery_users_and_roles.rst
+++ b/chef_master/source/delivery_users_and_roles.rst
@@ -303,9 +303,9 @@ Install the CLI
 -----------------------------------------------------
 .. tag delivery_cli_install
 
-The Delivery CLI is required for the workstation and for many Chef Automate functions. It is included in the ChefDK and can be obtained by `installing the latest version </install_dk.html>`__.
+The Delivery CLI is required for the workstation and for many Chef Automate functions. It is included in ChefDK and can be obtained by `installing the latest version </install_dk.html>`__.
 
-.. note:: You must delete your old Delivery CLI if you installed it prior to it being included in the ChefDK.
+.. note:: You must delete your old Delivery CLI if you installed it prior to it being included in ChefDK.
 
 .. end_tag
 

--- a/chef_master/source/delivery_users_and_roles.rst
+++ b/chef_master/source/delivery_users_and_roles.rst
@@ -303,9 +303,9 @@ Install the CLI
 -----------------------------------------------------
 .. tag delivery_cli_install
 
-The Delivery CLI is required for the workstation and for many Chef Automate functions. It is included in the Chef DK and can be obtained by `installing the latest version </install_dk.html>`__.
+The Delivery CLI is required for the workstation and for many Chef Automate functions. It is included in the ChefDK and can be obtained by `installing the latest version </install_dk.html>`__.
 
-.. note:: You must delete your old Delivery CLI if you installed it prior to it being included in the Chef DK.
+.. note:: You must delete your old Delivery CLI if you installed it prior to it being included in the ChefDK.
 
 .. end_tag
 

--- a/chef_master/source/dk_windows.rst
+++ b/chef_master/source/dk_windows.rst
@@ -3,7 +3,7 @@ ChefDK on Windows Workstations
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/dk_windows.rst>`__
 
-This guide details some of the common considerations that come into play when using the Chef Development Kit on Windows. Download the ChefDK by following the installation instructions on `Installing the ChefDK </install_dk.html>`_.
+This guide details some of the common considerations that come into play when using the Chef Development Kit on Windows. Download ChefDK by following the installation instructions on `Installing ChefDK </install_dk.html>`_.
 
 .. note:: `Chef Workstation <https://downloads.chef.io/chef-workstation/>`__ gives you everything you need to get started with Chef — ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software — all in one easy-to-install package. Chef Workstation replaces ChefDK, combining all the existing features with new features, such as ad-hoc task support and the new Chef Workstation desktop application. Chef will continue to maintain ChefDK, but new development will take place in Chef Workstation without backporting features.
 

--- a/chef_master/source/errors.rst
+++ b/chef_master/source/errors.rst
@@ -3,7 +3,7 @@ Troubleshooting
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/errors.rst>`__
 
-The following sections describe how to troubleshoot the Chef server, Chef client and Chef DK.
+The following sections describe how to troubleshoot the Chef server, Chef client and ChefDK.
 
 401 Unauthorized
 =====================================================

--- a/chef_master/source/fips.rst
+++ b/chef_master/source/fips.rst
@@ -27,7 +27,7 @@ Supported Products
 
 * `Chef Automate </fips.html#how-to-enable-fips-mode-for-the-chef-automate-server>`__
 * `Chef Client </fips.html#how-to-enable-fips-mode-for-the-chef-client>`__
-* `Chef DK </fips.html#how-to-enable-fips-mode-for-workstations>`__
+* `ChefDK </fips.html#how-to-enable-fips-mode-for-workstations>`__
 * `Chef server </fips.html#how-to-enable-fips-mode-for-the-chef-server>`__
 
 **Unsupported:**

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -270,7 +270,7 @@ Cookbook Reference
 ChefDK
 -----------------------------------------------------
 
-`About the ChefDK </about_chefdk.html>`__ |
+`About ChefDK </about_chefdk.html>`__ |
 `Berkshelf </berkshelf.html>`__ |
 `chef-apply (executable) </ctl_chef_apply.html>`__ |
 `chef-shell (executable) </chef_shell.html>`__

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -6,7 +6,7 @@ Site Map
 This is the documentation for:
 
 * Chef, including the Chef server, the Chef client, the Chef
-  development kit (Chef DK) and related tools
+  development kit (ChefDK) and related tools
 * Chef Automate
 
 For information on Habitat and InSpec, see their respective documentation:
@@ -95,7 +95,7 @@ Concepts
 Setup
 -----------------------------------------------------
 `Proxies </proxies.html>`__ |
-`Chef DK on Windows </dk_windows.html>`__ |
+`ChefDK on Windows </dk_windows.html>`__ |
 `Workstation </install_dk.html>`__
 
 **Nodes**: `Install via Bootstrap </install_bootstrap.html>`__ | `Install via URL </install_omnibus.html>`__ | `Install on Windows </install_windows.html>`__ | `Install on Junos OS </junos.html>`__ | `chef-client (executable) </ctl_chef_client.html>`__ | `client.rb </config_rb_client.html>`__ | `Upgrades </upgrade_client.html>`__ | `Security </chef_client_security.html>`__
@@ -267,7 +267,7 @@ Cookbook Reference
 
 **Chef Automate Cookbooks**: `build-cookbook (cookbook) </delivery_build_cookbook.html>`__ | `delivery-truck (cookbook) </delivery_truck.html>`__ | `Publish Cookbooks to Multiple Chef Servers </publish_cookbooks_multiple_servers.html>`__
 
-Chef DK
+ChefDK
 -----------------------------------------------------
 
 `About the ChefDK </about_chefdk.html>`__ |

--- a/chef_master/source/install_chef_air_gap.rst
+++ b/chef_master/source/install_chef_air_gap.rst
@@ -144,7 +144,7 @@ Chef workstation
 
 Install ChefDK
 -----------------------------------------------------
-#. Your workstation should have a copy of the ChefDK `installer package <https://downloads.chef.io/chefdk>`__. Use the appropriate tool to run the installer:
+#. Your workstation should have a copy of ChefDK `installer package <https://downloads.chef.io/chefdk>`__. Use the appropriate tool to run the installer:
 
    .. code-block:: bash
 

--- a/chef_master/source/install_chef_air_gap.rst
+++ b/chef_master/source/install_chef_air_gap.rst
@@ -15,7 +15,7 @@ Since a variety of different practices are used to create an air-gapped network,
 * A server's Fully Qualified Domain Name (FQDN) is the name that will be used by other servers to access it
 * You have a private Ruby gem mirror to supply gems as needed
 * You have an artifact store for file downloads. At a minimum, it should have the following packages available:
-    * Chef DK
+    * ChefDK
     * Chef client
     * Chef Supermarket
     * An `install script </install_chef_air_gap.html#create-an-install-script>`__ for Chef client
@@ -142,9 +142,9 @@ In this section you'll install the Chef server, and create your organization and
 Chef workstation
 =====================================================
 
-Install Chef DK
+Install ChefDK
 -----------------------------------------------------
-#. Your workstation should have a copy of the Chef DK `installer package <https://downloads.chef.io/chefdk>`__. Use the appropriate tool to run the installer:
+#. Your workstation should have a copy of the ChefDK `installer package <https://downloads.chef.io/chefdk>`__. Use the appropriate tool to run the installer:
 
    .. code-block:: bash
 

--- a/chef_master/source/install_chef_automate.rst
+++ b/chef_master/source/install_chef_automate.rst
@@ -333,7 +333,7 @@ The following steps show how to set up a runner from a Chef Automate server. Whi
 
    .. important:: The ``install-runner`` command creates a new file called ``job_runner`` in the ``/etc/sudoers.d`` directory that gives the runner the appropriate ``sudo`` access. If your runner does not have the ``#includedir /etc/sudoers.d`` directive included in its ``/etc/sudoers`` file, you must put that directive in before you run the ``install-runner`` command. Additionally, the line ``Defaults requiretty`` must not occur in the ``/etc/sudoers`` file on any runner. This will prevent proper installation of runners.
 
-   .. note:: You can optionally download the latest ChefDK from `<https://downloads.chef.io/chefdk/>`_ to specify a local package via ``--installer``. Doing so is useful if you are in an air-gapped environment. Version 0.15.16 or greater of the ChefDK is required. The download location is referred to below as ``OPTIONAL_CHEF_DK_PACKAGE_PATH``. This option cannot be used with the ``--chefdk-version`` as the version of the local package will be used.
+   .. note:: You can optionally download the latest ChefDK from `<https://downloads.chef.io/chefdk/>`_ to specify a local package via ``--installer``. Doing so is useful if you are in an air-gapped environment. Version 0.15.16 or greater of ChefDK is required. The download location is referred to below as ``OPTIONAL_CHEF_DK_PACKAGE_PATH``. This option cannot be used with the ``--chefdk-version`` as the version of the local package will be used.
 
    .. code-block:: bash
 
@@ -347,7 +347,7 @@ The following steps show how to set up a runner from a Chef Automate server. Whi
 
    The ``SSH_USERNAME`` provided must have ``sudo`` access on the intended runner, and at least one of ``--password PASSWORD`` or ``--ssh-identity-file FILE`` is required by Chef Automate in order to communicate with it.
 
-   If you require a specific version of the ChefDK to be downloaded and installed on your runners, you can specify it in the ``--chefdk-version`` option. This is useful if your cookbooks are not compatible the Chef client that comes with the latest version of the ChefDK.
+   If you require a specific version of ChefDK to be downloaded and installed on your runners, you can specify it in the ``--chefdk-version`` option. This is useful if your cookbooks are not compatible the Chef client that comes with the latest version of ChefDK.
 
    For more ``install-runner`` usage examples, see `install-runner </ctl_automate_server.html#install-runner>`__, and for more information on runners and the SSH-based job dispatch system, see `Runners </runners.html>`_.
 

--- a/chef_master/source/install_dk.rst
+++ b/chef_master/source/install_dk.rst
@@ -1,9 +1,9 @@
 =====================================================
-Install the ChefDK
+Install ChefDK
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/install_dk.rst>`__
 
-Use the Chef Development Kit installer to set up the ChefDK on a workstation. ChefDK includes the chef-client, an embedded version of Ruby, RubyGems, and OpenSSL, as well as our tools: Test Kitchen, Cookstyle, Foodcritic and ChefSpec. The Chef installer puts everything into a unique directory (``/opt/chefdk/`` on macOS / Linux and ``C:\opscode\chefdk\`` on Windows) so that these components will not interfere with other applications that may be running on the target machine.
+Use the Chef Development Kit installer to set up ChefDK on a workstation. ChefDK includes the chef-client, an embedded version of Ruby, RubyGems, and OpenSSL, as well as our tools: Test Kitchen, Cookstyle, Foodcritic and ChefSpec. The Chef installer puts everything into a unique directory (``/opt/chefdk/`` on macOS / Linux and ``C:\opscode\chefdk\`` on Windows) so that these components will not interfere with other applications that may be running on the target machine.
 
 .. note:: The Chef installer must run as a privileged user.
 

--- a/chef_master/source/knife_cookbook_site.rst
+++ b/chef_master/source/knife_cookbook_site.rst
@@ -20,7 +20,7 @@ Use the ``knife cookbook site`` subcommand to interact with cookbooks that are a
 
 .. warning:: .. tag notes_knife_cookbook_site_use_devkit_berkshelf
 
-             Please consider managing community cookbooks using the version of Berkshelf that ships with the Chef Development Kit. For more information about the Chef Development Kit, see `About the Chef DK </about_chefdk.html>`__.
+             Please consider managing community cookbooks using the version of Berkshelf that ships with the Chef Development Kit. For more information about the Chef Development Kit, see `About ChefDK </about_chefdk.html>`__.
 
              .. end_tag
 

--- a/chef_master/source/knife_supermarket.rst
+++ b/chef_master/source/knife_supermarket.rst
@@ -12,7 +12,7 @@ The ``knife supermarket`` subcommand is used to interact with cookbooks that are
 
 .. note:: .. tag notes_knife_cookbook_site_use_devkit_berkshelf
 
-          Please consider managing community cookbooks using the version of Berkshelf that ships with the Chef Development Kit. For more information about the Chef Development Kit, see `About the Chef DK </about_chefdk.html>`__.
+          Please consider managing community cookbooks using the version of Berkshelf that ships with the Chef Development Kit. For more information about the Chef Development Kit, see `About ChefDK </about_chefdk.html>`__.
 
           .. end_tag
 

--- a/chef_master/source/platform_overview.rst
+++ b/chef_master/source/platform_overview.rst
@@ -29,13 +29,13 @@ Using the workstation
 -----------------------------------------------------
 You create and test your code on your workstation before you deploy it to other environments. Your workstation is the computer where you author your cookbooks and administer your infrastructure. It's typically the machine you use everyday. It can be any OS you choose, whether it's Linux, macOS, or Windows.
 
-You'll need to install a text editor (whichever you like) to write code and the Chef Development Kit (Chef DK) to get the tools to test your code. The primary testing tools you'll use are Cookstyle, Foodcritic, ChefSpec, InSpec, and Test Kitchen. With them, you can make sure your Chef code does what you intended before you deploy it to environments used by others, such as staging or production.
+You'll need to install a text editor (whichever you like) to write code and the Chef Development Kit (ChefDK) to get the tools to test your code. The primary testing tools you'll use are Cookstyle, Foodcritic, ChefSpec, InSpec, and Test Kitchen. With them, you can make sure your Chef code does what you intended before you deploy it to environments used by others, such as staging or production.
 
 When you write your code, you use resources to describe your infrastructure. A resource corresponds to some piece of infrastructure, such as a file, a template, or a package. Each resource declares what state a part of the system should be in, but not how to get there. Chef handles these complexities for you. Chef provides many resources that are ready for you to use. You can also utilize resources shipped in community cookbooks, or write your own resources specific to your infrastructure.
 
 A Chef recipe is a file that groups related resources, such as everything needed to configure a web server, database server, or a load balancer. A Chef cookbook provides structure to your recipes and, in general, helps you stay organized.
 
-The Chef DK includes other command line tools for interacting with Chef. These include knife for interacting with the Chef server, and chef for interacting with your local chef code repository (chef-repo).
+The ChefDK includes other command line tools for interacting with Chef. These include knife for interacting with the Chef server, and chef for interacting with your local chef code repository (chef-repo).
 
 Uploading your code to Chef server
 -----------------------------------------------------

--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -108,13 +108,13 @@ The following platforms are supported only via the community:
      - ``x86_64``
      - ``Windows Server, Semi-annual channel (SAC) (Server Core only)``
 
-Chef DK
+ChefDK
 ------------------------------------------------------
 
 Commercial Support
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-The following table lists the commercially-supported platforms and versions for the Chef Development Kit (Chef DK):
+The following table lists the commercially-supported platforms and versions for the Chef Development Kit (ChefDK):
 
 .. list-table::
    :widths: 280 100 120
@@ -516,15 +516,15 @@ Versions and Status
      - 12.x
      - `EOL <https://www.chef.io/eol-chef12-and-chefdk1/>`__
      - April 30, 2018
-   * - Chef DK
+   * - ChefDK
      - 3.x
      - GA
      - n/a
-   * - Chef DK
+   * - ChefDK
      - 2.x
      - Deprecated
      - n/a
-   * - Chef DK
+   * - ChefDK
      - 1.x
      - `EOL <https://www.chef.io/eol-chef12-and-chefdk1/>`__
      - April 30, 2018

--- a/chef_master/source/policyfile.rst
+++ b/chef_master/source/policyfile.rst
@@ -224,7 +224,7 @@ A ``Policyfile.rb`` file may contain the following settings:
       named_run_list :update_app, "my_app_cookbook::default"
 
 ``include_policy "NAME", *args``
-   **New in Chef DK 2.4** Specify a policyfile lock to be merged with this policy. Chef DK supports pulling this lock from a local file or from Chef server. When the policyfile lock is included, its run-lists will appear before the current policyfile's run-list. This setting requires that the solved cookbooks appear as-is from the included policyfile lock. If conflicting attributes or cookbooks are provided, an error will be presented. See `RFC097 <https://github.com/chef/chef-rfc/blob/master/rfc097-policyfile-includes.md>`__ for the full specifications of this feature.
+   **New in ChefDK 2.4** Specify a policyfile lock to be merged with this policy. ChefDK supports pulling this lock from a local file or from Chef server. When the policyfile lock is included, its run-lists will appear before the current policyfile's run-list. This setting requires that the solved cookbooks appear as-is from the included policyfile lock. If conflicting attributes or cookbooks are provided, an error will be presented. See `RFC097 <https://github.com/chef/chef-rfc/blob/master/rfc097-policyfile-includes.md>`__ for the full specifications of this feature.
 
 
   Pull the policyfile lock from ``./NAME.lock.json``:

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -1469,7 +1469,7 @@ Please use ``knife cookbook site install`` instead.
 
 ``knife cookbook create`` has been removed
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-Please use ``chef generate cookbook`` from the ChefDK instead.
+Please use ``chef generate cookbook`` from ChefDK instead.
 
 Verify commands no longer support "%{file}"
 +++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -856,7 +856,7 @@ What's New in 13.7.16
 
 * **Credentials Handling**
 
-  Previously, Chef DK workstations used ``knife.rb`` or ``config.rb`` to handle credentials. This didn’t do a great job of interacting with multiple Chef servers, which lead to the need for tools like `knife_block <https://github.com/knife-block/knife-block>`__. We’ve added support for a credentials file that contains configuration information for many Chef servers / organizations, and we’ve made it easy to indicate which account you mean to use.
+  Previously, ChefDK workstations used ``knife.rb`` or ``config.rb`` to handle credentials. This didn’t do a great job of interacting with multiple Chef servers, which lead to the need for tools like `knife_block <https://github.com/knife-block/knife-block>`__. We’ve added support for a credentials file that contains configuration information for many Chef servers / organizations, and we’ve made it easy to indicate which account you mean to use.
 
 * **Bug Fixes**
 
@@ -1532,7 +1532,7 @@ This release fixes an issue in our Windows security support code that would occa
 
 This issue is also fixed in the recent Chef 14.0.190 release, and will be included in the next Chef 13 release expected by the end of the month.
 
-This is the final planned Chef 12 release, which is currently deprecated and will become End of Life on April 30th. For additional information on that process, please see our `Chef 12 and Chef DK 1 EOL information <https://www.chef.io/eol-chef12-and-chefdk1>`__.
+This is the final planned Chef 12 release, which is currently deprecated and will become End of Life on April 30th. For additional information on that process, please see our `Chef 12 and ChefDK 1 EOL information <https://www.chef.io/eol-chef12-and-chefdk1>`__.
 
 What's New in 12.22.1
 =====================================================

--- a/chef_master/source/release_notes_chefdk.rst
+++ b/chef_master/source/release_notes_chefdk.rst
@@ -3,7 +3,7 @@ Release Notes: Chef Development Kit 0.19 - 3.1
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/release_notes_chefdk.rst>`__
 
-Chef Development Kit is released on a monthly schedule with new releases the third Monday of every month. Below are the major changes for each release. For a detailed list of changes see the `Chef DK Changelog on GitHub <https://github.com/chef/chef-dk/blob/master/CHANGELOG.md>`__
+Chef Development Kit is released on a monthly schedule with new releases the third Monday of every month. Below are the major changes for each release. For a detailed list of changes see the `ChefDK Changelog on GitHub <https://github.com/chef/chef-dk/blob/master/CHANGELOG.md>`__
 
 What's New in 3.1
 =====================================================
@@ -124,7 +124,7 @@ What's New in 2.5.3
 
 * **Chef 13.8.5**
 
-  Chef DK now ships with Chef 13.8.5. See the `Chef release notes </release_notes.html#what-s-new-in-13-8-5>`__ for more information.
+  ChefDK now ships with Chef 13.8.5. See the `Chef release notes </release_notes.html#what-s-new-in-13-8-5>`__ for more information.
 
 * **Updated chef_version in cookbook generator** 
 
@@ -245,7 +245,7 @@ What's New in 2.4.17
 
 * **New tools bundled**
 
-  We are now shipping these tools as part of Chef DK:
+  We are now shipping these tools as part of ChefDK:
 
     * `kitchen-digitalocean <https://github.com/test-kitchen/kitchen-digitalocean>`__
     * `kitchen-google <https://github.com/test-kitchen/kitchen-google>`__
@@ -308,7 +308,7 @@ ChefDK 2.2.1 includes:
 
 What's New in 2.1.11
 =====================================================
-This release updates the version of git shipped in Chef DK to 2.14.1 to address `CVE-2017-1000117 <https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2017-1000117>`__.
+This release updates the version of git shipped in ChefDK to 2.14.1 to address `CVE-2017-1000117 <https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2017-1000117>`__.
 
 Notable Updated Gems
 -----------------------------------------------------
@@ -329,7 +329,7 @@ See the detailed `change log <https://github.com/chef/chef-dk/blob/master/CHANGE
 
 What's New in 2.0.28
 =====================================================
-Chef 2.0.28 fixes an `issue <https://github.com/chef/chef-dk/issues/1322>`__ in Chef DK 2.0 where ``chef push`` would upload incomplete cookbooks.
+Chef 2.0.28 fixes an `issue <https://github.com/chef/chef-dk/issues/1322>`__ in ChefDK 2.0 where ``chef push`` would upload incomplete cookbooks.
 
 What's New in 2.0
 =====================================================

--- a/chef_master/source/runners.rst
+++ b/chef_master/source/runners.rst
@@ -32,7 +32,7 @@ Adding a Runner
 
 You can add a new runner via ``automate-ctl`` from your Chef Automate server. Log in to your Chef Automate server and run the `install-runner </ctl_automate_server.html#install-runner>`__ command.
 
-.. note:: You can pin to a specific ChefDK version through the ``--chefdk-version`` option on the ``install-runner`` command or by using a version of the ChefDK that you have installed locally on your Chef Automate server using the ``-I`` option. As an example, this is useful if you have not upgraded your cookbooks to be Chef 13 compliant and the latest version of the ChefDK installs Chef 13 on your runner.
+.. note:: You can pin to a specific ChefDK version through the ``--chefdk-version`` option on the ``install-runner`` command or by using a version of ChefDK that you have installed locally on your Chef Automate server using the ``-I`` option. As an example, this is useful if you have not upgraded your cookbooks to be Chef 13 compliant and the latest version of ChefDK installs Chef 13 on your runner.
 
 After the `install-runner </ctl_automate_server.html#install-runner>`__ command succeeds, the new runner should show up in the UI under ``Workflow -> Runners -> Manage Runners``. If you see it there, click the ``Test`` button. That will test an ssh connection to your runner to verify that jobs can be dispatched to it. If there are any issues, you should get an error in the UI.
 
@@ -64,7 +64,7 @@ To delete a runner:
 Upgrading the version of ChefDK on a Runner
 -----------------------------------------------------
 
-If you need to upgrade the version of ChefDK on your runner, you can do so by logging into the runner, upgrading the ChefDK, and manually appending the Chef Automate server certificate to the cert file that ships in the ChefDK.
+If you need to upgrade the version of ChefDK on your runner, you can do so by logging into the runner, upgrading ChefDK, and manually appending the Chef Automate server certificate to the cert file that ships in ChefDK.
 
 Typically, we recommend re-running the ``install-runner`` command rather than manually updating as the installation process will take care of this certification change for you when it bootstraps the node.
 

--- a/chef_master/source/supermarket_share_cookbook.rst
+++ b/chef_master/source/supermarket_share_cookbook.rst
@@ -29,7 +29,7 @@ Share Cookbooks via Stove
 -------------------------------------------------------
 `Stove <https://github.com/sethvargo/stove>`__ is a cookbook release utility that keeps the upload process localized to the cookbook itself, as opposed to the `Knife </supermarket_share_cookbook.html#share-cookbooks-via-knife>`__ method which requires a cookbook repository.
 
-.. note:: Stove is included in the Chef DK. If you are not using the Chef DK, follow the `Stove installation instructions <https://github.com/sethvargo/stove#installation>`__ to install Stove separately.
+.. note:: Stove is included in the ChefDK. If you are not using the ChefDK, follow the `Stove installation instructions <https://github.com/sethvargo/stove#installation>`__ to install Stove separately.
 
 #. Add your Hosted Chef credentials to Stove. Replace ``USER`` with your Hosted Chef user, and ``KEY.pem`` with your the full path to Hosted Chef private key:
 

--- a/chef_master/source/supermarket_share_cookbook.rst
+++ b/chef_master/source/supermarket_share_cookbook.rst
@@ -29,7 +29,7 @@ Share Cookbooks via Stove
 -------------------------------------------------------
 `Stove <https://github.com/sethvargo/stove>`__ is a cookbook release utility that keeps the upload process localized to the cookbook itself, as opposed to the `Knife </supermarket_share_cookbook.html#share-cookbooks-via-knife>`__ method which requires a cookbook repository.
 
-.. note:: Stove is included in the ChefDK. If you are not using the ChefDK, follow the `Stove installation instructions <https://github.com/sethvargo/stove#installation>`__ to install Stove separately.
+.. note:: Stove is included in ChefDK. If you are not using ChefDK, follow the `Stove installation instructions <https://github.com/sethvargo/stove#installation>`__ to install Stove separately.
 
 #. Add your Hosted Chef credentials to Stove. Replace ``USER`` with your Hosted Chef user, and ``KEY.pem`` with your the full path to Hosted Chef private key:
 

--- a/chef_master/source/uninstall.rst
+++ b/chef_master/source/uninstall.rst
@@ -81,7 +81,7 @@ push-jobs-client
 -----------------------------------------------------
 Use the package manager for the platform on which Chef push jobs is installed to uninstall Chef push jobs.
 
-Chef DK
+ChefDK
 =====================================================
 .. tag uninstall_chef_dk
 


### PR DESCRIPTION
Signed-off-by: Mary Jinglewski <mjinglewski@chef.io>

### Description

40 or so instances of "Chef DK" currently exist in documentation. This PR will remove the space between and allow documentation to follow proper "ChefDK" usage. This PR will also remove most instances of "the" in "the ChefDK" throughout the documentation. The extra "the" is a bit clunky and we could do without most of the time.

### Definition of Done
When all the green lights up...

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
