### PR TITLE
Kg/a warning too far

### DIFF
--- a/chef_master/source/config_rb_manage.rst
+++ b/chef_master/source/config_rb_manage.rst
@@ -3,16 +3,6 @@ manage.rb
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/config_rb_manage.rst>`__
 
-.. tag chef_automate_mark
-
-.. image:: ../../images/chef_automate_full.png
-   :width: 40px
-   :height: 17px
-
-.. danger:: This documentation covers an outdated version of Chef Automate. See the `Chef Automate site <https://automate.chef.io/docs/quickstart/>`__ for current documentation. The new Chef Automate includes newer out-of-the-box compliance profiles, an improved compliance scanner with total cloud scanning functionality, better visualizations, role-based access control and many other features.
-
-.. end_tag
-
 .. tag chef_manager
 
 Chef management console is a web-based interface for the Chef server that provides users a way to manage the following objects:

--- a/chef_master/source/ctl_manage.rst
+++ b/chef_master/source/ctl_manage.rst
@@ -3,16 +3,6 @@ chef-manage-ctl (executable)
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/ctl_manage.rst>`__
 
-.. tag chef_automate_mark
-
-.. image:: ../../images/chef_automate_full.png
-   :width: 40px
-   :height: 17px
-
-.. danger:: This documentation covers an outdated version of Chef Automate. See the `Chef Automate site <https://automate.chef.io/docs/quickstart/>`__ for current documentation. The new Chef Automate includes newer out-of-the-box compliance profiles, an improved compliance scanner with total cloud scanning functionality, better visualizations, role-based access control and many other features.
-
-.. end_tag
-
 The Chef management console includes a command-line utility named ``chef-manage-ctl``. This command-line tool is used to reconfigure, cleanse (reset the Chef management console to initial configuration settings), and uninstall the Chef management console.
 
 cleanse

--- a/chef_master/source/manage.rst
+++ b/chef_master/source/manage.rst
@@ -3,16 +3,6 @@ Chef Manage
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/manage.rst>`__
 
-.. tag chef_automate_mark
-
-.. image:: ../../images/chef_automate_full.png
-   :width: 40px
-   :height: 17px
-
-.. danger:: This documentation covers an outdated version of Chef Automate. See the `Chef Automate site <https://automate.chef.io/docs/quickstart/>`__ for current documentation. The new Chef Automate includes newer out-of-the-box compliance profiles, an improved compliance scanner with total cloud scanning functionality, better visualizations, role-based access control and many other features.
-
-.. end_tag
-
 .. tag manage_summary
 
 The Chef management console enables the management of nodes, data bags, roles, environments, and cookbooks by using a web user interface. In addition, access to nodes, data bags, roles, environments, and cookbooks is configurable using role-based access control (RBAC).

--- a/chef_master/source/server_manage_clients.rst
+++ b/chef_master/source/server_manage_clients.rst
@@ -3,16 +3,6 @@ Manage Client Keys
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/server_manage_clients.rst>`__
 
-.. tag chef_automate_mark
-
-.. image:: ../../images/chef_automate_full.png
-   :width: 40px
-   :height: 17px
-
-.. danger:: This documentation covers an outdated version of Chef Automate. See the `Chef Automate site <https://automate.chef.io/docs/quickstart/>`__ for current documentation. The new Chef Automate includes newer out-of-the-box compliance profiles, an improved compliance scanner with total cloud scanning functionality, better visualizations, role-based access control and many other features.
-
-.. end_tag
-
 .. note:: This topic is about using the Chef management console to manage keys.
 
 .. tag server_rbac_clients

--- a/chef_master/source/server_manage_cookbooks.rst
+++ b/chef_master/source/server_manage_cookbooks.rst
@@ -3,16 +3,6 @@ Manage Cookbooks
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/server_manage_cookbooks.rst>`__
 
-.. tag chef_automate_mark
-
-.. image:: ../../images/chef_automate_full.png
-   :width: 40px
-   :height: 17px
-
-.. danger:: This documentation covers an outdated version of Chef Automate. See the `Chef Automate site <https://automate.chef.io/docs/quickstart/>`__ for current documentation. The new Chef Automate includes newer out-of-the-box compliance profiles, an improved compliance scanner with total cloud scanning functionality, better visualizations, role-based access control and many other features.
-
-.. end_tag
-
 .. note:: This topic is about using the Chef management console to manage cookbooks.
 
 .. tag cookbooks_summary

--- a/chef_master/source/server_manage_data_bags.rst
+++ b/chef_master/source/server_manage_data_bags.rst
@@ -3,16 +3,6 @@ Manage Data Bags
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/server_manage_data_bags.rst>`__
 
-.. tag chef_automate_mark
-
-.. image:: ../../images/chef_automate_full.png
-   :width: 40px
-   :height: 17px
-
-.. danger:: This documentation covers an outdated version of Chef Automate. See the `Chef Automate site <https://automate.chef.io/docs/quickstart/>`__ for current documentation. The new Chef Automate includes newer out-of-the-box compliance profiles, an improved compliance scanner with total cloud scanning functionality, better visualizations, role-based access control and many other features.
-
-.. end_tag
-
 .. note:: This topic is about using the Chef management console to manage data bags.
 
 .. tag data_bag

