### PR TITLE
Update client perms script for modern Chef Clients

### DIFF
--- a/chef_master/source/auth.rst
+++ b/chef_master/source/auth.rst
@@ -507,7 +507,6 @@ Use the following code to set the correct permissions:
    require 'chef/knife'
 
    #previously knife.rb
-   
    Chef::Config.from_file(File.join(Chef::Knife.chef_config_dir, 'knife.rb'))
 
    rest = Chef::ServerAPI.new(Chef::Config[:chef_server_url])

--- a/chef_master/source/auth.rst
+++ b/chef_master/source/auth.rst
@@ -505,11 +505,12 @@ Use the following code to set the correct permissions:
 
    #!/usr/bin/env ruby
    require 'chef/knife'
-   require 'chef/rest'
 
-   Chef::Config.from_file(File.join(Chef::Knife.chef_config_dir, 'config.rb'))
+   #previously knife.rb
+   
+   Chef::Config.from_file(File.join(Chef::Knife.chef_config_dir, 'knife.rb'))
 
-   rest = Chef::REST.new(Chef::Config[:chef_server_url])
+   rest = Chef::ServerAPI.new(Chef::Config[:chef_server_url])
 
    Chef::Node.list.each do |node|
      %w{read update delete grant}.each do |perm|

--- a/chef_master/source/server_orgs.rst
+++ b/chef_master/source/server_orgs.rst
@@ -162,11 +162,11 @@ Use the following code to set the correct permissions:
 
    #!/usr/bin/env ruby
    require 'chef/knife'
-   require 'chef/rest'
 
-   Chef::Config.from_file(File.join(Chef::Knife.chef_config_dir, 'config.rb'))
+   #previously knife.rb
+   Chef::Config.from_file(File.join(Chef::Knife.chef_config_dir, 'knife.rb'))
 
-   rest = Chef::REST.new(Chef::Config[:chef_server_url])
+   rest = Chef::ServerAPI.new(Chef::Config[:chef_server_url])
 
    Chef::Node.list.each do |node|
      %w{read update delete grant}.each do |perm|


### PR DESCRIPTION
Modern Chef Clients, 13.x and 14.x, offer the Chef::ServerAPI for working directly with Chef Servers, rather than the earlier stuff found in chef/rest.

Make it obvious that config.rb is not in wide use so that the customer know what to do if the script fails the first time.