### PR TITLE
Updates install_server and related docs

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -286,8 +286,64 @@
           },
           {
             "title": "Management Console",
-            "hasSubItems": false,
-            "url": "/manage.html"
+            "hasSubItems": true,
+            "subItems": [
+              {
+                "title": "About the Management Console",
+                "hasSubItems": false,
+                "url": "/manage.html"
+              },
+              {
+                "title": "Configure SAML",
+                "hasSubItems": false,
+                "url": "/server_configure_saml.html"
+              },
+              {
+                "title": "Clients",
+                "hasSubItems": false,
+                "url": "/server_manage_clients.html"
+              },
+              {
+                "title": "Cookbooks",
+                "hasSubItems": false,
+                "url": "/server_manage_cookbooks.html"
+              },
+              {
+                "title": "Data Bags",
+                "hasSubItems": false,
+                "url": "/server_manage_data_bags.html"
+              },
+              {
+                "title": "Environments",
+                "hasSubItems": false,
+                "url": "/server_manage_environments.html"
+              },
+              {
+                "title": "Nodes",
+                "hasSubItems": false,
+                "url": "/server_manage_nodes.html"
+              },
+              {
+                "title": "Roles",
+                "hasSubItems": false,
+                "url": "/server_manage_roles.html"
+              },
+              {
+                "title": "Users",
+                "hasSubItems": false,
+                "url": "/server_users.html#chef-manage"
+              },
+              {
+                "title": "manage.rb",
+                "hasSubItems": false,
+                "url": "/config_rb_manage.html"
+              },
+              {
+                "title": "chef-manage-ctl",
+                "hasSubItems": false,
+                "url": "/ctl_manage.html"
+              }
+            ]
           },
           {
             "title": "Push Jobs",
@@ -2003,67 +2059,6 @@
                 "title": "Upgrades",
                 "hasSubItems": false,
                 "url": "/upgrade_chef_automate.html"
-              }
-            ]
-          },
-          {
-            "title": "Management Console",
-            "hasSubItems": true,
-            "subItems": [
-              {
-                "title": "About the Management Console",
-                "hasSubItems": false,
-                "url": "/manage.html"
-              },
-              {
-                "title": "Configure SAML",
-                "hasSubItems": false,
-                "url": "/server_configure_saml.html"
-              },
-              {
-                "title": "Clients",
-                "hasSubItems": false,
-                "url": "/server_manage_clients.html"
-              },
-              {
-                "title": "Cookbooks",
-                "hasSubItems": false,
-                "url": "/server_manage_cookbooks.html"
-              },
-              {
-                "title": "Data Bags",
-                "hasSubItems": false,
-                "url": "/server_manage_data_bags.html"
-              },
-              {
-                "title": "Environments",
-                "hasSubItems": false,
-                "url": "/server_manage_environments.html"
-              },
-              {
-                "title": "Nodes",
-                "hasSubItems": false,
-                "url": "/server_manage_nodes.html"
-              },
-              {
-                "title": "Roles",
-                "hasSubItems": false,
-                "url": "/server_manage_roles.html"
-              },
-              {
-                "title": "Users",
-                "hasSubItems": false,
-                "url": "/server_users.html#chef-manage"
-              },
-              {
-                "title": "manage.rb",
-                "hasSubItems": false,
-                "url": "/config_rb_manage.html"
-              },
-              {
-                "title": "chef-manage-ctl",
-                "hasSubItems": false,
-                "url": "/ctl_manage.html"
               }
             ]
           },

--- a/chef_master/source/ctl_chef_server.rst
+++ b/chef_master/source/ctl_chef_server.rst
@@ -264,67 +264,25 @@ The ``install`` subcommand downloads packages from https://packages.chef.io/ by 
 
        .. code-block:: bash
 
-          $ chef-server-ctl install chef-manage
+          $ sudo chef-server-ctl install chef-manage
 
        then:
 
        .. code-block:: bash
 
-          $ chef-server-ctl reconfigure
+          $ sudo chef-server-ctl reconfigure
 
        and then:
 
        .. code-block:: bash
 
