### PR TITLE
Deprecating LC_ALL from locale resource

### DIFF
--- a/chef_master/source/chef_deprecations_client.rst
+++ b/chef_master/source/chef_deprecations_client.rst
@@ -163,6 +163,10 @@ All Deprecations
     - Resource(s) in a cookbook collide with the same resource(s) now included in Chef.
     - XX.X
     - 15.0
+  * - `CHEF-27 </deprecations_locale_lc_all.html>`__
+    - Deprecation of lc_all from locale resource
+    - 14.12
+    - 16.0
   * - `CHEF-3694 </deprecations_resource_cloning.html>`__
     - Resource Cloning will no longer work.
     - 10.18

--- a/chef_master/source/chef_deprecations_client.rst
+++ b/chef_master/source/chef_deprecations_client.rst
@@ -165,7 +165,7 @@ All Deprecations
     - 15.0
   * - `CHEF-27 </deprecations_locale_lc_all.html>`__
     - Deprecation of lc_all from locale resource
-    - 14.12
+    - 15.0
     - 16.0
   * - `CHEF-3694 </deprecations_resource_cloning.html>`__
     - Resource Cloning will no longer work.

--- a/chef_master/source/deprecations_locale_lc_all.rst
+++ b/chef_master/source/deprecations_locale_lc_all.rst
@@ -1,0 +1,45 @@
+=======================================================================
+Deprecation: Deprecation of lc_all from locale resource (CHEF-27)
+=======================================================================
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_locale_lc_all.rst>`__
+
+.. tag deprecations_locale_lc_all
+
+Setting the *LC_ALL* variable is NOT recommended. As a system-wide setting, *LANG* should provide the desired behavior. *LC_ALL* is intended to be used for temporarily troubleshooting issues rather than an every day system setting.
+Changing *LC_ALL* can break Chef's parsing of command output in unexpected ways. Use one of the more specific *LC_* properties as needed.
+
+.. end_tag
+
+This deprecation warning was added ln Chef 14.12. Support for property lc_all will be removed for Chef 16.0
+
+
+Remediation
+=======================================================================
+
+Setting *LC_* variables varies by platform, but common locations to configure *LC_* variables are:
+
+.. code-block:: ruby
+
+	export LC_ALL="<locale_name>"
+
+1. /etc/default/locale
+2. /etc/sysconfig/i18n
+3. /etc/environment
+
+
+You can also use *file* resource and add this variable in any other file of your choice and then can source that file to reflect changes.
+
+.. code-block:: ruby
+
+	file "<path_to_file>" do
+	  content "LC_ALL=<locale_name>"
+	end
+
+
+To check the locale value, run
+
+.. code-block:: ruby
+
+	locale -v
+
+.. warning:: Be cautious while using *file* resource on any existing or above listed files. As it replaces all the file contents, you may loose any previous information.

--- a/chef_master/source/deprecations_locale_lc_all.rst
+++ b/chef_master/source/deprecations_locale_lc_all.rst
@@ -15,17 +15,21 @@ This deprecation warning was added in Chef 14.12. Support for property ``lc_all`
 Remediation
 =======================================================================
 
-Setting *LC_* variables varies by platform, but common locations to configure *LC_* variables are:
+Set ``LC_ALL`` in current shell as:
 
-.. code-block:: ruby
+.. code-block:: bash
 
 	export LC_ALL="<locale_name>"
 
-1. /etc/default/locale
-2. /etc/sysconfig/i18n
-3. /etc/environment
 
-You can also use the **file** Resource and add this variable to any other file of your choice. Then, you can source that file to reflect changes.
+To check the ``locale`` value, run:
+
+.. code-block:: bash
+
+	locale -v
+
+
+You can also use **file** Resource and add this variable in any other file of your choice and then can source that file to reflect changes.
 
 .. code-block:: ruby
 
@@ -33,10 +37,13 @@ You can also use the **file** Resource and add this variable to any other file o
 	  content "LC_ALL=<locale_name>"
 	end
 
-To check the ``locale`` value, run:
 
-.. code-block:: ruby
+Where ``path_to_file`` could be any one of:
 
-	locale -v
+1. /etc/default/locale
+2. /etc/sysconfig/i18n
+3. /etc/environment
+
+Setting **LC_** variables varies by platform, but these are the common locations to configure **LC_** variables.
 
 .. warning:: Be cautious while using the **file** Resource on any existing or above listed files. As it replaces all the file contents, you may lose any previous information.

--- a/chef_master/source/deprecations_locale_lc_all.rst
+++ b/chef_master/source/deprecations_locale_lc_all.rst
@@ -5,12 +5,11 @@ Deprecation: Deprecation of lc_all from locale resource (CHEF-27)
 
 .. tag deprecations_locale_lc_all
 
