### PR TITLE
Add install addon names

### DIFF
--- a/chef_master/source/ctl_chef_server.rst
+++ b/chef_master/source/ctl_chef_server.rst
@@ -210,7 +210,7 @@ install
 =====================================================
 .. tag ctl_chef_server_install
 
-The ``install`` subcommand is used to install premium features of the Chef server: Chef management console, Chef Analytics, chef-client run reporting, high availability configurations, Chef push jobs, and Chef server replication.
+The ``install`` subcommand is used to install premium features of the Chef server: Chef management console(``chef-manage``), Chef Analytics(``opscode-analytics``?), chef-client run reporting(``opscode-reporting``), high availability configurations(``chef-ha``), Chef push jobs(``opscode-push-jobs-server``), and Chef server replication(``opscode-replication``?).
 
 .. end_tag
 


### PR DESCRIPTION
Not sure about addon names: opscode-analytics and opscode-replication

### Description

First time I had to install push jobs I didn't know what command to enter. It is not mentioned in the docs. It's not that hard to figure out but it would be nice for the names to be listed.