### PR TITLE
Update cookbook_repo.rst

### DIFF
--- a/chef_master/source/cookbook_repo.rst
+++ b/chef_master/source/cookbook_repo.rst
@@ -25,7 +25,7 @@ To create a cookbook (including all default components), run the following comma
 
 .. code-block:: bash
 
-   $ knife cookbook create COOKBOOK_NAME
+   $ chef generate cookbook COOKBOOK_NAME
 
 where ``COOKBOOK_NAME`` is the name of the cookbook that will be created. Any unneeded directory components can be left unused or deleted, if preferred.
 


### PR DESCRIPTION
### Description

"`knife cookbook create` to `chef generate cookbook`"

This applies the documentation made in remote fork of https://github.com/chef/chef-web-docs/pull/1873 by @daxgames to chef-web-docs.

### Definition of Done

### Issues Resolved

"Updates deprecated command to the current command"

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
