### PR TITLE
Note 12.18.14 + berks 7.04 compatibility issue

### DIFF
--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -31,7 +31,7 @@ This release:
 * Removed nodejs (a build dependency that was shipped).
 
 .. note:: Chef Server 12.18.14 introduces an incompatibility between older versions of Berkshelf and the ChefDK. We recommend using the minimum versions of  Berkshelf >= 7.0.5 and ChefDK >= 3.2.30. 
-A Berkshelf upload to Chef Server failing with ``Net::HTTPServerException: 400 "Bad Request"`` and opscode-erchef logs containing ``status=400`` and ``req_api_version=1`` in the log line for the related cookbook upload API request, are strong evidence of this incompatibility.
+This incompatibility manifests with a Berkshelf upload to Chef Server failure of ``Net::HTTPServerException: 400 "Bad Request"`` and opscode-erchef logs containing ``status=400`` and ``req_api_version=1`` in the log line for the corresponding cookbook upload API request.
 
 What's New in 12.17.33
 =====================================================

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -30,8 +30,7 @@ This release:
 * Fix for SUSE SLES-11 sysvinit install
 * Removed nodejs (a build dependency that was shipped).
 
-.. note:: Chef Server 12.18.14 introduces an incompatibility between older versions of Berkshelf and the ChefDK. We recommend using the minimum versions of  Berkshelf >= 7.0.5 and ChefDK >= 3.2.30. 
-This incompatibility manifests with a Berkshelf upload to Chef Server failure of ``Net::HTTPServerException: 400 "Bad Request"`` and opscode-erchef logs containing ``status=400`` and ``req_api_version=1`` in the log line for the corresponding cookbook upload API request.
+.. note:: Chef Server 12.18.14 introduces an incompatibility between older versions of Berkshelf and ChefDK. We recommend using the minimum versions of  Berkshelf >= 7.0.5 and ChefDK >= 3.2.30. This incompatibility manifests with a Berkshelf upload to Chef Server failure of ``Net::HTTPServerException: 400 "Bad Request"`` and opscode-erchef logs containing ``status=400`` and ``req_api_version=1`` in the log line for the corresponding cookbook upload API request.
 
 What's New in 12.17.33
 =====================================================

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -30,7 +30,8 @@ This release:
 * Fix for SUSE SLES-11 sysvinit install
 * Removed nodejs (a build dependency that was shipped).
 
-.. note:: The API version bump introduces an incompatibility with older versions of Berkshelf, which means that Berkshelf >= 7.0.5 and ChefDK >= 3.2.30 should be used. If your Berkshelf uploads to Chef Server fail with ``Net::HTTPServerException: 400 "Bad Request"`` and opscode-erchef logs contain ``status=400`` and ``req_api_version=1`` in the log line for the related cookbook upload API request, you may be experiencing this incompatibility.
+.. note:: Chef Server 12.18.14 introduces an incompatibility between older versions of Berkshelf and the ChefDK. We recommend using the minimum versions of  Berkshelf >= 7.0.5 and ChefDK >= 3.2.30. 
+A Berkshelf upload to Chef Server failing with ``Net::HTTPServerException: 400 "Bad Request"`` and opscode-erchef logs containing ``status=400`` and ``req_api_version=1`` in the log line for the related cookbook upload API request, are strong evidence of this incompatibility.
 
 What's New in 12.17.33
 =====================================================

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -30,6 +30,7 @@ This release:
 * Fix for SUSE SLES-11 sysvinit install
 * Removed nodejs (a build dependency that was shipped).
 
+.. note:: The API version bump introduces an incompatibility with older versions of Berkshelf, which means that Berkshelf >= 7.0.5 and ChefDK >= 3.2.30 should be used. If your Berkshelf uploads to Chef Server fail with ``Net::HTTPServerException: 400 "Bad Request"`` and opscode-erchef logs contain ``status=400`` and ``req_api_version=1`` in the log line for the related cookbook upload API request, you may be experiencing this incompatibility.
 
 What's New in 12.17.33
 =====================================================


### PR DESCRIPTION
### Description

This change documents a potential issue users may experience when using older versions of Berkshelf to upload cookbooks to Chef Server version 12.18.14

### Definition of Done

### Issues Resolved

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
