### PR TITLE
Updating dsc_resource actions and properties

### DIFF
--- a/chef_master/source/resource_dsc_resource.rst
+++ b/chef_master/source/resource_dsc_resource.rst
@@ -74,7 +74,7 @@ The full syntax for all of the properties that are available to the **dsc_resour
      module_version             String
      property                   Symbol
      reboot_action              Symbol # default value: :nothing
-     resource                   String
+     resource                   Symbol
      timeout                    Integer
    end
 
@@ -93,7 +93,6 @@ Actions
 The dsc_resource resource has the following actions:
 
 ``:nothing``
-   Default.
 
    .. tag resources_common_actions_nothing
 
@@ -101,8 +100,8 @@ The dsc_resource resource has the following actions:
 
    .. end_tag
 
-``:reboot_action``
-   Use to request an immediate reboot or to queue a reboot using the ``:reboot_now`` (immediate reboot) or ``:request_reboot`` (queued reboot) actions built into the **reboot** resource.
+``:run``
+   Default. Use to run the DSC configuration defined as defined in this resource.
 
 Properties
 =====================================================
@@ -162,7 +161,7 @@ The dsc_resource resource has the following properties:
    Use to request an immediate reboot or to queue a reboot using the :reboot_now (immediate reboot) or :request_reboot (queued reboot) actions built into the reboot resource.
 
 ``resource``
-   **Ruby Type:** String
+   **Ruby Type:** Symbol
 
    The name of the DSC resource. This value is case-insensitive and must be a symbol that matches the name of the DSC resource.
 

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -742,7 +742,7 @@ The full syntax for all of the properties that are available to the **dsc_resour
      module_version             String
      property                   Symbol
      reboot_action              Symbol # default value: :nothing
-     resource                   String
+     resource                   Symbol
      timeout                    Integer
    end
 
@@ -813,7 +813,7 @@ The dsc_resource resource has the following properties:
    Use to request an immediate reboot or to queue a reboot using the :reboot_now (immediate reboot) or :request_reboot (queued reboot) actions built into the reboot resource.
 
 ``resource``
-   **Ruby Type:** String
+   **Ruby Type:** Symbol
 
    The name of the DSC resource. This value is case-insensitive and must be a symbol that matches the name of the DSC resource.
 


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

The **dsc_resource** resource was out of sync with reality:

1. Missing action `:run` added and provided description
2. Default action set to `:run`
3. Update type for `resource` property to `Symbol`

### Definition of Done

Update the docs with the correct actions and property descriptions.

### Issues Resolved

As per discussion on Discourse https://discourse.chef.io/t/actions-supported-by-dsc-resource/14240

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
