### PR TITLE
Clarify backend cluster member count

### DIFF
--- a/chef_master/source/install_server_ha.rst
+++ b/chef_master/source/install_server_ha.rst
@@ -71,7 +71,7 @@ Recommended Cluster Topology
 
 Nodes
 ----------------------------------------------------------------
-* Three backend cluster nodes
+* Three backend cluster nodes are required. Less and more than this number is neither tested nor supported by Chef
 * One or more frontend group nodes
 
 Hardware Requirements

--- a/chef_master/source/install_server_ha.rst
+++ b/chef_master/source/install_server_ha.rst
@@ -71,7 +71,7 @@ Recommended Cluster Topology
 
 Nodes
 ----------------------------------------------------------------
-* Three backend cluster nodes are required. Less and more than this number is neither tested nor supported by Chef
+* The HA backend installation requires three cluster nodes. Chef has not tested and does not support installations with other numbers of backend cluster nodes.
 * One or more frontend group nodes
 
 Hardware Requirements


### PR DESCRIPTION
The count of backend cluster members should be three and only three during normal operations.