### PR TITLE
Add Chef Server 12 to the list of supported free distributions, it was missing

### DIFF
--- a/chef_master/source/versions.rst
+++ b/chef_master/source/versions.rst
@@ -110,6 +110,10 @@ Supported Free Distributions
      - 3.x
      - GA
      - April 30, 2020
+   * - Chef Server
+     - 12.x
+     - GA
+     - April 30, 2020
    * - InSpec
      - 3.x
      - GA


### PR DESCRIPTION

Signed-off-by: Irving Popovetsky <irving@chef.io>

### Description

Chef Server 12.x was missing from the versions page

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [x] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [x] All tests pass
