### PR TITLE
More resource cleanup from automation

### DIFF
--- a/chef_master/source/debug.rst
+++ b/chef_master/source/debug.rst
@@ -104,7 +104,7 @@ The log resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -473,7 +473,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/debug.rst
+++ b/chef_master/source/debug.rst
@@ -81,7 +81,7 @@ The full syntax for all of the properties that are available to the **log** reso
 .. code-block:: ruby
 
   log 'name' do
-    level        Symbol # default value: info
+    level        Symbol # default value: :info
     message      String # default value: 'name' unless specified
     action       Symbol # defaults to :write if not specified
   end

--- a/chef_master/source/ohai.rst
+++ b/chef_master/source/ohai.rst
@@ -450,7 +450,7 @@ The ohai resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/provisioning.rst
+++ b/chef_master/source/provisioning.rst
@@ -179,7 +179,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -263,7 +263,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -682,7 +682,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -851,7 +851,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -937,7 +937,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -1074,7 +1074,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -2985,6 +2985,13 @@ The launchd resource has the following actions:
 ``:restart``
    Restart a launchd managed daemon or agent.
 
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+
+   .. end_tag
+
 .. end_tag
 
 Properties
@@ -3731,11 +3738,11 @@ The osx_profile resource has the following actions:
    Default. Install the specified configuration profile.
 
 ``:nothing``
-   Default. .. tag resources_common_actions_nothing
+   .. tag resources_common_actions_nothing
 
-            Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
 
-            .. end_tag
+   .. end_tag
 
 ``:remove``
    Remove the specified configuration profile.

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -2988,7 +2988,7 @@ The launchd resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -3507,7 +3507,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -3740,7 +3740,7 @@ The osx_profile resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -3919,7 +3919,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -7548,7 +7548,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -7754,7 +7754,7 @@ The openbsd_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -8760,7 +8760,7 @@ The bff_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -8993,7 +8993,7 @@ The homebrew_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -9254,7 +9254,7 @@ The reboot resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_apt_package.rst
+++ b/chef_master/source/resource_apt_package.rst
@@ -62,7 +62,7 @@ The apt_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_apt_repository.rst
+++ b/chef_master/source/resource_apt_repository.rst
@@ -36,7 +36,7 @@ The full syntax for all of the properties that are available to the **apt_reposi
     distribution       String, false # default value: The LSB codename of the host such as 'bionic'.
     key                String, Array, false
     key_proxy          String, false
-    keyserver          String, false # default value: keyserver.ubuntu.com
+    keyserver          String, false # default value: "keyserver.ubuntu.com"
     repo_name          String # default value: 'name' unless specified
     trusted            true, false # default value: false
     uri                String

--- a/chef_master/source/resource_apt_update.rst
+++ b/chef_master/source/resource_apt_update.rst
@@ -55,7 +55,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_batch.rst
+++ b/chef_master/source/resource_batch.rst
@@ -68,7 +68,7 @@ The batch resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_bff_package.rst
+++ b/chef_master/source/resource_bff_package.rst
@@ -63,7 +63,7 @@ The bff_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_breakpoint.rst
+++ b/chef_master/source/resource_breakpoint.rst
@@ -39,7 +39,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_build_essential.rst
+++ b/chef_master/source/resource_build_essential.rst
@@ -36,7 +36,7 @@ The build_essential resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_acl.rst
+++ b/chef_master/source/resource_chef_acl.rst
@@ -53,7 +53,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_client.rst
+++ b/chef_master/source/resource_chef_client.rst
@@ -56,7 +56,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_container.rst
+++ b/chef_master/source/resource_chef_container.rst
@@ -55,7 +55,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_data_bag.rst
+++ b/chef_master/source/resource_chef_data_bag.rst
@@ -49,7 +49,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_data_bag_item.rst
+++ b/chef_master/source/resource_chef_data_bag_item.rst
@@ -63,7 +63,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_environment.rst
+++ b/chef_master/source/resource_chef_environment.rst
@@ -49,7 +49,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_gem.rst
+++ b/chef_master/source/resource_chef_gem.rst
@@ -106,7 +106,7 @@ The chef_gem resource has the following properties:
    Controls the phase during which a gem is installed on a node. Set to ``true`` to install a gem while the resource collection is being built (the "compile phase"). Set to ``false`` to install a gem while the chef-client is configuring the node (the "converge phase"). Possible values: ``nil`` (for verbose warnings), ``true`` (to warn once per chef-client run), or ``false`` (to remove all warnings). Recommended value: ``false``.
 
 ``gem_binary``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``Chef's built-in gem binary``
 
    The path of a gem binary to use for the installation. By default, the same version of Ruby that is used by the chef-client will be installed.
 

--- a/chef_master/source/resource_chef_gem.rst
+++ b/chef_master/source/resource_chef_gem.rst
@@ -65,7 +65,7 @@ The chef_gem resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_group.rst
+++ b/chef_master/source/resource_chef_group.rst
@@ -55,7 +55,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_handler.rst
+++ b/chef_master/source/resource_chef_handler.rst
@@ -183,7 +183,7 @@ Properties
 The chef_handler resource has the following properties:
 
 ``arguments``
-   **Ruby Type:** Array, Hash | **Default Value:** ``[]``
+   **Ruby Type:** Array, Hash
 
    An array of arguments that are passed to the initializer for the handler class. For example:
 
@@ -198,7 +198,7 @@ The chef_handler resource has the following properties:
       arguments [:key1 => 'val1', :key2 => 'val2']
 
 ``class_name``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``'name'``
 
    The name of the handler class. This can be module name-spaced.
 

--- a/chef_master/source/resource_chef_handler.rst
+++ b/chef_master/source/resource_chef_handler.rst
@@ -173,7 +173,7 @@ The chef_handler resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_mirror.rst
+++ b/chef_master/source/resource_chef_mirror.rst
@@ -52,7 +52,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_node.rst
+++ b/chef_master/source/resource_chef_node.rst
@@ -49,7 +49,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_organization.rst
+++ b/chef_master/source/resource_chef_organization.rst
@@ -55,7 +55,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_role.rst
+++ b/chef_master/source/resource_chef_role.rst
@@ -49,7 +49,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chef_user.rst
+++ b/chef_master/source/resource_chef_user.rst
@@ -42,7 +42,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chocolatey_config.rst
+++ b/chef_master/source/resource_chocolatey_config.rst
@@ -40,7 +40,7 @@ The chocolatey_config resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chocolatey_package.rst
+++ b/chef_master/source/resource_chocolatey_package.rst
@@ -64,7 +64,7 @@ The chocolatey_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_chocolatey_source.rst
+++ b/chef_master/source/resource_chocolatey_source.rst
@@ -42,7 +42,7 @@ The chocolatey_source resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_common.rst
+++ b/chef_master/source/resource_common.rst
@@ -20,7 +20,7 @@ The following actions may be used with any resource:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_cookbook_file.rst
+++ b/chef_master/source/resource_cookbook_file.rst
@@ -76,7 +76,7 @@ The cookbook_file resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_cron.rst
+++ b/chef_master/source/resource_cron.rst
@@ -75,7 +75,7 @@ The cron resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_cron.rst
+++ b/chef_master/source/resource_cron.rst
@@ -49,8 +49,8 @@ The full syntax for all of the properties that are available to the **cron** res
     path             String
     shell            String
     time             Symbol
-    user             String # default value: root
-    weekday
+    user             String # default value: "root"
+    weekday          
     action           Symbol # defaults to :create if not specified
   end
 

--- a/chef_master/source/resource_cron_access.rst
+++ b/chef_master/source/resource_cron_access.rst
@@ -39,7 +39,7 @@ The cron_access resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_cron_d.rst
+++ b/chef_master/source/resource_cron_d.rst
@@ -40,20 +40,20 @@ The full syntax for all of the properties that are available to the **cron_d** r
     comment               String
     cookbook              String
     cron_name             String # default value: 'name' unless specified
-    day                   Integer, String # default value: *
+    day                   Integer, String # default value: "*"
     environment           Hash
     home                  String
-    hour                  Integer, String # default value: *
+    hour                  Integer, String # default value: "*"
     mailto                String
-    minute                Integer, String # default value: *
-    mode                  String, Integer # default value: 0600
-    month                 Integer, String # default value: *
+    minute                Integer, String # default value: "*"
+    mode                  String, Integer # default value: "0600"
+    month                 Integer, String # default value: "*"
     path                  String
     predefined_value      String
     random_delay          Integer
     shell                 String
-    user                  String # default value: root
-    weekday               Integer, String # default value: *
+    user                  String # default value: "root"
+    weekday               Integer, String # default value: "*"
     action                Symbol # defaults to :create if not specified
   end
 

--- a/chef_master/source/resource_cron_d.rst
+++ b/chef_master/source/resource_cron_d.rst
@@ -81,7 +81,7 @@ The cron_d resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_deploy.rst
+++ b/chef_master/source/resource_deploy.rst
@@ -250,7 +250,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_directory.rst
+++ b/chef_master/source/resource_directory.rst
@@ -63,7 +63,7 @@ The directory resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_dmg_package.rst
+++ b/chef_master/source/resource_dmg_package.rst
@@ -18,7 +18,7 @@ The dmg_package resource has the following syntax:
     allow_untrusted      true, false # default value: false
     app                  String # default value: 'name' unless specified
     checksum             String