-          $ chef-manage-ctl reconfigure
+          $ sudo chef-manage-ctl reconfigure
 
        .. note:: .. tag chef_license_reconfigure_manage
 
                  Starting with the Chef management console 2.3.0, the `Chef MLSA </chef_license.html>`__ must be accepted when reconfiguring the product. If the Chef MLSA has not already been accepted, the reconfigure process will prompt for a ``yes`` to accept it. Or run ``chef-manage-ctl reconfigure --accept-license`` to automatically accept the license.
 
                  .. end_tag
-
-   * - Chef Push Jobs
-     - Use Chef push jobs to run jobs---an action or a command to be executed---against nodes independently of a chef-client run.
-
-       On the Chef server, run:
-
-       .. code-block:: bash
-
-          $ chef-server-ctl install opscode-push-jobs-server
-
-       then:
-
-       .. code-block:: bash
-
-          $ chef-server-ctl reconfigure
-
-       and then:
-
-       .. code-block:: bash
-
-          $ opscode-push-jobs-server-ctl reconfigure
-
-   * - Reporting
-     - Use Reporting to keep track of what happens during every chef-client runs across all of the infrastructure being managed by Chef. Run Reporting with Chef management console to view reports from a web user interface.
-
-       On the Chef server, run:
-
-       .. code-block:: bash
-
-          $ chef-server-ctl install opscode-reporting
-
-       then:
-
-       .. code-block:: bash
-
-          $ chef-server-ctl reconfigure
-
-       and then:
-
-       .. code-block:: bash
-
-          $ opscode-reporting-ctl reconfigure
 
 .. end_tag
 
@@ -336,13 +294,13 @@ The ``install`` subcommand downloads packages from https://packages.chef.io/ by 
 
 .. code-block:: bash
 
-   $ chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
+   $ sudo chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
 
 For example:
 
 .. code-block:: bash
 
-   $ chef-server-ctl install chef-manage --path /root/packages
+   $ sudo chef-server-ctl install chef-manage --path /root/packages
 
 The ``chef-server-ctl`` command will install the first ``chef-manage`` package found in the ``/root/packages`` directory.
 

--- a/chef_master/source/errors.rst
+++ b/chef_master/source/errors.rst
@@ -302,3 +302,21 @@ Work around this issue by supplying the full path to the client.rb file:
 .. code-block:: bash
 
    $ chef-client -c /etc/chef/client.rb
+
+Pivotal.rb does not exist
+-----------------------------------------------------
+If you're seeing an error like: 
+
+.. code-block:: bash
+
+   $ ERROR: CONFIGURATION ERROR:Specified config file /etc/opscode/pivotal.rb does not exist
+
+**Troubleshooting Steps**
+
+Run the following to restart all of the services:
+
+   .. code-block:: bash
+
+      $ chef-server-ctl reconfigure
+
+Because the Chef server is composed of many different services that work together to create a functioning system, this step may take a few minutes to complete.

--- a/chef_master/source/install_chef_air_gap.rst
+++ b/chef_master/source/install_chef_air_gap.rst
@@ -103,7 +103,7 @@ In this section you'll install the Chef server, and create your organization and
 
    .. code-block:: bash
 
-      $ chef-server-ctl user-create USER_NAME FIRST_NAME LAST_NAME EMAIL 'PASSWORD' --filename FILE_NAME
+      $ sudo chef-server-ctl user-create USER_NAME FIRST_NAME LAST_NAME EMAIL 'PASSWORD' --filename FILE_NAME
 
    An RSA private key is generated automatically. This is the user's private key and should be saved to a safe location. The ``--filename`` option will save the RSA private key to the specified absolute path.
 
@@ -111,7 +111,7 @@ In this section you'll install the Chef server, and create your organization and
 
    .. code-block:: bash
 
-      $ chef-server-ctl user-create stevedanno Steve Danno steved@chef.io 'abc123' --filename /path/to/stevedanno.pem
+      $ sudo chef-server-ctl user-create janedoe Jane Doe janed@example.com 'abc123' --filename /path/to/janedoe.pem
 
    .. end_tag
 
@@ -121,7 +121,13 @@ In this section you'll install the Chef server, and create your organization and
 
    .. code-block:: bash
 
-      $ chef-server-ctl org-create short_name 'full_organization_name' --association_user user_name --filename ORGANIZATION-validator.pem
+      $ sudo chef-server-ctl org-create short_name 'full_organization_name' --association_user user_name --filename ORGANIZATION-validator.pem
+
+   For example:
+
+   .. code-block:: bash
+
+      $ sudo chef-server-ctl org-create 4thcoffee 'Fourth Coffee, Inc.' --association_user janedoe --filename /path/to/4thcoffee-validator.pem
 
    The name must begin with a lower-case letter or digit, may only contain lower-case letters, digits, hyphens, and underscores, and must be between 1 and 255 characters. For example: ``4thcoffee``.
 
