### PR TITLE
Warn customers about FQDN length and lowercase

### DIFF
--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -73,7 +73,7 @@ Because the FQDN has already been configured, do the following:
 
 .. tag server_openssl_fqdn
 
-.. warning:: The FQDN for the Chef server should be resolvable, lowercase, and should not exceed 64 characters when using OpenSSL, as OpenSSL requires the ``CN`` in a certificate to be no longer than 64 characters.
+.. warning:: The FQDN for the Chef server should be resolvable, lowercase, and have fewer than 64 characters including the domain suffix, when using OpenSSL, as OpenSSL requires the ``CN`` in a certificate to be no longer than 64 characters.
 
 .. end_tag
 

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -73,7 +73,7 @@ Because the FQDN has already been configured, do the following:
 
 .. tag server_openssl_fqdn
 
-.. warning:: The FQDN for the Chef server should be lowercase and should not exceed 64 characters when using OpenSSL, as OpenSSL requires the ``CN`` in a certificate to be no longer than 64 characters.
+.. warning:: The FQDN for the Chef server should be resolvable, lowercase, and should not exceed 64 characters when using OpenSSL, as OpenSSL requires the ``CN`` in a certificate to be no longer than 64 characters.
 
 .. end_tag
 

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -71,7 +71,11 @@ Because the FQDN has already been configured, do the following:
 
       $ chef-server-ctl restart nginx
 
-.. warning:: The FQDN for the Chef server should not exceed 64 characters when using OpenSSL. OpenSSL requires the ``CN`` in a certificate to be no longer than 64 characters.
+.. tag server_openssl_fqdn
+
+.. warning:: The FQDN for the Chef server should be lowercase and should not exceed 64 characters when using OpenSSL, as OpenSSL requires the ``CN`` in a certificate to be no longer than 64 characters.
+
+.. end_tag
 
 SSL Protocols
 -----------------------------------------------------


### PR DESCRIPTION
Chef Server FQDNs should be

* Less than 64 characters
* lowercase