### PR TITLE
Update config_rb_delivery.rst

### DIFF
--- a/chef_master/source/config_rb_delivery.rst
+++ b/chef_master/source/config_rb_delivery.rst
@@ -15,7 +15,7 @@ delivery.rb Settings
 
 .. end_tag
 
-The ``delivery.rb`` file, located at ``/etc/delivery/delivery.rb``, contains all of the non-default configuration settings used by the Chef Automate. (The default settings are built-in to the Chef Automate configuration and should only be added to the ``delivery.rb`` file to apply non-default values.) These configuration settings are processed when the ``delivery-server-ctl reconfigure`` command is run, such as immediately after setting up Chef Automate or after making a change to the underlying configuration settings after the server has been deployed. The ``delivery.rb`` file is a Ruby file, which means that conditional statements can be used in the configuration file.
+The ``delivery.rb`` file, located at ``/etc/delivery/delivery.rb``, contains all of the non-default configuration settings used by the Chef Automate. (The default settings are built-in to the Chef Automate configuration and should only be added to the ``delivery.rb`` file to apply non-default values.) These configuration settings are processed when the ``automate-ctl reconfigure`` command is run, such as immediately after setting up Chef Automate or after making a change to the underlying configuration settings after the server has been deployed. The ``delivery.rb`` file is a Ruby file, which means that conditional statements can be used in the configuration file.
 
 Recommended Settings
 =====================================================
@@ -114,6 +114,6 @@ Additional settings are available for performance tuning of the Chef Automate se
 
           .. code-block:: bash
 
-             $ delivery-server-ctl reconfigure
+             $ automate-ctl reconfigure
 
 .. note:: Review the full list of `optional settings </config_rb_delivery_optional_settings.html>`__ that can be added to the ``delivery.rb`` file. Many of these optional settings should not be added without first consulting with Chef support.


### PR DESCRIPTION
Change both instances of string `delivery-server-ctl reconfigure` to string `automate-ctl reconfigure`

### Description

The documentation at https://docs.chef.io/config_rb_delivery.html states that the `delivery-server-ctl reconfigure` command should be run after updating the `delivery.rb` configuration file. Upon attempting to run this command on my Chef Automate server (version 1.8.96) I got error `delivery-server-ctl: command not found`.

Several online searches failed to yield any relevant results for command `delivery-server-ctl`, however did lead me to https://docs.chef.io/ctl_automate_server.html. Specifically, https://docs.chef.io/ctl_automate_server.html#reconfigure claims that command `automate-ctl reconfigure` should be run after updates are made to the `delivery.rb` file.

### Definition of Done

Documentation is updated to remove outdated/inaccurate references to commands.

### Issues Resolved

N/A

### Check List

- [ x ] Spell Check
- [ x ] Local build
- [ x ] Examine the local build
- [ x ] All tests pass