@@ -130,12 +136,6 @@ In this section you'll install the Chef server, and create your organization and
    The ``--association_user`` option will associate the ``user_name`` with the ``admins`` security group on the Chef server.
 
    An RSA private key is generated automatically. This is the chef-validator key and should be saved to a safe location. The ``--filename`` option will save the RSA private key to the specified absolute path.
-
-   For example:
-
-   .. code-block:: bash
-
-      $ chef-server-ctl org-create 4thcoffee 'Fourth Coffee, Inc.' --association_user stevedanno --filename /path/to/4thcoffee-validator.pem
 
    .. end_tag
 

--- a/chef_master/source/install_server.rst
+++ b/chef_master/source/install_server.rst
@@ -57,7 +57,7 @@ To install Chef server 12:
 
    .. code-block:: bash
 
-      $ chef-server-ctl reconfigure
+      $ sudo chef-server-ctl reconfigure
 
    Because the Chef server is composed of many different services that work together to create a functioning system, this step may take a few minutes to complete.
 
@@ -67,7 +67,7 @@ To install Chef server 12:
 
    .. code-block:: bash
 
-      $ chef-server-ctl user-create USER_NAME FIRST_NAME LAST_NAME EMAIL 'PASSWORD' --filename FILE_NAME
+      $ sudo chef-server-ctl user-create USER_NAME FIRST_NAME LAST_NAME EMAIL 'PASSWORD' --filename FILE_NAME
 
    An RSA private key is generated automatically. This is the user's private key and should be saved to a safe location. The ``--filename`` option will save the RSA private key to the specified absolute path.
 
@@ -75,7 +75,7 @@ To install Chef server 12:
 
    .. code-block:: bash
 
-      $ chef-server-ctl user-create stevedanno Steve Danno steved@chef.io 'abc123' --filename /path/to/stevedanno.pem
+      $ sudo chef-server-ctl user-create janedoe Jane Doe janed@example.com 'abc123' --filename /path/to/janedoe.pem
 
    .. end_tag
 
@@ -85,7 +85,13 @@ To install Chef server 12:
 
    .. code-block:: bash
 
-      $ chef-server-ctl org-create short_name 'full_organization_name' --association_user user_name --filename ORGANIZATION-validator.pem
+      $ sudo chef-server-ctl org-create short_name 'full_organization_name' --association_user user_name --filename ORGANIZATION-validator.pem
+
+   For example:
+
+   .. code-block:: bash
+
+      $ sudo chef-server-ctl org-create 4thcoffee 'Fourth Coffee, Inc.' --association_user janedoe --filename /path/to/4thcoffee-validator.pem
 
    The name must begin with a lower-case letter or digit, may only contain lower-case letters, digits, hyphens, and underscores, and must be between 1 and 255 characters. For example: ``4thcoffee``.
 
@@ -95,126 +101,12 @@ To install Chef server 12:
 
    An RSA private key is generated automatically. This is the chef-validator key and should be saved to a safe location. The ``--filename`` option will save the RSA private key to the specified absolute path.
 
-   For example:
-
-   .. code-block:: bash
-
-      $ chef-server-ctl org-create 4thcoffee 'Fourth Coffee, Inc.' --association_user stevedanno --filename /path/to/4thcoffee-validator.pem
-
    .. end_tag
 