-    destination          String # default value: /Applications
+    destination          String # default value: "/Applications"
     dmg_name             String
     dmg_passphrase       String
     file                 String
@@ -26,7 +26,7 @@ The dmg_package resource has the following syntax:
     owner                String
     package_id           String
     source               String
-    type                 String # default value: app
+    type                 String # default value: "app"
     volumes_dir          String
     action               Symbol # defaults to :install if not specified
   end

--- a/chef_master/source/resource_dmg_package.rst
+++ b/chef_master/source/resource_dmg_package.rst
@@ -49,7 +49,7 @@ The dmg_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_dnf_package.rst
+++ b/chef_master/source/resource_dnf_package.rst
@@ -61,7 +61,7 @@ The dnf_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_dpkg_package.rst
+++ b/chef_master/source/resource_dpkg_package.rst
@@ -56,7 +56,7 @@ The dpkg_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_dsc_resource.rst
+++ b/chef_master/source/resource_dsc_resource.rst
@@ -95,7 +95,7 @@ The dsc_resource resource has the following actions:
 
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_dsc_script.rst
+++ b/chef_master/source/resource_dsc_script.rst
@@ -85,7 +85,7 @@ The dsc_script resource has the following actions:
 
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_file.rst
+++ b/chef_master/source/resource_file.rst
@@ -74,7 +74,7 @@ The file resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_freebsd_package.rst
+++ b/chef_master/source/resource_freebsd_package.rst
@@ -56,7 +56,7 @@ The freebsd_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_gem_package.rst
+++ b/chef_master/source/resource_gem_package.rst
@@ -37,8 +37,8 @@ The full syntax for all of the properties that are available to the **gem_packag
 
    gem_package 'name' do
      clear_sources              true, false
-     include_default_source     true, false
      gem_binary                 String
+     include_default_source     true, false
      options                    String
      package_name               String, Array # defaults to 'name' if not specified
      source                     String, Array

--- a/chef_master/source/resource_gem_package.rst
+++ b/chef_master/source/resource_gem_package.rst
@@ -184,7 +184,7 @@ The gem_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_git.rst
+++ b/chef_master/source/resource_git.rst
@@ -64,7 +64,7 @@ The git resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_git.rst
+++ b/chef_master/source/resource_git.rst
@@ -27,16 +27,16 @@ The full syntax for all of the properties that are available to the **git** reso
 
   git 'name' do
     additional_remotes      Hash
-    checkout_branch         String # default value: deploy
+    checkout_branch         String # default value: "deploy"
     depth                   Integer
     destination             String # default value: 'name' unless specified
     enable_checkout         true, false # default value: true
     enable_submodules       true, false # default value: false
     environment             Hash
     group                   String, Integer
-    remote                  String # default value: origin
+    remote                  String # default value: "origin"
     repository              String
-    revision                String # default value: HEAD
+    revision                String # default value: "HEAD"
     ssh_wrapper             String
     timeout                 Integer
     user                    String, Integer
@@ -92,7 +92,7 @@ The git resource has the following properties:
    The number of past revisions to be included in the git shallow clone. The default behavior will do a full clone.
 
 ``destination``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``'name'``
 
    The location path to which the source is to be cloned, checked out, or exported. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 
@@ -120,7 +120,7 @@ The git resource has the following properties:
 
 
 ``remote``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``"origin"``
 
    The remote repository to use when synchronizing an existing clone.
 

--- a/chef_master/source/resource_group.rst
+++ b/chef_master/source/resource_group.rst
@@ -50,7 +50,7 @@ The group resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_homebrew_cask.rst
+++ b/chef_master/source/resource_homebrew_cask.rst
@@ -15,7 +15,7 @@ The homebrew_cask resource has the following syntax:
 
   homebrew_cask 'name' do
     cask_name          String # default value: 'name' unless specified
-    homebrew_path      String # default value: /usr/local/bin/brew
+    homebrew_path      String # default value: "/usr/local/bin/brew"
     install_cask       true, false # default value: true
     options            String
     owner              String
@@ -55,9 +55,9 @@ Properties
    The name of the Homebrew cask, if it differs from the resource block name.
 
 ``homebrew_path``
-   **Ruby Type:** String | **Default Value:** ``/usr/local/bin/brew``
+   **Ruby Type:** String | **Default Value:** ``"/usr/local/bin/brew"``
 
-   The path to the Homebrew binary.
+   The path to the homebrew binary.
 
 ``install_cask``
    **Ruby Type:** true, false | **Default Value:** ``true``

--- a/chef_master/source/resource_homebrew_cask.rst
+++ b/chef_master/source/resource_homebrew_cask.rst
@@ -43,7 +43,7 @@ The homebrew_cask resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_homebrew_package.rst
+++ b/chef_master/source/resource_homebrew_package.rst
@@ -62,7 +62,7 @@ The homebrew_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_homebrew_tap.rst
+++ b/chef_master/source/resource_homebrew_tap.rst
@@ -15,7 +15,7 @@ The homebrew_tap resource has the following syntax:
 
   homebrew_tap 'name' do
     full               true, false # default value: false
-    homebrew_path      String # default value: /usr/local/bin/brew
+    homebrew_path      String # default value: "/usr/local/bin/brew"
     owner              String
     tap_name           String # default value: 'name' unless specified
     url                String
@@ -58,7 +58,7 @@ The homebrew_tap resource has the following properties:
    Perform a full clone on the tap, as opposed to a shallow clone.
 
 ``homebrew_path``
-   **Ruby Type:** String | **Default Value:** ``/usr/local/bin/brew``
+   **Ruby Type:** String | **Default Value:** ``"/usr/local/bin/brew"``
 
    The path to the Homebrew binary.
 

--- a/chef_master/source/resource_homebrew_tap.rst
+++ b/chef_master/source/resource_homebrew_tap.rst
@@ -43,7 +43,7 @@ The homebrew_tap resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_hostname.rst
+++ b/chef_master/source/resource_hostname.rst
@@ -40,7 +40,7 @@ The hostname resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_http_request.rst
+++ b/chef_master/source/resource_http_request.rst
@@ -57,7 +57,7 @@ The http_request resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_ifconfig.rst
+++ b/chef_master/source/resource_ifconfig.rst
@@ -29,7 +29,7 @@ The full syntax for all of the properties that are available to the **ifconfig**
     bootproto         String
     device            String
     ethtool_opts      String
-    family            String # default value: inet
+    family            String # default value: "inet"
     gateway           String
     hwaddr            String
     inet_addr         String
@@ -112,7 +112,7 @@ The ifconfig resource has the following properties:
    New in Chef Client 13.4.
 
 ``family``
-   **Ruby Type:** String | **Default Value:** ``inet``
+   **Ruby Type:** String | **Default Value:** ``"inet"``
 
    Networking family option for Debian-based systems; for example: ``inet`` or ``inet6``.
 

--- a/chef_master/source/resource_ifconfig.rst
+++ b/chef_master/source/resource_ifconfig.rst
@@ -73,7 +73,7 @@ The ifconfig resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_ips_package.rst
+++ b/chef_master/source/resource_ips_package.rst
@@ -30,7 +30,7 @@ The full syntax for all of the properties that are available to the **ips_packag
 .. code-block:: ruby
 
    ips_package 'name' do
-     accept_license             true, false
+     accept_license             true, false # default value: false
      options                    String
      package_name               String, Array # defaults to 'name' if not specified
      source                     String

--- a/chef_master/source/resource_ips_package.rst
+++ b/chef_master/source/resource_ips_package.rst
@@ -57,7 +57,7 @@ The ips_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_kernel_module.rst
+++ b/chef_master/source/resource_kernel_module.rst
@@ -14,9 +14,9 @@ The kernel_module resource has the following syntax:
 .. code-block:: ruby
 
   kernel_module 'name' do
-    load_dir        String # default value: /etc/modules-load.d
+    load_dir        String # default value: "/etc/modules-load.d"
     modname         String # default value: 'name' unless specified
-    unload_dir      String # default value: /etc/modprobe.d
+    unload_dir      String # default value: "/etc/modprobe.d"
     action          Symbol # defaults to :install if not specified
   end
 
@@ -60,7 +60,7 @@ Properties
 The kernel_module resource has the following properties:
 
 ``load_dir``
-   **Ruby Type:** String | **Default Value:** ``/etc/modules-load.d``
+   **Ruby Type:** String | **Default Value:** ``"/etc/modules-load.d"``
 
    The directory to load modules from.
 
@@ -70,7 +70,7 @@ The kernel_module resource has the following properties:
    The name of the kernel module.
 
 ``unload_dir``
-   **Ruby Type:** String | **Default Value:** ``/etc/modprobe.d``
+   **Ruby Type:** String | **Default Value:** ``"/etc/modprobe.d"``
 
    The modprobe.d directory.
 