--- a/chef_master/source/server_manage_environments.rst
+++ b/chef_master/source/server_manage_environments.rst
@@ -3,16 +3,6 @@ Manage Environments
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/server_manage_environments.rst>`__
 
-.. tag chef_automate_mark
-
-.. image:: ../../images/chef_automate_full.png
-   :width: 40px
-   :height: 17px
-
-.. danger:: This documentation covers an outdated version of Chef Automate. See the `Chef Automate site <https://automate.chef.io/docs/quickstart/>`__ for current documentation. The new Chef Automate includes newer out-of-the-box compliance profiles, an improved compliance scanner with total cloud scanning functionality, better visualizations, role-based access control and many other features.
-
-.. end_tag
-
 .. note:: This topic is about using the Chef management console to manage environments.
 
 .. tag environment

--- a/chef_master/source/server_manage_nodes.rst
+++ b/chef_master/source/server_manage_nodes.rst
@@ -3,16 +3,6 @@ Manage Nodes
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/server_manage_nodes.rst>`__
 
-.. tag chef_automate_mark
-
-.. image:: ../../images/chef_automate_full.png
-   :width: 40px
-   :height: 17px
-
-.. danger:: This documentation covers an outdated version of Chef Automate. See the `Chef Automate site <https://automate.chef.io/docs/quickstart/>`__ for current documentation. The new Chef Automate includes newer out-of-the-box compliance profiles, an improved compliance scanner with total cloud scanning functionality, better visualizations, role-based access control and many other features.
-
-.. end_tag
-
 .. note:: This topic is about using the Chef management console to manage nodes.
 
 .. tag node

--- a/chef_master/source/server_manage_roles.rst
+++ b/chef_master/source/server_manage_roles.rst
@@ -5,16 +5,6 @@ Manage Roles
 
 .. note:: This topic is about using the Chef management console to manage roles.
 
-.. tag chef_automate_mark
-
-.. image:: ../../images/chef_automate_full.png
-   :width: 40px
-   :height: 17px
-
-.. danger:: This documentation covers an outdated version of Chef Automate. See the `Chef Automate site <https://automate.chef.io/docs/quickstart/>`__ for current documentation. The new Chef Automate includes newer out-of-the-box compliance profiles, an improved compliance scanner with total cloud scanning functionality, better visualizations, role-based access control and many other features.
-
-.. end_tag
-
 .. tag role
 
 A role is a way to define certain patterns and processes that exist across nodes in an organization as belonging to a single job function. Each role consists of zero (or more) attributes and a run-list. Each node can have zero (or more) roles assigned to it. When a role is run against a node, the configuration details of that node are compared against the attributes of the role, and then the contents of that role's run-list are applied to the node's configuration details. When a chef-client runs, it merges its own attributes and run-lists with those contained within each assigned role.

--- a/chef_master/source/server_users.rst
+++ b/chef_master/source/server_users.rst
@@ -3,16 +3,6 @@ Users
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/server_users.rst>`__
 
-.. tag chef_automate_mark
-
-.. image:: ../../images/chef_automate_full.png
-   :width: 40px
-   :height: 17px
-
-.. danger:: This documentation covers an outdated version of Chef Automate. See the `Chef Automate site <https://automate.chef.io/docs/quickstart/>`__ for current documentation. The new Chef Automate includes newer out-of-the-box compliance profiles, an improved compliance scanner with total cloud scanning functionality, better visualizations, role-based access control and many other features.
-
-.. end_tag
-
 The following tasks are available for user management in Chef server:
 
 * Creating users

--- a/chef_master/source/upgrade_server_ha_v2.rst
+++ b/chef_master/source/upgrade_server_ha_v2.rst
@@ -3,15 +3,9 @@ High Availability: Backend Cluster
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/upgrade_server_ha_v2.rst>`__
 
-.. tag chef_automate_mark
-
 .. image:: ../../images/chef_automate_full.png
    :width: 40px
    :height: 17px
-
-.. danger:: This documentation covers an outdated version of Chef Automate. See the `Chef Automate site <https://automate.chef.io/docs/quickstart/>`__ for current documentation. The new Chef Automate includes newer out-of-the-box compliance profiles, an improved compliance scanner with total cloud scanning functionality, better visualizations, role-based access control and many other features.
-
-.. end_tag
 
 This topic describes the process of upgrading a highly available Chef server cluster.
 


### PR DESCRIPTION
### Description

The A1 icon was enthusiastically applied at some point in the past, which would be nearly unnoticeable, except that I put a gigantic "USE THE A2 DOCS" warning into the dtag.
I've removed the dtag from the non-A1 pages (Thanks, @teknofire!) 

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [x ] Local build
- [x ] Examine the local build
- [ ] All tests pass