-#. .. tag ctl_chef_server_install_features
-
-   Enable additional features of the Chef server! The packages may be downloaded directly as part of the installation process or they may be first downloaded to a local directory, and then installed.
-
-   .. end_tag
-
-   **Use Downloads**
-
-   .. tag ctl_chef_server_install_features_download
-
-   The ``install`` subcommand downloads packages from https://packages.chef.io/ by default. For systems that are not behind a firewall (and have connectivity to https://packages.chef.io/), these packages can be installed as described below.
-
-   .. list-table::
-      :widths: 100 400
-      :header-rows: 1
-
-      * - Feature
-        - Command
-      * - Chef Manage
-        - Use Chef management console to manage data bags, attributes, run-lists, roles, environments, and cookbooks from a web user interface.
-
-          On the Chef server, run:
-
-          .. code-block:: bash
-
-             $ chef-server-ctl install chef-manage
-
-          then:
-
-          .. code-block:: bash
-
-             $ chef-server-ctl reconfigure
-
-          and then:
-
-          .. code-block:: bash
-
-             $ chef-manage-ctl reconfigure
-
-          .. note:: .. tag chef_license_reconfigure_manage
-
-                    Starting with the Chef management console 2.3.0, the `Chef MLSA </chef_license.html>`__ must be accepted when reconfiguring the product. If the Chef MLSA has not already been accepted, the reconfigure process will prompt for a ``yes`` to accept it. Or run ``chef-manage-ctl reconfigure --accept-license`` to automatically accept the license.
-
-                    .. end_tag
-
-      * - Chef Push Jobs
-        - Use Chef push jobs to run jobs---an action or a command to be executed---against nodes independently of a chef-client run.
-
-          On the Chef server, run:
-
-          .. code-block:: bash
-
-             $ chef-server-ctl install opscode-push-jobs-server
-
-          then:
-
-          .. code-block:: bash
-
-             $ chef-server-ctl reconfigure
-
-          and then:
-
-          .. code-block:: bash
-
-             $ opscode-push-jobs-server-ctl reconfigure
-
-      * - Reporting
-        - Use Reporting to keep track of what happens during every chef-client runs across all of the infrastructure being managed by Chef. Run Reporting with Chef management console to view reports from a web user interface.
-
-          On the Chef server, run:
-
-          .. code-block:: bash
-
-             $ chef-server-ctl install opscode-reporting
-
-          then:
-
-          .. code-block:: bash
-
-             $ chef-server-ctl reconfigure
-
-          and then:
-
-          .. code-block:: bash
-
-             $ opscode-reporting-ctl reconfigure
-
-   .. end_tag
-
-   **Use Local Packages**
-
-   .. tag ctl_chef_server_install_features_manual
-
-   The ``install`` subcommand downloads packages from https://packages.chef.io/ by default. For systems that are behind a firewall (and may not have connectivity to packages.chef.io), these packages can be downloaded from https://downloads.chef.io/chef-manage/, and then installed manually. First download the package that is appropriate for the platform, save it to a local path, and then run the ``install`` command using the ``--path`` option to specify the directory in which the package is located:
-
-   .. code-block:: bash
-
-      $ chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
-
-   For example:
-
-   .. code-block:: bash
-
-      $ chef-server-ctl install chef-manage --path /root/packages
-
-   The ``chef-server-ctl`` command will install the first ``chef-manage`` package found in the ``/root/packages`` directory.
-
-   .. end_tag
-
-Update config for purchased nodes
+Update Configuration for Purchased Nodes
 =====================================================
-When using more than 25 nodes, a configuration change to your Chef server needs to be made in order for your Chef server to be properly configured and recognize your purchased licenses. You will need to edit your ``/etc/opscode/chef-server.rb`` file by following the process below:
+
+To use more than 25 nodes, you'll need to change Chef server configuration for the server to recognize your purchased licenses. Edit your ``/etc/opscode/chef-server.rb`` file by following the process below:
 
 #. On your Chef server, if the ``chef-server.rb`` file does not exist, create it.
 
@@ -222,19 +114,19 @@ When using more than 25 nodes, a configuration change to your Chef server needs 
 
       sudo mkdir /etc/opscode && sudo touch /etc/opscode/chef-server.rb
 
-#. Open up the newly created ``chef-server.rb`` file in your favorite text editor.
+#. Open up the newly created ``chef-server.rb`` file in your favorite text editor, for example:
 
    .. code-block:: bash
 
       sudo vi /etc/opscode/chef-server.rb
 
-#. Paste or add the following text. Please note the placement of the single quotation (') marks.
+#. Paste or add the following text. Please note the placement of the single quotation (') marks. If you're using the vi text editor, you'll need to use the `i` key to insert the text.
 
    .. code-block:: bash
 
       license['nodes'] = N where N is the number of licensed nodes you have purchased
 
-#. Save the file. Because we are using the vi editor, you can save your changes in vi with the following command:
+#. Save the file. If you're using vi, from the example above, use the `esc` key and then :
 
 .. code-block:: bash
 

