### PR TITLE
Resource cleanup v7

### DIFF
--- a/chef_master/source/debug.rst
+++ b/chef_master/source/debug.rst
@@ -125,7 +125,7 @@ The log resource has the following properties:
    The logging level for displaying this message.. Options (in order of priority): ``:debug``, ``:info``, ``:warn``, ``:error``, and ``:fatal``.
 
 ``message``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The message to be added to a log file. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -3779,7 +3779,7 @@ The osx_profile resource has the following properties:
    Use to specify a profile. This may be the name of a profile contained in a cookbook or a Hash that contains the contents of the profile.
 
 ``profile_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    Use to specify the name of the profile, if different from the name of the resource block.
 

--- a/chef_master/source/resource_apt_preference.rst
+++ b/chef_master/source/resource_apt_preference.rst
@@ -50,7 +50,7 @@ The apt_preference resource has the following properties:
    Pin by ``glob()`` expression or with regular expressions surrounded by ``/``.
 
 ``package_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property to set the package name if it differs from the resource block's name.
 

--- a/chef_master/source/resource_apt_repository.rst
+++ b/chef_master/source/resource_apt_repository.rst
@@ -112,7 +112,7 @@ The apt_repository resource has the following properties:
    The GPG keyserver where the key for the repo should be retrieved.
 
 ``repo_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property to set the repository name if it differs from the resource block's name. The value of this setting must not contain spaces.
 

--- a/chef_master/source/resource_chef_handler.rst
+++ b/chef_master/source/resource_chef_handler.rst
@@ -198,7 +198,7 @@ The chef_handler resource has the following properties:
       arguments [:key1 => 'val1', :key2 => 'val2']
 
 ``class_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the handler class. This can be module name-spaced.
 

--- a/chef_master/source/resource_chocolatey_config.rst
+++ b/chef_master/source/resource_chocolatey_config.rst
@@ -50,7 +50,7 @@ Properties
 The chocolatey_config resource has the following properties:
 
 ``config_key``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property to set the config key name if it differs from the resource block's name.
 

--- a/chef_master/source/resource_chocolatey_source.rst
+++ b/chef_master/source/resource_chocolatey_source.rst
@@ -67,7 +67,7 @@ The chocolatey_source resource has the following properties:
    The source URL.
 
 ``source_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property to set the source name if it differs from the resource block's name.
 

--- a/chef_master/source/resource_cookbook_file.rst
+++ b/chef_master/source/resource_cookbook_file.rst
@@ -154,7 +154,7 @@ The cookbook_file resource has the following properties:
    Microsoft Windows only. The permissions for users and groups in a Microsoft Windows environment. For example: ``rights <permissions>, <principal>, <options>`` where ``<permissions>`` specifies the rights granted to the principal, ``<principal>`` is the group or user name, and ``<options>`` is a Hash with one (or more) advanced rights options.
 
 ``source``
-   **Ruby Type:** String, Array | **Default Value:** ``'name'``
+   **Ruby Type:** String, Array | **Default Value:** ``The resource block's name``
 
    The name of the file in ``COOKBOOK_NAME/files/default`` or the path to a file located in ``COOKBOOK_NAME/files``. The path must include the file name and its extension. This can be used to distribute specific files depending upon the platform used - see `File Specificity <#file-specificity>`_ for more information.
 

--- a/chef_master/source/resource_cron.rst
+++ b/chef_master/source/resource_cron.rst
@@ -130,7 +130,7 @@ The cron resource has the following properties:
 ``environment``
    **Ruby Type:** Hash
 
-   A Hash of environment variables in the form of ``({"ENV_VARIABLE" => "VALUE"})``. (These variables must exist for a command to be run successfully.)
+   A Hash of environment variables in the form of ``({'ENV_VARIABLE' => 'VALUE'})``. (These variables must exist for a command to be run successfully.)
 
 ``home``
    **Ruby Type:** String
@@ -175,7 +175,7 @@ The cron resource has the following properties:
 ``user``
    **Ruby Type:** String | **Default Value:** ``"root"``
 
-   This attribute is not applicable on the AIX platform. The name of the user that runs the command. If the ``user`` property is changed, the original ``user`` for the crontab program continues to run until that crontab program is deleted.
+   The name of the user that runs the command. If the user property is changed, the original user for the crontab program continues to run until that crontab program is deleted. This property is not applicable on the AIX platform.
 
 ``weekday``
    **Ruby Type:** String | **Default Value:** ``*``

--- a/chef_master/source/resource_cron_access.rst
+++ b/chef_master/source/resource_cron_access.rst
@@ -49,7 +49,7 @@ Properties
 The cron_access resource has the following properties:
 
 ``user``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The user to allow or deny. If not provided we'll use the resource name.
    

--- a/chef_master/source/resource_cron_d.rst
+++ b/chef_master/source/resource_cron_d.rst
@@ -128,7 +128,7 @@ The cron_d resource has the following properties:
    **Ruby Type:** String
 
 ``cron_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property to set the cron name if it differs from the resource block's name.
 

--- a/chef_master/source/resource_directory.rst
+++ b/chef_master/source/resource_directory.rst
@@ -99,7 +99,7 @@ The directory resource has the following properties:
    A string or ID that identifies the group owner by user name, including fully qualified user names such as ``domain\user`` or ``user@domain``. If this value is not specified, existing owners remain unchanged and new owner assignments use the current user (when necessary).
 
 ``path``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The path to the directory. Using a fully qualified path is recommended, but is not always required. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 

