### PR TITLE
More resource cleanup from automation

### DIFF
--- a/chef_master/source/resource_powershell_package_source.rst
+++ b/chef_master/source/resource_powershell_package_source.rst
@@ -14,7 +14,7 @@ The powershell_package_source resource has the following syntax:
 .. code-block:: ruby
 
   powershell_package_source 'name' do
-    provider_name                String # default value: NuGet
+    provider_name                String # default value: "NuGet"
     publish_location             String
     script_publish_location      String
     script_source_location       String
@@ -46,42 +46,8 @@ Actions
 Properties
 =====================================================
 
-``notifies``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_notifies
-
-   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
-
-   The syntax for ``notifies`` is:
-
-   .. code-block:: ruby
-
-     notifies :action, 'resource[name]', :timer
-
-   .. end_tag
-
 ``provider_name``
-   **Ruby Type:** String | **Default Value:** ``NuGet``
+   **Ruby Type:** String | **Default Value:** ``"NuGet"``
 
    The package management provider for the source. It supports the following providers: 'Programs', 'msi', 'NuGet', 'msu', 'PowerShellGet', 'psl' and 'chocolatey'.
 
@@ -101,58 +67,9 @@ Properties
    The url where scripts are located for this source. Only valid if the provider is 'PowerShellGet'.
 
 ``source_name``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``'name'``
 
    The name of the package source.
-
-``subscribes``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_subscribes
-
-   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
-
-   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
-
-   .. code-block:: ruby
-
-    file '/etc/nginx/ssl/example.crt' do
-      mode '0600'
-      owner 'root'
-    end
-
-    service 'nginx' do
-      subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
-    end
-
-   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
-
-   The syntax for ``subscribes`` is:
-
-   .. code-block:: ruby
-
-      subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``trusted``
    **Ruby Type:** true, false | **Default Value:** ``false``
@@ -160,6 +77,151 @@ Properties
    Whether or not to trust packages from this source.
 
 ``url``
-   **Ruby Type:** String
+   **Ruby Type:** String | ``REQUIRED``
 
    The url to the package source.
+
+Common Resource Functionality
+=====================================================
+
+Chef resources include common properties, notifications, and resource guards.
+
+Common Properties
+-----------------------------------------------------
+
+.. tag resources_common_properties
+
+The following properties are common to every resource:
+
+``ignore_failure``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Continue running a recipe if a resource fails for any reason.
+
+``retries``
+  **Ruby Type:** Integer | **Default Value:** ``0``
+
+  The number of times to catch exceptions and retry the resource.
+
+``retry_delay``
+  **Ruby Type:** Integer | **Default Value:** ``2``
+
+  The retry delay (in seconds).
+
+``sensitive``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Ensure that sensitive resource data is not logged by the chef-client.
+
+.. end_tag
+
+Notifications
+-----------------------------------------------------
+
+``notifies``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+  .. tag resources_common_notification_notifies
+
+  A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+  .. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_notifies_syntax
+
+The syntax for ``notifies`` is:
+
+.. code-block:: ruby
+
+  notifies :action, 'resource[name]', :timer
+
+.. end_tag
+
+``subscribes``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+.. tag resources_common_notification_subscribes
+
+A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+.. code-block:: ruby
+
+ file '/etc/nginx/ssl/example.crt' do
+   mode '0600'
+   owner 'root'
+ end
+
+ service 'nginx' do
+   subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+ end
+
+In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+.. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_subscribes_syntax
+
+The syntax for ``subscribes`` is:
+
+.. code-block:: ruby
+
+   subscribes :action, 'resource[name]', :timer
+
+.. end_tag
+
+Guards
+-----------------------------------------------------
+
+.. tag resources_common_guards
+
+A guard property can be used to evaluate the state of a node during the execution phase of the chef-client run. Based on the results of this evaluation, a guard property is then used to tell the chef-client if it should continue executing a resource. A guard property accepts either a string value or a Ruby block value:
+
+* A string is executed as a shell command. If the command returns ``0``, the guard is applied. If the command returns any other value, then the guard property is not applied. String guards in a **powershell_script** run Windows PowerShell commands and may return ``true`` in addition to ``0``.
+* A block is executed as Ruby code that must return either ``true`` or ``false``. If the block returns ``true``, the guard property is applied. If the block returns ``false``, the guard property is not applied.
+
+A guard property is useful for ensuring that a resource is idempotent by allowing that resource to test for the desired state as it is being executed, and then if the desired state is present, for the chef-client to do nothing.
+
+.. end_tag
+.. tag resources_common_guards_properties
+
+The following properties can be used to define a guard that is evaluated during the execution phase of the chef-client run:
+
+``not_if``
+  Prevent a resource from executing when the condition returns ``true``.
+
+``only_if``
+  Allow a resource to execute only if the condition returns ``true``.
+
+.. end_tag

--- a/chef_master/source/resource_python.rst
+++ b/chef_master/source/resource_python.rst
@@ -77,7 +77,7 @@ Properties
 The python resource has the following properties:
 
 ``code``
-   **Ruby Type:** String
+   **Ruby Type:** String | ``REQUIRED``
 
    A quoted (" ") string of code to be executed.
 
@@ -89,7 +89,7 @@ The python resource has the following properties:
 ``cwd``
    **Ruby Type:** String
 
-   The current working directory.
+   The current working directory from which the command will be run.
 
 ``environment``
    **Ruby Type:** Hash

--- a/chef_master/source/resource_reboot.rst
+++ b/chef_master/source/resource_reboot.rst
@@ -17,7 +17,7 @@ The reboot resource has the following syntax:
 
   reboot 'name' do
     delay_mins      Integer # default value: 0
-    reason          String # default value: Reboot by Chef
+    reason          String # default value: "Reboot by Chef"
     action          Symbol # defaults to :nothing if not specified
   end
 
@@ -62,76 +62,156 @@ The reboot resource has the following properties:
 
    The amount of time (in minutes) to delay a reboot request.
 