--- a/chef_master/source/resource_kernel_module.rst
+++ b/chef_master/source/resource_kernel_module.rst
@@ -50,7 +50,7 @@ The kernel_module resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_launchd.rst
+++ b/chef_master/source/resource_launchd.rst
@@ -103,7 +103,7 @@ The launchd resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_launchd.rst
+++ b/chef_master/source/resource_launchd.rst
@@ -60,7 +60,7 @@ The launchd resource has the following syntax:
     start_on_mount                  true, false
     throttle_interval               Integer
     time_out                        Integer
-    type                            String # default value: daemon
+    type                            String # default value: "daemon"
     umask                           Integer
     username                        String
     wait_for_debugger               true, false
@@ -99,6 +99,13 @@ The launchd resource has the following actions:
 
 ``:restart``
    Restart a launchd managed daemon or agent.
+
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+
+   .. end_tag
 
 .. end_tag
 

--- a/chef_master/source/resource_link.rst
+++ b/chef_master/source/resource_link.rst
@@ -36,15 +36,15 @@ The full syntax for all of the properties that are available to the **link** res
 
 .. code-block:: ruby
 
-   link 'name' do
-     group                      Integer, String
-     link_type                  Symbol
-     mode                       Integer, String
-     owner                      Integer, String
-     target_file                String # defaults to 'name' if not specified
-     to                         String
-     action                     Symbol # defaults to :create if not specified
-   end
+  link 'name' do
+    group            String, Integer
+    link_type        String, Symbol # default value: :symbolic
+    mode             Integer, String
+    owner            String, Integer
+    target_file      String # default value: 'name' unless specified
+    to               String
+    action           Symbol # defaults to :create if not specified
+  end
 
 where:
 

--- a/chef_master/source/resource_link.rst
+++ b/chef_master/source/resource_link.rst
@@ -67,7 +67,7 @@ The link resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_load_balancer.rst
+++ b/chef_master/source/resource_load_balancer.rst
@@ -52,7 +52,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_locale.rst
+++ b/chef_master/source/resource_locale.rst
@@ -37,7 +37,7 @@ The locale resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_locale.rst
+++ b/chef_master/source/resource_locale.rst
@@ -14,8 +14,8 @@ The locale resource has the following syntax:
 .. code-block:: ruby
 
   locale 'name' do
-    lang        String # default value: en_US.utf8
-    lc_all      String # default value: en_US.utf8
+    lang        String # default value: "en_US.utf8"
+    lc_all      String # default value: "en_US.utf8"
     action      Symbol # defaults to :update if not specified
   end
 
@@ -47,12 +47,12 @@ Properties
 The locale resource has the following properties:
 
 ``lang``
-   **Ruby Type:** String | **Default Value:** ``en_US.utf8``
+   **Ruby Type:** String | **Default Value:** ``"en_US.utf8"``
 
    Sets the default system language.
 
 ``lc_all``
-   **Ruby Type:** String | **Default Value:** ``en_US.utf8``
+   **Ruby Type:** String | **Default Value:** ``"en_US.utf8"``
 
    Sets the fallback system language.
 

--- a/chef_master/source/resource_log.rst
+++ b/chef_master/source/resource_log.rst
@@ -52,7 +52,7 @@ The log resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_log.rst
+++ b/chef_master/source/resource_log.rst
@@ -29,7 +29,7 @@ The full syntax for all of the properties that are available to the **log** reso
 .. code-block:: ruby
 
   log 'name' do
-    level        Symbol # default value: info
+    level        Symbol # default value: :info
     message      String # default value: 'name' unless specified
     action       Symbol # defaults to :write if not specified
   end

--- a/chef_master/source/resource_machine.rst
+++ b/chef_master/source/resource_machine.rst
@@ -61,7 +61,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_machine_batch.rst
+++ b/chef_master/source/resource_machine_batch.rst
@@ -56,7 +56,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_machine_execute.rst
+++ b/chef_master/source/resource_machine_execute.rst
@@ -47,7 +47,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_machine_file.rst
+++ b/chef_master/source/resource_machine_file.rst
@@ -53,7 +53,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_machine_image.rst
+++ b/chef_master/source/resource_machine_image.rst
@@ -56,7 +56,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_macos_userdefaults.rst
+++ b/chef_master/source/resource_macos_userdefaults.rst
@@ -13,25 +13,23 @@ The macos_userdefaults resource has the following syntax:
 
 .. code-block:: ruby
 
-   macos_userdefaults 'name' do
-     domain                String # required
-     global                true, false # default value: 'false'
-     key                   String
-     notifies              # see description
-     subscribes            # see description
-     sudo                  true, false # default value: 'false'
-     type                  String # default value: ""
-     user                  String
-     value                 Integer, Float, String, true, false, Hash, Array
-     action                Symbol # defaults to :write if not specified
-   end
+  macos_userdefaults 'name' do
+    domain      String
+    global      true, false # default value: false
+    key         String
+    sudo        true, false # default value: false
+    type        String
+    user        String
+    value       Integer, Float, String, true, false, Hash, Array
+    action      Symbol # defaults to :write if not specified
+  end
 
 where:
 
 * ``macos_userdefaults`` is the resource.
 * ``name`` is the name given to the resource block.
 * ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
-* ``domain``, ``global``, ``is_set``, ``key``, ``sudo``, ``type``, ``user``, and ``value`` are the properties available to this resource.
+* ``domain``, ``global``, ``key``, ``sudo``, ``type``, ``user``, and ``value`` are the properties available to this resource.
 
 Actions
 =====================================================
@@ -56,7 +54,7 @@ The macos_userdefaults resource has the following properties:
 ``domain``
    **Ruby Type:** String | ``REQUIRED``
 
-   The domain that the user defaults belong to. 
+   The domain that the user defaults belong to.
 
 ``global``
    **Ruby Type:** true, false | **Default Value:** ``false``
@@ -66,91 +64,8 @@ The macos_userdefaults resource has the following properties:
 ``key``
    **Ruby Type:** String
 
-   The preference key. 
+   The preference key.
    
-``notifies``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_notifies
-
-   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
-
-   The syntax for ``notifies`` is:
-
-   .. code-block:: ruby
-
-     notifies :action, 'resource[name]', :timer
-
-   .. end_tag
-
-
-``subscribes``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_subscribes
-
-   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
-
-   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
-
-   .. code-block:: ruby
-
-    file '/etc/nginx/ssl/example.crt' do
-      mode '0600'
-      owner 'root'
-    end
-
-    service 'nginx' do
-      subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
-    end
-
-   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
-
-   The syntax for ``subscribes`` is:
-
-   .. code-block:: ruby
-
-      subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``sudo``
    **Ruby Type:** true, false | **Default Value:** ``false``
@@ -158,20 +73,164 @@ The macos_userdefaults resource has the following properties:
    Set to ``true`` if the setting you wish to modify requires privileged access.
 
 ``type``
-   **Ruby Type:** String | **Default Value:** ``""``
+   **Ruby Type:** String
 
    The value type of the preference key.
 
 ``user``
    **Ruby Type:** String
 
-   The system user that the default will be applied to. 
+   The system user that the default will be applied to.
 
 ``value``
    **Ruby Type:** Integer, Float, String, true, false, Hash, Array | ``REQUIRED``
 
    The value of the key.
 
+Common Resource Functionality
+=====================================================
+
+Chef resources include common properties, notifications, and resource guards.
+
+Common Properties
+-----------------------------------------------------
+
+.. tag resources_common_properties
+
+The following properties are common to every resource:
+
+``ignore_failure``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Continue running a recipe if a resource fails for any reason.
+
+``retries``
+  **Ruby Type:** Integer | **Default Value:** ``0``
+
+  The number of attempts to catch exceptions and retry the resource.
+
+``retry_delay``
+  **Ruby Type:** Integer | **Default Value:** ``2``
+
+  The retry delay (in seconds).
+
+``sensitive``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Ensure that sensitive resource data is not logged by the chef-client.
+
+.. end_tag
+
+Notifications
+-----------------------------------------------------
+
+``notifies``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+  .. tag resources_common_notification_notifies
+
+  A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+  .. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_notifies_syntax
+
+The syntax for ``notifies`` is:
+
+.. code-block:: ruby
+
+  notifies :action, 'resource[name]', :timer
+
+.. end_tag
+
+``subscribes``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+.. tag resources_common_notification_subscribes
+
+A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+.. code-block:: ruby
+
+ file '/etc/nginx/ssl/example.crt' do
+   mode '0600'
+   owner 'root'
+ end
+
+ service 'nginx' do
+   subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+ end
+
+In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+.. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_subscribes_syntax
+
+The syntax for ``subscribes`` is:
+
+.. code-block:: ruby
+
+   subscribes :action, 'resource[name]', :timer
+
+.. end_tag
+
+Guards
+-----------------------------------------------------
+
+.. tag resources_common_guards
+
+A guard property can be used to evaluate the state of a node during the execution phase of the chef-client run. Based on the results of this evaluation, a guard property is then used to tell the chef-client if it should continue executing a resource. A guard property accepts either a string value or a Ruby block value:
+
+* A string is executed as a shell command. If the command returns ``0``, the guard is applied. If the command returns any other value, then the guard property is not applied. String guards in a **powershell_script** run Windows PowerShell commands and may return ``true`` in addition to ``0``.
+* A block is executed as Ruby code that must return either ``true`` or ``false``. If the block returns ``true``, the guard property is applied. If the block returns ``false``, the guard property is not applied.
+
+A guard property is useful for ensuring that a resource is idempotent by allowing that resource to test for the desired state as it is being executed, and then if the desired state is present, for the chef-client to do nothing.
+
+.. end_tag
+.. tag resources_common_guards_properties
+
+The following properties can be used to define a guard that is evaluated during the execution phase of the chef-client run:
+
+``not_if``
+  Prevent a resource from executing when the condition returns ``true``.
+
+``only_if``
+  Allow a resource to execute only if the condition returns ``true``.
+
+.. end_tag
 
 Examples
 =====================================================