--- a/chef_master/source/install_server_ha_aws.rst
+++ b/chef_master/source/install_server_ha_aws.rst
@@ -358,7 +358,7 @@ Use the following steps to set up each frontend Chef server:
 
    .. code-block:: bash
 
-      $ chef-server-ctl user-create USER_NAME FIRST_NAME LAST_NAME EMAIL 'PASSWORD' --filename FILE_NAME
+      $ sudo chef-server-ctl user-create USER_NAME FIRST_NAME LAST_NAME EMAIL 'PASSWORD' --filename FILE_NAME
 
    An RSA private key is generated automatically. This is the user's private key and should be saved to a safe location. The ``--filename`` option will save the RSA private key to the specified absolute path.
 
@@ -366,7 +366,7 @@ Use the following steps to set up each frontend Chef server:
 
    .. code-block:: bash
 
-      $ chef-server-ctl user-create stevedanno Steve Danno steved@chef.io 'abc123' --filename /path/to/stevedanno.pem
+      $ sudo chef-server-ctl user-create janedoe Jane Doe janed@example.com 'abc123' --filename /path/to/janedoe.pem
 
    .. end_tag
 
@@ -376,7 +376,13 @@ Use the following steps to set up each frontend Chef server:
 
    .. code-block:: bash
 
-      $ chef-server-ctl org-create short_name 'full_organization_name' --association_user user_name --filename ORGANIZATION-validator.pem
+      $ sudo chef-server-ctl org-create short_name 'full_organization_name' --association_user user_name --filename ORGANIZATION-validator.pem
+
+   For example:
+
+   .. code-block:: bash
+
+      $ sudo chef-server-ctl org-create 4thcoffee 'Fourth Coffee, Inc.' --association_user janedoe --filename /path/to/4thcoffee-validator.pem
 
    The name must begin with a lower-case letter or digit, may only contain lower-case letters, digits, hyphens, and underscores, and must be between 1 and 255 characters. For example: ``4thcoffee``.
 
@@ -385,12 +391,6 @@ Use the following steps to set up each frontend Chef server:
    The ``--association_user`` option will associate the ``user_name`` with the ``admins`` security group on the Chef server.
 
    An RSA private key is generated automatically. This is the chef-validator key and should be saved to a safe location. The ``--filename`` option will save the RSA private key to the specified absolute path.
-
-   For example:
-
-   .. code-block:: bash
-
-      $ chef-server-ctl org-create 4thcoffee 'Fourth Coffee, Inc.' --association_user stevedanno --filename /path/to/4thcoffee-validator.pem
 
    .. end_tag
 
@@ -460,13 +460,13 @@ The ``install`` subcommand downloads packages from https://packages.chef.io/ by 
 
 .. code-block:: bash
 
-   $ chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
+   $ sudo chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
 
 For example:
 
 .. code-block:: bash
 
-   $ chef-server-ctl install chef-manage --path /root/packages
+   $ sudo chef-server-ctl install chef-manage --path /root/packages
 
 The ``chef-server-ctl`` command will install the first ``chef-manage`` package found in the ``/root/packages`` directory.
 

--- a/chef_master/source/install_server_ha_drbd.rst
+++ b/chef_master/source/install_server_ha_drbd.rst
@@ -458,7 +458,7 @@ For each frontend server, use the following steps to set up the Chef server:
 
    .. code-block:: bash
 
-      $ chef-server-ctl user-create USER_NAME FIRST_NAME LAST_NAME EMAIL 'PASSWORD' --filename FILE_NAME
+      $ sudo chef-server-ctl user-create USER_NAME FIRST_NAME LAST_NAME EMAIL 'PASSWORD' --filename FILE_NAME
 
    An RSA private key is generated automatically. This is the user's private key and should be saved to a safe location. The ``--filename`` option will save the RSA private key to the specified absolute path.
 
@@ -466,7 +466,7 @@ For each frontend server, use the following steps to set up the Chef server:
 
    .. code-block:: bash
 
-      $ chef-server-ctl user-create stevedanno Steve Danno steved@chef.io 'abc123' --filename /path/to/stevedanno.pem
+      $ sudo chef-server-ctl user-create janedoe Jane Doe janed@example.com 'abc123' --filename /path/to/janedoe.pem
 
    .. end_tag
 
@@ -476,7 +476,13 @@ For each frontend server, use the following steps to set up the Chef server:
 
    .. code-block:: bash
 
