### PR TITLE
Update cookbooks.rst

### DIFF
--- a/chef_master/source/cookbooks.rst
+++ b/chef_master/source/cookbooks.rst
@@ -70,7 +70,7 @@ In addition to attributes and recipes, the following items are also part of cook
    * - `Metadata </cookbook_repo.html>`__
      - A metadata file is used to ensure that each cookbook is correctly deployed to each node.\
    * - `Resources </resource.html>`__
-     - A resource instructs the chef-client to complete various tasks like installing packages, running Ruby code, or accessing directories and file systems. The chef-client includes built-in resources that cover many common scenarios. For the full list of resources that are built-in to the chef-client, see /resources.html.
+     - A resource instructs the chef-client to complete various tasks like installing packages, running Ruby code, or accessing directories and file systems. The chef-client includes built-in resources that cover many common scenarios. For the full list of resources that are built-in to the chef-client, see `</resources.html>`__.
    * - `Templates </templates.html>`__
      - A template is a file written in markup language that uses Ruby statements to solve complex configuration scenarios.
    * - `Cookbook Versioning </cookbook_versioning.html>`__


### PR DESCRIPTION
Make `/resources.html` a link

### Description

Simply updates the text `/resources.html` a link that users can click rather than having to manually enter or copy/paste it into their browser.

### Definition of Done

Link works as expected.

### Issues Resolved

N/A

### Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