--- a/chef_master/source/resource_macos_userdefaults.rst
+++ b/chef_master/source/resource_macos_userdefaults.rst
@@ -42,7 +42,7 @@ The macos_userdefaults resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_macports_package.rst
+++ b/chef_master/source/resource_macports_package.rst
@@ -56,7 +56,7 @@ The macports_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_macports_package.rst
+++ b/chef_master/source/resource_macports_package.rst
@@ -30,11 +30,9 @@ The full syntax for all of the properties that are available to the **macports_p
 .. code-block:: ruby
 
    macports_package 'name' do
-     notifies                   # see description
      options                    String
      package_name               String
      source                     String
-     subscribes                 # see description
      timeout                    String, Integer
      version                    String, Array
      action                     Symbol # defaults to :install if not specified
@@ -73,46 +71,8 @@ The macports_package resource has the following actions:
 
 Properties
 =====================================================
-This resource has the following properties:
 
-``ignore_failure``
-   **Ruby Type:** true, false | **Default Value:** ``false``
-
-   Continue running a recipe if a resource fails for any reason.
-
-``notifies``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_notifies
-
-   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
-
-   The syntax for ``notifies`` is:
-
-   .. code-block:: ruby
-
-     notifies :action, 'resource[name]', :timer
-
-   .. end_tag
+The macports_package resource has the following properties:
 
 ``options``
    **Ruby Type:** String
@@ -124,69 +84,11 @@ This resource has the following properties:
 
    The name of the package. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 
-``retries``
-   **Ruby Type:** Integer | **Default Value:** ``0``
-
-   The number of attempts to catch exceptions and retry the resource.
-
-``retry_delay``
-   **Ruby Type:** Integer | **Default Value:** ``2``
-
-   The retry delay (in seconds).
 
 ``source``
    **Ruby Type:** String
 
    Optional. The path to a package in the local file system.
-
-``subscribes``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_subscribes
-
-   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
-
-   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
-
-   .. code-block:: ruby
-
-    file '/etc/nginx/ssl/example.crt' do
-      mode '0600'
-      owner 'root'
-    end
-
-    service 'nginx' do
-      subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
-    end
-
-   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
-
-   The syntax for ``subscribes`` is:
-
-   .. code-block:: ruby
-
-      subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``timeout``
    **Ruby Type:** String, Integer
@@ -197,6 +99,151 @@ This resource has the following properties:
    **Ruby Type:** String, Array
 
    The version of a package to be installed or upgraded.
+
+Common Resource Functionality
+=====================================================
+
+Chef resources include common properties, notifications, and resource guards.
+
+Common Properties
+-----------------------------------------------------
+
+.. tag resources_common_properties
+
+The following properties are common to every resource:
+
+``ignore_failure``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Continue running a recipe if a resource fails for any reason.
+
+``retries``
+  **Ruby Type:** Integer | **Default Value:** ``0``
+
+  The number of attempts to catch exceptions and retry the resource.
+
+``retry_delay``
+  **Ruby Type:** Integer | **Default Value:** ``2``
+
+  The retry delay (in seconds).
+
+``sensitive``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Ensure that sensitive resource data is not logged by the chef-client.
+
+.. end_tag
+
+Notifications
+-----------------------------------------------------
+
+``notifies``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+  .. tag resources_common_notification_notifies
+
+  A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+  .. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_notifies_syntax
+
+The syntax for ``notifies`` is:
+
+.. code-block:: ruby
+
+  notifies :action, 'resource[name]', :timer
+
+.. end_tag
+
+``subscribes``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+.. tag resources_common_notification_subscribes
+
+A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+.. code-block:: ruby
+
+ file '/etc/nginx/ssl/example.crt' do
+   mode '0600'
+   owner 'root'
+ end
+
+ service 'nginx' do
+   subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+ end
+
+In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+.. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_subscribes_syntax
+
+The syntax for ``subscribes`` is:
+
+.. code-block:: ruby
+
+   subscribes :action, 'resource[name]', :timer
+
+.. end_tag
+
+Guards
+-----------------------------------------------------
+
+.. tag resources_common_guards
+
+A guard property can be used to evaluate the state of a node during the execution phase of the chef-client run. Based on the results of this evaluation, a guard property is then used to tell the chef-client if it should continue executing a resource. A guard property accepts either a string value or a Ruby block value:
+
+* A string is executed as a shell command. If the command returns ``0``, the guard is applied. If the command returns any other value, then the guard property is not applied. String guards in a **powershell_script** run Windows PowerShell commands and may return ``true`` in addition to ``0``.
+* A block is executed as Ruby code that must return either ``true`` or ``false``. If the block returns ``true``, the guard property is applied. If the block returns ``false``, the guard property is not applied.
+
+A guard property is useful for ensuring that a resource is idempotent by allowing that resource to test for the desired state as it is being executed, and then if the desired state is present, for the chef-client to do nothing.
+
+.. end_tag
+.. tag resources_common_guards_properties
+
+The following properties can be used to define a guard that is evaluated during the execution phase of the chef-client run:
+
+``not_if``
+  Prevent a resource from executing when the condition returns ``true``.
+
+``only_if``
+  Allow a resource to execute only if the condition returns ``true``.
+
+.. end_tag
 
 Examples
 =====================================================

--- a/chef_master/source/resource_mdadm.rst
+++ b/chef_master/source/resource_mdadm.rst
@@ -15,10 +15,9 @@ The mdadm resource has the following syntax:
     bitmap           String
     chunk            Integer # default value: 16
     devices          Array
-    exists           true, false # default value: false
     layout           String
     level            Integer # default value: 1
-    metadata         String # default value: 0.90
+    metadata         String # default value: "0.90"
     raid_device      String # default value: 'name' unless specified
     action           Symbol # defaults to :create if not specified
   end
@@ -28,7 +27,7 @@ where:
 * ``mdadm`` is the resource.
 * ``name`` is the name given to the resource block.
 * ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
-* ``bitmap``, ``chunk``, ``devices``, ``exists``, ``layout``, ``level``, ``metadata``, and ``raid_device`` are the properties available to this resource.
+* ``bitmap``, ``chunk``, ``devices``, ``layout``, ``level``, ``metadata``, and ``raid_device`` are the properties available to this resource.
 
 Actions
 =====================================================
@@ -71,16 +70,6 @@ The mdadm resource has the following properties:
 
    The devices to be part of a RAID array.
 
-``exists``
-   **Ruby Type:** true, false | **Default Value:** ``false``
-
-   Indicates whether the RAID array exists.
-
-``ignore_failure``
-   **Ruby Type:** true, false | **Default Value:** ``false``
-
-   Continue running a recipe if a resource fails for any reason.
-
 ``layout``
    **Ruby Type:** String
 
@@ -92,107 +81,162 @@ The mdadm resource has the following properties:
    The RAID level.
 
 ``metadata``
-   **Ruby Type:** String | **Default Value:** ``0.90``
+   **Ruby Type:** String | **Default Value:** ``"0.90"``
 
    The superblock type for RAID metadata.
 
-``notifies``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_notifies
-
-   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
-
-   The syntax for ``notifies`` is:
-
-   .. code-block:: ruby
-
-     notifies :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``raid_device``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``'name'``
 
-   The name of the RAID device. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
+   Optional property to specify the name of the RAID device if it differs from the resource block's name.
+
+
+
+Common Resource Functionality
+=====================================================
+
+Chef resources include common properties, notifications, and resource guards.
+
+Common Properties
+-----------------------------------------------------
+
+.. tag resources_common_properties
+
+The following properties are common to every resource:
+
+``ignore_failure``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Continue running a recipe if a resource fails for any reason.
 
 ``retries``
-   **Ruby Type:** Integer | **Default Value:** ``0``
+  **Ruby Type:** Integer | **Default Value:** ``0``
 
-   The number of attempts to catch exceptions and retry the resource.
+  The number of attempts to catch exceptions and retry the resource.
 
 ``retry_delay``
-   **Ruby Type:** Integer | **Default Value:** ``2``
+  **Ruby Type:** Integer | **Default Value:** ``2``
 
-   The retry delay (in seconds).
+  The retry delay (in seconds).
+
+``sensitive``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Ensure that sensitive resource data is not logged by the chef-client.
+
+.. end_tag
+
+Notifications
+-----------------------------------------------------
+
+``notifies``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+  .. tag resources_common_notification_notifies
+
+  A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+  .. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_notifies_syntax
+
+The syntax for ``notifies`` is:
+
+.. code-block:: ruby
+
+  notifies :action, 'resource[name]', :timer
+
+.. end_tag
 
 ``subscribes``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_subscribes
