### PR TITLE
locale resource: Support LC_ Env Vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ docker-preview: docker-build
 	docker run -it -v $(shell pwd):/chef-web-docs \
 		-w /chef-web-docs/public \
 		-p 8000:8000 chefes/buildkite \
-		bash -c 'export PATH=$$PATH:/chef-web-docs/doctools; python -m SimpleHTTPServer'
+		bash -c 'export PATH=$$PATH:/chef-web-docs/doctools; python -m http.server'
 
 docker-dtags:
 	docker run -it -v $(shell pwd):/chef-web-docs \

--- a/chef_master/source/resource_locale.rst
+++ b/chef_master/source/resource_locale.rst
@@ -14,8 +14,8 @@ The locale resource has the following syntax:
 .. code-block:: ruby
 
   locale 'name' do
-    lang        String # default value: "en_US.utf8"
-    lc_all      String # default value: "en_US.utf8"
+    lang        String
+    lc_env      Hash
     action      Symbol # defaults to :update if not specified
   end
 
@@ -24,7 +24,7 @@ where:
 * ``locale`` is the resource.
 * ``name`` is the name given to the resource block.
 * ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
-* ``lang`` and ``lc_all`` are the properties available to this resource.
+* ``lang`` and ``lc_env`` are the properties available to this resource.
 
 Actions
 =====================================================
@@ -47,14 +47,26 @@ Properties
 The locale resource has the following properties:
 
 ``lang``
-   **Ruby Type:** String | **Default Value:** ``"en_US.utf8"``
+   **Ruby Type:** String
 
    Sets the default system language.
 
-``lc_all``
-   **Ruby Type:** String | **Default Value:** ``"en_US.utf8"``
+``lc_env``
+   **Ruby Type:** Hash
 
-   Sets the fallback system language.
+   Sets the locale category that corresponds to environment variable.
+
+   * *lc_env* is a hash of LC_* env variables in the form of ({'LC_ENV_VARIABLE' => 'VALUE'}).
+   * Valid values that can be used to set *LC_ENV_VARIABLE* are: LC_ADDRESS, LC_COLLATE, LC_CTYPE, LC_IDENTIFICATION, LC_MEASUREMENT, LC_MESSAGES, LC_MONETARY, LC_NAME, LC_NUMERIC, LC_PAPER, LC_TELEPHONE and LC_TIME.
+
+For example:
+
+.. code-block:: ruby
+
+  lc_env ({"LC_TIME" => "en_US.UTF8"})
+
+.. note:: These properties can also be used to unset the system locale by not passing their value or simply by ommitting the property itself.
+
 
 Common Resource Functionality
 =====================================================


### PR DESCRIPTION
Signed-off-by: Nimesh-Msys <nimesh.patni@msystechnologies.com>

### Description

Doc changes related to [8324](https://github.com/chef/chef/pull/8324).

*lc_all* property has been deprecated from locale resource, instead we have provided support to set values for other LC env variables. For that, we have introduced *lc_env* property, of Hash type that could accept any LC var as the key and language as its value.

### Definition of Done

### Issues Resolved

Based on the [following conversations](https://github.com/chef/chef/pull/8100), it would be a possible solution for [7904](https://github.com/chef/chef/issues/7904)
This would also complete the [deprecation](https://github.com/chef/chef-web-docs/pull/1848) [docs](https://github.com/chef/chef-web-docs/pull/1858)

### Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
