### PR TITLE
correct the description of Supermarket's search endpoint

### DIFF
--- a/chef_master/source/supermarket_api.rst
+++ b/chef_master/source/supermarket_api.rst
@@ -416,11 +416,7 @@ The response will return details for a cookbook version, including the license u
 /search
 -----------------------------------------------------
 
-.. tag search
-
-Search indexes allow queries to be made for any type of data that is indexed by the Chef server, including data bags (and data bag items), environments, nodes, and roles. A defined query syntax is used to support search patterns like exact, wildcard, range, and fuzzy. A search is a full-text query that can be done from several locations, including from within a recipe, by using the ``search`` subcommand in knife, the ``search`` method in the Recipe DSL, the search box in the Chef management console, and by using the ``/search`` or ``/search/INDEX`` endpoints in the Chef server API. The search engine is based on Apache Solr and is run from the Chef server.
-
-.. end_tag
+Search performs a fuzzy, keyword search on cookbook names, cookbook descriptions, and the cookbook owners' usernames.
 
 The ``/search`` endpoint has the following methods: ``GET``.
 


### PR DESCRIPTION
### Description

Corrects the description of Supermarket's search endpoint which looks like it came from Chef Server's API documentation. 😶 

### Definition of Done

Maybe some word smithing? I'm not particularly proud of "Search returns cookbooks that match a query."

### Issues Resolved

@Xorima is trying to build a client library for the API and noticed this documentation was a bit off.

### Check List

- [x] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
