### PR TITLE
Custom Knife Plugins: fix nesting of first code example

### DIFF
--- a/chef_master/source/plugin_knife_custom.rst
+++ b/chef_master/source/plugin_knife_custom.rst
@@ -29,23 +29,24 @@ There are many ways to structure a knife plugin. The following syntax shows a ty
    module ModuleName
      class SubclassName < Chef::Knife
 
-     deps do
-       require 'chef/dependency'
-       # other dependencies, as needed
-     end
+       deps do
+         require 'chef/dependency'
+         # other dependencies, as needed
+       end
 
-     banner "knife subcommand argument VALUE (options)"
+       banner "knife subcommand argument VALUE (options)"
 
-     option :name_of_option,
-       :short => "-l VALUE",
-       :long => "--long-option-name VALUE",
-       :description => "The description for the option.",
-       :proc => Proc.new { code_to_run }
-       :boolean => true | false
-       :default => default_value
+       option :name_of_option,
+         :short => "-l VALUE",
+         :long => "--long-option-name VALUE",
+         :description => "The description for the option.",
+         :proc => Proc.new { code_to_run }
+         :boolean => true | false
+         :default => default_value
 
-     def run
-       # Ruby code goes here
+       def run
+         # Ruby code goes here
+       end
      end
    end
 


### PR DESCRIPTION
### Description

This applies the documentation made in remote fork of https://github.com/chef/chef-web-docs/pull/1833 by @dnrce to chef-web-docs.

### Issues Resolved

On the "Custom Knife Plugins" page, this changes fixes the indentation and properly closes the blocks in the first example so that it is complete and valid Ruby.

### Check List

- [x] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
