### PR TITLE
Fix a bad registry_key resource example

### DIFF
--- a/chef_master/source/resource_examples.rst
+++ b/chef_master/source/resource_examples.rst
@@ -4748,7 +4748,7 @@ Use a double-quoted string:
 .. code-block:: ruby
 
    proxy = URI.parse(Chef::Config[:http_proxy])
-   registry_key "HKCU\Software\Microsoft\path\to\key\Internet Settings" do
+   registry_key 'HKCU\Software\Microsoft\path\to\key\Internet Settings' do
      values [{name: 'ProxyEnable', type: :reg_dword, data: 1},
              {name: 'ProxyServer', data: "#{proxy.host}:#{proxy.port}"},
              {name: 'ProxyOverride', type: :reg_string, data: <local>},

--- a/chef_master/source/resource_registry_key.rst
+++ b/chef_master/source/resource_registry_key.rst
@@ -574,7 +574,7 @@ Use a double-quoted string:
 .. code-block:: ruby
 
    proxy = URI.parse(Chef::Config[:http_proxy])
-   registry_key "HKCU\Software\Microsoft\path\to\key\Internet Settings" do
+   registry_key 'HKCU\Software\Microsoft\path\to\key\Internet Settings' do
      values [{name: 'ProxyEnable', type: :reg_dword, data: 1},
              {name: 'ProxyServer', data: "#{proxy.host}:#{proxy.port}"},
              {name: 'ProxyOverride', type: :reg_string, data: <local>},


### PR DESCRIPTION
If we double quote we need to escape the \.