### PR TITLE
Update the foodcritic flags to match current use

### DIFF
--- a/chef_master/source/foodcritic.rst
+++ b/chef_master/source/foodcritic.rst
@@ -123,7 +123,7 @@ This command has the following options:
    Environment path(s) to check.
       
 ``-G``, ``--search-gems``
-   Search rubygems for rule files with the path foodcritic/rules/**/*.rb
+   Search rubygems for rule files with the path ``foodcritic/rules/**/*.rb``.
 
 ``-I PATH``, ``--include PATH``
    Use to specify the path to a file that contains additional Foodcritic rules.
@@ -142,7 +142,7 @@ This command has the following options:
    
 ``-X``, ``--exclude PATH``
    Exclude path(s) from being linted. PATH is relative to the cookbook, not an absolute PATH.
-   Default test/**/*,spec/**/*,features/**/*  
+   Default ``test/**/*,spec/**/*,features/**/*``.
 
 For more information ...
 =====================================================

--- a/chef_master/source/foodcritic.rst
+++ b/chef_master/source/foodcritic.rst
@@ -110,24 +110,39 @@ This command has the following options:
 ``-c VERSION``, ``--chef-version VERSION``
    Use to specify the chef version to evaluate against instead of Foodcritic's default.
 
+``-r``, ``--rule-file PATH``
+   Specify file with rules to be used or ignored.
+
 ``-B PATH``, ``--cookbook-path PATH``
    Use to specify the path to a cookbook to check
 
 ``-C``, ``--[no-]context``
    Use to show lines matched against Foodcritic rules, rather than the default summary.
+   
+``-E``, ``--environment-path PATH``      
+   Environment path(s) to check.
+      
+``-G``, ``--search-gems``
+   Search rubygems for rule files with the path foodcritic/rules/**/*.rb
 
 ``-I PATH``, ``--include PATH``
    Use to specify the path to a file that contains additional Foodcritic rules.
 
-``-r``, ``--[no-]repl``
-   Use to drop into a REPL for interactive rule editing.
+``-P``, ``--[no-]progress``
+   Show progress of files being checked.
+
+``-R``, ``--role-path PATH``
+   Role path(s) to check.
 
 ``-S PATH``, ``--search-grammar PATH``
    Use to specify the path to a file that contains additional grammar used when validating search syntax.
 
-
 ``-V``, ``--version``
    Use to display the version of Foodcritic.
+   
+``-X``, ``--exclude PATH``
+   Exclude path(s) from being linted. PATH is relative to the cookbook, not an absolute PATH.
+   Default test/**/*,spec/**/*,features/**/*  
 
 For more information ...
 =====================================================


### PR DESCRIPTION
### Description

"The foodcritic flags have evolved since this doc was written.  I don't know why the lower case flags are not sorted by alphabetic order but decided they were not the core issue here, so I left them alone.

Signed-off-by: markgibbons <mark.gibbons@nordstrom.com>"

This applies the documentation made in remote fork of https://github.com/chef/chef-web-docs/pull/1871 by @MarkGibbons to chef-web-docs.

### Definition of Done

### Issues Resolved

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
