### PR TITLE
property install_method missing

### DIFF
--- a/chef_master/source/resource_windows_feature.rst
+++ b/chef_master/source/resource_windows_feature.rst
@@ -58,12 +58,17 @@ Properties
 ``feature_name``
    **Ruby Type:** Array, String | **Default Value:** ``'name'``
 
-   The name of the feature(s) or role(s) to install, if it differs from the resource block name.
+   The name of the feature/role(s) to install. The same feature may have different names depending on the underlying resource being used (ie DHCPServer vs DHCP; DNS-Server-Full-Role vs DNS).
 
 ``management_tools``
    **Ruby Type:** true, false | **Default Value:** ``false``
 
    Install all applicable management tools for the roles, role services, or features (PowerShell-only).
+
+``install_method``
+   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+   If DISM or PowerShell should be used for the installation. Note feature names differ between the two installation methods. Possible values: ``:windows_feature_dism``, ``:windows_feature_powershell``, ``:windows_feature_servermanagercmd``.
 
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'


### PR DESCRIPTION
add install_method description from resource

### Description

Provides missing property info for installer_type to be displayed on the web_docs matching the current resource.

### Check List

- [X] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