--- a/chef_master/source/resource_dmg_package.rst
+++ b/chef_master/source/resource_dmg_package.rst
@@ -69,7 +69,7 @@ The dmg_package resource has the following properties:
    Allow installation of packages that do not have trusted certificates.
 
 ``app``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the application as it appears in the ``/Volumes`` directory, if it differs from the resource block name.
 

--- a/chef_master/source/resource_git.rst
+++ b/chef_master/source/resource_git.rst
@@ -92,7 +92,7 @@ The git resource has the following properties:
    The number of past revisions to be included in the git shallow clone. The default behavior will do a full clone.
 
 ``destination``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The location path to which the source is to be cloned, checked out, or exported. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 

--- a/chef_master/source/resource_group.rst
+++ b/chef_master/source/resource_group.rst
@@ -78,7 +78,7 @@ The group resource has the following properties:
    The identifier for the group.
 
 ``group_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the group. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 

--- a/chef_master/source/resource_homebrew_cask.rst
+++ b/chef_master/source/resource_homebrew_cask.rst
@@ -53,7 +53,7 @@ Properties
 The homebrew_cask resource has the following properties:
 
 ``cask_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property to set the cask name if it differs from the resource block's name.
 

--- a/chef_master/source/resource_homebrew_tap.rst
+++ b/chef_master/source/resource_homebrew_tap.rst
@@ -68,7 +68,7 @@ The homebrew_tap resource has the following properties:
    The owner of the Homebrew installation.
 
 ``tap_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property to set the tap name if it differs from the resource block's name.
 

--- a/chef_master/source/resource_hostname.rst
+++ b/chef_master/source/resource_hostname.rst
@@ -60,7 +60,7 @@ The hostname resource has the following properties:
    Determines whether or not the resource should be run at compile time.
 
 ``hostname``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property to set the hostnam if it differs from the resource block's name.
 

--- a/chef_master/source/resource_ifconfig.rst
+++ b/chef_master/source/resource_ifconfig.rst
@@ -180,7 +180,7 @@ The ifconfig resource has the following properties:
    *New in Chef Client 13.4.*
 
 ``target``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The IP address that is to be assigned to the network interface. If not specified we'll use the resource's name.
 

--- a/chef_master/source/resource_kernel_module.rst
+++ b/chef_master/source/resource_kernel_module.rst
@@ -65,7 +65,7 @@ The kernel_module resource has the following properties:
    The directory to load modules from.
 
 ``modname``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property to set the kernel module name if it differs from the resource block's name.
 

--- a/chef_master/source/resource_link.rst
+++ b/chef_master/source/resource_link.rst
@@ -103,7 +103,7 @@ The link resource has the following properties:
    The owner associated with a symbolic link.
 
 ``target_file``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property to set the target file if it differs from the resource block's name.
 

--- a/chef_master/source/resource_log.rst
+++ b/chef_master/source/resource_log.rst
@@ -73,7 +73,7 @@ The log resource has the following properties:
    The logging level for displaying this message.. Options (in order of priority): ``:debug``, ``:info``, ``:warn``, ``:error``, and ``:fatal``.
 
 ``message``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The message to be added to a log file. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 

--- a/chef_master/source/resource_mdadm.rst
+++ b/chef_master/source/resource_mdadm.rst
@@ -87,7 +87,7 @@ The mdadm resource has the following properties:
 
 
 ``raid_device``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    Optional property to specify the name of the RAID device if it differs from the resource block's name.
 

--- a/chef_master/source/resource_mount.rst
+++ b/chef_master/source/resource_mount.rst
@@ -110,7 +110,7 @@ The mount resource has the following properties:
    The file system type (fstype) of the device.
 
 ``mount_point``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The directory (or path) in which the device is to be mounted. Defaults to the name of the resource block if not provided.
 

--- a/chef_master/source/resource_ohai_hint.rst
+++ b/chef_master/source/resource_ohai_hint.rst
@@ -57,7 +57,7 @@ The ohai_hint resource has the following properties:
    Values to include in the hint file.
 
 ``hint_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property to set the hint name if it differs from the resource block's name.
 

--- a/chef_master/source/resource_openssl_dhparam.rst
+++ b/chef_master/source/resource_openssl_dhparam.rst
@@ -77,7 +77,7 @@ The openssl_dhparam resource has the following properties:
    The owner applied to all files created by the resource.
 
 ``path``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The path to write the file to if it's different than the resource name.
 

--- a/chef_master/source/resource_openssl_ec_private_key.rst
+++ b/chef_master/source/resource_openssl_ec_private_key.rst
@@ -89,7 +89,7 @@ The openssl_ec_private_key resource has the following properties:
    The owner applied to all files created by the resource.
 
 ``path``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The path to write the file to it's different than the resource name.
 

--- a/chef_master/source/resource_openssl_ec_public_key.rst
+++ b/chef_master/source/resource_openssl_ec_public_key.rst
@@ -67,7 +67,7 @@ The openssl_ec_public_key resource has the following properties:
    The owner applied to all files created by the resource.
 
 ``path``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The path of the public key file, if it differs from the resource name.
 