-      $ chef-server-ctl org-create short_name 'full_organization_name' --association_user user_name --filename ORGANIZATION-validator.pem
+      $ sudo chef-server-ctl org-create short_name 'full_organization_name' --association_user user_name --filename ORGANIZATION-validator.pem
+
+   For example:
+
+   .. code-block:: bash
+
+      $ sudo chef-server-ctl org-create 4thcoffee 'Fourth Coffee, Inc.' --association_user janedoe --filename /path/to/4thcoffee-validator.pem
 
    The name must begin with a lower-case letter or digit, may only contain lower-case letters, digits, hyphens, and underscores, and must be between 1 and 255 characters. For example: ``4thcoffee``.
 
@@ -485,12 +491,6 @@ For each frontend server, use the following steps to set up the Chef server:
    The ``--association_user`` option will associate the ``user_name`` with the ``admins`` security group on the Chef server.
 
    An RSA private key is generated automatically. This is the chef-validator key and should be saved to a safe location. The ``--filename`` option will save the RSA private key to the specified absolute path.
-
-   For example:
-
-   .. code-block:: bash
-
-      $ chef-server-ctl org-create 4thcoffee 'Fourth Coffee, Inc.' --association_user stevedanno --filename /path/to/4thcoffee-validator.pem
 
    .. end_tag
 
@@ -560,13 +560,13 @@ The ``install`` subcommand downloads packages from https://packages.chef.io/ by 
 
 .. code-block:: bash
 
-   $ chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
+   $ sudo chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
 
 For example:
 
 .. code-block:: bash
 
-   $ chef-server-ctl install chef-manage --path /root/packages
+   $ sudo chef-server-ctl install chef-manage --path /root/packages
 
 The ``chef-server-ctl`` command will install the first ``chef-manage`` package found in the ``/root/packages`` directory.
 

--- a/chef_master/source/install_server_tiered.rst
+++ b/chef_master/source/install_server_tiered.rst
@@ -221,7 +221,7 @@ On a single frontend server, create an administrator and an organization:
 
    .. code-block:: bash
 
-      $ chef-server-ctl user-create USER_NAME FIRST_NAME LAST_NAME EMAIL 'PASSWORD' --filename FILE_NAME
+      $ sudo chef-server-ctl user-create USER_NAME FIRST_NAME LAST_NAME EMAIL 'PASSWORD' --filename FILE_NAME
 
    An RSA private key is generated automatically. This is the user's private key and should be saved to a safe location. The ``--filename`` option will save the RSA private key to the specified absolute path.
 
@@ -229,7 +229,7 @@ On a single frontend server, create an administrator and an organization:
 
    .. code-block:: bash
 
-      $ chef-server-ctl user-create stevedanno Steve Danno steved@chef.io 'abc123' --filename /path/to/stevedanno.pem
+      $ sudo chef-server-ctl user-create janedoe Jane Doe janed@example.com 'abc123' --filename /path/to/janedoe.pem
 
    .. end_tag
 
@@ -239,7 +239,13 @@ On a single frontend server, create an administrator and an organization:
 
    .. code-block:: bash
 
-      $ chef-server-ctl org-create short_name 'full_organization_name' --association_user user_name --filename ORGANIZATION-validator.pem
+      $ sudo chef-server-ctl org-create short_name 'full_organization_name' --association_user user_name --filename ORGANIZATION-validator.pem
+
+   For example:
+
+   .. code-block:: bash
+
+      $ sudo chef-server-ctl org-create 4thcoffee 'Fourth Coffee, Inc.' --association_user janedoe --filename /path/to/4thcoffee-validator.pem
 
    The name must begin with a lower-case letter or digit, may only contain lower-case letters, digits, hyphens, and underscores, and must be between 1 and 255 characters. For example: ``4thcoffee``.
 
@@ -248,12 +254,6 @@ On a single frontend server, create an administrator and an organization:
    The ``--association_user`` option will associate the ``user_name`` with the ``admins`` security group on the Chef server.
 
    An RSA private key is generated automatically. This is the chef-validator key and should be saved to a safe location. The ``--filename`` option will save the RSA private key to the specified absolute path.