+.. tag resources_common_notification_subscribes
 
-   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
 
-   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
 
-   .. code-block:: ruby
+.. code-block:: ruby
 
-    file '/etc/nginx/ssl/example.crt' do
-      mode '0600'
-      owner 'root'
-    end
+ file '/etc/nginx/ssl/example.crt' do
+   mode '0600'
+   owner 'root'
+ end
 
-    service 'nginx' do
-      subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
-    end
+ service 'nginx' do
+   subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+ end
 
-   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
 
-   .. end_tag
+.. end_tag
 
-   .. tag resources_common_notification_timers
+.. tag resources_common_notification_timers
 
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
 
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
 
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
 
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
+.. end_tag
 
-   .. tag resources_common_notification_subscribes_syntax
+.. tag resources_common_notification_subscribes_syntax
 
-   The syntax for ``subscribes`` is:
+The syntax for ``subscribes`` is:
 
-   .. code-block:: ruby
+.. code-block:: ruby
 
-      subscribes :action, 'resource[name]', :timer
+   subscribes :action, 'resource[name]', :timer
 
-   .. end_tag
+.. end_tag
+
+Guards
+-----------------------------------------------------
+
+.. tag resources_common_guards
+
+A guard property can be used to evaluate the state of a node during the execution phase of the chef-client run. Based on the results of this evaluation, a guard property is then used to tell the chef-client if it should continue executing a resource. A guard property accepts either a string value or a Ruby block value:
+
+* A string is executed as a shell command. If the command returns ``0``, the guard is applied. If the command returns any other value, then the guard property is not applied. String guards in a **powershell_script** run Windows PowerShell commands and may return ``true`` in addition to ``0``.
+* A block is executed as Ruby code that must return either ``true`` or ``false``. If the block returns ``true``, the guard property is applied. If the block returns ``false``, the guard property is not applied.
+
+A guard property is useful for ensuring that a resource is idempotent by allowing that resource to test for the desired state as it is being executed, and then if the desired state is present, for the chef-client to do nothing.
+
+.. end_tag
+.. tag resources_common_guards_properties
+
+The following properties can be used to define a guard that is evaluated during the execution phase of the chef-client run:
+
+``not_if``
+  Prevent a resource from executing when the condition returns ``true``.
+
+``only_if``
+  Allow a resource to execute only if the condition returns ``true``.
+
+.. end_tag
 
 Examples
 =====================================================

--- a/chef_master/source/resource_mdadm.rst
+++ b/chef_master/source/resource_mdadm.rst
@@ -43,7 +43,7 @@ The mdadm resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_mount.rst
+++ b/chef_master/source/resource_mount.rst
@@ -13,18 +13,17 @@ The mount resource has the following syntax:
 
   mount 'name' do
     device           String
-    device_type      String, Symbol # default value: device
+    device_type      String, Symbol # default value: :device
     domain           String
     dump             Integer, false # default value: 0
     enabled          true, false # default value: false
-    fsck_device      String # default value: -
-    fstype           String, nil # default value: auto
+    fsck_device      String # default value: "-"
+    fstype           String # default value: "auto"
     mount_point      String # default value: 'name' unless specified
-    mounted          true, false # default value: false
-    options          Array, String, nil # default value: ["defaults"]
+    options          Array, String # default value: ["defaults"]
     pass             Integer, false # default value: 2
     password         String
-    supports         Hash
+    supports         Array, Hash
     username         String
     action           Symbol # defaults to :mount if not specified
   end
@@ -34,7 +33,7 @@ where:
 * ``mount`` is the resource.
 * ``name`` is the name given to the resource block.
 * ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
-* ``device``, ``device_type``, ``domain``, ``dump``, ``enabled``, ``fsck_device``, ``fstype``, ``mount_point``, ``mounted``, ``options``, ``pass``, ``password``, ``supports``, and ``username`` are the properties available to this resource.
+* ``device``, ``device_type``, ``domain``, ``dump``, ``enabled``, ``fsck_device``, ``fstype``, ``mount_point``, ``options``, ``pass``, ``password``, ``supports``, and ``username`` are the properties available to this resource.
 
 Actions
 =====================================================
@@ -79,7 +78,7 @@ The mount resource has the following properties:
    Required for ``:umount`` and ``:remount`` actions (for the purpose of checking the mount command output for presence). The special block device or remote node, a label, or a uuid to be mounted.
 
 ``device_type``
-   **Ruby Type:** String, Symbol | **Default Value:** ``device``
+   **Ruby Type:** String, Symbol | **Default Value:** ``:device``
 
    The type of device: :device, :label, or :uuid
 
@@ -100,69 +99,26 @@ The mount resource has the following properties:
    Use to specify if a mounted file system is enabled.
 
 ``fsck_device``
-   **Ruby Type:** String | **Default Value:** ``-``
+   **Ruby Type:** String | **Default Value:** ``"-"``
 
    Solaris only: The fsck device.
 
 
 ``fstype``
-   **Ruby Type:** String, nil | **Default Value:** ``auto``
+   **Ruby Type:** String | **Default Value:** ``"auto"``
 
-   Required. The file system type (fstype) of the device.
-
-``ignore_failure``
-   **Ruby Type:** true, false | **Default Value:** ``false``
-
-   Continue running a recipe if a resource fails for any reason.
+   The file system type (fstype) of the device.
 
 ``mount_point``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``'name'``
 
-   The directory (or path) in which the device is to be mounted. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
+   The directory (or path) in which the device is to be mounted. Defaults to the name of the resource block if not provided.
 
-``mounted``
-   **Ruby Type:** true, false | **Default Value:** ``false``
-
-   Use to specify if a file system is already mounted.
-
-``notifies``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_notifies
-
-   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
-
-   The syntax for ``notifies`` is:
-
-   .. code-block:: ruby
-
-     notifies :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``options``
-   **Ruby Type:** Array, String | **Default Value:** ``defaults``
+   **Ruby Type:** Array, String | **Default Value:** ``["defaults"]``
 
-   An array or string that contains mount options. If this value is a string, it is converted to an array.
+   An array or comma separated list of options for the mount.
 
 ``pass``
    **Ruby Type:** Integer, false | **Default Value:** ``2``
@@ -172,76 +128,162 @@ The mount resource has the following properties:
 ``password``
    **Ruby Type:** String
 
-   Microsoft Windows only. Use to specify the password for ``username``.
-
-``retries``
-   **Ruby Type:** Integer | **Default Value:** ``0``
-
-   The number of attempts to catch exceptions and retry the resource.
-
-``retry_delay``
-   **Ruby Type:** Integer | **Default Value:** ``2``
-
-   The retry delay (in seconds).
-
-``subscribes``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_subscribes
-
-   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
-
-   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
-
-   .. code-block:: ruby
-
-    file '/etc/nginx/ssl/example.crt' do
-      mode '0600'
-      owner 'root'
-    end
-
-    service 'nginx' do
-      subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
-    end
-
-   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
-
-   The syntax for ``subscribes`` is:
-
-   .. code-block:: ruby
-
-      subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
+   Windows only. Use to specify the password for ``username``.
 
 ``supports``
-   **Ruby Type:** Hash, Array
+   **Ruby Type:** Array, Hash
 
    Specify a Hash of supported mount features. Default value: ``remount: false`` (preferred). Array defaults to ``remount: true`` (non-preferred).
 
 ``username``
    **Ruby Type:** String
 
-   Microsoft Windows only. Use to specify the user name.
+   Windows only: Use to specify the user name.
+
+Common Resource Functionality
+=====================================================
+
+Chef resources include common properties, notifications, and resource guards.
+
+Common Properties
+-----------------------------------------------------
+
+.. tag resources_common_properties
+
+The following properties are common to every resource:
+
+``ignore_failure``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Continue running a recipe if a resource fails for any reason.
+
+``retries``
+  **Ruby Type:** Integer | **Default Value:** ``0``
+
+  The number of attempts to catch exceptions and retry the resource.
+
+``retry_delay``
+  **Ruby Type:** Integer | **Default Value:** ``2``
+
+  The retry delay (in seconds).
+
+``sensitive``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Ensure that sensitive resource data is not logged by the chef-client.
+
+.. end_tag
+
+Notifications
+-----------------------------------------------------
+
+``notifies``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+  .. tag resources_common_notification_notifies
+
+  A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+  .. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_notifies_syntax
+
+The syntax for ``notifies`` is:
+
+.. code-block:: ruby
+
+  notifies :action, 'resource[name]', :timer
+
+.. end_tag
+
+``subscribes``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+.. tag resources_common_notification_subscribes
+
+A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+.. code-block:: ruby
+
+ file '/etc/nginx/ssl/example.crt' do
+   mode '0600'
+   owner 'root'
+ end
+
+ service 'nginx' do
+   subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+ end
+
+In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+.. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of the Chef Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_subscribes_syntax
+
+The syntax for ``subscribes`` is:
+
+.. code-block:: ruby
+
+   subscribes :action, 'resource[name]', :timer
+
+.. end_tag
+
+Guards
+-----------------------------------------------------
+
+.. tag resources_common_guards
+
+A guard property can be used to evaluate the state of a node during the execution phase of the chef-client run. Based on the results of this evaluation, a guard property is then used to tell the chef-client if it should continue executing a resource. A guard property accepts either a string value or a Ruby block value:
+
+* A string is executed as a shell command. If the command returns ``0``, the guard is applied. If the command returns any other value, then the guard property is not applied. String guards in a **powershell_script** run Windows PowerShell commands and may return ``true`` in addition to ``0``.
+* A block is executed as Ruby code that must return either ``true`` or ``false``. If the block returns ``true``, the guard property is applied. If the block returns ``false``, the guard property is not applied.
+
+A guard property is useful for ensuring that a resource is idempotent by allowing that resource to test for the desired state as it is being executed, and then if the desired state is present, for the chef-client to do nothing.
+
+.. end_tag
+.. tag resources_common_guards_properties
+
+The following properties can be used to define a guard that is evaluated during the execution phase of the chef-client run:
+
+``not_if``
+  Prevent a resource from executing when the condition returns ``true``.
+
+``only_if``
+  Allow a resource to execute only if the condition returns ``true``.
+
+.. end_tag
 
 Examples
 =====================================================