-``ignore_failure``
-   **Ruby Type:** true, false | **Default Value:** ``false``
-
-   Continue running a recipe if a resource fails for any reason.
-
-``notifies``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_notifies
-
-   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers_reboot
-
-   A timer specifies the point during the chef-client run at which a notification is run. The following timer is available:
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
 ``reason``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``"Reboot by Chef"``
 
    A string that describes the reboot action.
 
-``retries``
-   **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of times to catch exceptions and retry the resource.
+Common Resource Functionality
+=====================================================
+
+Chef resources include common properties, notifications, and resource guards.
+
+Common Properties
+-----------------------------------------------------
+
+.. tag resources_common_properties
+
+The following properties are common to every resource:
+
+``ignore_failure``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Continue running a recipe if a resource fails for any reason.
+
+``retries``
+  **Ruby Type:** Integer | **Default Value:** ``0``
+
+  The number of times to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer | **Default Value:** ``2``
+  **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds).
+  The retry delay (in seconds).
+
+``sensitive``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Ensure that sensitive resource data is not logged by the chef-client.
+
+.. end_tag
+
+Notifications
+-----------------------------------------------------
+
+``notifies``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+  .. tag resources_common_notification_notifies
+
+  A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+  .. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_notifies_syntax
+
+The syntax for ``notifies`` is:
+
+.. code-block:: ruby
+
+  notifies :action, 'resource[name]', :timer
+
+.. end_tag
 
 ``subscribes``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_subscribes
+.. tag resources_common_notification_subscribes
 
-   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
 
-   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
 
-   .. code-block:: ruby
+.. code-block:: ruby
 
-    file '/etc/nginx/ssl/example.crt' do
-      mode '0600'
-      owner 'root'
-    end
+ file '/etc/nginx/ssl/example.crt' do
+   mode '0600'
+   owner 'root'
+ end
 
-    service 'nginx' do
-      subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
-    end
+ service 'nginx' do
+   subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+ end
 
-   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
 
-   .. end_tag
+.. end_tag
 
-   .. tag resources_common_notification_timers_reboot
+.. tag resources_common_notification_timers
 
-   A timer specifies the point during the chef-client run at which a notification is run. The following timer is available:
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
 
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
 
-   .. end_tag
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_subscribes_syntax
+
+The syntax for ``subscribes`` is:
+
+.. code-block:: ruby
+
+   subscribes :action, 'resource[name]', :timer
+
+.. end_tag
+
+Guards
+-----------------------------------------------------
+
+.. tag resources_common_guards
+
+A guard property can be used to evaluate the state of a node during the execution phase of the chef-client run. Based on the results of this evaluation, a guard property is then used to tell the chef-client if it should continue executing a resource. A guard property accepts either a string value or a Ruby block value:
+
+* A string is executed as a shell command. If the command returns ``0``, the guard is applied. If the command returns any other value, then the guard property is not applied. String guards in a **powershell_script** run Windows PowerShell commands and may return ``true`` in addition to ``0``.
+* A block is executed as Ruby code that must return either ``true`` or ``false``. If the block returns ``true``, the guard property is applied. If the block returns ``false``, the guard property is not applied.
+
+A guard property is useful for ensuring that a resource is idempotent by allowing that resource to test for the desired state as it is being executed, and then if the desired state is present, for the chef-client to do nothing.
+
+.. end_tag
+.. tag resources_common_guards_properties
+
+The following properties can be used to define a guard that is evaluated during the execution phase of the chef-client run:
+
+``not_if``
+  Prevent a resource from executing when the condition returns ``true``.
+
+``only_if``
+  Allow a resource to execute only if the condition returns ``true``.
+
+.. end_tag
 
 Examples
 =====================================================

--- a/chef_master/source/resource_registry_key.rst
+++ b/chef_master/source/resource_registry_key.rst
@@ -376,13 +376,13 @@ The registry_key resource has the following properties:
              .. end_tag
 
 ``key``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``'name'``
 
    The path to the location in which a registry key is to be created or from which a registry key is to be deleted. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
    The path must include the registry hive, which can be specified either as its full name or as the 3- or 4-letter abbreviation. For example, both ``HKLM\SECURITY`` and ``HKEY_LOCAL_MACHINE\SECURITY`` are both valid and equivalent. The following hives are valid: ``HKEY_LOCAL_MACHINE``, ``HKLM``, ``HKEY_CURRENT_CONFIG``, ``HKCC``, ``HKEY_CLASSES_ROOT``, ``HKCR``, ``HKEY_USERS``, ``HKU``, ``HKEY_CURRENT_USER``, and ``HKCU``.
 
 ``recursive``
-   **Ruby Type:** true, false
+   **Ruby Type:** true, false | **Default Value:** ``false``
 
    When creating a key, this value specifies that the required keys for the specified path are to be created. When using the ``:delete_key`` action in a recipe, and if the registry key has subkeys, then set the value for this property to ``true``.
 

--- a/chef_master/source/resource_rhsm_errata.rst
+++ b/chef_master/source/resource_rhsm_errata.rst
@@ -43,7 +43,7 @@ The rhsm_errata resource has the following actions:
 Properties
 =====================================================
 ``errata_id``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``'name'``
 
    Specify the Errata ID if it differs from the resource name.
 

--- a/chef_master/source/resource_rhsm_register.rst
+++ b/chef_master/source/resource_rhsm_register.rst
@@ -35,6 +35,9 @@ where:
 
 Actions
 =====================================================
+
+The rhsm_register resource has the following actions:
+
 ``:register``
    Default. Register the node with RHSM.
 
@@ -50,6 +53,9 @@ Actions
 
 Properties
 =====================================================
+
+The rhsm_register resource has the following properties:
+
 ``activation_key``
    **Ruby Type:** String, Array
 

--- a/chef_master/source/resource_rhsm_repo.rst
+++ b/chef_master/source/resource_rhsm_repo.rst
@@ -27,6 +27,9 @@ where:
 
 Actions
 =====================================================
+
+The rhsm_repo resource has the following actions:
+
 ``:enable``
    Default. Enable an RHSM repository.
 

