### PR TITLE
Fix of pessimistic locking example for chef_version

### DIFF
--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -68,7 +68,7 @@ This configuration file has the following settings:
 
    .. code-block:: ruby
 
-      chef_version '~> 14'
+      chef_version '~> 14.0'
 
    A more complex example where you set both a lower and upper bound of the chef-client version:
 

--- a/chef_master/source/cookbook_repo.rst
+++ b/chef_master/source/cookbook_repo.rst
@@ -106,7 +106,7 @@ This configuration file has the following settings:
 
    .. code-block:: ruby
 
-      chef_version '~> 14'
+      chef_version '~> 14.0'
 
    A more complex example where you set both a lower and upper bound of the chef-client version:
 


### PR DESCRIPTION
### Description

"minor version is required too"

This applies the documentation made in remote fork of https://github.com/chef/chef-web-docs/pull/1846 by @artem-sidorenko to chef-web-docs.

### Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