-
-   For example:
-
-   .. code-block:: bash
-
-      $ chef-server-ctl org-create 4thcoffee 'Fourth Coffee, Inc.' --association_user stevedanno --filename /path/to/4thcoffee-validator.pem
 
    .. end_tag
 
@@ -310,13 +310,13 @@ The ``install`` subcommand downloads packages from https://packages.chef.io/ by 
 
 .. code-block:: bash
 
-   $ chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
+   $ sudo chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
 
 For example:
 
 .. code-block:: bash
 
-   $ chef-server-ctl install chef-manage --path /root/packages
+   $ sudo chef-server-ctl install chef-manage --path /root/packages
 
 The ``chef-server-ctl`` command will install the first ``chef-manage`` package found in the ``/root/packages`` directory.
 

--- a/chef_master/source/manage.rst
+++ b/chef_master/source/manage.rst
@@ -349,3 +349,64 @@ The Chef server uses role-based access control (RBAC) to restrict access to obje
 
 .. image:: ../../images/step_manage_webui_admin.png
 
+Install Chef Manage
+=====================================================
+
+   .. tag ctl_chef_server_install_features_download
+
+   The ``install`` subcommand downloads packages from https://packages.chef.io/ by default. For systems that are not behind a firewall (and have connectivity to https://packages.chef.io/), these packages can be installed as described below.  
+
+   .. list-table::
+      :widths: 100 400
+      :header-rows: 1
+
+      * - Feature
+        - Command
+      * - Chef Manage
+        - Use Chef management console to manage data bags, attributes, run-lists, roles, environments, and cookbooks from a web user interface.
+
+          On the Chef server, run:
+
+          .. code-block:: bash
+
+             $ sudo chef-server-ctl install chef-manage
+
+          then:
+
+          .. code-block:: bash
+
+             $ sudo chef-server-ctl reconfigure
+
+          and then:
+
+          .. code-block:: bash
+
+             $ sudo chef-manage-ctl reconfigure
+
+          .. note:: .. tag chef_license_reconfigure_manage
+
+                    Starting with the Chef management console 2.3.0, the `Chef MLSA </chef_license.html>`__ must be accepted when reconfiguring the product. If the Chef MLSA has not already been accepted, the reconfigure process will prompt for a ``yes`` to accept it. Or run ``chef-manage-ctl reconfigure --accept-license`` to automatically accept the license.
+
+                    .. end_tag
+
+   .. end_tag
+
+Chef Manage Local Installation
+---------------------------------------------
+   .. tag ctl_chef_server_install_features_manual
+
+   The ``install`` subcommand downloads packages from https://packages.chef.io/ by default. For systems that are behind a firewall (and may not have connectivity to packages.chef.io), these packages can be downloaded from https://downloads.chef.io/chef-manage/, and then installed manually. First download the package that is appropriate for the platform, save it to a local path, and then run the ``install`` command using the ``--path`` option to specify the directory in which the package is located:
+
+   .. code-block:: bash
+
+      $ sudo chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
+
+   For example:
+
+   .. code-block:: bash
+
+      $ sudo chef-server-ctl install chef-manage --path /root/packages
+
+   The ``chef-server-ctl`` command will install the first ``chef-manage`` package found in the ``/root/packages`` directory.
+
+   .. end_tag

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -2752,67 +2752,25 @@ The ``install`` subcommand downloads packages from https://packages.chef.io/ by 
 
        .. code-block:: bash
 
-          $ chef-server-ctl install chef-manage
+          $ sudo chef-server-ctl install chef-manage
 
        then:
 
        .. code-block:: bash
 
-          $ chef-server-ctl reconfigure
+          $ sudo chef-server-ctl reconfigure
 
        and then:
 
        .. code-block:: bash
 
-          $ chef-manage-ctl reconfigure
+          $ sudo chef-manage-ctl reconfigure
 
        .. note:: .. tag chef_license_reconfigure_manage
 
                  Starting with the Chef management console 2.3.0, the `Chef MLSA </chef_license.html>`__ must be accepted when reconfiguring the product. If the Chef MLSA has not already been accepted, the reconfigure process will prompt for a ``yes`` to accept it. Or run ``chef-manage-ctl reconfigure --accept-license`` to automatically accept the license.
 
                  .. end_tag
