### PR TITLE
Add deprecation warning for `berks test`

### DIFF
--- a/chef_master/source/berkshelf.rst
+++ b/chef_master/source/berkshelf.rst
@@ -464,13 +464,7 @@ berks test
 -----------------------------------------------------
 Use ``berks test`` to run Test Kitchen from within Berkshelf.
 
-Syntax
-+++++++++++++++++++++++++++++++++++++++++++++++++++++
-This subcommand has the following syntax:
-
-.. code-block:: bash
-
-   $ berks test KITCHEN_COMMAND (options)
+.. warning:: This command is deprecated. Please use ``kitchen test`` instead.
 
 Options
 +++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
### Description

This applies the documentation made in remote fork of https://github.com/chef/chef-web-docs/pull/1826 by @matteb22 to chef-web-docs.

### Definition of Done

### Issues Resolved

Adds deprecation warning for `berks test`

### Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [ ] All tests pass