--- a/chef_master/source/resource_mount.rst
+++ b/chef_master/source/resource_mount.rst
@@ -52,7 +52,7 @@ The mount resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_ohai.rst
+++ b/chef_master/source/resource_ohai.rst
@@ -32,7 +32,7 @@ The ohai resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_openbsd_package.rst
+++ b/chef_master/source/resource_openbsd_package.rst
@@ -61,7 +61,7 @@ The openbsd_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_openssl_dhparam.rst
+++ b/chef_master/source/resource_openssl_dhparam.rst
@@ -41,7 +41,7 @@ The openssl_dhparam resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_openssl_ec_private_key.rst
+++ b/chef_master/source/resource_openssl_ec_private_key.rst
@@ -43,7 +43,7 @@ The openssl_ec_private_key resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_openssl_ec_public_key.rst
+++ b/chef_master/source/resource_openssl_ec_public_key.rst
@@ -42,7 +42,7 @@ The openssl_ec_public_key resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_openssl_rsa_private_key.rst
+++ b/chef_master/source/resource_openssl_rsa_private_key.rst
@@ -45,7 +45,7 @@ The openssl_rsa_private_key resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_openssl_rsa_public_key.rst
+++ b/chef_master/source/resource_openssl_rsa_public_key.rst
@@ -69,7 +69,7 @@ The openssl_rsa_public_key resource has the following properties:
 ``path``
    **Ruby Type:** String | **Default Value:** ``'name'``
 
-   The path to the public key file, if it differs from the resource name.
+   An optional property for specifying the path to the public key if it differs from the resource block's name.
 
 ``private_key_content``
    **Ruby Type:** String

--- a/chef_master/source/resource_openssl_rsa_public_key.rst
+++ b/chef_master/source/resource_openssl_rsa_public_key.rst
@@ -42,7 +42,7 @@ The openssl_rsa_public_key resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_openssl_x509_certificate.rst
+++ b/chef_master/source/resource_openssl_x509_certificate.rst
@@ -64,15 +64,8 @@ The openssl_x509_certificate resource has the following actions:
 
 Properties
 =====================================================
-``city``
-   **Ruby Type:** String
 
-   Value for the ``L`` certificate field.
-
-``email``
-   **Ruby Type:** String
-
-   Value for the ``email`` ssl field.
+The openssl_x509_certificate resource has the following properties:
 
 ``ca_cert_file``
    **Ruby Type:** String
@@ -88,7 +81,6 @@ Properties
    **Ruby Type:** String
 
    The passphrase for CA private key's passphrase.
-
 
 ``city``
    **Ruby Type:** String
@@ -109,7 +101,6 @@ Properties
    **Ruby Type:** String
 
    The path to a X509 Certificate Request (CSR) on the filesystem. If the csr_file property is specified, the resource will attempt to source a CSR from this location. If no CSR file is found, the resource will generate a Self-Signed Certificate and the certificate fields must be specified (common_name at last).
-
 
 ``email``
    **Ruby Type:** String

--- a/chef_master/source/resource_openssl_x509_certificate.rst
+++ b/chef_master/source/resource_openssl_x509_certificate.rst
@@ -58,7 +58,7 @@ The openssl_x509_certificate resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_openssl_x509_crl.rst
+++ b/chef_master/source/resource_openssl_x509_crl.rst
@@ -90,7 +90,7 @@ Properties
 ``path``
    **Ruby Type:** String | **Default Value:** ``'name'``
 
-   The path to write the file to, if it differs from the resource name.
+   An optional property for specifying the path to write the file to if it differs from the resource block's name.
 
 ``renewal_threshold``
    **Ruby Type:** Integer | **Default Value:** ``1``

--- a/chef_master/source/resource_openssl_x509_crl.rst
+++ b/chef_master/source/resource_openssl_x509_crl.rst
@@ -46,7 +46,7 @@ The openssl_x509_crl resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_openssl_x509_request.rst
+++ b/chef_master/source/resource_openssl_x509_request.rst
@@ -51,7 +51,7 @@ The openssl_x509_request resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_openssl_x509_request.rst
+++ b/chef_master/source/resource_openssl_x509_request.rst
@@ -133,7 +133,7 @@ The openssl_x509_request resource has the following properties:
 ``path``
    **Ruby Type:** String | **Default Value:** ``'name'``
 
-   The path to write the file to, if it differs from the resource name.
+   An optional property for specifying the path to write the file to if it differs from the resource block's name.
 
 ``state``
    **Ruby Type:** String

--- a/chef_master/source/resource_osx_profile.rst
+++ b/chef_master/source/resource_osx_profile.rst
@@ -40,11 +40,11 @@ The osx_profile resource has the following actions:
    Default. Install the specified configuration profile.
 
 ``:nothing``
-   Default. .. tag resources_common_actions_nothing
+   .. tag resources_common_actions_nothing
 
-            Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
 
-            .. end_tag
+   .. end_tag
 
 ``:remove``
    Remove the specified configuration profile.

--- a/chef_master/source/resource_osx_profile.rst
+++ b/chef_master/source/resource_osx_profile.rst
@@ -42,7 +42,7 @@ The osx_profile resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_package.rst
+++ b/chef_master/source/resource_package.rst
@@ -219,7 +219,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_pacman_package.rst
+++ b/chef_master/source/resource_pacman_package.rst
@@ -57,7 +57,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_paludis_package.rst
+++ b/chef_master/source/resource_paludis_package.rst
@@ -63,7 +63,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_portage_package.rst
+++ b/chef_master/source/resource_portage_package.rst
@@ -56,7 +56,7 @@ The portage_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_powershell_package_source.rst
+++ b/chef_master/source/resource_powershell_package_source.rst
@@ -36,14 +36,18 @@ Actions
 
 The powershell_package_source resource has the following actions:
 
-``register``
+``:register``
    Default. Registers and updates the PowerShell package source.
 
-``unregister``
+``:unregister``
    Unregisters the PowerShell package source.
 
 ``:nothing``
+   .. tag resources_common_actions_nothing
+
    Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+
+   .. end_tag
 
 Properties
 =====================================================

--- a/chef_master/source/resource_powershell_package_source.rst
+++ b/chef_master/source/resource_powershell_package_source.rst
@@ -45,7 +45,7 @@ The powershell_package_source resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_private_key.rst
+++ b/chef_master/source/resource_private_key.rst
@@ -43,7 +43,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_public_key.rst
+++ b/chef_master/source/resource_public_key.rst
@@ -43,7 +43,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_python.rst
+++ b/chef_master/source/resource_python.rst
@@ -46,7 +46,7 @@ The full syntax for all of the properties that are available to the **python** r
     live_stream      true, false # default value: false
     password         String
     returns          Integer, Array # default value: 0
-    sensitive        true, false
+    sensitive        true, false # default value: "True if the password property is set. False otherwise."
     timeout          Integer, Float
     umask            String, Integer
     user             String, Integer

--- a/chef_master/source/resource_reboot.rst
+++ b/chef_master/source/resource_reboot.rst
@@ -40,7 +40,7 @@ The reboot resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_reference.rst
+++ b/chef_master/source/resource_reference.rst
@@ -19,7 +19,7 @@ The following actions may be used with any resource:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_registry_key.rst
+++ b/chef_master/source/resource_registry_key.rst
@@ -55,7 +55,7 @@ The full syntax for all of the properties that are available to the **registry_k
 .. code-block:: ruby
 
   registry_key 'name' do
-    architecture      Symbol # default value: machine
+    architecture      Symbol # default value: :machine
     key               String # default value: 'name' unless specified
     recursive         true, false # default value: false
     values
@@ -327,7 +327,7 @@ Actions
 =====================================================
 .. tag resource_registry_key_actions
 
-This resource has the following actions:
+The registry_key resource has the following actions:
 
 ``:create``
    Default. Create a registry key. If a registry key already exists (but does not match), update that registry key to match.

