### PR TITLE
Remove macOS 10.11 as a supported version

### DIFF
--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -48,7 +48,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``11.x``
    * - macOS
      - ``x86_64``
-     - ``10.11``, ``10.12``, ``10.13``, ``10.14``
+     - ``10.12``, ``10.13``, ``10.14``
    * - Oracle Enterprise Linux
      - ``x86_64``
      - ``6.x``, ``7.x``
@@ -125,7 +125,7 @@ The following table lists the commercially-supported platforms and versions for 
      - Version
    * - macOS
      -
-     - ``10.11``, ``10.12``, ``10.13``, ``10.14``
+     - ``10.12``, ``10.13``, ``10.14``
    * - Red Hat Enterprise Linux
      -
      - ``6.x``, ``7.x``


### PR DESCRIPTION
We're not shipping 10.11 packages anymore