--- a/chef_master/source/resource_rhsm_subscription.rst
+++ b/chef_master/source/resource_rhsm_subscription.rst
@@ -27,6 +27,9 @@ where:
 
 Actions
 =====================================================
+
+The rhsm_subscription resource has the following actions:
+
 ``:attach``
    Default. Attach the node to a subscription pool.
 
@@ -46,7 +49,7 @@ Properties
 The rhsm_subscription resource has the following properties:
 
 ``pool_id``
-  **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``'name'``
 
   An optional property for specifying the Pool ID if it differs from the resource's name.
 

--- a/chef_master/source/resource_route.rst
+++ b/chef_master/source/resource_route.rst
@@ -25,19 +25,14 @@ The full syntax for all of the properties that are available to the **route** re
 .. code-block:: ruby
 
   route 'name' do
-    comment              String
-    device               String
-    domain               String
-    domainname           String
-    gateway              String
-    hostname             String
-    metric               Integer
-    netmask              String
-    networking           String
-    networking_ipv6      String
-    route_type           host, net # default value: host
-    target               String # default value: 'name' unless specified
-    action               Symbol # defaults to :add if not specified
+    comment         String
+    device          String
+    gateway         String
+    metric          Integer
+    netmask         String
+    route_type      Symbol, String # default value: :host
+    target          String # default value: 'name' unless specified
+    action          Symbol # defaults to :add if not specified
   end
 
 where:
@@ -45,7 +40,7 @@ where:
 * ``route`` is the resource.
 * ``name`` is the name given to the resource block.
 * ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
-* ``comment``, ``device``, ``domain``, ``domainname``, ``gateway``, ``hostname``, ``metric``, ``netmask``, ``networking``, ``networking_ipv6``, ``route_type``, and ``target`` are the properties available to this resource.
+* ``comment``, ``device``, ``gateway``, ``metric``, ``netmask``, ``route_type``, and ``target`` are the properties available to this resource.
 
 Actions
 =====================================================
@@ -73,7 +68,7 @@ The route resource has the following properties:
 ``comment``
    **Ruby Type:** String
 
-   Add a comment.
+   Add a comment for the route.
 
    New in Chef Client 14.0.
 
@@ -87,113 +82,24 @@ The route resource has the following properties:
 
    The gateway for the route.
 
-``ignore_failure``
-   **Ruby Type:** true, false | **Default Value:** ``false``
+``metric``
+   **Ruby Type:** Integer
 
-   Continue running a recipe if a resource fails for any reason.
+   The route metric value.
 
 ``netmask``
    **Ruby Type:** String
 
    The decimal representation of the network mask. For example: ``255.255.255.0``.
 
-``notifies``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_notifies
-
-   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
-
-   The syntax for ``notifies`` is:
-
-   .. code-block:: ruby
-
-     notifies :action, 'resource[name]', :timer
-
-   .. end_tag
-
-``retries``
-   **Ruby Type:** Integer | **Default Value:** ``0``
-
-   The number of times to catch exceptions and retry the resource.
-
-``retry_delay``
-   **Ruby Type:** Integer | **Default Value:** ``2``
-
-   The retry delay (in seconds).
-
-``subscribes``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_subscribes
-
-   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
-
-   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
-
-   .. code-block:: ruby
-
-    file '/etc/nginx/ssl/example.crt' do
-      mode '0600'
-      owner 'root'
-    end
-
-    service 'nginx' do
-      subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
-    end
-
-   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
-
-   The syntax for ``subscribes`` is:
-
-   .. code-block:: ruby
-
-      subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
+``route_type``
+   **Ruby Type:** Symbol, String | **Default Value:** ``:host``
 
 ``target``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``'name'``
 
-   The IP address of the target route. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
+   The IP address of the target route.
 
 Common Resource Functionality
 =====================================================

--- a/chef_master/source/resource_rpm_package.rst
+++ b/chef_master/source/resource_rpm_package.rst
@@ -75,45 +75,6 @@ This resource has the following properties:
 
    Downgrade a package to satisfy requested version requirements.
 
-``ignore_failure``
-   **Ruby Type:** true, false | **Default Value:** ``false``
-
-   Continue running a recipe if a resource fails for any reason.
-
-``notifies``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_notifies
-
-   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
-
-   The syntax for ``notifies`` is:
-
-   .. code-block:: ruby
-
-     notifies :action, 'resource[name]', :timer
-
-   .. end_tag
-
 ``options``
    **Ruby Type:** String
 
@@ -124,69 +85,10 @@ This resource has the following properties:
 
    The name of the package. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 
-``retries``
-   **Ruby Type:** Integer | **Default Value:** ``0``
-
-   The number of times to catch exceptions and retry the resource.
-
-``retry_delay``
-   **Ruby Type:** Integer | **Default Value:** ``2``
-
-   The retry delay (in seconds).
-
 ``source``
    **Ruby Type:** String
 
    Optional. The path to a package in the local file system.
-
-``subscribes``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_subscribes
-
-   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
-
-   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
-
-   .. code-block:: ruby
-
-    file '/etc/nginx/ssl/example.crt' do
-      mode '0600'
-      owner 'root'
-    end
-
-    service 'nginx' do
-      subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
-    end
-
-   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
-
-   The syntax for ``subscribes`` is:
-
-   .. code-block:: ruby
-
-      subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``timeout``
    **Ruby Type:** String, Integer
@@ -198,6 +100,151 @@ This resource has the following properties:
 
    The version of a package to be installed or upgraded.
 