--- a/chef_master/source/resource_openssl_rsa_private_key.rst
+++ b/chef_master/source/resource_openssl_rsa_private_key.rst
@@ -90,7 +90,7 @@ The openssl_rsa_private_key resource has the following properties:
    The owner applied to all files created by the resource.
 
 ``path``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The path where the private key file will be created, if it differs from the resource name.
 

--- a/chef_master/source/resource_openssl_rsa_public_key.rst
+++ b/chef_master/source/resource_openssl_rsa_public_key.rst
@@ -67,7 +67,7 @@ The openssl_rsa_public_key resource has the following properties:
    The owner applied to all files created by the resource.
 
 ``path``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property for specifying the path to the public key if it differs from the resource block's name.
 

--- a/chef_master/source/resource_openssl_x509_certificate.rst
+++ b/chef_master/source/resource_openssl_x509_certificate.rst
@@ -168,7 +168,7 @@ The openssl_x509_certificate resource has the following properties:
    The owner applied to all files created by the resource.
 
 ``path``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The path to write the file to, if it differs from the resource name.
 

--- a/chef_master/source/resource_openssl_x509_crl.rst
+++ b/chef_master/source/resource_openssl_x509_crl.rst
@@ -88,7 +88,7 @@ Properties
    The owner permission for the CRL file.
 
 ``path``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property for specifying the path to write the file to if it differs from the resource block's name.
 

--- a/chef_master/source/resource_openssl_x509_request.rst
+++ b/chef_master/source/resource_openssl_x509_request.rst
@@ -131,7 +131,7 @@ The openssl_x509_request resource has the following properties:
    The owner applied to all files created by the resource.
 
 ``path``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property for specifying the path to write the file to if it differs from the resource block's name.
 

--- a/chef_master/source/resource_osx_profile.rst
+++ b/chef_master/source/resource_osx_profile.rst
@@ -74,7 +74,7 @@ The osx_profile resource has the following properties:
    Use to specify a profile. This may be the name of a profile contained in a cookbook or a Hash that contains the contents of the profile.
 
 ``profile_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    Use to specify the name of the profile, if different from the name of the resource block.
 

--- a/chef_master/source/resource_powershell_package_source.rst
+++ b/chef_master/source/resource_powershell_package_source.rst
@@ -75,7 +75,7 @@ The powershell_package_source resource has the following properties:
    The url where scripts are located for this source. Only valid if the provider is 'PowerShellGet'.
 
 ``source_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the package source.
 

--- a/chef_master/source/resource_registry_key.rst
+++ b/chef_master/source/resource_registry_key.rst
@@ -376,7 +376,7 @@ The registry_key resource has the following properties:
              .. end_tag
 
 ``key``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The path to the location in which a registry key is to be created or from which a registry key is to be deleted. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
    The path must include the registry hive, which can be specified either as its full name or as the 3- or 4-letter abbreviation. For example, both ``HKLM\SECURITY`` and ``HKEY_LOCAL_MACHINE\SECURITY`` are both valid and equivalent. The following hives are valid: ``HKEY_LOCAL_MACHINE``, ``HKLM``, ``HKEY_CURRENT_CONFIG``, ``HKCC``, ``HKEY_CLASSES_ROOT``, ``HKCR``, ``HKEY_USERS``, ``HKU``, ``HKEY_CURRENT_USER``, and ``HKCU``.

--- a/chef_master/source/resource_rhsm_errata.rst
+++ b/chef_master/source/resource_rhsm_errata.rst
@@ -43,7 +43,7 @@ The rhsm_errata resource has the following actions:
 Properties
 =====================================================
 ``errata_id``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    Specify the Errata ID if it differs from the resource name.
 

--- a/chef_master/source/resource_rhsm_errata_level.rst
+++ b/chef_master/source/resource_rhsm_errata_level.rst
@@ -48,7 +48,7 @@ Properties
 The rhsm_errata_level resource has the following properties:
 
 ``errata_level``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The errata level of packages to install, if it differs from the resource block's name.
 

--- a/chef_master/source/resource_rhsm_repo.rst
+++ b/chef_master/source/resource_rhsm_repo.rst
@@ -49,7 +49,7 @@ Properties
 The rhsm_repo resource has the following properties:
 
 ``repo_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property for specifying the repository name if it differs from the resource block's name.
 

--- a/chef_master/source/resource_rhsm_subscription.rst
+++ b/chef_master/source/resource_rhsm_subscription.rst
@@ -49,7 +49,7 @@ Properties
 The rhsm_subscription resource has the following properties:
 
 ``pool_id``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property for specifying the Pool ID if it differs from the resource block's name.
 

--- a/chef_master/source/resource_route.rst
+++ b/chef_master/source/resource_route.rst
@@ -97,7 +97,7 @@ The route resource has the following properties:
    **Ruby Type:** Symbol, String | **Default Value:** ``:host``
 
 ``target``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The IP address of the target route.
 

--- a/chef_master/source/resource_ruby_block.rst
+++ b/chef_master/source/resource_ruby_block.rst
@@ -69,7 +69,7 @@ The ruby_block resource has the following properties:
    A block of Ruby code.
 
 ``block_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the Ruby block. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 

--- a/chef_master/source/resource_service.rst
+++ b/chef_master/source/resource_service.rst
@@ -81,6 +81,7 @@ The service resource has the following actions:
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
+   
 Properties
 =====================================================
 

