### PR TITLE
Remove Juniper marketing copy from Chef for Junos OS docs

### DIFF
--- a/chef_master/source/junos.rst
+++ b/chef_master/source/junos.rst
@@ -3,7 +3,7 @@ Chef for Junos OS
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/junos.rst>`__
 
-Juniper Networks is a leading provider of network routing, switching and security solutions for enterprises and service providers. Juniper Networks routers and switches help solve some of the most difficult problems in the data center. Junos OS is the operating system that runs on Juniper Networks routers and switches.
+Junos OS is the operating system that runs on routers and switches sold by `[Juniper Networks] <https://en.wikipedia.org/wiki/Juniper_Networks>`.
 
 .. image:: ../../images/overview_junos.png
 


### PR DESCRIPTION
### Description

Neither what Juniper Networks do (which is to sell hardware and software, not "solutions" to unspecified problems) nor anyone's assessment of their lead in doing so among competing equipment sellers is relevant to the description of Chef for Junos OS.  Link to the Wikipedia entry about the company upon first mention and remove the irrelevant marketing-speak.