+
+Common Resource Functionality
+=====================================================
+
+Chef resources include common properties, notifications, and resource guards.
+
+Common Properties
+-----------------------------------------------------
+
+.. tag resources_common_properties
+
+The following properties are common to every resource:
+
+``ignore_failure``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Continue running a recipe if a resource fails for any reason.
+
+``retries``
+  **Ruby Type:** Integer | **Default Value:** ``0``
+
+  The number of times to catch exceptions and retry the resource.
+
+``retry_delay``
+  **Ruby Type:** Integer | **Default Value:** ``2``
+
+  The retry delay (in seconds).
+
+``sensitive``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Ensure that sensitive resource data is not logged by the chef-client.
+
+.. end_tag
+
+Notifications
+-----------------------------------------------------
+
+``notifies``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+  .. tag resources_common_notification_notifies
+
+  A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+  .. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_notifies_syntax
+
+The syntax for ``notifies`` is:
+
+.. code-block:: ruby
+
+  notifies :action, 'resource[name]', :timer
+
+.. end_tag
+
+``subscribes``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+.. tag resources_common_notification_subscribes
+
+A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+.. code-block:: ruby
+
+ file '/etc/nginx/ssl/example.crt' do
+   mode '0600'
+   owner 'root'
+ end
+
+ service 'nginx' do
+   subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+ end
+
+In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+.. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_subscribes_syntax
+
+The syntax for ``subscribes`` is:
+
+.. code-block:: ruby
+
+   subscribes :action, 'resource[name]', :timer
+
+.. end_tag
+
+Guards
+-----------------------------------------------------
+
+.. tag resources_common_guards
+
+A guard property can be used to evaluate the state of a node during the execution phase of the chef-client run. Based on the results of this evaluation, a guard property is then used to tell the chef-client if it should continue executing a resource. A guard property accepts either a string value or a Ruby block value:
+
+* A string is executed as a shell command. If the command returns ``0``, the guard is applied. If the command returns any other value, then the guard property is not applied. String guards in a **powershell_script** run Windows PowerShell commands and may return ``true`` in addition to ``0``.
+* A block is executed as Ruby code that must return either ``true`` or ``false``. If the block returns ``true``, the guard property is applied. If the block returns ``false``, the guard property is not applied.
+
+A guard property is useful for ensuring that a resource is idempotent by allowing that resource to test for the desired state as it is being executed, and then if the desired state is present, for the chef-client to do nothing.
+
+.. end_tag
+.. tag resources_common_guards_properties
+
+The following properties can be used to define a guard that is evaluated during the execution phase of the chef-client run:
+
+``not_if``
+  Prevent a resource from executing when the condition returns ``true``.
+
+``only_if``
+  Allow a resource to execute only if the condition returns ``true``.
+
+.. end_tag
 
 Examples
 =====================================================

--- a/chef_master/source/resource_ssh_known_hosts_entry.rst
+++ b/chef_master/source/resource_ssh_known_hosts_entry.rst
@@ -14,14 +14,14 @@ The ssh_known_hosts_entry resource has the following syntax:
 .. code-block:: ruby
 
   ssh_known_hosts_entry 'name' do
-    file_location      String # default value: /etc/ssh/ssh_known_hosts
+    file_location      String # default value: "/etc/ssh/ssh_known_hosts"
     group              String
     hash_entries       true, false # default value: false
     host               String # default value: 'name' unless specified
     key                String
-    key_type           String # default value: rsa
-    mode               String # default value: 0644
-    owner              String # default value: root
+    key_type           String # default value: "rsa"
+    mode               String # default value: "0644"
+    owner              String # default value: "root"
     port               Integer # default value: 22
     timeout            Integer # default value: 30
     action             Symbol # defaults to :create if not specified
@@ -58,7 +58,7 @@ Properties
 The ssh_known_hosts_entry resource has the following properties:
 
 ``file_location``
-   **Ruby Type:** String | **Default Value:** ``/etc/ssh/ssh_known_hosts``
+   **Ruby Type:** String | **Default Value:** ``"/etc/ssh/ssh_known_hosts"``
 
    The location of the ssh known hosts file. Change this to set a known host file for a particular user.
 
@@ -83,17 +83,17 @@ The ssh_known_hosts_entry resource has the following properties:
    An optional key for the host. If not provided this will be automatically determined.
 
 ``key_type``
-   **Ruby Type:** String | **Default Value:** ``rsa``
+   **Ruby Type:** String | **Default Value:** ``"rsa"``
 
    The type of key to store.
 
 ``mode``
-   **Ruby Type:** String | **Default Value:** ``0644``
+   **Ruby Type:** String | **Default Value:** ``"0644"``
 
    The file mode for the ssh_known_hosts file.
 
 ``owner``
-   **Ruby Type:** String | **Default Value:** ``root``
+   **Ruby Type:** String | **Default Value:** ``"root"``
 
    The file owner for the ssh_known_hosts file.
 

--- a/chef_master/source/resource_subversion.rst
+++ b/chef_master/source/resource_subversion.rst
@@ -14,20 +14,20 @@ The subversion resource has the following syntax:
 .. code-block:: ruby
 
   subversion 'name' do
-    checkout_branch        String # default value: deploy
+    checkout_branch        String # default value: "deploy"
     depth                  Integer
     destination            String # default value: 'name' unless specified
     enable_checkout        true, false # default value: true
     enable_submodules      true, false # default value: false
-    environment            Hash, nil
+    environment            Hash
     group                  String, Integer
-    remote                 String # default value: origin
+    remote                 String # default value: "origin"
     repository             String
-    revision               String # default value: HEAD
+    revision               String # default value: "HEAD"
     ssh_wrapper            String
-    svn_arguments          String, nil, false # default value: --no-auth-cache
+    svn_arguments          String, false # default value: "--no-auth-cache"
     svn_binary             String
-    svn_info_args          String, nil, false # default value: --no-auth-cache
+    svn_info_args          String, false # default value: "--no-auth-cache"
     svn_password           String
     svn_username           String
     timeout                Integer
@@ -72,7 +72,7 @@ Properties
 The subversion resource has the following properties:
 
 ``destination``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``'name'``
 
    The location path to which the source is to be cloned, checked out, or exported. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 

--- a/chef_master/source/resource_sudo.rst
+++ b/chef_master/source/resource_sudo.rst
@@ -16,21 +16,21 @@ The sudo resource has the following syntax:
   sudo 'name' do
     command_aliases        Array
     commands               Array # default value: ["ALL"]
-    config_prefix          String
+    config_prefix          String # default value: Prefix values based on the node's platform
     defaults               Array
     env_keep_add           Array
     env_keep_subtract      Array
     filename               String # default value: 'name' unless specified
     groups                 String, Array