--- a/chef_master/source/resource_service.rst
+++ b/chef_master/source/resource_service.rst
@@ -21,28 +21,31 @@ The full syntax for all of the properties that are available to the **service** 
 
 .. code-block:: ruby
 
-   service 'name' do
-     init_command               String
-     options                    Array, String
-     pattern                    String
-     priority                   Integer, String, Hash
-     reload_command             String
-     restart_command            String
-     service_name               String # defaults to 'name' if not specified
-     start_command              String
-     status_command             String
-     stop_command               String
-     supports                   Hash
-     timeout                    Integer # Microsoft Windows only
-     action                     Symbol # defaults to :nothing if not specified
-   end
+  service 'name' do
+    init_command         String
+    options              Array, String
+    parameters           Hash
+    pattern              String
+    priority             Integer, String, Hash
+    reload_command       String, false
+    restart_command      String, false
+    run_levels           Array
+    service_name         String # default value: 'name' unless specified
+    start_command        String, false
+    status_command       String, false
+    stop_command         String, false
+    supports             Hash # default value: {"restart"=>nil, "reload"=>nil, "status"=>nil}
+    timeout              Integer
+    user                 String
+    action               Symbol # defaults to :nothing if not specified
+  end
 
-where
+where:
 
-* ``service`` is the resource
-* ``name`` is the name of the resource block; when the ``path`` property is not specified, ``name`` is also the path to the directory, from the root
-* ``action`` identifies the steps the chef-client will take to bring the node into the desired state
-* ``init_command``, ``options``, ``pattern``, ``priority``, ``reload_command``, ``restart_command``, ``service_name``, ``start_command``, ``status_command``, ``stop_command``, ``supports``, and ``timeout`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
+* ``service`` is the resource.
+* ``name`` is the name given to the resource block.
+* ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
+* ``init_command``, ``options``, ``parameters``, ``pattern``, ``priority``, ``reload_command``, ``restart_command``, ``run_levels``, ``service_name``, ``start_command``, ``status_command``, ``stop_command``, ``supports``, ``timeout``, and ``user`` are the properties available to this resource.
 
 Actions
 =====================================================
@@ -72,6 +75,12 @@ The service resource has the following actions:
 
 .. note:: To manage a Microsoft Windows service with a ``Manual`` startup type, the **windows_service** resource must be used.
 
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
+
+   .. end_tag
 Properties
 =====================================================
 
@@ -87,8 +96,13 @@ The service resource has the following properties:
 
    Solaris platform only. Options to pass to the service command. See the ``svcadm`` manual for details of possible options.
 
+``parameters``
+   **Ruby Type:** Hash
+
+   Upstart only: A hash of parameters to pass to the service command for use in the service definition.
+
 ``pattern``
-   **Ruby Type:** String | **Default Value:** ``service_name``
+   **Ruby Type:** String | **Default Value:** ``The value provided to 'service_name' or the resource block's name``
 
    The pattern to look for in the process table.
 
@@ -98,19 +112,24 @@ The service resource has the following properties:
    Debian platform only. The relative priority of the program for start and shutdown ordering. May be an integer or a Hash. An integer is used to define the start run levels; stop run levels are then 100-integer. A Hash is used to define values for specific run levels. For example, ``{ 2 => [:start, 20], 3 => [:stop, 55] }`` will set a priority of twenty for run level two and a priority of fifty-five for run level three.
 
 ``reload_command``
-   **Ruby Type:** String
+   **Ruby Type:** String, false
 
    The command used to tell a service to reload its configuration.
 
 ``restart_command``
-   **Ruby Type:** String
+   **Ruby Type:** String, false
 
    The command used to restart a service.
+
+``run_levels``
+   **Ruby Type:** Array
+
+   RHEL platforms only: Specific run_levels the service will run under.
 
 ``service_name``
    **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
-   The name of the service. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
+   An optional property to set the service name if it differs from the resource block's name.
 
 ``start_command``
    **Ruby Type:** String
@@ -136,6 +155,13 @@ The service resource has the following properties:
    **Ruby Type:** Integer | **Default Value:** ``60``
 
    Microsoft Windows platform only. The amount of time (in seconds) to wait before timing out.
+
+``user``
+   **Ruby Type:** String
+
+   systemd only: A username to run the service under.
+
+   *New in Chef Client 12.21.*
 
 Common Resource Functionality
 =====================================================

--- a/chef_master/source/resource_service.rst
+++ b/chef_master/source/resource_service.rst
@@ -108,7 +108,7 @@ The service resource has the following properties:
    The command used to restart a service.
 
 ``service_name``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the service. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 

--- a/chef_master/source/resource_ssh_known_hosts_entry.rst
+++ b/chef_master/source/resource_ssh_known_hosts_entry.rst
@@ -73,7 +73,7 @@ The ssh_known_hosts_entry resource has the following properties:
    Hash the hostname and addresses in the ssh_known_hosts file for privacy.
 
 ``host``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The host to add to the known hosts file.
 

--- a/chef_master/source/resource_subversion.rst
+++ b/chef_master/source/resource_subversion.rst
@@ -72,7 +72,7 @@ Properties
 The subversion resource has the following properties:
 
 ``destination``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The location path to which the source is to be cloned, checked out, or exported. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
 

--- a/chef_master/source/resource_sudo.rst
+++ b/chef_master/source/resource_sudo.rst
@@ -98,7 +98,7 @@ The sudo resource has the following properties:
    An array of strings to remove from ``env_keep``.
 
 ``filename``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the sudoers.d file, if it differs from the name of the resource block
 

--- a/chef_master/source/resource_swap_file.rst
+++ b/chef_master/source/resource_swap_file.rst
@@ -53,7 +53,7 @@ Properties
 The swap_file resource has the following properties:
 
 ``path``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The path where the swap file will be created on the system, if it differs from the resource block name.
 

--- a/chef_master/source/resource_sysctl.rst
+++ b/chef_master/source/resource_sysctl.rst
@@ -62,7 +62,7 @@ The sysctl resource has the following properties:
    Ignore any errors when setting the value on the command line.
 
 ``key``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The kernel parameter key in dotted format, if it differs from the resource block name.
 

--- a/chef_master/source/resource_systemd_unit.rst
+++ b/chef_master/source/resource_systemd_unit.rst
@@ -123,7 +123,7 @@ The systemd_unit resource has the following properties:
    Specifies whether to trigger a daemon reload when creating or deleting a unit.
 
 ``unit_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the unit file if it differs from the resource block name.
 

--- a/chef_master/source/resource_template.rst
+++ b/chef_master/source/resource_template.rst
@@ -170,7 +170,7 @@ This resource has the following properties:
    A string or ID that identifies the group owner by user name, including fully qualified user names such as ``domain\user`` or ``user@domain``. If this value is not specified, existing owners remain unchanged and new owner assignments use the current user (when necessary).
 
 ``path``
-   **Ruby Type:** String
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The full path to the file, including the file name and its extension.
 

--- a/chef_master/source/resource_template.rst
+++ b/chef_master/source/resource_template.rst
@@ -99,15 +99,16 @@ This resource has the following actions:
 
 Properties
 =====================================================
-This resource has the following properties:
+
+The template resource has the following properties:
 
 ``atomic_update``
-   **Ruby Type:** true, false | **Default Value:** ``true``
+   **Ruby Type:** true, false
 
    Perform atomic file updates on a per-resource basis. Set to ``true`` for atomic file updates. Set to ``false`` for non-atomic file updates. This setting overrides ``file_atomic_update``, which is a global setting found in the client.rb file.
 
 ``backup``
-   **Ruby Type:** false, Integer | **Default Value:** ``5``
+   **Ruby Type:** Integer, false | **Default Value:** ``5``
 
    The number of backups to be kept in ``/var/chef/backup`` (for UNIX- and Linux-based platforms) or ``C:/chef/backup`` (for the Microsoft Windows platform). Set to ``false`` to prevent backups from being kept.
 
@@ -180,11 +181,6 @@ This resource has the following properties:
    **Ruby Type:** Integer, String
 
    Microsoft Windows only. The permissions for users and groups in a Microsoft Windows environment. For example: ``rights <permissions>, <principal>, <options>`` where ``<permissions>`` specifies the rights granted to the principal, ``<principal>`` is the group or user name, and ``<options>`` is a Hash with one (or more) advanced rights options.
-
-``sensitive``
-   **Ruby Type:** true, false | **Default Value:** ``false``
-
-   Ensure that sensitive resource data is not logged by the chef-client.
 
 ``source``
    **Ruby Type:** String, Array

--- a/chef_master/source/resource_timezone.rst
+++ b/chef_master/source/resource_timezone.rst
@@ -47,7 +47,7 @@ Properties
 The timezone resource has the following properties:
 
 ``timezone``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The timezone value to set.
 

--- a/chef_master/source/resource_windows_ad_join.rst
+++ b/chef_master/source/resource_windows_ad_join.rst
@@ -52,7 +52,7 @@ Properties
 The windows_ad_join resource has the following properties:
 
 ``domain_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The FQDN of the Active Directory domain to join.
 

--- a/chef_master/source/resource_windows_auto_run.rst
+++ b/chef_master/source/resource_windows_auto_run.rst
@@ -62,7 +62,7 @@ The windows_auto_run resource has the following properties:
    The path to the program that will run at login.
 
 ``program_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the program to run at login, if it differs from the resource block name.
 

--- a/chef_master/source/resource_windows_certificate.rst
+++ b/chef_master/source/resource_windows_certificate.rst
@@ -76,7 +76,7 @@ The windows_certificate resource has the following properties:
    An array of 'domain\account' entries to be granted read-only access to the certificate's private key. Not idempotent.
 
 ``source``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The source file (for create and acl_add), thumbprint (for delete and acl_add) or subject (for delete).
 

--- a/chef_master/source/resource_windows_env.rst
+++ b/chef_master/source/resource_windows_env.rst
@@ -70,7 +70,7 @@ The windows_env resource has the following properties:
    The delimiter that is used to separate multiple values for a single key.
 
 ``key_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the key that is to be created, deleted, or modified.
 

--- a/chef_master/source/resource_windows_feature.rst
+++ b/chef_master/source/resource_windows_feature.rst
@@ -62,7 +62,7 @@ The windows_feature resource has the following properties:
    Install all subfeatures.
 
 ``feature_name``
-   **Ruby Type:** Array, String | **Default Value:** ``'name'``
+   **Ruby Type:** Array, String | **Default Value:** ``The resource block's name``
 
    The name of the feature(s) or role(s) to install, if it differs from the resource block name. The same feature may have different names depending on the underlying installation method being used (ie DHCPServer vs DHCP; DNS-Server-Full-Role vs DNS).
 

--- a/chef_master/source/resource_windows_feature.rst
+++ b/chef_master/source/resource_windows_feature.rst
@@ -3,7 +3,7 @@ windows_feature resource
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_windows_feature.rst>`__
 
