### PR TITLE
policy_group and policy_name description around the wrong way

### DIFF
--- a/chef_master/source/config_rb_client.rst
+++ b/chef_master/source/config_rb_client.rst
@@ -280,10 +280,10 @@ This configuration file has the following settings:
    The location in which a process identification number (pid) is saved. An executable, when started as a daemon, writes the pid to the specified file. Default value: ``/tmp/name-of-executable.pid``.
 
 ``policy_group``
-   The name of a policy, as identified by the ``name`` setting in a Policyfile.rb file. ``policy_name`` must also be specified.
+   The name of a policy group that exists on the Chef server. ``policy_name`` must also be specified.
 
 ``policy_name``
-   The name of a policy group that exists on the Chef server. ``policy_group`` must also be specified.
+   The name of a policy, as identified by the ``name`` setting in a Policyfile.rb file. ``policy_group`` must also be specified.
 
 ``rest_timeout``
    The time (in seconds) after which an HTTP REST request is to time out. Default value: ``300``.

--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -214,9 +214,9 @@ This command has the following options:
       * - Setting
         - Description
       * - ``policy_group``
-        - The name of a policy, as identified by the ``name`` setting in a Policyfile.rb file.
-      * - ``policy_name``
         - The name of a policy group that exists on the Chef server.
+      * - ``policy_name``
+        - The name of a policy, as identified by the ``name`` setting in a Policyfile.rb file.
 
    For example:
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -5388,9 +5388,9 @@ Or use the following settings to specify a policy revision in the client.rb file
    * - Setting
      - Description
    * - ``policy_group``
-     - The name of a policy, as identified by the ``name`` setting in a Policyfile.rb file.
-   * - ``policy_name``
      - The name of a policy group that exists on the Chef server.
+   * - ``policy_name``
+     - The name of a policy, as identified by the ``name`` setting in a Policyfile.rb file.
 
 New Configuration Settings
 -----------------------------------------------------
@@ -5405,9 +5405,9 @@ The following settings are new for the client.rb file and enable the use of poli
    * - ``named_run_list``
      - The run-list associated with a policy file.
    * - ``policy_group``
-     - The name of a policy, as identified by the ``name`` setting in a Policyfile.rb file. (See "Specify Policy Revision" in this readme for more information.)
-   * - ``policy_name``
      - The name of a policy group that exists on the Chef server. (See "Specify Policy Revision" in this readme for more information.)
+   * - ``policy_name``
+     - The name of a policy, as identified by the ``name`` setting in a Policyfile.rb file. (See "Specify Policy Revision" in this readme for more information.)
 
 chef-client Options
 -----------------------------------------------------
@@ -5430,9 +5430,9 @@ The following options are new or updated for the chef-client executable and enab
       * - Setting
         - Description
       * - ``policy_group``
-        - The name of a policy, as identified by the ``name`` setting in a Policyfile.rb file.
-      * - ``policy_name``
         - The name of a policy group that exists on the Chef server.
+      * - ``policy_name``
+        - The name of a policy, as identified by the ``name`` setting in a Policyfile.rb file.
 
    For example:
 


### PR DESCRIPTION
### Description

"Swap text descriptions of policy_group and policy_name. Signed-off-by: Adam Ward <adamw@subdesigns.net>"

This applies the documentation made in remote fork of https://github.com/chef/chef-web-docs/pull/1872 by @atward to chef-web-docs.

### Definition of Done

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