-    host                   String # default value: ALL
+    host                   String # default value: "ALL"
     noexec                 true, false # default value: false
     nopasswd               true, false # default value: false
-    runas                  String # default value: ALL
+    runas                  String # default value: "ALL"
     setenv                 true, false # default value: false
     template               String
     users                  String, Array
-    variables              Hash, nil
-    visudo_binary          String # default value: /usr/sbin/visudo
+    variables              Hash
+    visudo_binary          String # default value: "/usr/sbin/visudo"
     visudo_path            String
     action                 Symbol # defaults to :create if not specified
   end
@@ -100,15 +100,15 @@ The sudo resource has the following properties:
 ``filename``
    **Ruby Type:** String | **Default Value:** ``'name'``
 
-   Optional. The name of the ``sudoers.d`` file, if it differs from the name of the resource block.
+   The name of the sudoers.d file, if it differs from the name of the resource block
 
 ``groups``
-   **Ruby Type:** String, Array | **Default Value:** ``[]``
+   **Ruby Type:** String, Array
 
    Group(s) to provide sudo privileges to. This accepts either an array or a comma-separated list. Leading % on group names is optional.
 
 ``host``
-   **Ruby Type:** String| **Default Value:** ``"ALL"``
+   **Ruby Type:** String | **Default Value:** ``"ALL"``
 
    The host to set in the sudo configuration.
 
@@ -122,39 +122,6 @@ The sudo resource has the following properties:
 
    Allow sudo to be run without specifying a password.
 
-``notifies``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_notifies
-
-   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
-
-   The syntax for ``notifies`` is:
-
-   .. code-block:: ruby
-
-     notifies :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``runas``
    **Ruby Type:** String | **Default Value:** ``"ALL"``
@@ -173,12 +140,12 @@ The sudo resource has the following properties:
    The name of the ``.erb`` template in your cookbook, if you wish to supply your own template.
 
 ``users``
-   **Ruby Type:** String, Array | **Default Value:** ``[]``
+   **Ruby Type:** String, Array
 
    User(s) to provide sudo privileges to. This property accepts either an array or a comma-separated list.
 
 ``variables``
-   **Ruby Type:** Hash, nil | **Default Value:** ``nil``
+   **Ruby Type:** Hash
 
    The variables to pass to the custom template. This property is ignored if not using a custom template.
 

--- a/chef_master/source/resource_sysctl.rst
+++ b/chef_master/source/resource_sysctl.rst
@@ -14,7 +14,7 @@ The sysctl resource has the following syntax:
 .. code-block:: ruby
 
   sysctl 'name' do
-    conf_dir          String # default value: /etc/sysctl.d
+    conf_dir          String # default value: "/etc/sysctl.d"
     ignore_error      true, false # default value: false
     key               String # default value: 'name' unless specified
     value             Array, String, Integer, Float
@@ -52,7 +52,7 @@ Properties
 The sysctl resource has the following properties:
 
 ``conf_dir``
-   **Ruby Type:** String | **Default Value:** ``/etc/sysctl.d``
+   **Ruby Type:** String | **Default Value:** ``"/etc/sysctl.d"``
 
    The configuration directory to write the config to.
 

--- a/chef_master/source/resource_systemd_unit.rst
+++ b/chef_master/source/resource_systemd_unit.rst
@@ -112,9 +112,20 @@ Properties
 
 The systemd_unit resource has the following properties:
 
+``content``
+   **Ruby Type:** String, Hash
+
+   A string or hash that contains a systemd `unit file <https://www.freedesktop.org/software/systemd/man/systemd.unit.html>`_ definition that describes the properties of systemd-managed entities, such as services, sockets, devices, and so on. In Chef 14.4 or later, repeatable options can be implemented with an array.
+
+``triggers_reload``
+   **Ruby Type:** true, false | **Default Value:** ``true``
+
+   Specifies whether to trigger a daemon reload when creating or deleting a unit.
+
 ``unit_name``
    **Ruby Type:** String | **Default Value:** ``'name'``
 
+   The name of the unit file if it differs from the resource block name.
 
    New in Chef Client 13.7.
 
@@ -124,15 +135,6 @@ The systemd_unit resource has the following properties:
    The user account that the systemd unit process is run under. The path to the unit for that user would be something like
    ``/etc/systemd/user/sshd.service``. If no user account is specified, the systemd unit will run under a ``system`` account, with the path to the unit being something like ``/etc/systemd/system/sshd.service``.
 
-``content``
-   **Ruby Type:** String, Hash
-
-   A string or hash that contains a systemd `unit file <https://www.freedesktop.org/software/systemd/man/systemd.unit.html>`_ definition that describes the properties of systemd-managed entities, such as services, sockets, devices, and so on. In Chef 14.4, repeatable options can be implemented with an array.
-
-``triggers_reload``
-   **Ruby Type:** true, false | **Default Value:** ``true``
-
-   Specifies whether to trigger a daemon reload when creating or deleting a unit.
 
 ``verify``
    **Ruby Type:** true, false | **Default Value:** ``true``

