### PR TITLE
Correcting link and load path info

### DIFF
--- a/chef_master/source/knife_setup.rst
+++ b/chef_master/source/knife_setup.rst
@@ -1,7 +1,7 @@
 =====================================================
 Setting up Knife
 =====================================================
-`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/knife_using.rst>`__
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/knife_setup.rst>`__
 
 The knife command line tool must be configured to communicate with the Chef Server as well as any other infrastructure within your organization. This is done initially during the workstation setup, but subsequent modifications can be made using the config.rb configuration file.
 
@@ -16,6 +16,8 @@ Load Path Priority
 The config.rb file is loaded every time the knife command is invoked using the following load order:
 
 * From a specified location given the ``--config`` flag
+* From a specified location given the ``$KNIFE_HOME`` environment variable, if set
+* From a ``config.rb`` file within the current working directory ex: ``./config.rb``
 * From a ``config.rb`` file within a ``.chef`` directory in the current working directory ex: ``./.chef/config.rb``
 * From a ``config.rb`` file within a ``.chef`` directory located one directory above the current working directory: ex: ``../.chef/config.rb``
 * From ``~/.chef/config.rb`` (macOS and Linux platforms) or ``c:\Users\<username>\.chef`` (Microsoft Windows platform)

--- a/chef_master/source/knife_setup.rst
+++ b/chef_master/source/knife_setup.rst
@@ -19,7 +19,7 @@ The config.rb file is loaded every time the knife command is invoked using the f
 * From a specified location given the ``$KNIFE_HOME`` environment variable, if set
 * From a ``config.rb`` file within the current working directory, e.g., ``./config.rb``
 * From a ``config.rb`` file within a ``.chef`` directory in the current working directory, e.g., ``./.chef/config.rb``
-* From a ``config.rb`` file within a ``.chef`` directory located one directory above the current working directory: e.g., ``../.chef/config.rb``
+* From a ``config.rb`` file within a ``.chef`` directory located one directory above the current working directory, e.g., ``../.chef/config.rb``
 * From ``~/.chef/config.rb`` (macOS and Linux platforms) or ``c:\Users\<username>\.chef`` (Microsoft Windows platform)
 
 .. note:: When running Microsoft Windows, the config.rb file is located at ``%HOMEDRIVE%:%HOMEPATH%\.chef`` (e.g. ``c:\Users\<username>\.chef``). If this path needs to be scripted, use ``%USERPROFILE%\chef-repo\.chef``.

--- a/chef_master/source/knife_setup.rst
+++ b/chef_master/source/knife_setup.rst
@@ -17,9 +17,9 @@ The config.rb file is loaded every time the knife command is invoked using the f
 
 * From a specified location given the ``--config`` flag
 * From a specified location given the ``$KNIFE_HOME`` environment variable, if set
-* From a ``config.rb`` file within the current working directory ex: ``./config.rb``
-* From a ``config.rb`` file within a ``.chef`` directory in the current working directory ex: ``./.chef/config.rb``
-* From a ``config.rb`` file within a ``.chef`` directory located one directory above the current working directory: ex: ``../.chef/config.rb``
+* From a ``config.rb`` file within the current working directory, e.g., ``./config.rb``
+* From a ``config.rb`` file within a ``.chef`` directory in the current working directory, e.g., ``./.chef/config.rb``
+* From a ``config.rb`` file within a ``.chef`` directory located one directory above the current working directory: e.g., ``../.chef/config.rb``
 * From ``~/.chef/config.rb`` (macOS and Linux platforms) or ``c:\Users\<username>\.chef`` (Microsoft Windows platform)
 
 .. note:: When running Microsoft Windows, the config.rb file is located at ``%HOMEDRIVE%:%HOMEPATH%\.chef`` (e.g. ``c:\Users\<username>\.chef``). If this path needs to be scripted, use ``%USERPROFILE%\chef-repo\.chef``.


### PR DESCRIPTION
### Description
"This change corrects the 'Edit on Github' link to point at the current documentation (it has been renamed.) I have also updated the load path information to include all the conditions from https://github.com/chef/chef/blob/master/chef-config/lib/chef-config/workstation_config_loader.rb ."

This applies the documentation made in remote fork of https://github.com/chef/chef-web-docs/pull/1837 by @gryfft to chef-web-docs.

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
