### PR TITLE
Update knife_windows.rst

### DIFF
--- a/chef_master/source/knife_windows.rst
+++ b/chef_master/source/knife_windows.rst
@@ -541,7 +541,7 @@ Options
 This argument has the following options:
 
 ``-a ATTR``, ``--attribute ATTR``
-   The attribute used when opening an SSH connection. The default attribute is the FQDN of the host. Other possible values include a public IP address, a private IP address, or a hostname.
+   The attribute used when opening a connection. The default attribute is the FQDN of the host. Other possible values include a public IP address, a private IP address, or a hostname.
 
 ``-C NUM``, ``--concurrency NUM``
    Changed in knife-windows 1.9.0. The number of allowed concurrent connections. Defaults to 1.


### PR DESCRIPTION
The `-a` option seems to have effect for WinRM connections as well, not just SSH.

### Description

This corrects a seemingly misleading description of the `-a` option when used with `knife winrm`

### Definition of Done

### Issues Resolved

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