--- a/chef_master/source/resource_timezone.rst
+++ b/chef_master/source/resource_timezone.rst
@@ -2,8 +2,8 @@
 timezone resource
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_timezone.rst>`__
- 
-Use the **timezone** resource to change the system timezone.
+
+Use the **timezone** resource to change the system **timezone** on Linux and macOS hosts. Timezones are specified in tz database format, with a complete list of available TZ values here https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
 
  **New in Chef Client 14.6.**
 
@@ -48,9 +48,9 @@ Properties
 The timezone resource has the following properties:
 
 ``timezone``
-     **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``'name'``
 
-     The timezone value to set.
+   The timezone value to set.
 
 
 Common Resource Functionality

--- a/chef_master/source/resource_windows_ad_join.rst
+++ b/chef_master/source/resource_windows_ad_join.rst
@@ -19,7 +19,7 @@ The windows_ad_join resource has the following syntax:
     domain_user          String
     new_hostname         String
     ou_path              String
-    reboot               Symbol # default value: immediate
+    reboot               Symbol # default value: :immediate
     sensitive            true, false # default value: true
     action               Symbol # defaults to :join if not specified
   end
@@ -59,7 +59,7 @@ The windows_ad_join resource has the following properties:
 ``domain_password``
    **Ruby Type:** String | ``REQUIRED``
 
-   The password for the domain user. Note that this resource is set to hide sensitive information by default.
+   The password for the domain user. Note that this resource is set to hide sensitive information by default. 
 
 ``domain_user``
    **Ruby Type:** String | ``REQUIRED``

--- a/chef_master/source/resource_windows_auto_run.rst
+++ b/chef_master/source/resource_windows_auto_run.rst
@@ -17,7 +17,7 @@ The windows_auto_run resource has the following syntax:
     args              String
     path              String
     program_name      String # default value: 'name' unless specified
-    root              Symbol # default value: machine
+    root              Symbol # default value: :machine
     action            Symbol # defaults to :create if not specified
   end
 

--- a/chef_master/source/resource_windows_env.rst
+++ b/chef_master/source/resource_windows_env.rst
@@ -20,9 +20,9 @@ The windows_env resource has the following syntax:
 .. code-block:: ruby
 
   windows_env 'name' do
-    delim         String, nil, false
+    delim         String, false
     key_name      String # default value: 'name' unless specified
-    user          String # default value: <System>
+    user          String # default value: "<System>"
     value         String
     action        Symbol # defaults to :create if not specified
   end
@@ -74,10 +74,13 @@ The windows_env resource has the following properties:
 
    The name of the key that is to be created, deleted, or modified. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 
+``user``
+   **Ruby Type:** String | **Default Value:** ``"<System>"``
+
 ``value``
    **Ruby Type:** String | ``REQUIRED``
 
-   The value with which ``key_name`` is set.
+   The value of the environmental variable to set.
 
 .. end_tag
 

--- a/chef_master/source/resource_windows_font.rst
+++ b/chef_master/source/resource_windows_font.rst
@@ -40,6 +40,9 @@ Actions
 
 Properties
 =====================================================
+
+The windows_font resource has the following properties:
+
 ``font_name``
    **Ruby Type:** String | **Default Value:** ``'name'``
 

--- a/chef_master/source/resource_windows_printer.rst
+++ b/chef_master/source/resource_windows_printer.rst
@@ -18,7 +18,6 @@ The windows_printer resource has the following syntax:
     default           true, false # default value: false
     device_id         String # default value: 'name' unless specified
     driver_name       String
-    exists            true, false
     ipv4_address      String
     location          String
     share_name        String
@@ -31,7 +30,7 @@ where:
 * ``windows_printer`` is the resource.
 * ``name`` is the name given to the resource block.
 * ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
-* ``comment``, ``default``, ``device_id``, ``driver_name``, ``exists``, ``ipv4_address``, ``location``, ``share_name``, and ``shared`` are the properties available to this resource.
+* ``comment``, ``default``, ``device_id``, ``driver_name``, ``ipv4_address``, ``location``, ``share_name``, and ``shared`` are the properties available to this resource.
 
 Actions
 =====================================================

--- a/chef_master/source/resource_windows_printer_port.rst
+++ b/chef_master/source/resource_windows_printer_port.rst
@@ -14,7 +14,6 @@ The windows_printer_port resource has the following syntax:
 .. code-block:: ruby
 
   windows_printer_port 'name' do
-    exists                true, false
     ipv4_address          String # default value: 'name' unless specified
     port_description      String
     port_name             String
@@ -29,7 +28,7 @@ where:
 * ``windows_printer_port`` is the resource.
 * ``name`` is the name given to the resource block.
 * ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
-* ``exists``, ``ipv4_address``, ``port_description``, ``port_name``, ``port_number``, ``port_protocol``, and ``snmp_enabled`` are the properties available to this resource.
+* ``ipv4_address``, ``port_description``, ``port_name``, ``port_number``, ``port_protocol``, and ``snmp_enabled`` are the properties available to this resource.
 
 Actions
 =====================================================
@@ -82,7 +81,7 @@ The windows_printer_port resource has the following properties:
 ``snmp_enabled``
    **Ruby Type:** true, false | **Default Value:** ``false``
 
-   Determines if SNMP is enabled on the port
+   Determines if SNMP is enabled on the port.
 
 Common Resource Functionality
 =====================================================

--- a/chef_master/source/resource_windows_workgroup.rst
+++ b/chef_master/source/resource_windows_workgroup.rst
@@ -15,7 +15,7 @@ The windows_workgroup resource has the following syntax:
 
   windows_workgroup 'name' do
     password            String
-    reboot              Symbol # default value: immediate
+    reboot              Symbol # default value: :immediate
     sensitive           true, false # default value: true
     user                String
     workgroup_name      String # default value: 'name' unless specified
@@ -55,7 +55,7 @@ The windows_workgroup resource has the following properties:
    The password for the local administrator user.
 
 ``reboot``
-   **Ruby Type:** Symbol | **Default Value:** ``immediate``
+   **Ruby Type:** Symbol | **Default Value:** ``:immediate``
 
    Controls the system reboot behavior post workgroup joining. Reboot immediately, after the Chef run completes, or never. Note that a reboot is necessary for changes to take effect.
 

--- a/chef_master/source/resource_yum_repository.rst
+++ b/chef_master/source/resource_yum_repository.rst
@@ -18,7 +18,7 @@ The yum_repository resource has the following syntax:
     clean_headers              true, false # default value: false
     clean_metadata             true, false # default value: true
     cost                       String
-    description                String # default value: Yum Repository
+    description                String # default value: "Yum Repository"
     enabled                    true, false # default value: true
     enablegroups               true, false
     exclude                    String
@@ -37,7 +37,7 @@ The yum_repository resource has the following syntax:
     mirror_expire              String
     mirrorlist                 String
     mirrorlist_expire          String
-    mode                       String, Integer # default value: 0644
+    mode                       String, Integer # default value: "0644"
     options                    Hash
     password                   String
     priority                   String
@@ -109,7 +109,7 @@ The yum_repository resource has the following properties:
    Relative cost of accessing this repository. Useful for weighing one repo's packages as greater/less than any other.
 
 ``description``
-   **Ruby Type:** String | **Default Value:** ``Yum Repository``
+   **Ruby Type:** String | **Default Value:** ``"Yum Repository"``
 
    Descriptive name for the repository channel and maps to the 'name' parameter in a repository .conf.
 

--- a/chef_master/source/resource_zypper_package.rst
+++ b/chef_master/source/resource_zypper_package.rst
@@ -108,44 +108,6 @@ The zypper_package resource has the following properties:
 
    Verify the package's GPG signature. Can also be controlled site-wide using the ``zypper_check_gpg`` config option.
 
-``ignore_failure``
-   **Ruby Type:** true, false | **Default Value:** ``false``
-
-   Continue running a recipe if a resource fails for any reason.
-
-``notifies``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_notifies
-
-   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
-
-   The syntax for ``notifies`` is:
-
-   .. code-block:: ruby
-
-     notifies :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``options``
    **Ruby Type:** String, Array
@@ -157,69 +119,10 @@ The zypper_package resource has the following properties:
 
    The name of the package. Defaults to the name of the resourse block unless specified.
 
-``retries``
-   **Ruby Type:** Integer | **Default Value:** ``0``
-
-   The number of times to catch exceptions and retry the resource.
-
-``retry_delay``
-   **Ruby Type:** Integer | **Default Value:** ``2``
-
-   The retry delay (in seconds).
-
 ``source``
    **Ruby Type:** String
 
    The direct path to a the package on the host.
-
-``subscribes``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_subscribes
-
-   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
-
-   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
-
-   .. code-block:: ruby
-
-    file '/etc/nginx/ssl/example.crt' do
-      mode '0600'
-      owner 'root'
-    end
-
-    service 'nginx' do
-      subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
-    end
-
-   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
-
-   The syntax for ``subscribes`` is:
-
-   .. code-block:: ruby
-
-      subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``timeout``
    **Ruby Type:** String, Integer
@@ -291,6 +194,150 @@ Notifications, via an implicit name:
    end
 
 .. note:: Notifications and subscriptions do not need to be updated when packages and versions are added or removed from the ``package_name`` or ``version`` properties.
+
+.. end_tag
+
+Common Resource Functionality
+=====================================================
+
+Chef resources include common properties, notifications, and resource guards.
+
+Common Properties
+-----------------------------------------------------
+
+.. tag resources_common_properties
+
+The following properties are common to every resource:
+
+``ignore_failure``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Continue running a recipe if a resource fails for any reason.
+
+``retries``
+  **Ruby Type:** Integer | **Default Value:** ``0``
+
+  The number of times to catch exceptions and retry the resource.
+
+``retry_delay``
+  **Ruby Type:** Integer | **Default Value:** ``2``
+
+  The retry delay (in seconds).
+
+``sensitive``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Ensure that sensitive resource data is not logged by the chef-client.
+
+.. end_tag
+
+Notifications
+-----------------------------------------------------
+``notifies``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+  .. tag resources_common_notification_notifies
+
+  A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+  .. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_notifies_syntax
+
+The syntax for ``notifies`` is:
+
+.. code-block:: ruby
+
+  notifies :action, 'resource[name]', :timer
+
+.. end_tag
+
+``subscribes``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+.. tag resources_common_notification_subscribes
+
+A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+.. code-block:: ruby
+
+ file '/etc/nginx/ssl/example.crt' do
+   mode '0600'
+   owner 'root'
+ end
+
+ service 'nginx' do
+   subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+ end
+
+In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+.. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_subscribes_syntax
+
+The syntax for ``subscribes`` is:
+
+.. code-block:: ruby
+
+   subscribes :action, 'resource[name]', :timer
+
+.. end_tag
+
+Guards
+-----------------------------------------------------
+
+.. tag resources_common_guards
+
+A guard property can be used to evaluate the state of a node during the execution phase of the chef-client run. Based on the results of this evaluation, a guard property is then used to tell the chef-client if it should continue executing a resource. A guard property accepts either a string value or a Ruby block value:
+
+* A string is executed as a shell command. If the command returns ``0``, the guard is applied. If the command returns any other value, then the guard property is not applied. String guards in a **powershell_script** run Windows PowerShell commands and may return ``true`` in addition to ``0``.
+* A block is executed as Ruby code that must return either ``true`` or ``false``. If the block returns ``true``, the guard property is applied. If the block returns ``false``, the guard property is not applied.
+
+A guard property is useful for ensuring that a resource is idempotent by allowing that resource to test for the desired state as it is being executed, and then if the desired state is present, for the chef-client to do nothing.
+
+.. end_tag
+.. tag resources_common_guards_properties
+
+The following properties can be used to define a guard that is evaluated during the execution phase of the chef-client run:
+
+``not_if``
+  Prevent a resource from executing when the condition returns ``true``.
+
+``only_if``
+  Allow a resource to execute only if the condition returns ``true``.
 
 .. end_tag
 

--- a/chef_master/source/resource_zypper_repository.rst
+++ b/chef_master/source/resource_zypper_repository.rst
@@ -24,13 +24,13 @@ The zypper_repository resource has the following syntax:
     gpgkey                 String
     keeppackages           true, false # default value: false
     mirrorlist             String
-    mode                   String, Integer # default value: 0644
+    mode                   String, Integer # default value: "0644"
     path                   String
     priority               Integer # default value: 99
     refresh_cache          true, false # default value: true
     repo_name              String # default value: 'name' unless specified
     source                 String
-    type                   String # default value: NONE
+    type                   String # default value: "NONE"
     action                 Symbol # defaults to :create if not specified
   end
 
@@ -113,43 +113,9 @@ The zypper_repository resource has the following properties:
    The URL of the mirror list that will be used.
 
 ``mode``
-   **Ruby Type:** String, Integer | **Default Value:** ``0644``
+   **Ruby Type:** String, Integer | **Default Value:** ``"0644"``
 
    The file mode of the repository file.
-
-``notifies``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_notifies
-
-   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
-
-   The syntax for ``notifies`` is:
-
-   .. code-block:: ruby
-
-     notifies :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``path``
    **Ruby Type:** String
@@ -157,9 +123,9 @@ The zypper_repository resource has the following properties:
    The relative path from the repository's base URL.
 
 ``priority``
-   **Ruby Type:** Integer  |  **Default Value:** ``99``
+   **Ruby Type:** Integer | **Default Value:** ``99``
 
-   Determines the priority of the Zypper repository.
+   Determines the priority of the Zypper repository. 
 
 ``refresh_cache``
    **Ruby Type:** true, false | **Default Value:** ``true``
@@ -177,59 +143,154 @@ The zypper_repository resource has the following properties:
    The name of the template for the repository file. Only necessary if you're not using the built in template.
 
 
-``subscribes``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_subscribes
-
-   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
-
-   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
-
-   .. code-block:: ruby
-
-    file '/etc/nginx/ssl/example.crt' do
-      mode '0600'
-      owner 'root'
-    end
-
-    service 'nginx' do
-      subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
-    end
-
-   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
-
-   The syntax for ``subscribes`` is:
-
-   .. code-block:: ruby
-
-      subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
-
 ``type``
-   **Ruby Type:** String  |  **Default Value:** ``NONE``
+   **Ruby Type:** String | **Default Value:** ``"NONE"``
 
    Specifies the repository type.
+
+Common Resource Functionality
+=====================================================
+
+Chef resources include common properties, notifications, and resource guards.
+
+Common Properties
+-----------------------------------------------------
+
+.. tag resources_common_properties
+
+The following properties are common to every resource:
+
+``ignore_failure``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Continue running a recipe if a resource fails for any reason.
+
+``retries``
+  **Ruby Type:** Integer | **Default Value:** ``0``
+
+  The number of times to catch exceptions and retry the resource.
+
+``retry_delay``
+  **Ruby Type:** Integer | **Default Value:** ``2``
+
+  The retry delay (in seconds).
+
+``sensitive``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Ensure that sensitive resource data is not logged by the chef-client.
+
+.. end_tag
+
+Notifications
+-----------------------------------------------------
+``notifies``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+  .. tag resources_common_notification_notifies
+
+  A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+  .. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_notifies_syntax
+
+The syntax for ``notifies`` is:
+
+.. code-block:: ruby
+
+  notifies :action, 'resource[name]', :timer
+
+.. end_tag
+
+``subscribes``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+.. tag resources_common_notification_subscribes
+
+A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+.. code-block:: ruby
+
+ file '/etc/nginx/ssl/example.crt' do
+   mode '0600'
+   owner 'root'
+ end
+
+ service 'nginx' do
+   subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+ end
+
+In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+.. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_subscribes_syntax
+
+The syntax for ``subscribes`` is:
+
+.. code-block:: ruby
+
+   subscribes :action, 'resource[name]', :timer
+
+.. end_tag
+
+Guards
+-----------------------------------------------------
+
+.. tag resources_common_guards
+
+A guard property can be used to evaluate the state of a node during the execution phase of the chef-client run. Based on the results of this evaluation, a guard property is then used to tell the chef-client if it should continue executing a resource. A guard property accepts either a string value or a Ruby block value:
+
+* A string is executed as a shell command. If the command returns ``0``, the guard is applied. If the command returns any other value, then the guard property is not applied. String guards in a **powershell_script** run Windows PowerShell commands and may return ``true`` in addition to ``0``.
+* A block is executed as Ruby code that must return either ``true`` or ``false``. If the block returns ``true``, the guard property is applied. If the block returns ``false``, the guard property is not applied.
+
+A guard property is useful for ensuring that a resource is idempotent by allowing that resource to test for the desired state as it is being executed, and then if the desired state is present, for the chef-client to do nothing.
+
+.. end_tag
+.. tag resources_common_guards_properties
+
+The following properties can be used to define a guard that is evaluated during the execution phase of the chef-client run:
+
+``not_if``
+  Prevent a resource from executing when the condition returns ``true``.
+
+``only_if``
+  Allow a resource to execute only if the condition returns ``true``.
+
+.. end_tag
 
 Examples
 ==========================================

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -1426,10 +1426,13 @@ The windows_env resource has the following properties:
 
    The name of the key that is to be created, deleted, or modified. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 
+``user``
+   **Ruby Type:** String | **Default Value:** ``"<System>"``
+
 ``value``
    **Ruby Type:** String | ``REQUIRED``
 
-   The value with which ``key_name`` is set.
+   The value of the environmental variable to set.
 
 .. end_tag
 
@@ -2092,13 +2095,13 @@ The registry_key resource has the following properties:
              .. end_tag
 
 ``key``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``'name'``
 
    The path to the location in which a registry key is to be created or from which a registry key is to be deleted. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
    The path must include the registry hive, which can be specified either as its full name or as the 3- or 4-letter abbreviation. For example, both ``HKLM\SECURITY`` and ``HKEY_LOCAL_MACHINE\SECURITY`` are both valid and equivalent. The following hives are valid: ``HKEY_LOCAL_MACHINE``, ``HKLM``, ``HKEY_CURRENT_CONFIG``, ``HKCC``, ``HKEY_CLASSES_ROOT``, ``HKCR``, ``HKEY_USERS``, ``HKU``, ``HKEY_CURRENT_USER``, and ``HKCU``.
 
 ``recursive``
-   **Ruby Type:** true, false
+   **Ruby Type:** true, false | **Default Value:** ``false``
 
    When creating a key, this value specifies that the required keys for the specified path are to be created. When using the ``:delete_key`` action in a recipe, and if the registry key has subkeys, then set the value for this property to ``true``.
 


### PR DESCRIPTION
Move more common properties over to the common properties section
Quote all the defaults
Remove some nil values
Add REQUIRED property designations
Reorder some properties
Add a few missing property descriptions
Fix some indentation
Remove some empty array defaults

Signed-off-by: Tim Smith <tsmith@chef.io>