-Use the windows_feature resource to add, remove or entirely delete Windows features and roles. This resource calls the `windows_feature_dism </resource_windows_feature_dism.html>`__ or `windows_feature_powershell </resource_windows_feature_powershell.html>`__ resources depending on the specified installation method, and defaults to DISM, which is available on both Workstation and Server editions of Windows.
+Use the **windows_feature** resource to add, remove or entirely delete Windows features and roles. This resource calls the `windows_feature_dism </resource_windows_feature_dism.html>`__ or `windows_feature_powershell </resource_windows_feature_powershell.html>`__ resources depending on the specified installation method, and defaults to DISM, which is available on both Workstation and Server editions of Windows.
 
 **New in Chef Client 14.0.**
 

--- a/chef_master/source/resource_windows_feature_dism.rst
+++ b/chef_master/source/resource_windows_feature_dism.rst
@@ -53,7 +53,7 @@ The windows_feature_dism resource has the following properties:
    Install all sub-features. When set to ``true``, this is the equivalent of specifying the ``/All`` switch to ``dism.exe``.
 
 ``feature_name``
-   **Ruby Type:** Array, String | **Default Value:** ``'name'``
+   **Ruby Type:** Array, String | **Default Value:** ``The resource block's name``
 
    The name of the feature(s) or role(s) to install, if it differs from the resource name.
 