--- a/chef_master/source/resource_registry_key.rst
+++ b/chef_master/source/resource_registry_key.rst
@@ -344,7 +344,7 @@ The registry_key resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_remote_directory.rst
+++ b/chef_master/source/resource_remote_directory.rst
@@ -78,7 +78,7 @@ The remote_directory resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_remote_file.rst
+++ b/chef_master/source/resource_remote_file.rst
@@ -93,7 +93,7 @@ The remote_file resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_remote_file.rst
+++ b/chef_master/source/resource_remote_file.rst
@@ -78,7 +78,8 @@ where:
 
 Actions
 =====================================================
-This resource has the following actions:
+
+The remote_file resource has the following actions:
 
 ``:create``
    Default. Create a file. If a file already exists (but does not match), update that file to match.
@@ -101,15 +102,16 @@ This resource has the following actions:
 
 Properties
 =====================================================
-This resource has the following properties:
+
+The remote_file resource has the following properties:
 
 ``atomic_update``
-   **Ruby Type:** true, false | **Default Value:** ``true``
+   **Ruby Type:** true, false
 
    Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file.
 
 ``backup``
-   **Ruby Type:** false, Integer | **Default Value:** ``5``
+   **Ruby Type:** Integer, false | **Default Value:** ``5``
 
    The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept.
 
@@ -133,8 +135,8 @@ This resource has the following properties:
 
    A string or ID that identifies the group owner by group name, including fully qualified group names such as ``domain\group`` or ``group@domain``. If this value is not specified, existing groups remain unchanged and new group assignments use the default ``POSIX`` group (if available).
 
-``headers()``
-   **Ruby Type:** Hash | **Default Value:** ``{}``
+``headers``
+   **Ruby Type:** Hash
 
    A Hash of custom headers. For example:
 

--- a/chef_master/source/resource_rhsm_errata.rst
+++ b/chef_master/source/resource_rhsm_errata.rst
@@ -36,7 +36,7 @@ The rhsm_errata resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_rhsm_errata_level.rst
+++ b/chef_master/source/resource_rhsm_errata_level.rst
@@ -50,7 +50,7 @@ The rhsm_errata_level resource has the following properties:
 ``errata_level``
    **Ruby Type:** String | **Default Value:** ``'name'``
 
-   The errata level of packages to install, if it differs from the resource name.
+   The errata level of packages to install, if it differs from the resource block's name.
 
 Common Resource Functionality
 =====================================================

--- a/chef_master/source/resource_rhsm_errata_level.rst
+++ b/chef_master/source/resource_rhsm_errata_level.rst
@@ -38,7 +38,7 @@ The rhsm_errata_level resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_rhsm_register.rst
+++ b/chef_master/source/resource_rhsm_register.rst
@@ -59,12 +59,12 @@ The rhsm_register resource has the following properties:
 ``activation_key``
    **Ruby Type:** String, Array
 
-   A string or array of  activation keys to use when registering; you must also specify the ``organization`` property when using this.
+   A string or array of activation keys to use when registering; you must also specify the 'organization' property when using this property.
 
 ``auto_attach``
    **Ruby Type:** true, false | **Default Value:** ``false``
 
-   If ``true``, RHSM will attempt to automatically attach the host to applicable subscriptions. It is generally better to use an activation key with the subscriptions predefined.
+   If true, RHSM will attempt to automatically attach the host to applicable subscriptions. It is generally better to use an activation key with the subscriptions pre-defined.
 
 ``environment``
    **Ruby Type:** String
@@ -95,6 +95,11 @@ The rhsm_register resource has the following properties:
    **Ruby Type:** String
 
    The FQDN of the Satellite host to register with. If this property is not specified, the host will register with Red Hat's public RHSM service.
+
+``username``
+   **Ruby Type:** String
+
+   The username to use when registering. This property is not applicable if using an activation key. If specified, password and environment properties are also required.
 
 Common Resource Functionality
 =====================================================

--- a/chef_master/source/resource_rhsm_register.rst
+++ b/chef_master/source/resource_rhsm_register.rst
@@ -47,7 +47,7 @@ The rhsm_register resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_rhsm_repo.rst
+++ b/chef_master/source/resource_rhsm_repo.rst
@@ -39,7 +39,7 @@ The rhsm_repo resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_rhsm_repo.rst
+++ b/chef_master/source/resource_rhsm_repo.rst
@@ -45,10 +45,13 @@ The rhsm_repo resource has the following actions:
 
 Properties
 =====================================================
+
+The rhsm_repo resource has the following properties:
+
 ``repo_name``
    **Ruby Type:** String | **Default Value:** ``'name'``
 
-   An optional property for specifying the repository name if it differs from the resource's name.
+   An optional property for specifying the repository name if it differs from the resource block's name.
 
 Common Resource Functionality
 =====================================================

--- a/chef_master/source/resource_rhsm_subscription.rst
+++ b/chef_master/source/resource_rhsm_subscription.rst
@@ -39,7 +39,7 @@ The rhsm_subscription resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_rhsm_subscription.rst
+++ b/chef_master/source/resource_rhsm_subscription.rst
@@ -51,7 +51,7 @@ The rhsm_subscription resource has the following properties:
 ``pool_id``
    **Ruby Type:** String | **Default Value:** ``'name'``
 
-  An optional property for specifying the Pool ID if it differs from the resource's name.
+   An optional property for specifying the Pool ID if it differs from the resource block's name.
 
 Common Resource Functionality
 =====================================================

--- a/chef_master/source/resource_route.rst
+++ b/chef_master/source/resource_route.rst
@@ -56,7 +56,7 @@ The route resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_rpm_package.rst
+++ b/chef_master/source/resource_rpm_package.rst
@@ -56,7 +56,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_ruby.rst
+++ b/chef_master/source/resource_ruby.rst
@@ -66,7 +66,7 @@ The ruby resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_ruby.rst
+++ b/chef_master/source/resource_ruby.rst
@@ -60,17 +60,23 @@ where:
 
 Actions
 =====================================================
-This resource has the following actions:
+
+The ruby resource has the following actions:
 
 ``:nothing``
-   Prevent a command from running. This action is used to specify that a command is run only when another resource notifies it.
+   .. tag resources_common_actions_nothing
+
+   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+
+   .. end_tag
 
 ``:run``
    Default. Run a script.
 
 Properties
 =====================================================
-This resource has the following properties:
+
+The ruby resource has the following properties:
 
 ``code``
    **Ruby Type:** String

--- a/chef_master/source/resource_ruby_block.rst
+++ b/chef_master/source/resource_ruby_block.rst
@@ -51,7 +51,7 @@ The ruby_block resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_smartos_package.rst
+++ b/chef_master/source/resource_smartos_package.rst
@@ -58,7 +58,7 @@ The smartos_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_smartos_package.rst
+++ b/chef_master/source/resource_smartos_package.rst
@@ -86,7 +86,7 @@ The smartos_package resource has the following properties:
 ``source``
    **Ruby Type:** String
 
-   Optional. The path to a package in the local file system.
+   The optional path to a package on the local file system.
 
 ``timeout``
    **Ruby Type:** String, Integer

--- a/chef_master/source/resource_solaris_package.rst
+++ b/chef_master/source/resource_solaris_package.rst
@@ -54,7 +54,7 @@ The solaris_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_ssh_known_hosts_entry.rst
+++ b/chef_master/source/resource_ssh_known_hosts_entry.rst
@@ -48,7 +48,7 @@ The ssh_known_hosts_entry resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_subversion.rst
+++ b/chef_master/source/resource_subversion.rst
@@ -59,7 +59,7 @@ The subversion resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_sudo.rst
+++ b/chef_master/source/resource_sudo.rst
@@ -56,7 +56,7 @@ The sudo resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_swap_file.rst
+++ b/chef_master/source/resource_swap_file.rst
@@ -43,7 +43,7 @@ The swap_file resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_sysctl.rst
+++ b/chef_master/source/resource_sysctl.rst
@@ -42,7 +42,7 @@ The sysctl resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_template.rst
+++ b/chef_master/source/resource_template.rst
@@ -90,7 +90,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_timezone.rst
+++ b/chef_master/source/resource_timezone.rst
@@ -12,19 +12,19 @@ Syntax
 
 The timezone resource has the following syntax:
 
- .. code-block:: ruby
+.. code-block:: ruby
 
-   timezone 'name' do
+  timezone 'name' do
     timezone      String # default value: 'name' unless specified
     action        Symbol # defaults to :set if not specified
   end
 
- where:
+where:
 
- * ``timezone`` is the resource.
- * ``name`` is the name given to the resource block.
- * ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
- * ``timezone`` is the property available to this resource.
+* ``timezone`` is the resource.
+* ``name`` is the name given to the resource block.
+* ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
+* ``timezone`` is the property available to this resource.
 
 Actions
 =====================================================

