### PR TITLE
Include example value for privacy

### DIFF
--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -245,7 +245,13 @@ This configuration file has the following settings:
    .. note:: This setting is not visible in Chef Supermarket.
 
 ``privacy``
-   Specify that a cookbook is private.
+   Specify that a cookbook is private. 
+   
+   For example:
+
+   .. code-block:: ruby
+
+      privacy true
 
 ``provides``
    Add a recipe, definition, or resource that is provided by this cookbook, should the auto-populated list be insufficient.

--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -245,7 +245,7 @@ This configuration file has the following settings:
    .. note:: This setting is not visible in Chef Supermarket.
 
 ``privacy``
-   Specify that a cookbook is private. 
+   Specify a cookbook as private. 
    
    For example:
 


### PR DESCRIPTION
### Description

Gives a default example for the `privacy` attribute in the metadata.rb file. Had to go through the source code to find the answer to this, so hopefully this helps someone else in the future.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