-Setting the *LC_ALL* variable is NOT recommended. As a system-wide setting, *LANG* should provide the desired behavior. *LC_ALL* is intended to be used for temporarily troubleshooting issues rather than an every day system setting.
-Changing *LC_ALL* can break Chef's parsing of command output in unexpected ways. Use one of the more specific *LC_* properties as needed.
+Setting the ``LC_ALL`` variable is NOT recommended. As a system-wide setting, ``LANG`` should provide the desired behavior. ``LC_ALL`` is intended to be used for temporarily troubleshooting issues rather than an everyday system setting.
+Changing ``LC_ALL`` can break Chef's parsing of command output in unexpected ways. Use one of the more specific ``LC_`` properties as needed.
+This deprecation warning was added in Chef 14.12. Support for property ``lc_all`` will be removed for Chef 16.0.
 
 .. end_tag
-
-This deprecation warning was added ln Chef 14.12. Support for property lc_all will be removed for Chef 16.0
 
 
 Remediation
@@ -26,8 +25,7 @@ Setting *LC_* variables varies by platform, but common locations to configure *L
 2. /etc/sysconfig/i18n
 3. /etc/environment
 
-
-You can also use *file* resource and add this variable in any other file of your choice and then can source that file to reflect changes.
+You can also use the **file** Resource and add this variable to any other file of your choice. Then, you can source that file to reflect changes.
 
 .. code-block:: ruby
 
@@ -35,11 +33,10 @@ You can also use *file* resource and add this variable in any other file of your
 	  content "LC_ALL=<locale_name>"
 	end
 
-
-To check the locale value, run
+To check the ``locale`` value, run:
 
 .. code-block:: ruby
 
 	locale -v
 
-.. warning:: Be cautious while using *file* resource on any existing or above listed files. As it replaces all the file contents, you may loose any previous information.
+.. warning:: Be cautious while using the **file** Resource on any existing or above listed files. As it replaces all the file contents, you may lose any previous information.

--- a/chef_master/source/deprecations_locale_lc_all.rst
+++ b/chef_master/source/deprecations_locale_lc_all.rst
@@ -7,7 +7,7 @@ Deprecation: Deprecation of lc_all from locale resource (CHEF-27)
 
 Setting the ``LC_ALL`` variable is NOT recommended. As a system-wide setting, ``LANG`` should provide the desired behavior. ``LC_ALL`` is intended to be used for temporarily troubleshooting issues rather than an everyday system setting.
 Changing ``LC_ALL`` can break Chef's parsing of command output in unexpected ways. Use one of the more specific ``LC_`` properties as needed.
-This deprecation warning was added in Chef 14.12. Support for property ``lc_all`` will be removed for Chef 16.0.
+This deprecation warning was added in Chef 15.0. Support for property ``lc_all`` will be removed for Chef 16.0.
 
 .. end_tag
 
@@ -46,4 +46,5 @@ Where ``path_to_file`` could be any one of:
 
 Setting **LC_** variables varies by platform, but these are the common locations to configure **LC_** variables.
 
-.. warning:: Be cautious while using the **file** Resource on any existing or above listed files. As it replaces all the file contents, you may lose any previous information.
+.. warning:: Using the **file** Resource or other manual management method of LC configuration may overwrite settings from this resource and break your system.
+

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -573,6 +573,7 @@ Addenda
    deprecations_legacy_hwrp_mixins
    deprecations_local_listen
    deprecations_map_collision
+   deprecations_locale_lc_all
    deprecations_namespace_collisions
    deprecations_ohai_amazon_linux
    deprecations_ohai_cloud

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -572,8 +572,8 @@ Addenda
    deprecations_launchd_hash_property
    deprecations_legacy_hwrp_mixins
    deprecations_local_listen
-   deprecations_map_collision
    deprecations_locale_lc_all
+   deprecations_map_collision
    deprecations_namespace_collisions
    deprecations_ohai_amazon_linux
    deprecations_ohai_cloud


### PR DESCRIPTION
### Description

"Added a deprecation doc to inform users that we no longer support changing lc_all locale. Instead we may change other specific lc_ property as needed"

This applies the documentation made in remote fork of https://github.com/chef/chef-web-docs/pull/1848 by @Nimesh-Msys to chef-web-docs.

### Definition of Done

### Issues Resolved

"Based on the [following conversations](https://github.com/chef/chef/pull/8100), it would be a possible solution for [7904](https://github.com/chef/chef/issues/7904)"

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
