### PR TITLE
Update release notes for chef server 12.18.14

### DIFF
--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -5,6 +5,32 @@ Release Notes: Chef Server 12.0 - 12.17.33
 
 The Chef server acts as a hub for configuration data by storing cookbooks, the policies that are applied to nodes, and metadata that describes each registered node that is managed by the chef-client.
 
+What's New in 12.18.14
+=====================================================
+This release:
+
+* Segment free cookbooks are implemented. (https://github.com/chef/chef-rfc/blob/master/rfc067-cookbook-segment-deprecation.md) This bumps the API version
+* ACLs for cookbook artifacts
+* /nodes/NODENAME endpoint has HEAD operation
+* Security headers for HTTP
+* Optional disabling of welcome page
+* chef-server-ctl now has version subcommand
+* chef-server-ctl appbundled to better control gem loading.
+* Support for SSL auth between internal Chef Server Services. This includes connections to bifrost and the internal Postgresql server
+* All datestamps in logs are now in UTC. SOLR GC log now datestamped.
+* Nginx logs now include the request id
+* Fixie is now shipped with chef server
+* Security issue with old doorkeeper fixed by upgrading. CVE-2018-1000211
+* Fixed issue migrating rabbitmq passwords (migration 031)
+* Chef indexing queue times now reported in stats in log messages and status endpoint
+* Ruby updated to 2.5.1
+* Update gems
+* Chef Client updated to 14.3
+* Postgresql updated to 9.6.10 and 9.2.24 (latter only for upgrades from older Chef Servers)
+* Fix for SUSE SLES-11 sysvinit install
+* Removed nodejs (a build dependency that was shipped)
+
+
 What's New in 12.17.33
 =====================================================
 This release:

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -1,5 +1,5 @@
 =====================================================
-Release Notes: Chef Server 12.0 - 12.17.33
+Release Notes: Chef Server 12.0 - 12.18.14
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/release_notes_server.rst>`__
 
@@ -9,26 +9,26 @@ What's New in 12.18.14
 =====================================================
 This release:
 
-* Segment free cookbooks are implemented. (https://github.com/chef/chef-rfc/blob/master/rfc067-cookbook-segment-deprecation.md) This bumps the API version
+* Segment free cookbooks are implemented. (https://github.com/chef/chef-rfc/blob/master/rfc067-cookbook-segment-deprecation.md) This bumps the API version.
 * ACLs for cookbook artifacts
-* /nodes/NODENAME endpoint has HEAD operation
+* /nodes/NODENAME endpoint has HEAD operation.
 * Security headers for HTTP
 * Optional disabling of welcome page
-* chef-server-ctl now has version subcommand
+* chef-server-ctl now has version subcommand.
 * chef-server-ctl appbundled to better control gem loading.
-* Support for SSL auth between internal Chef Server Services. This includes connections to bifrost and the internal Postgresql server
+* Support for SSL auth between internal Chef Server Services. This includes connections to bifrost and the internal Postgresql server.
 * All datestamps in logs are now in UTC. SOLR GC log now datestamped.
-* Nginx logs now include the request id
-* Fixie is now shipped with chef server
+* Nginx logs now include the request id.
+* Fixie is now shipped with chef server.
 * Security issue with old doorkeeper fixed by upgrading. CVE-2018-1000211
-* Fixed issue migrating rabbitmq passwords (migration 031)
-* Chef indexing queue times now reported in stats in log messages and status endpoint
+* Fixed issue migrating rabbitmq passwords (migration 031).
+* Chef indexing queue times now reported in stats in log messages and status endpoint.
 * Ruby updated to 2.5.1
 * Update gems
-* Chef Client updated to 14.3
-* Postgresql updated to 9.6.10 and 9.2.24 (latter only for upgrades from older Chef Servers)
+* Chef Client updated to 14.3.
+* Postgresql updated to 9.6.10 and 9.2.24 (latter only for upgrades from older Chef Servers).
 * Fix for SUSE SLES-11 sysvinit install
-* Removed nodejs (a build dependency that was shipped)
+* Removed nodejs (a build dependency that was shipped).
 
 
 What's New in 12.17.33


### PR DESCRIPTION
Signed-off-by: Mark Anderson <mark@chef.io>

### Description

Adds release notes for chef server 12.18.14

### Definition of Done

### Issues Resolved

### Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