-
-   * - Chef Push Jobs
-     - Use Chef push jobs to run jobs---an action or a command to be executed---against nodes independently of a chef-client run.
-
-       On the Chef server, run:
-
-       .. code-block:: bash
-
-          $ chef-server-ctl install opscode-push-jobs-server
-
-       then:
-
-       .. code-block:: bash
-
-          $ chef-server-ctl reconfigure
-
-       and then:
-
-       .. code-block:: bash
-
-          $ opscode-push-jobs-server-ctl reconfigure
-
-   * - Reporting
-     - Use Reporting to keep track of what happens during every chef-client runs across all of the infrastructure being managed by Chef. Run Reporting with Chef management console to view reports from a web user interface.
-
-       On the Chef server, run:
-
-       .. code-block:: bash
-
-          $ chef-server-ctl install opscode-reporting
-
-       then:
-
-       .. code-block:: bash
-
-          $ chef-server-ctl reconfigure
-
-       and then:
-
-       .. code-block:: bash
-
-          $ opscode-reporting-ctl reconfigure
 
 .. end_tag
 
@@ -2824,13 +2782,13 @@ The ``install`` subcommand downloads packages from https://packages.chef.io/ by 
 
 .. code-block:: bash
 
-   $ chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
+   $ sudo chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
 
 For example:
 
 .. code-block:: bash
 
-   $ chef-server-ctl install chef-manage --path /root/packages
+   $ sudo chef-server-ctl install chef-manage --path /root/packages
 
 The ``chef-server-ctl`` command will install the first ``chef-manage`` package found in the ``/root/packages`` directory.
 

--- a/chef_master/source/upgrade_server.rst
+++ b/chef_master/source/upgrade_server.rst
@@ -438,67 +438,25 @@ This section details the process for upgrading additional features after the Che
 
           .. code-block:: bash
 
-             $ chef-server-ctl install chef-manage
+             $ sudo chef-server-ctl install chef-manage
 
           then:
 
           .. code-block:: bash
 
-             $ chef-server-ctl reconfigure
+             $ sudo chef-server-ctl reconfigure
 
           and then:
 
           .. code-block:: bash
 
-             $ chef-manage-ctl reconfigure
+             $ sudo chef-manage-ctl reconfigure
 
           .. note:: .. tag chef_license_reconfigure_manage
 
                     Starting with the Chef management console 2.3.0, the `Chef MLSA </chef_license.html>`__ must be accepted when reconfiguring the product. If the Chef MLSA has not already been accepted, the reconfigure process will prompt for a ``yes`` to accept it. Or run ``chef-manage-ctl reconfigure --accept-license`` to automatically accept the license.
 
                     .. end_tag
-
-      * - Chef Push Jobs
-        - Use Chef push jobs to run jobs---an action or a command to be executed---against nodes independently of a chef-client run.
-
-          On the Chef server, run:
-
-          .. code-block:: bash
-
-             $ chef-server-ctl install opscode-push-jobs-server
-
-          then:
-
-          .. code-block:: bash
-
-             $ chef-server-ctl reconfigure
-
-          and then:
-
-          .. code-block:: bash
-
-             $ opscode-push-jobs-server-ctl reconfigure
-
-      * - Reporting
-        - Use Reporting to keep track of what happens during every chef-client runs across all of the infrastructure being managed by Chef. Run Reporting with Chef management console to view reports from a web user interface.
-
-          On the Chef server, run:
-
-          .. code-block:: bash
-
-             $ chef-server-ctl install opscode-reporting
-
-          then:
-
-          .. code-block:: bash
-
-             $ chef-server-ctl reconfigure
-
-          and then:
-
-          .. code-block:: bash
-
-             $ opscode-reporting-ctl reconfigure
 
    .. end_tag
 
@@ -510,13 +468,13 @@ This section details the process for upgrading additional features after the Che
 
    .. code-block:: bash
 
-      $ chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
+      $ sudo chef-server-ctl install PACKAGE_NAME --path /path/to/package/directory
 
    For example:
 
    .. code-block:: bash
 
-      $ chef-server-ctl install chef-manage --path /root/packages
+      $ sudo chef-server-ctl install chef-manage --path /root/packages
 
    The ``chef-server-ctl`` command will install the first ``chef-manage`` package found in the ``/root/packages`` directory.
 


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### Description

This updates the Chef Server installation docs and a cascade of changes to downstream docs. Adds an error message. Moves Chef Manage from A1 back into Server. 

### Definition of Done


### Issues Resolved


### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
