### PR TITLE
Update the default value for max_request_size, now that it has been changed in chef-server

### DIFF
--- a/chef_master/source/config_rb_server.rst
+++ b/chef_master/source/config_rb_server.rst
@@ -209,7 +209,7 @@ The maximum field length setting for Apache Solr should be greater than any expe
 and
 
 ``opscode_erchef['max_request_size']``
-   When the request body size is greater than this value, a 413 Request Entity Too Large error is returned. Default value: ``1000000``.
+   When the request body size is greater than this value, a 413 Request Entity Too Large error is returned. Default value: ``2000000``.
 
 to ensure that those settings are not part of the reasons for incomplete indexing, and then update the following setting so that its value is greater than the expected node file sizes:
 

--- a/chef_master/source/config_rb_server_optional_settings.rst
+++ b/chef_master/source/config_rb_server_optional_settings.rst
@@ -1088,7 +1088,7 @@ This configuration file has the following settings for ``opscode-erchef``:
    Default value: ``10000``.
 
 ``opscode_erchef['max_request_size']``
-   When the request body size is greater than this value, a ``413 Request Entity Too Large`` error is returned. Default value: ``1000000``.
+   When the request body size is greater than this value, a ``413 Request Entity Too Large`` error is returned. Default value: ``2000000``.
 
 ``opscode_erchef['nginx_bookshelf_caching']``
    Whether Nginx is used to cache cookbooks. When ``:on``, Nginx serves up the cached content instead of forwarding the request. Default value: ``:off``.

--- a/chef_master/source/install_chef_air_gap.rst
+++ b/chef_master/source/install_chef_air_gap.rst
@@ -609,4 +609,4 @@ Additional configuration options include:
    min}``.
  * ``data_collector['http_max_connection_duration']``: maximum duration an HTTP connection is allowed
    to exist before it is terminated, specified as an Erlang tuple. Default: ``{70, sec}``.
- * ``opscode_erchef['max_request_size']``: When the request body size is greater than this value, a ``413 Request Entity Too Large`` error   is returned. Default value: ``1000000``.
+ * ``opscode_erchef['max_request_size']``: When the request body size is greater than this value, a ``413 Request Entity Too Large`` error   is returned. Default value: ``2000000``.

--- a/chef_master/source/perform_compliance_scan.rst
+++ b/chef_master/source/perform_compliance_scan.rst
@@ -55,7 +55,7 @@ To make this change you'll add the following configuration options to ``/etc/ops
 .. code-block:: ruby
 
   opscode_erchef['max_request_size'] = '10000000'
-  nginx['client_max_body_size'] = '2500m'
+  nginx['client_max_body_size'] = '250m'
 
 After you have finished editing the file, run ``chef-server-ctl reconfigure`` to enable the changes.
 

--- a/chef_master/source/server_tuning.rst
+++ b/chef_master/source/server_tuning.rst
@@ -193,7 +193,7 @@ The maximum field length setting for Apache Solr should be greater than any expe
 and
 
 ``opscode_erchef['max_request_size']``
-   When the request body size is greater than this value, a 413 Request Entity Too Large error is returned. Default value: ``1000000``.
+   When the request body size is greater than this value, a 413 Request Entity Too Large error is returned. Default value: ``2000000``.
 
 to ensure that those settings are not part of the reasons for incomplete indexing, and then update the following setting so that its value is greater than the expected node file sizes:
 


### PR DESCRIPTION
also fix a crazy recommendation for nginx

Signed-off-by: Irving Popovetsky <irving@chef.io>

### Description

Updating the docs to match this change to chef server: https://github.com/chef/chef-server/pull/1649

### Definition of Done

### Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