--- a/chef_master/source/resource_windows_feature_powershell.rst
+++ b/chef_master/source/resource_windows_feature_powershell.rst
@@ -61,7 +61,7 @@ The windows_feature_powershell resource has the following properties:
    Install all subfeatures. When set to ``true``, this is the equivalent of specifying the ``-InstallAllSubFeatures`` switch with ``Add-WindowsFeature``.
 
 ``feature_name``
-   **Ruby Type:** Array, String | **Default Value:** ``'name'``
+   **Ruby Type:** Array, String | **Default Value:** ``The resource block's name``
 
    The name of the feature(s) or role(s) to install, if it differs from the resource block name.
 

--- a/chef_master/source/resource_windows_firewall_rule.rst
+++ b/chef_master/source/resource_windows_firewall_rule.rst
@@ -122,7 +122,7 @@ The windows_firewall_rule resource has the following properties:
    The remote port the firewall rule applies to.
 
 ``rule_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name to assign to the firewall rule.
 

--- a/chef_master/source/resource_windows_font.rst
+++ b/chef_master/source/resource_windows_font.rst
@@ -44,7 +44,7 @@ Properties
 The windows_font resource has the following properties:
 
 ``font_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the font file to install, if it differs from the resource name.
 

--- a/chef_master/source/resource_windows_pagefile.rst
+++ b/chef_master/source/resource_windows_pagefile.rst
@@ -68,7 +68,7 @@ The windows_pagefile resource has the following properties:
    Maximum size of the pagefile in megabytes.
 
 ``path``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The path to the pagefile if different from the resource name.
 

--- a/chef_master/source/resource_windows_path.rst
+++ b/chef_master/source/resource_windows_path.rst
@@ -42,7 +42,7 @@ Properties
 The windows_path resource has the following properties:
 
 ``path``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the value to add to the system path
 

--- a/chef_master/source/resource_windows_printer.rst
+++ b/chef_master/source/resource_windows_printer.rst
@@ -66,7 +66,7 @@ The windows_printer resource has the following properties:
    Determines whether or not this should be the system's default printer.
 
 ``device_id``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    Printer queue name, such as: ``"HP LJ 5200 in fifth floor copy room"``.
 

--- a/chef_master/source/resource_windows_printer_port.rst
+++ b/chef_master/source/resource_windows_printer_port.rst
@@ -54,7 +54,7 @@ Properties
 The windows_printer_port resource has the following properties:
 
 ``ipv4_address``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property for the IPv4 address of the printer if it differs from the resource block's name.
 

--- a/chef_master/source/resource_windows_service.rst
+++ b/chef_master/source/resource_windows_service.rst
@@ -109,6 +109,7 @@ The windows_service resource has the following actions:
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
+   
 .. end_tag
 
 Properties

--- a/chef_master/source/resource_windows_service.rst
+++ b/chef_master/source/resource_windows_service.rst
@@ -37,13 +37,13 @@ The full syntax for all of the properties that are available to the **windows_se
     restart_command       String, false
     run_as_password       String
     run_as_user           String # default value: "LocalSystem"
-    service_name          String # default value: "name" unless specified
+    service_name          String # default value: 'name' unless specified
     service_type          Integer # default value: "SERVICE_WIN32_OWN_PROCESS"
-    start_command         String, NilClass, false
+    start_command         String, false
     startup_type          Symbol # default value: :automatic
