### PR TITLE
Update doc for windows timezones support

### DIFF
--- a/chef_master/source/resource_timezone.rst
+++ b/chef_master/source/resource_timezone.rst
@@ -3,7 +3,7 @@ timezone resource
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_timezone.rst>`__
 
-Use the **timezone** resource to change the system **timezone** on Windows, Linux, and macOS hosts. Timezones are specified in tz database format, with a complete list of available TZ values for linux and macOS here https://en.wikipedia.org/wiki/List_of_tz_database_time_zones and for windows here https://ss64.com/nt/timezones.html.
+Use the **timezone** resource to change the system **timezone** on Windows, Linux, and macOS hosts. Timezones are specified in tz database format, with a complete list of available TZ values for Linux and macOS here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones and for Windows here: https://ss64.com/nt/timezones.html.
 
  **New in Chef Client 14.6.**
 

--- a/chef_master/source/resource_timezone.rst
+++ b/chef_master/source/resource_timezone.rst
@@ -3,7 +3,7 @@ timezone resource
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_timezone.rst>`__
 
-Use the **timezone** resource to change the system **timezone** on Linux and macOS hosts. Timezones are specified in tz database format, with a complete list of available TZ values here https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+Use the **timezone** resource to change the system **timezone** on Windows, Linux, and macOS hosts. Timezones are specified in tz database format, with a complete list of available TZ values for linux and macOS here https://en.wikipedia.org/wiki/List_of_tz_database_time_zones and for windows here https://ss64.com/nt/timezones.html.
 
  **New in Chef Client 14.6.**
 


### PR DESCRIPTION
https://github.com/chef/chef/blob/master/lib/chef/resource/timezone.rb the timezone resource also supports windows and this adds mention of that as well as a link to a list of windows timezone names to use.

### Description

Current resource description sounds like it only supports Linux and Mac when resource also supports windows. This also adds a link to windows timezone names.

### Definition of Done

### Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [ ] All tests pass