--- a/chef_master/source/resource_timezone.rst
+++ b/chef_master/source/resource_timezone.rst
@@ -37,7 +37,7 @@ The timezone resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_user.rst
+++ b/chef_master/source/resource_user.rst
@@ -73,7 +73,7 @@ This resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_ad_join.rst
+++ b/chef_master/source/resource_windows_ad_join.rst
@@ -42,7 +42,7 @@ The windows_ad_join resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_auto_run.rst
+++ b/chef_master/source/resource_windows_auto_run.rst
@@ -42,7 +42,7 @@ The windows_auto_run resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_certificate.rst
+++ b/chef_master/source/resource_windows_certificate.rst
@@ -53,7 +53,7 @@ The windows_certificate resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_env.rst
+++ b/chef_master/source/resource_windows_env.rst
@@ -52,7 +52,7 @@ The windows_env resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_feature.rst
+++ b/chef_master/source/resource_windows_feature.rst
@@ -47,7 +47,7 @@ The windows_feature resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_feature.rst
+++ b/chef_master/source/resource_windows_feature.rst
@@ -16,7 +16,7 @@ The windows_feature resource has the following syntax:
   windows_feature 'name' do
     all                   true, false # default value: false
     feature_name          Array, String # default value: 'name' unless specified
-    install_method        Symbol
+    install_method        Symbol # default value: :windows_feature_dism
     management_tools      true, false # default value: false
     source                String
     timeout               Integer # default value: 600
@@ -64,7 +64,13 @@ The windows_feature resource has the following properties:
 ``feature_name``
    **Ruby Type:** Array, String | **Default Value:** ``'name'``
 
-   The name of the feature(s) or role(s) to install, if it differs from the resource block name.
+   The name of the feature(s) or role(s) to install, if it differs from the resource block name. The same feature may have different names depending on the underlying installation method being used (ie DHCPServer vs DHCP; DNS-Server-Full-Role vs DNS).
+
+``install_method``
+   **Ruby Type:** Symbol | **Default Value:** ``:windows_feature_dism``
+
+   The underlying installation method to use for feature installation. Specify ':windows_feature_dism' for DISM or ':windows_feature_powershell' for PowerShell.
+
 
 ``management_tools``
    **Ruby Type:** true, false | **Default Value:** ``false``

--- a/chef_master/source/resource_windows_feature_powershell.rst
+++ b/chef_master/source/resource_windows_feature_powershell.rst
@@ -46,7 +46,7 @@ The windows_feature_powershell resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_firewall_rule.rst
+++ b/chef_master/source/resource_windows_firewall_rule.rst
@@ -52,7 +52,7 @@ The windows_firewall_rule resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_firewall_rule.rst
+++ b/chef_master/source/resource_windows_firewall_rule.rst
@@ -20,12 +20,12 @@ The windows_firewall_rule resource has the following syntax:
     firewall_action      Symbol, String # default value: :allow
     interface_type       Symbol, String # default value: :any
     local_address        String
-    local_port           String
+    local_port           String, Integer, Array
     profile              Symbol, String # default value: :any
     program              String
     protocol             String # default value: "TCP"
     remote_address       String
-    remote_port          String
+    remote_port          String, Integer, Array
     rule_name            String # default value: 'name' unless specified
     service              String
     action               Symbol # defaults to :create if not specified
@@ -92,7 +92,7 @@ The windows_firewall_rule resource has the following properties:
    The local address the firewall rule applies to.
 
 ``local_port``
-   **Ruby Type:** String
+   **Ruby Type:** String, Integer, Array
 
    The local port the firewall rule applies to.
 
@@ -117,7 +117,7 @@ The windows_firewall_rule resource has the following properties:
    The remote address the firewall rule applies to.
 
 ``remote_port``
-   **Ruby Type:** String
+   **Ruby Type:** String, Integer, Array
 
    The remote port the firewall rule applies to.
 

--- a/chef_master/source/resource_windows_font.rst
+++ b/chef_master/source/resource_windows_font.rst
@@ -34,7 +34,7 @@ Actions
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_package.rst
+++ b/chef_master/source/resource_windows_package.rst
@@ -61,7 +61,7 @@ The windows_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_pagefile.rst
+++ b/chef_master/source/resource_windows_pagefile.rst
@@ -43,7 +43,7 @@ The windows_pagefile resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_printer.rst
+++ b/chef_master/source/resource_windows_printer.rst
@@ -46,7 +46,7 @@ The windows_printer resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_printer.rst
+++ b/chef_master/source/resource_windows_printer.rst
@@ -73,7 +73,7 @@ The windows_printer resource has the following properties:
 ``driver_name``
    **Ruby Type:** String | ``REQUIRED``
 
-   The exact name of the installed printer driver on the system.
+   The exact name of printer driver installed on the system.
 
 ``ipv4_address``
    **Ruby Type:** String

--- a/chef_master/source/resource_windows_printer_port.rst
+++ b/chef_master/source/resource_windows_printer_port.rst
@@ -44,7 +44,7 @@ The windows_printer_port resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_share.rst
+++ b/chef_master/source/resource_windows_share.rst
@@ -50,7 +50,7 @@ The windows_share resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_shortcut.rst
+++ b/chef_master/source/resource_windows_shortcut.rst
@@ -41,7 +41,7 @@ The windows_shortcut resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_windows_workgroup.rst
+++ b/chef_master/source/resource_windows_workgroup.rst
@@ -40,7 +40,7 @@ The windows_workgroup resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_yum_package.rst
+++ b/chef_master/source/resource_yum_package.rst
@@ -65,7 +65,7 @@ The yum_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/resource_yum_package.rst
+++ b/chef_master/source/resource_yum_package.rst
@@ -142,7 +142,7 @@ The yum_package resource has the following properties:
 ``source``
    **Ruby Type:** String
 
-   Optional. The path to a package in the local file system.
+   The optional path to a package on the local file system.
 
 ``timeout``
    **Ruby Type:** String, Integer

--- a/chef_master/source/resource_yum_repository.rst
+++ b/chef_master/source/resource_yum_repository.rst
@@ -203,7 +203,7 @@ The yum_repository resource has the following properties:
 ``mirror_expire``
    **Ruby Type:** String
 
-   Time (in seconds) after which the mirrorlist locally cached will expire. If the current mirrorlist is less than this many seconds old then Yum will not download another copy of the mirrorlist, it has the same extra format as metadata_expire. If you find that Yum is not downloading the mirrorlists as often as you would like lower the value of this option.
+   Time (in seconds) after which the mirrorlist locally cached will expire. If the current mirrorlist is less than this many seconds old then Yum will not download another copy of the mirrorlist, it has the same extra format as metadata_expire. If you find that Yum is not downloading the mirrorlists as often as you would like lower the value of this option. You can also change from the default of using seconds to using days, hours or minutes by appending a 'd', 'h' or 'm' respectively.
 
 ``mirrorlist``
    **Ruby Type:** String
@@ -213,10 +213,10 @@ The yum_repository resource has the following properties:
 ``mirrorlist_expire``
    **Ruby Type:** String
 
-   Specifies the time (in seconds) after which the mirrorlist locally cached will expire. If the current mirrorlist is less than the value specified, then Yum will not download another copy of the mirrorlist.
+   Specifies the time (in seconds) after which the mirrorlist locally cached will expire. If the current mirrorlist is less than the value specified, then Yum will not download another copy of the mirrorlist. You can also change from the default of using seconds to using days, hours or minutes by appending a 'd', 'h' or 'm' respectively.
 
 ``mode``
-   **Ruby Type:** String, Integer | **Default Value:** ``0644``
+   **Ruby Type:** String, Integer | **Default Value:** ``"0644"``
 
    Permissions mode of .repo file on disk. This is useful for scenarios where secrets are in the repo file. If this value is set to '600', normal users will not be able to use Yum search, Yum info, etc.
 

--- a/chef_master/source/resource_zypper_package.rst
+++ b/chef_master/source/resource_zypper_package.rst
@@ -58,7 +58,7 @@ The zypper_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -80,7 +80,7 @@ The zypper_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -529,7 +529,7 @@ The batch resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -1056,7 +1056,7 @@ The dsc_script resource has the following actions:
 
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -1404,7 +1404,7 @@ The windows_env resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -2063,7 +2063,7 @@ The registry_key resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 
@@ -2275,7 +2275,7 @@ The windows_package resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, this resource block is either run immediately or it is queued up to be run at the end of the Chef Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
 

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -1774,7 +1774,7 @@ The full syntax for all of the properties that are available to the **registry_k
 .. code-block:: ruby
 
   registry_key 'name' do
-    architecture      Symbol # default value: machine
+    architecture      Symbol # default value: :machine
     key               String # default value: 'name' unless specified
     recursive         true, false # default value: false
     values
@@ -2046,7 +2046,7 @@ Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. tag resource_registry_key_actions
 
-This resource has the following actions:
+The registry_key resource has the following actions:
 
 ``:create``
    Default. Create a registry key. If a registry key already exists (but does not match), update that registry key to match.


### PR DESCRIPTION
Move some more common properties to their own section
Fix some default values
Remove duplicate properties
Fix formatting
Fix wording on the name_property type properties to better explain that they are an optional way to override the resource block's name value. We're still not very good at describing this, but I see a lot of people using them when they don't need them so hopefully this helps.

Signed-off-by: Tim Smith <tsmith@chef.io>