-    status_command        String, NilClass, false
-    stop_command          String, NilClass, false
-    supports              Hash
+    status_command        String, false
+    stop_command          String, false
+    supports              Hash # default value: {"restart"=>nil, "reload"=>nil, "status"=>nil}
     timeout               Integer
     action                Symbol # defaults to :nothing if not specified
   end

--- a/chef_master/source/resource_windows_service.rst
+++ b/chef_master/source/resource_windows_service.rst
@@ -22,31 +22,31 @@ The full syntax for all of the properties that are available to the **windows_se
 
 .. code-block:: ruby
 
-   windows_service 'name' do
-     binary_path_name           String
-     delayed_start              [Integer] # This only applies if startup_type is :automatic
-     dependencies               [String, Array]
-     description                String
-     desired_access             Integer # defaults to 983551
-     display_name               String
-     error_control              Integer
-     init_command               String
-     load_order_group           String
-     pattern                    String
-     reload_command             String # not used on the Windows platform
-     restart_command            String
-     run_as_password            String
-     run_as_user                String
-     service_name               String # defaults to 'name' if not specified
-     service_type               Integer # defaults to 'SERVICE_WIN32_OWN_PROCESS'
-     start_command              String
-     startup_type               Symbol
-     status_command             String
-     stop_command               String
-     supports                   Hash
-     timeout                    Integer
-     action                     Symbol # defaults to :nothing if not specified
-   end
+  windows_service 'name' do
+    binary_path_name      String
+    delayed_start         true, false # default value: false
+    dependencies          String, Array
+    description           String
+    desired_access        Integer # default value: 983551
+    display_name          String
+    error_control         Integer # default value: 1
+    init_command          String
+    load_order_group      String
+    pattern               String
+    reload_command        String, false
+    restart_command       String, false
+    run_as_password       String
+    run_as_user           String # default value: "LocalSystem"
+    service_name          String # default value: "name" unless specified
+    service_type          Integer # default value: "SERVICE_WIN32_OWN_PROCESS"
+    start_command         String, NilClass, false
+    startup_type          Symbol # default value: :automatic
+    status_command        String, NilClass, false
+    stop_command          String, NilClass, false
+    supports              Hash
+    timeout               Integer
+    action                Symbol # defaults to :nothing if not specified
+  end
 
 where:
 
@@ -102,7 +102,13 @@ The windows_service resource has the following actions:
 ``:stop``
    Stop a service.
 
-.. end_tag
+
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
+
+   .. end_tag
 
 Properties
 =====================================================
@@ -166,12 +172,12 @@ The windows_service resource has the following properties:
    The pattern to look for in the process table.
 
 ``reload_command``
-   **Ruby Type:** String
+   **Ruby Type:** String, false
 
    The command used to tell a service to reload its configuration.
 
 ``restart_command``
-   **Ruby Type:** String
+   **Ruby Type:** String, false
 
    The command used to restart a service.
 
@@ -186,7 +192,7 @@ The windows_service resource has the following properties:
    The user under which a Microsoft Windows service runs.
 
 ``service_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the service. Default value: the ``name`` of the resource block. See the "Syntax" section above for more information.
 
@@ -201,12 +207,12 @@ The windows_service resource has the following properties:
    Use to specify the startup type for a Microsoft Windows service. Possible values: ``:automatic``, ``:disabled``, or ``:manual``.
 
 ``status_command``
-   **Ruby Type:** String
+   **Ruby Type:** String, false
 
    The command used to check the run status for a service.
 
 ``stop_command``
-   **Ruby Type:** String
+   **Ruby Type:** String, false
 
    The command used to stop a service.
 

--- a/chef_master/source/resource_windows_service.rst
+++ b/chef_master/source/resource_windows_service.rst
@@ -102,7 +102,6 @@ The windows_service resource has the following actions:
 ``:stop``
    Stop a service.
 
-
 ``:nothing``
    .. tag resources_common_actions_nothing
 

--- a/chef_master/source/resource_windows_service.rst
+++ b/chef_master/source/resource_windows_service.rst
@@ -109,6 +109,7 @@ The windows_service resource has the following actions:
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
    .. end_tag
+.. end_tag
 
 Properties
 =====================================================

--- a/chef_master/source/resource_windows_share.rst
+++ b/chef_master/source/resource_windows_share.rst
@@ -110,7 +110,7 @@ The windows_share resource has the following properties:
    The scope name of the share.
 
 ``share_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name to assign to the share.
 

--- a/chef_master/source/resource_windows_shortcut.rst
+++ b/chef_master/source/resource_windows_shortcut.rst
@@ -71,7 +71,7 @@ The windows_shortcut resource has the following properties:
    Icon to use for the shortcut. Accepts the format of ``'path, index'``, where index is the icon file to use. See Microsoft's `documentation <https://msdn.microsoft.com/en-us/library/3s9bx7at.aspx>`__ for details.
 
 ``shortcut_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name for the shortcut, if it differs from the resource name.
 

--- a/chef_master/source/resource_windows_task.rst
+++ b/chef_master/source/resource_windows_task.rst
@@ -207,7 +207,7 @@ The windows_task resource has the following properties:
    *New in Chef Client 14.4.*
 
 ``task_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The task name, such as ``"Task Name"`` or ``"/Task Name"``
 

