### PR TITLE
URLs and pages added for CHEF 23 and CHEF 24 deprecations

### DIFF
--- a/chef_master/source/chef_deprecations_client.rst
+++ b/chef_master/source/chef_deprecations_client.rst
@@ -147,15 +147,15 @@ All Deprecations
     - Deprecation of the ``:uninstall`` action in the ``chocolatey_package`` resource.
     - 13.7
     - 14.0
-  * - `CHEF-22  </deprecations_erl_call_resource.html>`__
+  * - `CHEF-22 </deprecations_erl_call_resource.html>`__
     - Deprecation of the ``erl_call`` resource.
     - 13.7
     - 14.0
-  * - CHEF-23
+  * - `CHEF-23 </deprecations_legacy_hwrp_mixins.html>`__
     - Deprecation of legacy HWRP mixins.
     - 12.X
     - 14.0
-  * - CHEF-24
+  * - `CHEF-24 </deprecations_epic_fail.html>`__
     - Deprecation of ``epic_fail`` in favor of ``allow_failure``
     - 13.7
     - 14.0  

--- a/chef_master/source/deprecations_epic_fail.rst
+++ b/chef_master/source/deprecations_epic_fail.rst
@@ -1,5 +1,5 @@
 =====================================================
-Deprecation:  (CHEF-24)
+Deprecation: epic_fail (CHEF-24)
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_epic_fail.rst>`__
 

--- a/chef_master/source/deprecations_epic_fail.rst
+++ b/chef_master/source/deprecations_epic_fail.rst
@@ -1,0 +1,7 @@
+=====================================================
+Deprecation:  (CHEF-24)
+=====================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_epic_fail.rst>`__
+
+The original name for the ``ignore_failure`` property in resources was ``epic_fail``. Our documentation hasn’t referred to ``epic_fail`` for years and out of the 3500 cookbooks on the Supermarket only one uses ``epic_fail``. In Chef 14 we will remove the ``epic_fail`` property entirely. Foodcritic rule `FC107 <http://www.foodcritic.io/#FC107>`__ has been introduced to detect usage of ``epic_fail``.
+

--- a/chef_master/source/deprecations_legacy_hwrp_mixins.rst
+++ b/chef_master/source/deprecations_legacy_hwrp_mixins.rst
@@ -1,0 +1,12 @@
+=====================================================
+Deprecation: Legacy HWRP mixins (CHEF-23)
+=====================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_legacy_hwrp_mixins.rst>`__
+
+In Chef 14 several legacy mixins will be removed. Usage of these mixins has resulted in deprecation warnings for several years. They were traditionally used in some HWRPs, but are rarely found in code available on the Supermarket. Foodcritic rules `FC097 <http://www.foodcritic.io/#FC097>`__, `FC098 <http://www.foodcritic.io/#FC098>`__, `FC099 <http://www.foodcritic.io/#FC099>`__, `FC100 <http://www.foodcritic.io/#FC100>`__, and `FC102 <http://www.foodcritic.io/#FC102>`__ have been introduced to detect these mixins:
+
+* ``Chef::Mixin::LanguageIncludeAttribute``
+* ``Chef::Mixin::RecipeDefinitionDSLCore``
+* ``Chef::Mixin::LanguageIncludeRecipe``
+* ``Chef::Mixin::Language``
+* ``Chef::DSL::Recipe::FullDSL``

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -601,11 +601,13 @@ Addenda
    deprecations_deploy_resource
    deprecations_dnf_package_allow_downgrade
    deprecations_easy_install
+   deprecations_epic_fail
    deprecations_erl_call_resource
    deprecations_exit_code
    deprecations_internal_api
    deprecations_json_auto_inflate
    deprecations_launchd_hash_property
+   deprecations_legacy_hwrp_mixins
    deprecations_local_listen
    deprecations_map_collision
    deprecations_namespace_collisions


### PR DESCRIPTION
Signed-off-by: Mary Jinglewski <mjinglewski@chef.io>

### Description

URLs and pages added for CHEF 23 and CHEF 24 deprecations, which were previously missing.

### Issues Resolved

No documented issues within the repo, but probably an issue for someone somewhere. This is for you.

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