--- a/chef_master/source/resource_windows_workgroup.rst
+++ b/chef_master/source/resource_windows_workgroup.rst
@@ -65,7 +65,7 @@ The windows_workgroup resource has the following properties:
    The local administrator user to use to change the workgroup.
 
 ``workgroup_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the workgroup for the computer.
 

--- a/chef_master/source/resource_yum_repository.rst
+++ b/chef_master/source/resource_yum_repository.rst
@@ -261,7 +261,7 @@ The yum_repository resource has the following properties:
    Determines whether to report the instance ID when using Amazon Linux AMIs and repositories.
 
 ``repositoryid``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    Specifies a unique name for each repository, one word. Defaults to name attribute.
 

--- a/chef_master/source/resource_zypper_repository.rst
+++ b/chef_master/source/resource_zypper_repository.rst
@@ -133,7 +133,7 @@ The zypper_repository resource has the following properties:
    Determines whether or not the package cache should be refreshed.
 
 ``repo_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    Specifies the repository name, if it differs from the resource name.
 

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -1434,7 +1434,7 @@ The windows_env resource has the following properties:
    The delimiter that is used to separate multiple values for a single key.
 
 ``key_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the key that is to be created, deleted, or modified.
 
@@ -2107,7 +2107,7 @@ The registry_key resource has the following properties:
              .. end_tag
 
 ``key``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The path to the location in which a registry key is to be created or from which a registry key is to be deleted. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
    The path must include the registry hive, which can be specified either as its full name or as the 3- or 4-letter abbreviation. For example, both ``HKLM\SECURITY`` and ``HKEY_LOCAL_MACHINE\SECURITY`` are both valid and equivalent. The following hives are valid: ``HKEY_LOCAL_MACHINE``, ``HKLM``, ``HKEY_CURRENT_CONFIG``, ``HKCC``, ``HKEY_CLASSES_ROOT``, ``HKCR``, ``HKEY_USERS``, ``HKU``, ``HKEY_CURRENT_USER``, and ``HKCU``.
@@ -2661,7 +2661,7 @@ The windows_service resource has the following properties:
    The user under which a Microsoft Windows service runs.
 
 ``service_name``
-   **Ruby Type:** String | **Default Value:** ``'name'``
+   **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The name of the service. Default value: the ``name`` of the resource block. See the "Syntax" section above for more information.
 

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -2497,31 +2497,31 @@ The full syntax for all of the properties that are available to the **windows_se
 
 .. code-block:: ruby
 
-   windows_service 'name' do
-     binary_path_name           String
-     delayed_start              [Integer] # This only applies if startup_type is :automatic
-     dependencies               [String, Array]
-     description                String
-     desired_access             Integer # defaults to 983551
-     display_name               String
-     error_control              Integer
-     init_command               String
-     load_order_group           String
-     pattern                    String
-     reload_command             String # not used on the Windows platform
-     restart_command            String
-     run_as_password            String
-     run_as_user                String
-     service_name               String # defaults to 'name' if not specified
-     service_type               Integer # defaults to 'SERVICE_WIN32_OWN_PROCESS'
-     start_command              String
-     startup_type               Symbol
-     status_command             String
-     stop_command               String
-     supports                   Hash
-     timeout                    Integer
-     action                     Symbol # defaults to :nothing if not specified
-   end
+  windows_service 'name' do
+    binary_path_name      String
+    delayed_start         true, false # default value: false
+    dependencies          String, Array
+    description           String
+    desired_access        Integer # default value: 983551
+    display_name          String
+    error_control         Integer # default value: 1
+    init_command          String
+    load_order_group      String
+    pattern               String
+    reload_command        String, false
+    restart_command       String, false
+    run_as_password       String
+    run_as_user           String # default value: "LocalSystem"
+    service_name          String # default value: 'name' unless specified
+    service_type          Integer # default value: "SERVICE_WIN32_OWN_PROCESS"
+    start_command         String, false
+    startup_type          Symbol # default value: :automatic
+    status_command        String, false
+    stop_command          String, false
+    supports              Hash # default value: {"restart"=>nil, "reload"=>nil, "status"=>nil}
+    timeout               Integer
+    action                Symbol # defaults to :nothing if not specified
+  end
 
 where:
 
@@ -2576,6 +2576,13 @@ The windows_service resource has the following actions:
 
 ``:stop``
    Stop a service.
+
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
+
+   .. end_tag
 
 .. end_tag
 
@@ -2641,12 +2648,12 @@ The windows_service resource has the following properties:
    The pattern to look for in the process table.
 
 ``reload_command``
-   **Ruby Type:** String
+   **Ruby Type:** String, false
 
    The command used to tell a service to reload its configuration.
 
 ``restart_command``
-   **Ruby Type:** String
+   **Ruby Type:** String, false
 
    The command used to restart a service.
 
@@ -2676,12 +2683,12 @@ The windows_service resource has the following properties:
    Use to specify the startup type for a Microsoft Windows service. Possible values: ``:automatic``, ``:disabled``, or ``:manual``.
 
 ``status_command``
-   **Ruby Type:** String
+   **Ruby Type:** String, false
 
    The command used to check the run status for a service.
 
 ``stop_command``
-   **Ruby Type:** String
+   **Ruby Type:** String, false
 
    The command used to stop a service.
 


### PR DESCRIPTION
Most of this is the windows_service and service resource which received some cleanup in the chef-client codebase. There's other fixes though including better wording for the default value of a name_property type property.