### PR TITLE
Removes dtags from release notes

### DIFF
--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -4108,11 +4108,11 @@ The ksh resource has the following properties:
    The group name or group ID that must be changed before running a command.
 
 ``path``
+     .. warning:: The ``path`` property has been deprecated and will throw an exception in Chef Client 12 or later. We recommend you use the ``environment`` property instead.
+
    **Ruby Type:** Array
 
    An array of paths to use when searching for a command. These paths are not added to the command's environment $PATH. The default value uses the system path.
-
-                The ``path`` property has been deprecated and will throw an exception in Chef Client 12 or later. We recommend you use the ``environment`` property instead.
 
       For example:
 
@@ -5615,7 +5615,7 @@ This argument has the following options:
 ``-k``, ``--prevent-keygen``
    Create a user without a public key. This key may be managed later by using the ``knife user key`` subcommands.
 
-             This option is valid only with Chef server API, version 1.0, which was released with Chef server 12.1. If this option or the ``--user-key`` option are not passed in the command, the Chef server will create a user with a public key named ``default`` and will return the private key. For the Chef server versions earlier than 12.1, this option will not work; a public key is always generated unless ``--user-key`` is passed in the command.
+   .. note:: This option is valid only with Chef server API, version 1.0, which was released with Chef server 12.1. If this option or the ``--user-key`` option are not passed in the command, the Chef server will create a user with a public key named ``default`` and will return the private key. For the Chef server versions earlier than 12.1, this option will not work; a public key is always generated unless ``--user-key`` is passed in the command.
 
 ``-p FILE``, ``--public-key FILE``
    The path to a file that contains the public key. This option may not be passed in the same command with ``--prevent-keygen``. When using Chef a default key is generated if this option is not passed in the command. For Chef server version 12.x, see the ``--prevent-keygen`` option.
@@ -5636,7 +5636,7 @@ This argument has the following options:
 ``-k``, ``--prevent-keygen``
    Create a user without a public key. This key may be managed later by using the ``knife user key`` subcommands.
 
-             This option is valid only with Chef server API, version 1.0, which was released with Chef server 12.1. If this option or the ``--user-key`` option are not passed in the command, the Chef server will create a user with a public key named ``default`` and will return the private key. For the Chef server versions earlier than 12.1, this option will not work; a public key is always generated unless ``--user-key`` is passed in the command.
+   .. note:: This option is valid only with Chef server API, version 1.0, which was released with Chef server 12.1. If this option or the ``--user-key`` option are not passed in the command, the Chef server will create a user with a public key named ``default`` and will return the private key. For the Chef server versions earlier than 12.1, this option will not work; a public key is always generated unless ``--user-key`` is passed in the command.
 
 ``-p PASSWORD``, ``--password PASSWORD``
    The user password. This option only works when used with the open source Chef server and will have no effect when used with Enterprise Chef or Chef server 12.x.
@@ -5726,20 +5726,13 @@ Desired State Configuration (DSC) is a feature of Windows PowerShell that provid
 The **dsc_resource** resource allows any DSC resource to be used in a Chef recipe, as well as any custom resources that have been added to your Windows PowerShell environment. Microsoft `frequently adds new resources <https://github.com/powershell/DscResources>`_ to the DSC resource collection.
 
 
-             Using the **dsc_resource** has the following requirements:
+Using the **dsc_resource** has the following requirements:
 
-             * Windows Management Framework (WMF) 5.0 February Preview (or higher), which includes Windows PowerShell 5.0.10018.0 (or higher).
-             * The ``RefreshMode`` configuration setting in the Local Configuration Manager must be set to ``Disabled``.
-
-               **NOTE:** Starting with the chef-client 12.6 release, this requirement applies only for versions of Windows PowerShell earlier than 5.0.10586.0. The latest version of Windows Management Framework (WMF) 5 has relaxed the limitation that prevented the chef-client from running in non-disabled refresh mode.
-
-             * The **dsc_script** resource  may not be used in the same run-list with the **dsc_resource**. This is because the **dsc_script** resource requires that ``RefreshMode`` in the Local Configuration Manager be set to ``Push``, whereas the **dsc_resource** resource requires it to be set to ``Disabled``.
-
-               **NOTE:** Starting with the chef-client 12.6 release, this requirement applies only for versions of Windows PowerShell earlier than 5.0.10586.0. The latest version of Windows Management Framework (WMF) 5 has relaxed the limitation that prevented the chef-client from running in non-disabled refresh mode, which allows the Local Configuration Manager to be set to ``Push``.
-
-             * The **dsc_resource** resource can only use binary- or script-based resources. Composite DSC resources may not be used.
-
-               This is because composite resources aren't "real" resources from the perspective of the Local Configuration Manager (LCM). Composite resources are used by the "configuration" keyword from the ``PSDesiredStateConfiguration`` module, and then evaluated in that context. When using DSC to create the configuration document (the Managed Object Framework (MOF) file) from the configuration command, the composite resource is evaluated. Any individual resources from that composite resource are written into the Managed Object Framework (MOF) document. As far as the Local Configuration Manager (LCM) is concerned, there is no such thing as a composite resource. Unless that changes, the **dsc_resource** resource and/or ``Invoke-DscResource`` command cannot directly use them.
+   * Windows Management Framework (WMF) 5.0 February Preview (or higher), which includes Windows PowerShell 5.0.10018.0 (or higher).
+   * The ``RefreshMode`` configuration setting in the Local Configuration Manager must be set to ``Disabled``.
+      .. note:: Starting with the chef-client 12.6 release, the ``RefreshMode: Disabled`` requirement applies only for versions of Windows PowerShell earlier than 5.0.10586.0. The latest version of Windows Management Framework (WMF) 5 has relaxed the limitation that prevented the chef-client from running in non-disabled refresh mode.
+   * The **dsc_script** resource  may not be used in the same run-list with the **dsc_resource**. This is because the **dsc_script** resource requires that ``RefreshMode`` in the Local Configuration Manager be set to ``Push``, whereas the **dsc_resource** resource requires it to be set to ``Disabled``.
+   * The **dsc_resource** resource can only use binary- or script-based resources. Composite DSC resources may not be used. This is because composite resources aren't "real" resources from the perspective of the Local Configuration Manager (LCM). Composite resources are used by the "configuration" keyword from the ``PSDesiredStateConfiguration`` module, and then evaluated in that context. When using DSC to create the configuration document (the Managed Object Framework (MOF) file) from the configuration command, the composite resource is evaluated. Any individual resources from that composite resource are written into the Managed Object Framework (MOF) document. As far as the Local Configuration Manager (LCM) is concerned, there is no such thing as a composite resource. Unless that changes, the **dsc_resource** resource and/or ``Invoke-DscResource`` command cannot directly use them.
 
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -7099,7 +7092,7 @@ The following attribute is new for the **chef_gem** resource:
 ``compile_time``
    Controls the phase during which a gem is installed on a node. Set to ``true`` to install a gem while the resource collection is being built (the "compile phase"). Set to ``false`` to install a gem while the chef-client is configuring the node (the "converge phase"). Possible values: ``nil`` (for verbose warnings), ``true`` (to warn once per chef-client run), or ``false`` (to remove all warnings). Recommended value: ``false``.
 
-   .. This topic is hooked into client.rb topics, starting with 12.1, in addition to the resource reference pages.
+   .. note::  This topic is hooked into client.rb topics, starting with 12.1, in addition to the resource reference pages.
 
    To suppress warnings for cookbooks authored prior to chef-client 12.1, use a ``respond_to?`` check to ensure backward compatibility. For example:
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -271,7 +271,6 @@ What’s New in 14.6
           full_name 'John Doe'
         end
 
-
   * **zypper_package**
       The ``zypper_package`` resource now includes a new ``global_options`` property. This property can be used to specify one or more options for the zypper command line that are global in context.
 
@@ -862,7 +861,6 @@ Other Changes
 
         default['staging']['myapp']['title'] = "My Staging App" default['production']['myapp']['title'] = "My App"
 
-
      and then accesses the node attribute in their cookbook as:
 
      .. code-block:: ruby
@@ -1042,7 +1040,6 @@ What's New in 13.11
   - ``osx_profile`` now uses the full path the profiles CLI tool to avoid running other binaries of the same name in a users path
   - ``package`` resources that don't support the ``allow_downgrade`` property will no longer fail
   - ``knife bootstrap windows`` error messages have been improved
-
 
 * **Security Updates**
 
@@ -1226,7 +1223,6 @@ What's New in 13.7.16
 
   * OpenSSL has been upgraded to 1.0.2n to resolve `CVE-2017-3738 <https://nvd.nist.gov/vuln/detail/CVE-2017-3738>`__, `CVE-2017-3737 <https://nvd.nist.gov/vuln/detail/CVE-2017-3737>`__, `CVE-2017-3736 <https://nvd.nist.gov/vuln/detail/CVE-2017-3736>`__, and `CVE-2017-3735 <https://nvd.nist.gov/vuln/detail/CVE-2017-3735>`__
   * Ruby has been upgraded to 2.4.3 to resolve `CVE-2017-17405 <https://nvd.nist.gov/vuln/detail/CVE-2017-17405>`__
-
 
 Deprecations
 -----------------------------------------------------
@@ -1484,13 +1480,10 @@ What's New in 13.0/13.1
 * **New default encrypted databag format**
 * **Backwards compatibility breaks**
 
-
 It is now possible to blacklist node attributes
 -----------------------------------------------------
 Blacklist Attributes
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-.. tag node_attribute_blacklist
 
 .. warning:: When attribute blacklist settings are used, any attribute defined in a blacklist will not be saved and any attribute that is not defined in a blacklist will be saved. Each attribute type is blacklisted independently of the other attribute types. For example, if ``automatic_attribute_blacklist`` defines attributes that will not be saved, but ``normal_attribute_blacklist``, ``default_attribute_blacklist``, and ``override_attribute_blacklist`` are not defined, then all normal attributes, default attributes, and override attributes will be saved, as well as the automatic attributes that were not specifically excluded through blacklisting.
 
@@ -1501,7 +1494,6 @@ Attributes are blacklisted by attribute type, with each attribute type being bla
 .. list-table::
    :widths: 200 300
    :header-rows: 1
-
 
    * - Setting
      - Description
@@ -1550,8 +1542,6 @@ For attributes that contain slashes (``/``) within the attribute value, such as 
 .. code-block:: ruby
 
    automatic_attribute_blacklist [['filesystem','/dev/diskos2']]
-
-.. end_tag
 
 RubyGems provider sources behavior changed.
 -----------------------------------------------------
@@ -1709,7 +1699,6 @@ For example:
    n = node.to_hash   # or node.dup
    n["foo"] << "buzz"
 
-
 before this would have mutated the original string in-place so that ``node["foo"]`` and ``node.default["foo"]`` would have changed to "fizzbuzz" while now they remain "fizz" and only the mutable ``n["foo"]`` copy is changed to "fizzbuzz".
 
 Freezing immutable merged attributes
@@ -1787,7 +1776,6 @@ Accessing a provider class is a bit more complex, as you need a resource against
 
    Chef::ProviderResolver.new(node, find_resource!("mycook_thing[name]"), :nothing).resolve
 
-
 Default values for resource properties are frozen
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 A resource declaring something like:
@@ -1802,7 +1790,6 @@ will now see the default value set to be immutable. This prevents cases of modif
 
    property :x, default: lazy { {} }
 
-
 ResourceCollection and notifications
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 Resources which later modify their name during creation will have their name changed on the ResourceCollection and notifications
@@ -1811,7 +1798,6 @@ Resources which later modify their name during creation will have their name cha
 
 some_resource "name_one" do
   name "name_two"
-
 
 The fix for sending notifications to multipackage resources involved changing the API so that it no longer directly takes the string that is typed into the DSL but reads the (possibly coerced) name off of the resource after it is built.
 The result is that the above resource will be named ``some_resource[name_two]`` instead of ``some_resource[name_one]``.  Note that setting the name (*not* the ``name_property``, but actually renaming the resource) is very uncommon.  The fix is to name the resource correctly in the first place (``some_resource name_two do``).
@@ -2034,7 +2020,6 @@ Bugfixes
 -----------------------------------------------------
 Fixes issue where the `apt_repository </resource_apt_repository.html>`_ resource couldn't identify key fingerprints when gnupg 2.1.x was used.
 
-
 What's New in 12.19
 =====================================================
 
@@ -2123,7 +2108,6 @@ Highlighted bug fixes for this release:
 * **Ensure that the Windows Administrator group can access the chef-solo nodes directory**
 * **When loading a cookbook in Chef Solo, use ``metadata.json`` in preference to ``metadata.rb``.**
 
-
 What's New in 12.18
 =====================================================
 
@@ -2139,7 +2123,6 @@ New deprecations
 * `run_command helper method </deprecations_run_command.html>`__
 * `DNF package allow_downgrade property </deprecations_dnf_package_allow_downgrade.html>`__
 
-
 What's New in 12.17
 =====================================================
 
@@ -2154,8 +2137,6 @@ msu_package resource
 -----------------------------------------------------
 
 The **msu_package** resource installs or removes Microsoft Update(MSU) packages on Microsoft Windows machines. Here are some examples:
-
-.. tag msu_package_examples
 
 **Using local path in source**
 
@@ -2188,8 +2169,6 @@ The **msu_package** resource installs or removes Microsoft Update(MSU) packages 
      source 'https://s3.amazonaws.com/my_bucket/Windows8.1-KB2959977-x64.msu'
      action :remove
    end
-
-.. end_tag
 
 ``unmount`` alias for ``umount`` action
 -----------------------------------------------------
@@ -2229,11 +2208,9 @@ Haskell is now detected in a new haskell language plugin:
     }
   }
 
-
 **LSB Release Detection**
 
 The lsb_release command line tool is now preferred to the contents of ``/etc/lsb-release`` for release detection. This resolves an issue where a distro can be upgraded, but ``/etc/lsb-release`` is not upgraded to reflect the change.
-
 
 What's New in 12.16
 =====================================================
@@ -2378,11 +2355,8 @@ The following items are new for chef-client 12.14 and/or are changes from previo
 
 yum_repository
 -----------------------------------------------------
-.. tag resource_yum_repository_summary
 
 Use the **yum_repository** resource to manage a Yum repository configuration file located at ``/etc/yum.repos.d/repositoryid.repo`` on the local machine. This configuration file specifies which repositories to reference, how to handle cached data, etc.
-
-.. end_tag
 
 For syntax, a list of properties and actions, see `yum_repository </resource_yum_repository.html>`__.
 
@@ -2644,7 +2618,6 @@ This resource has the following properties:
 
    Specifies if the unit will be verified before installation. Systemd can be overly strict when verifying units, so in certain cases it is preferable not to verify the unit.
 
-
 What's New in 12.10
 =====================================================
 The following items are new for chef-client 12.10 and/or are changes from previous versions. The short version:
@@ -2655,7 +2628,6 @@ The following items are new for chef-client 12.10 and/or are changes from previo
 
 with_run_context
 -----------------------------------------------------
-.. tag dsl_recipe_method_with_run_context
 
 Use the ``with_run_context`` method to define a block that has a pointer to a location in the ``run_context`` hierarchy. Resources in recipes always run at the root of the ``run_context`` hierarchy, whereas custom resources and notification blocks always build a child ``run_context`` which contains their sub-resources.
 
@@ -2688,11 +2660,8 @@ For example:
      end
    end
 
-.. end_tag
-
 declare_resource
 -----------------------------------------------------
-.. tag dsl_recipe_method_declare_resource
 
 Use the ``declare_resource`` method to instantiate a resource and then add it to the resource collection.
 
@@ -2724,11 +2693,8 @@ is equivalent to:
      action :delete
    end
 
-.. end_tag
-
 delete_resource
 -----------------------------------------------------
-.. tag dsl_recipe_method_delete_resource
 
 Use the ``delete_resource`` method to find a resource in the resource collection, and then delete it.
 
@@ -2749,11 +2715,8 @@ For example:
 
    delete_resource(:template, '/x/y.erb')
 
-.. end_tag
-
 delete_resource!
 -----------------------------------------------------
-.. tag dsl_recipe_method_delete_resource_bang
 
 Use the ``delete_resource!`` method to find a resource in the resource collection, and then delete it. If the resource is not found, an exception is returned.
 
@@ -2774,11 +2737,8 @@ For example:
 
    delete_resource!(:file, '/x/file.txt')
 
-.. end_tag
-
 edit_resource
 -----------------------------------------------------
-.. tag dsl_recipe_method_edit_resource
 
 Use the ``edit_resource`` method to:
 
@@ -2816,11 +2776,8 @@ and a resource block:
      notifies :run, 'execute[newaliases]'
    end
 
-.. end_tag
-
 edit_resource!
 -----------------------------------------------------
-.. tag dsl_recipe_method_edit_resource_bang
 
 Use the ``edit_resource!`` method to:
 
@@ -2847,11 +2804,8 @@ For example:
 
    edit_resource!(:file, '/x/y.rst')
 
-.. end_tag
-
 find_resource
 -----------------------------------------------------
-.. tag dsl_recipe_method_find_resource
 
 Use the ``find_resource`` method to:
 
@@ -2886,11 +2840,8 @@ and a resource block:
      notifies :run, 'execute[newseapower]'
    end
 
-.. end_tag
-
 find_resource!
 -----------------------------------------------------
-.. tag dsl_recipe_method_find_resource_bang
 
 Use the ``find_resource!`` method to find a resource in the resource collection. If the resource is not found, an exception is returned.
 
@@ -2910,8 +2861,6 @@ For example:
 .. code-block:: ruby
 
    find_resource!(:template, '/x/y.erb')
-
-.. end_tag
 
 What's New in 12.9
 =====================================================
@@ -2965,7 +2914,6 @@ For more information, see: `File System Redirector <https://msdn.microsoft.com/e
 
 Key Redirection
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag notes_registry_key_redirection
 
 64-bit versions of Microsoft Windows have a 32-bit compatibility layer in the registry that reflects and redirects certain keys (and their values) into specific locations (or logical views) of the registry hive.
 
@@ -2974,8 +2922,6 @@ The chef-client can access any reflected or redirected registry key. The machine
 32-bit versions of the chef-client (12.8 and earlier) and 64-bit versions of the chef-client (12.9 and later) generally behave the same in this situation, with one exception: it is only possible to read and write from a redirected registry location using chef-client version 12.9 (and later).
 
 For more information, see: `Registry Reflection <https://msdn.microsoft.com/en-us/library/windows/desktop/aa384235(v=vs.85).aspx>`_.
-
-.. end_tag
 
 What's New in 12.8
 =====================================================
@@ -2991,7 +2937,6 @@ The following items are new for chef-client 12.8 and/or are changes from previou
 
 FIPS Mode
 -----------------------------------------------------
-.. tag fips_intro_client
 
 Federal Information Processing Standards (FIPS) is a United States government computer security standard that specifies security requirements for cryptography. The current version of the standard is FIPS 140-2. The chef-client can be configured to allow OpenSSL to enforce FIPS-validated security during a chef-client run. This will disable cryptography that is explicitly disallowed in FIPS-validated software, including certain ciphers and hashing algorithms. Any attempt to use any disallowed cryptography will cause the chef-client to throw an exception during a chef-client run.
 
@@ -3002,8 +2947,6 @@ Notes about FIPS:
 * May be enabled for nodes running on Microsoft Windows and Enterprise Linux platforms
 * Should only be enabled for environments that require FIPS 140-2 compliance
 * May not be enabled for any version of the chef-client earlier than 12.8
-
-.. end_tag
 
 Enable FIPS Mode
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -3022,8 +2965,6 @@ The following command-line option may be used to with a knife or chef-client exe
 
 **Bootstrap a node using FIPS**
 
-.. tag knife_bootstrap_node_fips
-
 .. To bootstrap a node:
 
 .. code-block:: bash
@@ -3038,8 +2979,6 @@ which shows something similar to:
    ...
    192.0.2.0 Chef Client finished, 12/12 resources updated in 78.942455583 seconds
 
-.. end_tag
-
 Configuration Setting
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 The following configuration setting may be set in the knife.rb, client.rb, or config.rb files:
@@ -3049,7 +2988,6 @@ The following configuration setting may be set in the knife.rb, client.rb, or co
 
 .d Directories
 -----------------------------------------------------
-.. tag config_rb_client_dot_d_directories
 
 The chef-client supports reading multiple configuration files by putting them inside a ``.d`` configuration directory. For example: ``/etc/chef/client.d``. All files that end in ``.rb`` in the ``.d`` directory are loaded; other non-``.rb`` files are ignored.
 
@@ -3072,19 +3010,13 @@ The ``old_settings.rb.bak`` file is ignored because it's not a configuration fil
 
 .. note:: If multiple configuration files exists in a ``.d`` directory, ensure that the same setting has the same value in all files.
 
-.. end_tag
-
 launchd
 -----------------------------------------------------
-.. tag resource_launchd_summary
 
 Use the **launchd** resource to manage system-wide services (daemons) and per-user services (agents) on the macOS platform.
 
-.. end_tag
-
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_launchd_syntax_12_8
 
 A **launchd** resource manages system-wide services (daemons) and per-user services (agents) on the macOS platform:
 
@@ -3166,11 +3098,8 @@ where
 * ``action`` identifies the steps the chef-client will take to bring the node into the desired state
 * ``abandon_process_group``, ``backup``, ``cookbook``, ``debug``, ``disabled``, ``enable_globbing``, ``enable_transactions``, ``environment_variables``, ``exit_timeout``, ``group``, ``hard_resource_limits``, ``hash``, ``inetd_compatibility``, ``init_groups``, ``keep_alive``, ``label``, ``launch_only_once``, ``limit_load_from_hosts``, ``limit_load_to_hosts``, ``limit_load_to_session_type``, ``low_priority_io``, ``mach_services``, ``mode``, ``nice``, ``on_demand``, ``owner``, ``path``, ``process_type``, ``program``, ``program_arguments``, ``queue_directories``, ``retries``, ``retry_delay``, ``root_directory``, ``run_at_load``, ``sockets``, ``soft_resource_limits``, ``standard_error_path``, ``standard_in_path``, ``standard_out_path``, ``start_calendar_interval``, ``start_interval``, ``start_on_mount``, ``throttle_interval``, ``time_out``, ``type``, ``umask``, ``username``, ``wait_for_debugger``, ``watch_paths``, and ``working_directory`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_launchd_actions
 
 The launchd resource has the following actions:
 
@@ -3193,17 +3122,12 @@ The launchd resource has the following actions:
    Restart a launchd managed daemon or agent.
 
 ``:nothing``
-   .. tag resources_common_actions_nothing
 
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
-   .. end_tag
-
-.. end_tag
 
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_launchd_attributes_12_8
 
 This resource has the following properties:
 
@@ -3251,13 +3175,8 @@ This resource has the following properties:
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_notifies
-
    A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_timers
 
    A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
 
@@ -3270,17 +3189,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
 
    The syntax for ``notifies`` is:
 
    .. code-block:: ruby
 
      notifies :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``owner``
    **Ruby Type:** Integer, String
@@ -3315,8 +3229,6 @@ This resource has the following properties:
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_subscribes
-
    A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
 
    Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
@@ -3334,9 +3246,6 @@ This resource has the following properties:
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
 
-   .. end_tag
-
-   .. tag resources_common_notification_timers
 
    A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
 
@@ -3349,17 +3258,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
 
    The syntax for ``subscribes`` is:
 
    .. code-block:: ruby
 
       subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``supports``
    **Ruby Type:** Array
@@ -3574,14 +3478,10 @@ The following resource properties may be used to define keys in the XML property
 
    ``chdir`` to this directory, and then run the job.
 
-.. end_tag
-
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **Create a Launch Daemon from a cookbook file**
-
-.. tag resource_launchd_create_from_cookbook
 
 .. Create a Launch Daemon from a cookbook file:
 
@@ -3591,11 +3491,7 @@ Examples
      source 'com.chef.every15.plist'
    end
 
-.. end_tag
-
 **Create a Launch Daemon using keys**
-
-.. tag resource_launchd_create_using_keys
 
 .. Create a Launch Daemon using keys**
 
@@ -3607,11 +3503,7 @@ Examples
      time_out 300
    end
 
-.. end_tag
-
 **Remove a Launch Daemon**
-
-.. tag resource_launchd_remove
 
 .. Remove a Launch Daemon:
 
@@ -3621,11 +3513,8 @@ Examples
      action :delete
    end
 
-.. end_tag
-
 gem, metadata.rb
 -----------------------------------------------------
-.. tag config_rb_metadata_settings_gem
 
 Specifies a gem dependency for installation into the chef-client through bundler. The gem installation occurs after all cookbooks are synchronized but before loading any other cookbooks. Use this attribute one time for each gem dependency. For example:
 
@@ -3633,8 +3522,6 @@ Specifies a gem dependency for installation into the chef-client through bundler
 
    gem "poise"
    gem "chef-sugar"
-
-.. end_tag
 
 What's New in 12.7
 =====================================================
@@ -3660,15 +3547,11 @@ For code that is run using knife or chef command line interfaces, consider using
 
 chocolatey_package
 -----------------------------------------------------
-.. tag resource_package_chocolatey
 
 Use the **chocolatey_package** resource to manage packages using Chocolatey on the Microsoft Windows platform.
 
-.. end_tag
-
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_package_chocolatey_syntax_12_7
 
 A **chocolatey_package** resource block manages packages using Chocolatey for the Microsoft Windows platform. The simplest use of the **chocolatey_package** resource is:
 
@@ -3700,11 +3583,8 @@ where
 * ``action`` identifies which steps the chef-client will take to bring the node into the desired state
 * ``options``, ``package_name``, ``source``, ``timeout``, and ``version`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_package_chocolatey_actions_12_7
 
 This resource has the following actions:
 
@@ -3712,11 +3592,8 @@ This resource has the following actions:
    Default. Install a package. If a version is specified, install the specified version of the package.
 
 ``:nothing``
-   .. tag resources_common_actions_nothing
 
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
-
-   .. end_tag
 
 ``:purge``
    Purge a package. This action typically removes the configuration files as well as the package.
@@ -3733,11 +3610,8 @@ This resource has the following actions:
 ``:upgrade``
    Install a package and/or ensure that a package is the latest version.
 
-.. end_tag
-
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_package_chocolatey_attributes_12_7
 
 This resource has the following properties:
 
@@ -3749,13 +3623,8 @@ This resource has the following properties:
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_notifies
-
    A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_timers
 
    A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
 
@@ -3768,17 +3637,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
 
    The syntax for ``notifies`` is:
 
    .. code-block:: ruby
 
      notifies :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``options``
    **Ruby Type:** String
@@ -3808,8 +3672,6 @@ This resource has the following properties:
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_subscribes
-
    A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
 
    Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
@@ -3827,9 +3689,6 @@ This resource has the following properties:
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
 
-   .. end_tag
-
-   .. tag resources_common_notification_timers
 
    A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
 
@@ -3842,17 +3701,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
 
    The syntax for ``subscribes`` is:
 
    .. code-block:: ruby
 
       subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``timeout``
    **Ruby Type:** String, Integer
@@ -3864,14 +3718,10 @@ This resource has the following properties:
 
    The version of a package to be installed or upgraded.
 
-.. end_tag
-
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **Install a package**
-
-.. tag resource_chocolatey_package_install
 
 .. To install a package:
 
@@ -3892,19 +3742,13 @@ This example uses Chocolatey's ``--checksum`` option:
      action :install
    end
 
-.. end_tag
-
 osx_profile
 -----------------------------------------------------
-.. tag resource_osx_profile_summary
 
 Use the **osx_profile** resource to manage configuration profiles (``.mobileconfig`` files) on the macOS platform. The **osx_profile** resource installs profiles by using the ``uuidgen`` library to generate a unique ``ProfileUUID``, and then using the ``profiles`` command to install the profile on the system.
 
-.. end_tag
-
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_osx_profile_syntax
 
 A **osx_profile** resource block manages configuration profiles on the macOS platform:
 
@@ -3933,11 +3777,8 @@ where
 * ``action`` identifies the steps the chef-client will take to bring the node into the desired state
 * ``profile``, ``profile_name``, and ``identifier`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_osx_profile_actions
 
 The osx_profile resource has the following actions:
 
@@ -3945,20 +3786,14 @@ The osx_profile resource has the following actions:
    Default. Install the specified configuration profile.
 
 ``:nothing``
-   .. tag resources_common_actions_nothing
 
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
-
-   .. end_tag
 
 ``:remove``
    Remove the specified configuration profile.
 
-.. end_tag
-
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_osx_profile_properties
 
 The osx_profile resource has the following properties:
 
@@ -3966,7 +3801,6 @@ The osx_profile resource has the following properties:
    **Ruby Type:** String
 
    Use to specify the identifier for the profile, such as ``com.company.screensaver``.
-
 
 ``path``
    **Ruby Type:** String
@@ -3983,14 +3817,10 @@ The osx_profile resource has the following properties:
 
    Use to specify the name of the profile, if different from the name of the resource block.
 
-.. end_tag
-
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **One liner to install profile from cookbook file**
-
-.. tag resource_osx_profile_install_file_oneline
 
 The ``profiles`` command will be used to install the specified configuration profile.
 
@@ -3998,11 +3828,7 @@ The ``profiles`` command will be used to install the specified configuration pro
 
    osx_profile 'com.company.screensaver.mobileconfig'
 
-.. end_tag
-
 **Install profile from cookbook file**
-
-.. tag resource_osx_profile_install_file
 
 The ``profiles`` command will be used to install the specified configuration profile. It can be in sub-directory within a cookbook.
 
@@ -4012,11 +3838,7 @@ The ``profiles`` command will be used to install the specified configuration pro
      profile 'screensaver/com.company.screensaver.mobileconfig'
    end
 
-.. end_tag
-
 **Install profile from a hash**
-
-.. tag resource_osx_profile_install_hash
 
 The ``profiles`` command will be used to install the configuration profile, which is provided as a hash.
 
@@ -4058,11 +3880,7 @@ The ``profiles`` command will be used to install the configuration profile, whic
      profile profile_hash
    end
 
-.. end_tag
-
 **Remove profile using identifier in resource name**
-
-.. tag resource_osx_profile_remove_by_name
 
 The ``profiles`` command will be used to remove the configuration profile specified by the provided ``identifier`` property.
 
@@ -4072,11 +3890,7 @@ The ``profiles`` command will be used to remove the configuration profile specif
      action :remove
    end
 
-.. end_tag
-
 **Remove profile by identifier and user friendly resource name**
-
-.. tag resource_osx_profile_remove_by_identifier
 
 The ``profiles`` command will be used to remove the configuration profile specified by the provided ``identifier`` property.
 
@@ -4087,16 +3901,10 @@ The ``profiles`` command will be used to remove the configuration profile specif
      action :remove
    end
 
-.. end_tag
-
 apt_update
 -----------------------------------------------------
 
-.. tag resource_apt_update_summary
-
 Use the **apt_update** resource to manage APT repository updates on Debian and Ubuntu platforms.
-
-.. end_tag
 
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -4119,16 +3927,12 @@ where
 
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_apt_update_actions
 
 The apt_update resource has the following actions:
 
 ``:nothing``
-   .. tag resources_common_actions_nothing
 
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
-
-   .. end_tag
 
 ``:periodic``
    Update the Apt repository at the interval specified by the ``frequency`` property.
@@ -4136,11 +3940,8 @@ The apt_update resource has the following actions:
 ``:update``
    Update the Apt repository at the start of the chef-client run.
 
-.. end_tag
-
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_apt_update_properties
 
 The apt_update resource has the following properties:
 
@@ -4149,14 +3950,10 @@ The apt_update resource has the following properties:
 
    Determines how frequently (in seconds) APT repository updates are made. Use this property when the ``:periodic`` action is specified.
 
-.. end_tag
-
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **Update the Apt repository at a specified interval**
-
-.. tag resource_apt_update_periodic
 
 .. To update the Apt repository at a specified interval:
 
@@ -4167,19 +3964,13 @@ Examples
      action :periodic
    end
 
-.. end_tag
-
 **Update the Apt repository at the start of a chef-client run**
-
-.. tag resource_apt_update_at_start_of_client_run
 
 .. To update the Apt repository at the start of a chef-client run:
 
 .. code-block:: ruby
 
    apt_update 'update'
-
-.. end_tag
 
 New chef-client options
 -----------------------------------------------------
@@ -4205,7 +3996,6 @@ The following items are new for chef-client 12.6 and/or are changes from previou
 
 Notification Timers
 -----------------------------------------------------
-.. tag resources_common_notification_timers
 
 A timer specifies the point during the Chef Client run at which a notification is run. The following timers are available:
 
@@ -4218,17 +4008,12 @@ A timer specifies the point during the Chef Client run at which a notification i
 ``:immediate``, ``:immediately``
    Specifies that a notification should be run immediately, per resource notified.
 
-.. end_tag
-
 ksh
 -----------------------------------------------------
-.. tag resource_script_ksh
 
 Use the **ksh** resource to execute scripts using the Korn shell (ksh) interpreter. This resource may also use any of the actions and properties that are available to the **execute** resource. Commands that are executed with this resource are (by their nature) not idempotent, as they are typically unique to the environment in which they are run. Use ``not_if`` and ``only_if`` to guard this resource for idempotence.
 
 .. note:: The **ksh** script resource (which is based on the **script** resource) is different from the **ruby_block** resource because Ruby code that is run with this resource is created as a temporary file and executed like other script resources, rather than run inline.
-
-.. end_tag
 
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -4276,10 +4061,8 @@ where
 * ``action`` identifies the steps the chef-client will take to bring the node into the desired state
 * ``code``, ``creates``, ``cwd``, ``environment``, ``flags``, ``group``, ``path``, ``returns``, ``timeout``, ``user``, and ``umask`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_script_ksh_actions
 
 The ksh resource has the following actions:
 
@@ -4289,11 +4072,8 @@ The ksh resource has the following actions:
 ``:run``
    Default. Run a script.
 
-.. end_tag
-
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_script_ksh_properties
 
 The ksh resource has the following properties:
 
@@ -4332,11 +4112,7 @@ The ksh resource has the following properties:
 
    An array of paths to use when searching for a command. These paths are not added to the command's environment $PATH. The default value uses the system path.
 
-   .. warning:: .. tag resources_common_resource_execute_attribute_path
-
                 The ``path`` property has been deprecated and will throw an exception in Chef Client 12 or later. We recommend you use the ``environment`` property instead.
-
-                .. end_tag
 
       For example:
 
@@ -4366,11 +4142,8 @@ The ksh resource has the following properties:
 
    The file mode creation mask, or umask.
 
-.. end_tag
-
 Changes for PowerShell 5.0.10586.0
 -----------------------------------------------------
-.. tag resource_dsc_resource_requirements
 
 Using the **dsc_resource** has the following requirements:
 
@@ -4386,8 +4159,6 @@ Using the **dsc_resource** has the following requirements:
 * The **dsc_resource** resource can only use binary- or script-based resources. Composite DSC resources may not be used.
 
   This is because composite resources aren't "real" resources from the perspective of the Local Configuration Manager (LCM). Composite resources are used by the "configuration" keyword from the ``PSDesiredStateConfiguration`` module, and then evaluated in that context. When using DSC to create the configuration document (the Managed Object Framework (MOF) file) from the configuration command, the composite resource is evaluated. Any individual resources from that composite resource are written into the Managed Object Framework (MOF) document. As far as the Local Configuration Manager (LCM) is concerned, there is no such thing as a composite resource. Unless that changes, the **dsc_resource** resource and/or ``Invoke-DscResource`` command cannot directly use them.
-
-.. end_tag
 
 New metadata.rb Settings
 -----------------------------------------------------
@@ -4417,15 +4188,11 @@ The following settings are new for metadata.rb:
    * - ``ohai_version``
      - A range of chef-client versions that are supported by this cookbook.
 
-       .. tag config_rb_metadata_settings_example_ohai_version
-
        For example, to match any 8.x version of Ohai, but not 7.x or 9.x:
 
        .. code-block:: ruby
 
           ohai_version "~> 8"
-
-       .. end_tag
 
 .. note:: These settings are not visible in Chef Supermarket.
 
@@ -4440,7 +4207,6 @@ The ``--identify-file`` option is now ``--ssh-identify-file``.
 
 --profile-ruby Option
 -----------------------------------------------------
-.. tag ctl_chef_client_profile_ruby
 
 Use the ``--profile-ruby`` option to dump a (large) profiling graph into ``/var/chef/cache/graph_profile.out``. Use the graph output to help identify, and then resolve performance bottlenecks in a chef-client run. This option:
 
@@ -4448,8 +4214,6 @@ Use the ``--profile-ruby`` option to dump a (large) profiling graph into ``/var/
 * Has a dependency on the ``ruby-prof`` gem, which is packaged as part of Chef and the Chef development kit.
 * Increases the amount of time required to complete the chef-client run.
 * Should not be used in a production environment.
-
-.. end_tag
 
 What's New in 12.5
 =====================================================
@@ -4467,7 +4231,6 @@ The following items are new for chef-client 12.5 and/or are changes from previou
 
 Custom Resources
 -----------------------------------------------------
-.. tag custom_resources_summary
 
 A custom resource:
 
@@ -4479,13 +4242,10 @@ A custom resource:
 
 For example, Chef includes built-in resources to manage files, packages, templates, and services, but it does not include a resource that manages websites.
 
-.. end_tag
-
 .. note:: See /custom_resources.html for more information about custom resources, including a scenario that shows how to build a ``website`` resource.
 
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag custom_resources_syntax
 
 A custom resource is defined as a Ruby file and is located in a cookbook's ``/resources`` directory. This file
 
@@ -4516,8 +4276,6 @@ where the first action listed is the default action.
 .. warning::
    Do not use existing keywords from the chef-client resource system in a custom resource, like "name". For example, ``property :property_name`` in the following invalid syntax:
    ``property :name, String, default: 'thename'``.
-
-.. end_tag
 
 This example ``site`` utilizes Chef's built in ``file``, ``service`` and ``package`` resources, and includes ``:create`` and ``:delete`` actions. Since it uses built in Chef resources, besides defining the property and actions, the code is very similar to that of a recipe.
 
@@ -4567,15 +4325,12 @@ and to delete the exampleco website, do the following:
 
 Custom Resource DSL
 -----------------------------------------------------
-.. tag dsl_custom_resource_summary
 
 Use the Custom Resource DSL to define property behaviors within custom resources, such as:
 
 * Loading the value of a specific property
 * Comparing the current property value against a desired property value
 * Telling the chef-client when and how to make changes
-
-.. end_tag
 
 action_class
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -4666,7 +4421,6 @@ When the file does not exist, the ``IO.write(path, content)`` code is executed a
        - update my_file[blah]
        -   set content to "hola mundo" (was "hello world")
 
-
 Multiple Properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -4704,7 +4458,6 @@ The chef-client will only update the property values that require updates and wi
 
 default_action
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_custom_resource_method_default_action
 
 The default action in a custom resource is, by default, the first action listed in the custom resource. For example, action ``aaaaa`` is the default resource:
 
@@ -4740,11 +4493,8 @@ The ``default_action`` method may also be used to specify the default action. Fo
 
 defines action ``aaaaa`` as the default action. If ``default_action :bbbbb`` is specified, then action ``bbbbb`` is the default action. Use this method for clarity in custom resources, if deliberately stating the default resource is desired, or to specify a default action that is not listed first in the custom resource.
 
-.. end_tag
-
 load_current_value
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_custom_resource_method_load_current_value
 
 Use the ``load_current_value`` method to load the specified property values from the node, and then use those values when the resource is converged. This method may take a block argument.
 
@@ -4764,11 +4514,8 @@ Use the ``load_current_value`` method to guard against property values being rep
 
 This ensures the values for ``homepage`` and ``page_not_found`` are not changed to the default values when the chef-client configures the node.
 
-.. end_tag
-
 new_resource.property
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_custom_resource_method_new_resource
 
 Custom resources are designed to use core resources that are built into Chef. In some cases, it may be necessary to specify a property in the custom resource that is the same as a property in a core resource, for the purpose of overriding that property when used with the custom resource. For example:
 
@@ -4850,11 +4597,8 @@ To prevent this behavior, use ``new_resource.`` to tell the chef-client to proce
 
 where ``cwd new_resource.cwd``, ``environment new_resource.environment``, ``user new_resource.user``, and ``sensitive new_resource.sensitive`` correctly use the properties of the **execute** resource and not the identically-named override properties of the custom resource.
 
-.. end_tag
-
 property
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_custom_resource_method_property
 
 Use the ``property`` method to define properties for the custom resource. The syntax is:
 
@@ -4876,11 +4620,8 @@ For example, the following properties define ``username`` and ``password`` prope
    property :username, String
    property :password, String
 
-.. end_tag
-
 ruby_type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag dsl_custom_resource_method_property_ruby_type
 
 The property ruby_type is a positional parameter. Use to ensure a property value is of a particular ruby class, such as ``true``, ``false``, ``nil``, ``String``, ``Array``, ``Hash``, ``Integer``, ``Symbol``. Use an array of ruby classes to allow a value to be of more than one type. For example:
 
@@ -4912,11 +4653,8 @@ The property ruby_type is a positional parameter. Use to ensure a property value
 
           property :gggg, [Array, Hash]
 
-.. end_tag
-
 validators
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag dsl_custom_resource_method_property_validation_parameter
 
 A validation parameter is used to add zero (or more) validation parameters to a property.
 
@@ -4998,11 +4736,8 @@ Some examples of combining validation parameters:
 
    property :enabled, equal_to: [true, false, 'true', 'false'], default: true
 
-.. end_tag
-
 desired_state
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag dsl_custom_resource_method_property_desired_state
 
 Add ``desired_state:`` to set the desired state property for a resource. This value may be ``true`` or ``false``, and all properties default to true.
 
@@ -5019,11 +4754,8 @@ For example, if you were to write a resource to create volumes on a cloud provid
    property :cloud_login, String, desired_state: false
    property :cloud_password, String, desired_state: false
 
-.. end_tag
-
 identity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag dsl_custom_resource_method_property_identity
 
 Add ``identity:`` to set a resource to a particular set of properties. This value may be ``true`` or ``false``.
 
@@ -5039,11 +4771,8 @@ For example, the following properties define ``username`` and ``password`` prope
    property :username, String, identity: true
    property :password, String
 
-.. end_tag
-
 Block Arguments
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag dsl_custom_resource_method_property_block_argument
 
 Any properties that are marked ``identity: true`` or ``desired_state: false`` will be available from ``load_current_value``. If access to other properties of a resource is needed, use a block argument that contains all of the properties of the requested resource. For example:
 
@@ -5055,11 +4784,8 @@ Any properties that are marked ``identity: true`` or ``desired_state: false`` wi
      puts "The user typed content = #{desired.content} in the resource"
    end
 
-.. end_tag
-
 property_is_set?
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_custom_resource_method_property_is_set
 
 Use the ``property_is_set?`` method to check if the value for a property is set. The syntax is:
 
@@ -5087,11 +4813,8 @@ For example, the following custom resource creates and/or updates user propertie
     end
   end
 
-.. end_tag
-
 provides
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_custom_resource_method_provides
 
 Use the ``provides`` method to associate a custom resource with the Recipe DSL on different operating systems. When multiple custom resources use the same DSL, specificity rules are applied to determine the priority, from highest to lowest:
 
@@ -5119,11 +4842,8 @@ For example:
 
 This allows you to use multiple custom resources files that provide the same resource to the user, but for different operating systems or operation system versions. With this you can eliminate the need for platform or platform version logic within your resources.
 
-.. end_tag
-
 override
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag dsl_custom_resource_method_provides_override
 
 Chef will warn you if the Recipe DSL is provided by another custom resource or built-in resource. For example:
 
@@ -5149,11 +4869,8 @@ This will emit a warning that ``Y`` is overriding ``X``. To disable this warning
      provides :file, override: true
    end
 
-.. end_tag
-
 reset_property
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_custom_resource_method_reset_property
 
 Use the ``reset_property`` method to clear the value for a property as if it had never been set, and then use the default value. For example, to clear the value for a property named ``password``:
 
@@ -5161,11 +4878,8 @@ Use the ``reset_property`` method to clear the value for a property as if it had
 
    reset_property(:password)
 
-.. end_tag
-
 Definition vs. Resource
 -----------------------------------------------------
-.. tag definition_example
 
 The following examples show:
 
@@ -5173,11 +4887,8 @@ The following examples show:
 #. The same definition rewritten as a custom resource
 #. The same definition, rewritten again to use a `common resource property </resource_common.html>`__
 
-.. end_tag
-
 As a Definition
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag definition_example_as_definition
 
 The following definition processes unique hostnames and ports, passed on as parameters:
 
@@ -5195,11 +4906,8 @@ The following definition processes unique hostnames and ports, passed on as para
      end
    end
 
-.. end_tag
-
 As a Resource
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag definition_example_as_resource
 
 The definition is improved by rewriting it as a custom resource:
 
@@ -5236,11 +4944,8 @@ or:
      port 4001
    end
 
-.. end_tag
-
 Common Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag definition_example_as_resource_with_common_properties
 
 Unlike definitions, custom resources are able to use `common resource properties </resource_common.html>`__. For example, ``only_if``:
 
@@ -5251,11 +4956,8 @@ Unlike definitions, custom resources are able to use `common resource properties
      only_if '{ node['hostname'] == 'foo.bar.com' }'
    end
 
-.. end_tag
-
 ps_credential Helper
 -----------------------------------------------------
-.. tag resource_dsc_script_helper_ps_credential
 
 Use the ``ps_credential`` helper to embed a ``PSCredential`` object--- `a set of security credentials, such as a user name or password <https://technet.microsoft.com/en-us/magazine/ff714574.aspx>`__ ---within a script, which allows that script to be run using security credentials.
 
@@ -5283,11 +4985,8 @@ For example, assuming the ``CertificateID`` is configured in the local configura
     EOH
   end
 
-.. end_tag
-
 Handler DSL
 -----------------------------------------------------
-.. tag dsl_handler_summary
 
 Use the Handler DSL to attach a callback to an event. If the event occurs during the chef-client run, the associated callback is executed. For example:
 
@@ -5295,11 +4994,8 @@ Use the Handler DSL to attach a callback to an event. If the event occurs during
 * Sending a notification to chat application if an audit run fails
 * Aggregating statistics about resources updated during a chef-client runs to StatsD
 
-.. end_tag
-
 on Method
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_handler_method_on
 
 Use the ``on`` method to associate an event type with a callback. The callback defines what steps are taken if the event occurs during the chef-client run and is defined using arbitrary Ruby code. The syntax is as follows:
 
@@ -5327,11 +5023,8 @@ For example:
      end
    end
 
-.. end_tag
-
 Example: Send Email
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_handler_slide_send_email
 
 Use the ``on`` method to create an event handler that sends email when the chef-client run fails. This will require:
 
@@ -5339,13 +5032,9 @@ Use the ``on`` method to create an event handler that sends email when the chef-
 * An event handler that describes what to do when the ``:run_failed`` event is triggered
 * A way to trigger the exception and test the behavior of the event handler
 
-.. end_tag
-
 .. note:: See /dsl_handler.html for more information about using event handlers in recipes.
 
 **Define How Email is Sent**
-
-.. tag dsl_handler_slide_send_email_library
 
 Use a library to define the code that sends email when a chef-client run fails. Name the file ``helper.rb`` and add it to a cookbook's ``/libraries`` directory:
 
@@ -5370,11 +5059,7 @@ Use a library to define the code that sends email when a chef-client run fails. 
      end
    end
 
-.. end_tag
-
 **Add the Handler**
-
-.. tag dsl_handler_slide_send_email_handler
 
 Invoke the library helper in a recipe:
 
@@ -5393,11 +5078,7 @@ Invoke the library helper in a recipe:
 
 Within the ``on`` block, tell the chef-client how to handle the event when it's triggered.
 
-.. end_tag
-
 **Test the Handler**
-
-.. tag dsl_handler_slide_send_email_test
 
 Use the following code block to trigger the exception and have the chef-client send email to the specified email address:
 
@@ -5408,8 +5089,6 @@ Use the following code block to trigger the exception and have the chef-client s
        fail 'deliberately fail the run'
      end
    end
-
-.. end_tag
 
 New Resource Properties
 -----------------------------------------------------
@@ -5483,8 +5162,6 @@ The following options are new or updated for the chef-client executable and enab
 ``-j PATH``, ``--json-attributes PATH``
    This option now supports using a JSON file to associate a policy revision.
 
-   .. tag policy_ctl_run_list
-
    Use this option to use policy files by specifying a JSON file that contains the following settings:
 
    .. list-table::
@@ -5507,11 +5184,7 @@ The following options are new or updated for the chef-client executable and enab
         "policy_group": "staging"
       }
 
-   .. end_tag
-
    This option also supports using a JSON file to associate an environment:
-
-   .. tag ctl_chef_client_environment
 
    Use this option to set the ``chef_environment`` value for a node.
 
@@ -5532,8 +5205,6 @@ The following options are new or updated for the chef-client executable and enab
       }
 
    This will set the environment for the node to ``pre-production``.
-
-   .. end_tag
 
 What's New in 12.4
 =====================================================
@@ -5560,7 +5231,6 @@ When using the **remote_file** resource, the location of a source file may be sp
 
 Import-Module chef
 -----------------------------------------------------
-.. tag knife_common_windows_quotes_module
 
 The chef-client version 12.4 release adds an optional feature to the Microsoft Installer Package (MSI) for Chef. This feature enables the ability to pass quoted strings from the Windows PowerShell command line without the need for triple single quotes (``''' '''``). This feature installs a Windows PowerShell module (typically in ``C:\opscode\chef\modules``) that is also appended to the ``PSModulePath`` environment variable. This feature is not enabled by default. To activate this feature, run the following command from within Windows PowerShell:
 
@@ -5606,8 +5276,6 @@ To remove this feature, run the following command from within Windows PowerShell
 
    $ Remove-Module chef
 
-.. end_tag
-
 client.rb Settings
 -----------------------------------------------------
 The following settings have changed:
@@ -5642,8 +5310,6 @@ Examples:
 
 **Specify a URL for the source attribute**
 
-.. tag resource_package_windows_source_url
-
 .. To install a package using a URL for the source:
 
 .. code-block:: ruby
@@ -5652,11 +5318,7 @@ Examples:
      source 'http://www.7-zip.org/a/7z938-x64.msi'
    end
 
-.. end_tag
-
 **Specify path and checksum**
-
-.. tag resource_package_windows_source_url_checksum
 
 .. To install a package using a URL for the source and specifying a checksum:
 
@@ -5667,11 +5329,7 @@ Examples:
      checksum '7c8e873991c82ad9cfc123415254ea6101e9a645e12977dcd518979e50fdedf3'
    end
 
-.. end_tag
-
 **Modify remote_file resource attributes**
-
-.. tag resource_package_windows_source_remote_file_properties
 
 The **windows_package** resource may specify a package at a remote location using the ``remote_file_attributes`` property. This uses the **remote_file** resource to download the contents at the specified URL and passes in a Hash that modifies the properties of the `remote_file resource </resource_remote_file.html>`__.
 
@@ -5687,27 +5345,18 @@ For example:
      })
    end
 
-.. end_tag
-
 knife client key
 -----------------------------------------------------
-.. tag knife_client_summary
 
 Use the ``knife client`` subcommand to manage an API client list and their associated RSA public key-pairs. This allows authentication requests to be made to the Chef server by any entity that uses the Chef server API, such as the chef-client and knife.
 
-.. end_tag
-
 key create
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag knife_client_key_create
 
 Use the ``key create`` argument to create a public key.
 
-.. end_tag
-
 Syntax
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_client_key_create_syntax
 
 This argument has the following syntax:
 
@@ -5715,11 +5364,8 @@ This argument has the following syntax:
 
    $ knife client key create CLIENT_NAME (options)
 
-.. end_tag
-
 Options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_client_key_create_options
 
 This argument has the following options:
 
@@ -5735,19 +5381,13 @@ This argument has the following options:
 ``-p FILE_NAME``, ``--public-key FILE_NAME``
    The path to a file that contains the public key. If this option is not specified, and only if ``--key-name`` is specified, the Chef server will generate a public/private key pair.
 
-.. end_tag
-
 key delete
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag knife_client_key_delete
 
 Use the ``key delete`` argument to delete a public key.
 
-.. end_tag
-
 Syntax
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_client_key_delete_syntax
 
 This argument has the following syntax:
 
@@ -5755,19 +5395,13 @@ This argument has the following syntax:
 
    $ knife client key delete CLIENT_NAME KEY_NAME
 
-.. end_tag
-
 key edit
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag knife_client_key_edit
 
 Use the ``key edit`` argument to modify or rename a public key.
 
-.. end_tag
-
 Syntax
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_client_key_edit_syntax
 
 This argument has the following syntax:
 
@@ -5775,11 +5409,8 @@ This argument has the following syntax:
 
    $ knife client key edit CLIENT_NAME KEY_NAME (options)
 
-.. end_tag
-
 Options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_client_key_edit_options
 
 This argument has the following options:
 
@@ -5798,19 +5429,13 @@ This argument has the following options:
 ``-p FILE_NAME``, ``--public-key FILE_NAME``
    The path to a file that contains the public key. If this option is not specified, and only if ``--key-name`` is specified, the Chef server will generate a public/private key pair.
 
-.. end_tag
-
 key list
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag knife_client_key_list
 
 Use the ``key list`` argument to view a list of public keys for the named client.
 
-.. end_tag
-
 Syntax
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_client_key_list_syntax
 
 This argument has the following syntax:
 
@@ -5818,11 +5443,8 @@ This argument has the following syntax:
 
    $ knife client key list CLIENT_NAME (options)
 
-.. end_tag
-
 Options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_client_key_list_options
 
 This argument has the following options:
 
@@ -5835,19 +5457,13 @@ This argument has the following options:
 ``-w``, ``--with-details``
    Show a list of public keys, including URIs and expiration status.
 
-.. end_tag
-
 key show
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag knife_client_key_show
 
 Use the ``key show`` argument to view details for a specific public key.
 
-.. end_tag
-
 Syntax
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_client_key_show_syntax
 
 This argument has the following syntax:
 
@@ -5855,27 +5471,18 @@ This argument has the following syntax:
 
    $ knife client key show CLIENT_NAME KEY_NAME
 
-.. end_tag
-
 knife user key
 -----------------------------------------------------
-.. tag knife_user_summary
 
 Use the ``knife user`` subcommand to manage the list of users and their associated RSA public key-pairs.
 
-.. end_tag
-
 key create
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag knife_user_key_create
 
 Use the ``key create`` argument to create a public key.
 
-.. end_tag
-
 Syntax
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_user_key_create_syntax
 
 This argument has the following syntax:
 
@@ -5883,11 +5490,8 @@ This argument has the following syntax:
 
    $ knife user key create USER_NAME (options)
 
-.. end_tag
-
 Options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_user_key_create_options
 
 This argument has the following options:
 
@@ -5903,19 +5507,13 @@ This argument has the following options:
 ``-p FILE_NAME``, ``--public-key FILE_NAME``
    The path to a file that contains the public key. If this option is not specified, and only if ``--key-name`` is specified, the Chef server will generate a public/private key pair.
 
-.. end_tag
-
 key delete
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag knife_user_key_delete
 
 Use the ``key delete`` argument to delete a public key.
 
-.. end_tag
-
 Syntax
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_user_key_delete_syntax
 
 This argument has the following syntax:
 
@@ -5923,19 +5521,13 @@ This argument has the following syntax:
 
    $ knife user key delete USER_NAME KEY_NAME
 
-.. end_tag
-
 key edit
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag knife_user_key_edit
 
 Use the ``key edit`` argument to modify or rename a public key.
 
-.. end_tag
-
 Syntax
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_user_key_edit_syntax
 
 This argument has the following syntax:
 
@@ -5943,11 +5535,8 @@ This argument has the following syntax:
 
    $ knife user key edit USER_NAME KEY_NAME (options)
 
-.. end_tag
-
 Options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_user_key_edit_options
 
 This argument has the following options:
 
@@ -5966,19 +5555,13 @@ This argument has the following options:
 ``-p FILE_NAME``, ``--public-key FILE_NAME``
    The path to a file that contains the public key. If this option is not specified, and only if ``--key-name`` is specified, the Chef server will generate a public/private key pair.
 
-.. end_tag
-
 key list
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag knife_user_key_list
 
 Use the ``key list`` argument to view a list of public keys for the named user.
 
-.. end_tag
-
 Syntax
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_user_key_list_syntax
 
 This argument has the following syntax:
 
@@ -5986,11 +5569,8 @@ This argument has the following syntax:
 
    $ knife user key list USER_NAME (options)
 
-.. end_tag
-
 Options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_user_key_list_options
 
 This argument has the following options:
 
@@ -6003,19 +5583,13 @@ This argument has the following options:
 ``-w``, ``--with-details``
    Show a list of public keys, including URIs and expiration status.
 
-.. end_tag
-
 key show
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag knife_user_key_show
 
 Use the ``key show`` argument to view details for a specific public key.
 
-.. end_tag
-
 Syntax
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag knife_user_key_show_syntax
 
 This argument has the following syntax:
 
@@ -6023,15 +5597,12 @@ This argument has the following syntax:
 
    $ knife user key show USER_NAME KEY_NAME
 
-.. end_tag
-
 Updated knife Options
 -----------------------------------------------------
 With the new key management subcommands, the options for ``knife client create`` and ``knife user create`` have changed.
 
 knife client create
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag knife_client_create_options
 
 This argument has the following options:
 
@@ -6044,19 +5615,13 @@ This argument has the following options:
 ``-k``, ``--prevent-keygen``
    Create a user without a public key. This key may be managed later by using the ``knife user key`` subcommands.
 
-   .. note:: .. tag notes_knife_prevent_keygen
-
              This option is valid only with Chef server API, version 1.0, which was released with Chef server 12.1. If this option or the ``--user-key`` option are not passed in the command, the Chef server will create a user with a public key named ``default`` and will return the private key. For the Chef server versions earlier than 12.1, this option will not work; a public key is always generated unless ``--user-key`` is passed in the command.
-
-             .. end_tag
 
 ``-p FILE``, ``--public-key FILE``
    The path to a file that contains the public key. This option may not be passed in the same command with ``--prevent-keygen``. When using Chef a default key is generated if this option is not passed in the command. For Chef server version 12.x, see the ``--prevent-keygen`` option.
 
 ``--validator``
    Create the client as the chef-validator. Default value: ``true``.
-
-.. end_tag
 
 knife user create
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -6071,11 +5636,7 @@ This argument has the following options:
 ``-k``, ``--prevent-keygen``
    Create a user without a public key. This key may be managed later by using the ``knife user key`` subcommands.
 
-   .. note:: .. tag notes_knife_prevent_keygen
-
              This option is valid only with Chef server API, version 1.0, which was released with Chef server 12.1. If this option or the ``--user-key`` option are not passed in the command, the Chef server will create a user with a public key named ``default`` and will return the private key. For the Chef server versions earlier than 12.1, this option will not work; a public key is always generated unless ``--user-key`` is passed in the command.
-
-             .. end_tag
 
 ``-p PASSWORD``, ``--password PASSWORD``
    The user password. This option only works when used with the open source Chef server and will have no effect when used with Enterprise Chef or Chef server 12.x.
@@ -6123,7 +5684,6 @@ This setting may be configured using the ``minimal_ohai`` setting in the client.
 
 Dynamic Resolution
 -----------------------------------------------------
-.. tag libraries_dynamic_resolution
 
 Resources and providers are resolved dynamically and can handle multiple ``provides`` lines for a specific platform. When multiple ``provides`` lines exist, such as ``Homebrew`` and ``MacPorts`` packages for the macOS platform, then one is selected based on resource priority mapping performed by the chef-client during the chef-client run.
 
@@ -6147,8 +5707,6 @@ For example:
 
    Chef.set_resource_priority_array(:package, [ Chef::Resource::MacportsPackage ], os: 'darwin')
 
-.. end_tag
-
 What's New in 12.2
 =====================================================
 The following items are new for chef-client 12.2 and/or are changes from previous versions. The short version:
@@ -6159,25 +5717,14 @@ The following items are new for chef-client 12.2 and/or are changes from previou
 dsc_resource
 -----------------------------------------------------
 
-.. tag resources_common_powershell
-
 Windows PowerShell is a task-based command-line shell and scripting language developed by Microsoft. Windows PowerShell uses a document-oriented approach for managing Microsoft Windows-based machines, similar to the approach that is used for managing Unix and Linux-based machines. Windows PowerShell is `a tool-agnostic platform <https://docs.microsoft.com/en-us/powershell/scripting/powershell-scripting>`_ that supports using Chef for configuration management.
 
-.. end_tag
-
-.. tag resources_common_powershell_dsc
 
 Desired State Configuration (DSC) is a feature of Windows PowerShell that provides `a set of language extensions, cmdlets, and resources <https://docs.microsoft.com/en-us/powershell/dsc/overview>`_ that can be used to declaratively configure software. DSC is similar to Chef, in that both tools are idempotent, take similar approaches to the concept of resources, describe the configuration of a system, and then take the steps required to do that configuration. The most important difference between Chef and DSC is that Chef uses Ruby and DSC is exposed as configuration data from within Windows PowerShell.
 
-.. end_tag
-
-.. tag resource_dsc_resource_summary
 
 The **dsc_resource** resource allows any DSC resource to be used in a Chef recipe, as well as any custom resources that have been added to your Windows PowerShell environment. Microsoft `frequently adds new resources <https://github.com/powershell/DscResources>`_ to the DSC resource collection.
 
-.. end_tag
-
-.. warning:: .. tag resource_dsc_resource_requirements
 
              Using the **dsc_resource** has the following requirements:
 
@@ -6194,11 +5741,8 @@ The **dsc_resource** resource allows any DSC resource to be used in a Chef recip
 
                This is because composite resources aren't "real" resources from the perspective of the Local Configuration Manager (LCM). Composite resources are used by the "configuration" keyword from the ``PSDesiredStateConfiguration`` module, and then evaluated in that context. When using DSC to create the configuration document (the Managed Object Framework (MOF) file) from the configuration command, the composite resource is evaluated. Any individual resources from that composite resource are written into the Managed Object Framework (MOF) document. As far as the Local Configuration Manager (LCM) is concerned, there is no such thing as a composite resource. Unless that changes, the **dsc_resource** resource and/or ``Invoke-DscResource`` command cannot directly use them.
 
-             .. end_tag
-
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_dsc_resource_syntax_12_2
 
 A **dsc_resource** resource block allows DSC resourcs to be used in a Chef recipe. For example, the DSC ``Archive`` resource:
 
@@ -6240,8 +5784,6 @@ where
 * ``property`` is zero (or more) properties in the DSC resource, where each property is entered on a separate line, ``:dsc_property_name`` is the case-insensitive name of that property, and ``"property_value"`` is a Ruby value to be applied by the chef-client
 * ``module_name``, ``property``, and ``resource`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
-.. end_tag
-
 Attributes
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 This resource has the following properties:
@@ -6259,13 +5801,8 @@ This resource has the following properties:
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_notifies
-
    A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
 
-   .. end_tag
-
-   .. tag 5
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timers are available:
 
@@ -6275,9 +5812,6 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
 
    The syntax for ``notifies`` is:
 
@@ -6285,16 +5819,12 @@ This resource has the following properties:
 
      notifies :action, 'resource[name]', :timer
 
-   .. end_tag
-
 ``property``
    **Ruby Type:** Symbol
 
    A property from a Desired State Configuration (DSC) resource. Use this property multiple times, one for each property in the Desired State Configuration (DSC) resource. The format for this property must follow ``property :dsc_property_name, "property_value"`` for each DSC property added to the resource block.
 
    The ``:dsc_property_name`` must be a symbol.
-
-   .. tag resource_dsc_resource_ruby_types
 
    Use the following Ruby types to define ``property_value``:
 
@@ -6321,14 +5851,10 @@ This resource has the following properties:
 
    These are converted into the corresponding Windows PowerShell type during the chef-client run.
 
-   .. end_tag
-
 ``resource``
    **Ruby Type:** String
 
    The name of the DSC resource. This value is case-insensitive and must be a symbol that matches the name of the DSC resource.
-
-   .. tag resource_dsc_resource_features
 
    For built-in DSC resources, use the following values:
 
@@ -6367,8 +5893,6 @@ This resource has the following properties:
 
    Any DSC resource may be used in a Chef recipe. For example, the DSC Resource Kit contains resources for `configuring Active Directory components <http://www.powershellgallery.com/packages/xActiveDirectory/2.8.0.0>`_, such as ``xADDomain``, ``xADDomainController``, and ``xADUser``. Assuming that these resources are available to the chef-client, the corresponding values for the ``resource`` attribute would be: ``:xADDomain``, ``:xADDomainController``, and ``xADUser``.
 
-   .. end_tag
-
 ``retries``
    **Ruby Type:** Integer | **Default Value:** ``0``
 
@@ -6381,8 +5905,6 @@ This resource has the following properties:
 
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_subscribes
 
    A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
 
@@ -6401,9 +5923,6 @@ This resource has the following properties:
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
 
-   .. end_tag
-
-   .. tag 5
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timers are available:
 
@@ -6413,9 +5932,6 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
 
    The syntax for ``subscribes`` is:
 
@@ -6423,14 +5939,10 @@ This resource has the following properties:
 
       subscribes :action, 'resource[name]', :timer
 
-   .. end_tag
-
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **Open a Zip file**
-
-.. tag resource_dsc_resource_zip_file
 
 .. To use a zip file:
 
@@ -6443,11 +5955,7 @@ Examples
       property :destination, 'C:\Users\Public\Documents\ExtractionPath'
     end
 
-.. end_tag
-
 **Manage users and groups**
-
-.. tag resource_dsc_resource_manage_users
 
 .. To manage users and groups
 
@@ -6473,8 +5981,6 @@ Examples
      property :MembersToInclude, ['Foobar1']
    end
 
-.. end_tag
-
 What's New in 12.1
 =====================================================
 The following items are new for chef-client 12.1 and/or are changes from previous versions. The short version:
@@ -6495,7 +6001,6 @@ The following items are new for chef-client 12.1 and/or are changes from previou
 
 chef-client, audit-mode
 -----------------------------------------------------
-.. tag chef_client_audit_mode
 
 The chef-client may be run in audit-mode. Use audit-mode to evaluate custom rules---also referred to as audits---that are defined in recipes. audit-mode may be run in the following ways:
 
@@ -6505,8 +6010,6 @@ The chef-client may be run in audit-mode. Use audit-mode to evaluate custom rule
 Each audit is authored within a recipe using the ``control_group`` and ``control`` methods that are part of the Recipe DSL. Recipes that contain audits are added to the run-list, after which they can be processed by the chef-client. Output will appear in the same location as the regular chef-client run (as specified by the ``log_location`` setting in the client.rb file).
 
 Finished audits are reported back to the Chef server. From there, audits are sent to the Chef Analytics platform for further analysis, such as rules processing and visibility from the actions web user interface.
-
-.. end_tag
 
 Use following option to run the chef-client in audit-mode mode:
 
@@ -6542,13 +6045,8 @@ control
 -----------------------------------------------------
 A control is an automated test that is built into a cookbook, and then used to test the state of the system for compliance. Compliance can be many things. For example, ensuring that file and directory management meets specific internal IT policies---"Does the file exist?", "Do the correct users or groups have access to this directory?". Compliance may also be complex, such as helping to ensure goals defined by large-scale compliance frameworks such as PCI, HIPAA, and Sarbanes-Oxley can be met.
 
-.. tag dsl_recipe_method_control
-
 Use the ``control`` method to define a specific series of tests that comprise an individual audit. A ``control`` method MUST be contained within a ``control_group`` block. A ``control_group`` block may contain multiple ``control`` methods.
 
-.. end_tag
-
-.. tag dsl_recipe_method_control_syntax
 
 The syntax for the ``control`` method is as follows:
 
@@ -6571,11 +6069,8 @@ where:
 * An ``expect(something).to/.to_not be_something`` is a statement that represents the individual test. In other words, this statement tests if something is expected to be (or not be) something. For example, a test that expects the PostgreSQL pacakge to not be installed would be similar to ``expect(package('postgresql')).to_not be_installed`` and a test that ensures a service is enabled would be similar to ``expect(service('init')).to be_enabled``
 * An ``it`` statement may contain multiple ``expect`` statements
 
-.. end_tag
-
 directory Matcher
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_recipe_method_control_matcher_directory
 
 Matchers are available for directories. Use this matcher to define audits for directories that test if the directory exists, is mounted, and if it is linked to. This matcher uses the same matching syntax---``expect(file('foo'))``---as the files. The following matchers are available for directories:
 
@@ -6631,11 +6126,8 @@ Matchers are available for directories. Use this matcher to define audits for di
           )
           end
 
-.. end_tag
-
 file Matcher
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_recipe_method_control_matcher_file
 
 Matchers are available for files and directories. Use this matcher to define audits for files that test if the file exists, its version, if it is executable, writable, or readable, who owns it, verify checksums (both MD5 and SHA-256) and so on. The following matchers are available for files:
 
@@ -6825,11 +6317,8 @@ Matchers are available for files and directories. Use this matcher to define aud
             expect(file('/etc/file')).to contain('docs.chef.io')
           end
 
-.. end_tag
-
 package Matcher
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_recipe_method_control_matcher_package
 
 Matchers are available for packages and may be used to define audits that test if a package or a package version is installed. The following matchers are available:
 
@@ -6856,11 +6345,8 @@ Matchers are available for packages and may be used to define audits that test i
             expect(package('httpd')).to be_installed.with_version('0.1.2')
           end
 
-.. end_tag
-
 port Matcher
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_recipe_method_control_matcher_port
 
 Matchers are available for ports and may be used to define audits that test if a port is listening. The following matchers are available:
 
@@ -6919,11 +6405,8 @@ Matchers are available for ports and may be used to define audits that test if a
             expect(port(23)).to_not be_listening.with('tcp6')
           end
 
-.. end_tag
-
 service Matcher
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_recipe_method_control_matcher_service
 
 Matchers are available for services and may be used to define audits that test for conditions related to services, such as if they are enabled, running, have the correct startup mode, and so on. The following matchers are available:
 
@@ -7010,14 +6493,10 @@ Matchers are available for services and may be used to define audits that test f
             expect(service('DNS Client')).to have_start_mode.Manual
           end
 
-.. end_tag
-
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **A package is installed**
-
-.. tag dsl_recipe_control_matcher_package_installed
 
 For example, a package is installed:
 
@@ -7063,11 +6542,7 @@ If an audit was unsuccessful, the chef-client will return output similar to:
 
    rspec /var/chef/cache/cookbooks/grantmc/recipes/default.rb:21 # Audit Mode mysql package should be installed
 
-.. end_tag
-
 **A package version is installed**
-
-.. tag dsl_recipe_control_matcher_package_installed_version
 
 A package that is installed with a specific version:
 
@@ -7081,11 +6556,7 @@ A package that is installed with a specific version:
      end
    end
 
-.. end_tag
-
 **A package is not installed**
-
-.. tag dsl_recipe_control_matcher_package_not_installed
 
 A package that is not installed:
 
@@ -7108,11 +6579,7 @@ If the audit was successful, the chef-client will return output similar to:
        postgres package
          is not installed
 
-.. end_tag
-
 **A service is enabled**
-
-.. tag dsl_recipe_control_matcher_service_enabled
 
 A service that is enabled and running:
 
@@ -7140,11 +6607,7 @@ If the audit was successful, the chef-client will return output similar to:
          is enabled
          is running
 
-.. end_tag
-
 **A configuration file contains specific settings**
-
-.. tag dsl_recipe_control_matcher_file_sshd_configuration
 
 The following example shows how to verify ``sshd`` configration, including whether it's installed, what the permissions are, and how it can be accessed:
 
@@ -7182,11 +6645,7 @@ where
 
 * ``let(:config_file) { file('/etc/ssh/sshd_config') }`` uses the ``file`` matcher to test specific settings within the ``sshd`` configuration file
 
-.. end_tag
-
 **A file contains desired permissions and contents**
-
-.. tag dsl_recipe_control_matcher_file_permissions
 
 The following example shows how to verify that a file has the desired permissions and contents:
 
@@ -7215,17 +6674,11 @@ If the audit was successful, the chef-client will return output similar to:
          exists with correct permissions
          contains required configuration
 
-.. end_tag
-
 control_group
 -----------------------------------------------------
-.. tag dsl_recipe_method_control_group
 
 Use the ``control_group`` method to define a group of ``control`` methods that comprise a single audit. The name of each ``control_group`` must be unique within the organization.
 
-.. end_tag
-
-.. tag dsl_recipe_method_control_group_syntax
 
 The syntax for the ``control_group`` method is as follows:
 
@@ -7249,14 +6702,10 @@ where:
 * ``'name'`` is the unique name for the ``control_group``; the chef-client will raise an exception if duplicate ``control_group`` names are present
 * ``control`` defines each individual audit within the ``control_group`` block. There is no limit to the number of ``control`` blocks that may defined within a ``control_group`` block
 
-.. end_tag
-
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **control_group block with multiple control blocks**
-
-.. tag dsl_recipe_control_group_many_controls
 
 The following ``control_group`` ensures that MySQL is installed, that PostgreSQL is not installed, and that the services and configuration files associated with MySQL are configured correctly:
 
@@ -7405,11 +6854,7 @@ If an audit was unsuccessful, the chef-client will return output similar to:
    rspec /var/chef/cache/cookbooks/grantmc/recipes/default.rb:59 # Audit Mode mysql config file should contain required configuration
    Auditing complete
 
-.. end_tag
-
 **Duplicate control_group names**
-
-.. tag dsl_recipe_control_group_duplicate_names
 
 If two ``control_group`` blocks have the same name, the chef-client will raise an exception. For example, the following ``control_group`` blocks exist in different cookbooks:
 
@@ -7471,11 +6916,7 @@ Because the two ``control_group`` block names are identical, the chef-client wil
    [2015-01-15T09:36:14-08:00] ERROR: Running exception handlers
    Running handlers complete
 
-.. end_tag
-
 **Verify a package is installed**
-
-.. tag dsl_recipe_control_group_simple_recipe
 
 The following ``control_group`` verifies that the ``git`` package has been installed:
 
@@ -7501,11 +6942,8 @@ The following ``control_group`` verifies that the ``git`` package has been insta
      end
    end
 
-.. end_tag
-
 Validatorless Bootstrap
 -----------------------------------------------------
-.. tag knife_bootstrap_no_validator
 
 The ORGANIZATION-validator.pem is typically added to the .chef directory on the workstation. When a node is bootstrapped from that workstation, the ORGANIZATION-validator.pem is used to authenticate the newly-created node to the Chef server during the initial chef-client run. Starting with Chef client 12.1, it is possible to bootstrap a node using the USER.pem file instead of the ORGANIZATION-validator.pem file. This is known as a "validatorless bootstrap".
 
@@ -7537,8 +6975,6 @@ When running a validatorless ``knife bootstrap`` operation, the output is simila
    10.1.1.1 Starting first Chef Client run...
    [....etc...]
 
-.. end_tag
-
 knife bootstrap Options
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 Use the following options to specify items that are stored in chef-vault:
@@ -7552,15 +6988,11 @@ Use the following options to specify items that are stored in chef-vault:
 ``--bootstrap-vault-json VAULT_JSON``
    A JSON string that contains a list of vaults and items to be updated.
 
-   .. tag knife_bootstrap_vault_json
-
    For example:
 
    .. code-block:: none
 
       --bootstrap-vault-json '{ "vault1": ["item1", "item2"], "vault2": "item2" }'
-
-   .. end_tag
 
 New Resource Attributes
 -----------------------------------------------------
@@ -7574,8 +7006,6 @@ The ``verify`` attribute may be used with the **cookbook_file**, **file**, **rem
    A block or a string that returns ``true`` or ``false``. A string, when ``true`` is executed as a system command.
 
    The following examples show how the ``verify`` attribute is used with the **template** resource. The same approach (but with different resource names) is true for the **cookbook_file**, **file**, and **remote_file** resources:
-
-   .. tag resource_template_attributes_verify
 
    A block is arbitrary Ruby defined within the resource block by using the ``verify`` property. When a block is ``true``, the chef-client will continue to update the file as appropriate.
 
@@ -7633,8 +7063,6 @@ The ``verify`` attribute may be used with the **cookbook_file**, **file**, **rem
 
    If a string or a block return ``false``, the chef-client run will stop and an error is returned.
 
-   .. end_tag
-
 imports
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 The following attribute is new for the **dsc_script** resource:
@@ -7671,8 +7099,6 @@ The following attribute is new for the **chef_gem** resource:
 ``compile_time``
    Controls the phase during which a gem is installed on a node. Set to ``true`` to install a gem while the resource collection is being built (the "compile phase"). Set to ``false`` to install a gem while the chef-client is configuring the node (the "converge phase"). Possible values: ``nil`` (for verbose warnings), ``true`` (to warn once per chef-client run), or ``false`` (to remove all warnings). Recommended value: ``false``.
 
-   .. tag resource_package_chef_gem_attribute_compile_time
-
    .. This topic is hooked into client.rb topics, starting with 12.1, in addition to the resource reference pages.
 
    To suppress warnings for cookbooks authored prior to chef-client 12.1, use a ``respond_to?`` check to ensure backward compatibility. For example:
@@ -7682,8 +7108,6 @@ The following attribute is new for the **chef_gem** resource:
       chef_gem 'aws-sdk' do
         compile_time false if respond_to?(:compile_time)
       end
-
-   .. end_tag
 
 run_as_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -7697,17 +7121,13 @@ The following attributes are new for the **windows_service** resource:
 
 paludis_package
 -----------------------------------------------------
-.. tag resource_package_paludis
 
 Use the **paludis_package** resource to manage packages for the Paludis platform.
-
-.. end_tag
 
 .. note:: In many cases, it is better to use the package resource instead of this one. This is because when the package resource is used in a recipe, the chef-client will use details that are collected by Ohai at the start of the chef-client run to determine the correct package application. Using the package resource allows a recipe to be authored in a way that allows it to be used across many platforms.
 
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_package_paludis_syntax
 
 A **paludis_package** resource block manages a package on a node, typically by installing it. The simplest use of the **paludis_package** resource is:
 
@@ -7739,11 +7159,8 @@ where:
 * ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
 * ``options``, ``package_name``, ``source``, ``recursive``, ``timeout``, and ``version`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_package_paludis_actions
 
 This resource has the following actions:
 
@@ -7751,19 +7168,14 @@ This resource has the following actions:
    Default. Install a package. If a version is specified, install the specified version of the package.
 
 ``:nothing``
-   .. tag resources_common_actions_nothing
 
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
-
-   .. end_tag
 
 ``:remove``
    Remove a package.
 
 ``:upgrade``
    Install a package and/or ensure that a package is the latest version.
-
-.. end_tag
 
 Attributes
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -7777,13 +7189,8 @@ This resource has the following properties:
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_notifies
-
    A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
 
-   .. end_tag
-
-   .. tag 5
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timers are available:
 
@@ -7793,17 +7200,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
 
    The syntax for ``notifies`` is:
 
    .. code-block:: ruby
 
      notifies :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``options``
    **Ruby Type:** String
@@ -7833,8 +7235,6 @@ This resource has the following properties:
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_subscribes
-
    A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
 
    Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
@@ -7852,9 +7252,6 @@ This resource has the following properties:
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
 
-   .. end_tag
-
-   .. tag 5
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timers are available:
 
@@ -7864,17 +7261,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
 
    The syntax for ``subscribes`` is:
 
    .. code-block:: ruby
 
       subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``timeout``
    **Ruby Type:** String, Integer
@@ -7891,8 +7283,6 @@ Examples
 
 **Install a package**
 
-.. tag resource_paludis_package_install
-
 .. To install a package:
 
 .. code-block:: ruby
@@ -7901,21 +7291,15 @@ Examples
      action :install
    end
 
-.. end_tag
-
 openbsd_package
 -----------------------------------------------------
-.. tag resource_package_openbsd
 
 Use the **openbsd_package** resource to manage packages for the OpenBSD platform.
-
-.. end_tag
 
 .. note:: In many cases, it is better to use the package resource instead of this one. This is because when the package resource is used in a recipe, the chef-client will use details that are collected by Ohai at the start of the chef-client run to determine the correct package application. Using the package resource allows a recipe to be authored in a way that allows it to be used across many platforms.
 
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_package_openbsd_syntax
 
 A **openbsd_package** resource block manages a package on a node, typically by installing it. The simplest use of the **openbsd_package** resource is:
 
@@ -7945,11 +7329,8 @@ where:
 * ``action`` identifies which steps the chef-client will take to bring the node into the desired state
 * ``options``, ``package_name``, ``source``, ``timeout``, and ``version`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_package_openbsd_actions
 
 The openbsd_package resource has the following actions:
 
@@ -7957,16 +7338,11 @@ The openbsd_package resource has the following actions:
    Default. Install a package. If a version is specified, install the specified version of the package.
 
 ``:nothing``
-   .. tag resources_common_actions_nothing
 
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
 
-   .. end_tag
-
 ``:remove``
    Remove a package.
-
-.. end_tag
 
 Attributes
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -7980,13 +7356,8 @@ This resource has the following properties:
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_notifies
-
    A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
 
-   .. end_tag
-
-   .. tag 5
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timers are available:
 
@@ -7996,17 +7367,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
 
    The syntax for ``notifies`` is:
 
    .. code-block:: ruby
 
      notifies :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``options``
    **Ruby Type:** String
@@ -8036,8 +7402,6 @@ This resource has the following properties:
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_subscribes
-
    A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
 
    Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
@@ -8055,9 +7419,6 @@ This resource has the following properties:
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
 
-   .. end_tag
-
-   .. tag 5
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timers are available:
 
@@ -8067,17 +7428,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
 
    The syntax for ``subscribes`` is:
 
    .. code-block:: ruby
 
       subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``timeout``
    **Ruby Type:** String, Integer
@@ -8094,8 +7450,6 @@ Examples
 
 **Install a package**
 
-.. tag resource_openbsd_package_install
-
 .. To install a package:
 
 .. code-block:: ruby
@@ -8104,16 +7458,12 @@ Examples
      action :install
    end
 
-.. end_tag
-
 New client.rb Settings
 -----------------------------------------------------
 The following client.rb settings are new:
 
 ``chef_gem_compile_time``
    Controls the phase during which a gem is installed on a node. Set to ``true`` to install a gem while the resource collection is being built (the "compile phase"). Set to ``false`` to install a gem while the chef-client is configuring the node (the "converge phase"). Recommended value: ``false``.
-
-   .. note:: .. tag resource_package_chef_gem_attribute_compile_time
 
              .. This topic is hooked into client.rb topics, starting with 12.1, in addition to the resource reference pages.
 
@@ -8125,14 +7475,11 @@ The following client.rb settings are new:
                   compile_time false if respond_to?(:compile_time)
                 end
 
-             .. end_tag
-
 ``windows_service.watchdog_timeout``
    The maximum amount of time (in seconds) available to the chef-client run when the chef-client is run as a service on the Microsoft Windows platform. If the chef-client run does not complete within the specified timeframe, the chef-client run is terminated. Default value: ``2 * (60 * 60)``.
 
 Multiple Packages and Versions
 -----------------------------------------------------
-.. tag resources_common_multiple_packages
 
 A resource may specify multiple packages and/or versions for platforms that use Yum, DNF, Apt, Zypper, or Chocolatey package managers. Specifying multiple packages and/or versions allows a single transaction to:
 
@@ -8191,8 +7538,6 @@ Notifications, via an implicit name:
 
 .. note:: Notifications and subscriptions do not need to be updated when packages and versions are added or removed from the ``package_name`` or ``version`` properties.
 
-.. end_tag
-
 What's New in 12.0
 =====================================================
 The following items are new for chef-client 12.0 and/or are changes from previous versions. The short version:
@@ -8237,7 +7582,6 @@ Please `view the notes </upgrade_client_notes.html>`__ for more background on th
 
 Change Attributes
 -----------------------------------------------------
-.. tag node_attribute_change
 
 Starting with chef-client 12.0, attribute precedence levels may be
 
@@ -8245,11 +7589,8 @@ Starting with chef-client 12.0, attribute precedence levels may be
 * Removed for all attribute precedence levels
 * Fully assigned attributes
 
-.. end_tag
-
 Remove Precedence Level
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag node_attribute_change_remove_level
 
 A specific attribute precedence level for default, normal, and override attributes may be removed by using one of the following syntax patterns.
 
@@ -8267,11 +7608,8 @@ For override attributes:
 
 These patterns return the computed value of the key being deleted for the specified precedence level.
 
-.. end_tag
-
 Examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag node_attribute_change_remove_level_examples
 
 The following examples show how to remove a specific, named attribute precedence level.
 
@@ -8411,11 +7749,8 @@ The other attribute precedence levels are unaffected:
 
    node.rm_default("no", "such", "thing") #=> nil
 
-.. end_tag
-
 Remove All Levels
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag node_attribute_change_remove_all
 
 All attribute precedence levels may be removed by using the following syntax pattern:
 
@@ -8423,11 +7758,8 @@ All attribute precedence levels may be removed by using the following syntax pat
 
 .. note:: Using ``node['foo'].delete('bar')`` will throw an exception that points to the new API.
 
-.. end_tag
-
 Examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag node_attribute_change_remove_all_examples
 
 The following examples show how to remove all attribute precedence levels.
 
@@ -8471,11 +7803,8 @@ Looking at ``'foo'``, all that's left is the ``'bat'`` entry:
 
    node.rm_default("no", "such", "thing") #=> nil
 
-.. end_tag
-
 Full Assignment
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag node_attribute_change_full_assignment
 
 Use ``!`` to clear out the key for the named attribute precedence level, and then complete the write by using one of the following syntax patterns:
 
@@ -8485,11 +7814,8 @@ Use ``!`` to clear out the key for the named attribute precedence level, and the
 * ``node.override!['foo']['bar'] = {...}``
 * ``node.force_override!['foo']['bar'] = {...}``
 
-.. end_tag
-
 Examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. tag node_attribute_change_full_assignment_examples
 
 The following examples show how to remove all attribute precedence levels.
 
@@ -8602,8 +7928,6 @@ the difference is:
    node.attributes.combined_override['foo'] #=> {'bar' => {'baz' => 99}}
    node['foo']['bar'] #=> {'baz' => 99}
 
-.. end_tag
-
 provides Method
 -----------------------------------------------------
 Use the ``provides`` method to map a custom resource/provider to an existing resource/provider, and then to also specify the platform(s) on which the behavior of the custom resource/provider will be applied. This method enables scenarios like:
@@ -8665,26 +7989,17 @@ Use an array to match any of the platforms within the array:
 
 AIX Platform Support
 -----------------------------------------------------
-.. tag ctl_chef_client_aix
 
 The chef-client may now be used to configure nodes that are running on the AIX platform, versions 6.1 (TL6 or higher, recommended) and 7.1 (TL0 SP3 or higher, recommended). The **service** resource supports starting, stopping, and restarting services that are managed by System Resource Controller (SRC), as well as managing all service states with BSD-based init systems.
 
-.. end_tag
-
 **System Requirements**
-
-.. tag ctl_chef_client_aix_requirements
 
 The chef-client has the `same system requirements </chef_system_requirements.html#chef-client>`_ on the AIX platform as any other platform, with the following notes:
 
 * Expand the file system on the AIX platform using ``chfs`` or by passing the ``-X`` flag to ``installp`` to automatically expand the logical partition (LPAR)
 * The EN_US (UTF-8) character set should be installed on the logical partition prior to installing the chef-client
 
-.. end_tag
-
 **Install the chef-client on the AIX platform**
-
-.. tag ctl_chef_client_aix_setup
 
 The chef-client is distributed as a Backup File Format (BFF) binary and is installed on the AIX platform using the following command run as a root user:
 
@@ -8692,11 +8007,7 @@ The chef-client is distributed as a Backup File Format (BFF) binary and is insta
 
    # installp -aYgd chef-12.0.0-1.powerpc.bff all
 
-.. end_tag
-
 **Increase system process limits**
-
-.. tag ctl_chef_client_aix_system_process_limits
 
 The out-of-the-box system process limits for maximum process memory size (RSS) and number of open files are typically too low to run the chef-client on a logical partition (LPAR). When the system process limits are too low, the chef-client will not be able to create threads. To increase the system process limits:
 
@@ -8738,11 +8049,7 @@ When the system process limits are too low, an error is returned similar to:
    -----------------
    ThreadError: can't create Thread: Resource temporarily unavailable
 
-.. end_tag
-
 **Install the UTF-8 character set**
-
-.. tag install_chef_client_aix_en_us
 
 The chef-client uses the EN_US (UTF-8) character set. By default, the AIX base operating system does not include the EN_US (UTF-8) character set and it must be installed prior to installing the chef-client. The EN_US (UTF-8) character set may be installed from the first disc in the AIX media or may be copied from ``/installp/ppc/*EN_US*`` to a location on the logical partition (LPAR). This topic assumes this location to be ``/tmp/rte``.
 
@@ -8805,11 +8112,7 @@ Remember to point ``INPUT device/directory`` to ``/tmp/rte`` when not installing
 
 #. Press ``Enter`` to apply and install the language set.
 
-.. end_tag
-
 **New providers**
-
-.. tag ctl_chef_client_aix_providers
 
 The **service** resource has the following providers to support the AIX platform:
 
@@ -8827,11 +8130,7 @@ The **service** resource has the following providers to support the AIX platform
      - ``service``
      -  The provider that is used to manage BSD-based init services on AIX.
 
-.. end_tag
-
 **Enable a service on AIX using the mkitab command**
-
-.. tag resource_service_aix_mkitab
 
 The **service** resource does not support using the ``:enable`` and ``:disable`` actions with resources that are managed using System Resource Controller (SRC). This is because System Resource Controller (SRC) does not have a standard mechanism for enabling and disabling services on system boot.
 
@@ -8866,11 +8165,8 @@ and then enable it using the ``mkitab`` command:
      not_if "lsitab #{node['chef_client']['svc_name']}"
    end
 
-.. end_tag
-
 Recipe DSL, Encrypted Data Bags
 -----------------------------------------------------
-.. tag data_bag_recipes_load_using_recipe_dsl
 
 The Recipe DSL provides access to data bags and data bag items (including encrypted data bag items) with the following methods:
 
@@ -8907,21 +8203,15 @@ will return something similar to:
 
 If ``item`` is encrypted, ``data_bag_item`` will automatically decrypt it using the key specified above, or (if none is specified) by the ``Chef::Config[:encrypted_data_bag_secret]`` method, which defaults to ``/etc/chef/encrypted_data_bag_secret``.
 
-.. end_tag
-
 bff_package
 -----------------------------------------------------
-.. tag resource_package_bff
 
 Use the **bff_package** resource to manage packages for the AIX platform using the installp utility. When a package is installed from a local file, it must be added to the node using the **remote_file** or **cookbook_file** resources.
 
 .. note:: A Backup File Format (BFF) package may not have a ``.bff`` file extension. The chef-client will still identify the correct provider to use based on the platform, regardless of the file extension.
 
-.. end_tag
-
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_package_bff_syntax
 
 A **bff_package** resource manages a package on a node, typically by installing it. The simplest use of the **bff_package** resource is:
 
@@ -8951,11 +8241,8 @@ where:
 * ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
 * ``options``, ``package_name``, ``source``, ``timeout``, and ``version`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_package_bff_actions
 
 The bff_package resource has the following actions:
 
@@ -8963,19 +8250,14 @@ The bff_package resource has the following actions:
    Default. Install a package. If a version is specified, install the specified version of the package.
 
 ``:nothing``
-   .. tag resources_common_actions_nothing
 
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
-
-   .. end_tag
 
 ``:purge``
    Purge a package. This action typically removes the configuration files as well as the package.
 
 ``:remove``
    Remove a package.
-
-.. end_tag
 
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -8989,13 +8271,8 @@ This resource has the following properties:
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_notifies
-
    A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
 
-   .. end_tag
-
-   .. tag 5
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timers are available:
 
@@ -9005,17 +8282,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
 
    The syntax for ``notifies`` is:
 
    .. code-block:: ruby
 
      notifies :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``options``
    **Ruby Type:** String
@@ -9045,8 +8317,6 @@ This resource has the following properties:
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_subscribes
-
    A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
 
    Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
@@ -9064,9 +8334,6 @@ This resource has the following properties:
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
 
-   .. end_tag
-
-   .. tag 5
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timers are available:
 
@@ -9076,17 +8343,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
 
    The syntax for ``subscribes`` is:
 
    .. code-block:: ruby
 
       subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``timeout``
    **Ruby Type:** String, Integer
@@ -9102,22 +8364,16 @@ Providers
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 This resource has the following providers:
 
-.. tag resource_package_bff_providers
-
 ``Chef::Provider::Package``, ``package``
    When this short name is used, the chef-client will attempt to determine the correct provider during the chef-client run.
 
 ``Chef::Provider::Package::Aix``, ``bff_package``
    The provider for the AIX platform. Can be used with the ``options`` attribute.
 
-.. end_tag
-
 Example
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **Install a package**
-
-.. tag resource_bff_package_install
 
 .. To install a package:
 
@@ -9141,19 +8397,13 @@ Using the **bff_package** resource:
      action :install
    end
 
-.. end_tag
-
 homebrew_package
 -----------------------------------------------------
-.. tag resource_package_homebrew
 
 Use the **homebrew_package** resource to manage packages for the macOS platform.
 
-.. end_tag
-
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_package_homebrew_syntax
 
 A **homebrew_package** resource block manages a package on a node, typically by installing it. The simplest use of the **homebrew_package** resource is:
 
@@ -9184,11 +8434,8 @@ where:
 * ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
 * ``homebrew_user``, ``options``, ``package_name``, ``source``, ``timeout``, and ``version`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_package_homebrew_actions
 
 The homebrew_package resource has the following actions:
 
@@ -9196,11 +8443,8 @@ The homebrew_package resource has the following actions:
    Default. Install a package. If a version is specified, install the specified version of the package.
 
 ``:nothing``
-   .. tag resources_common_actions_nothing
 
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
-
-   .. end_tag
 
 ``:purge``
    Purge a package. This action typically removes the configuration files as well as the package.
@@ -9211,8 +8455,6 @@ The homebrew_package resource has the following actions:
 ``:upgrade``
    Install a package and/or ensure that a package is the latest version.
 
-.. end_tag
-
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 This resource has the following properties:
@@ -9222,11 +8464,7 @@ This resource has the following properties:
 
    The name of the Homebrew owner to be used by the chef-client when executing a command.
 
-   .. tag resource_package_homebrew_user
-
    The chef-client, by default, will attempt to execute a Homebrew command as the owner of ``/usr/local/bin/brew``. If that executable does not exist, the chef-client will attempt to find the user by executing ``which brew``. If that executable cannot be found, the chef-client will print an error message: ``Could not find the "brew" executable in /usr/local/bin or anywhere on the path.``. Use the ``homebrew_user`` attribute to specify the Homebrew owner for situations where the chef-client cannot automatically detect the correct owner.
-
-   .. end_tag
 
 ``ignore_failure``
    **Ruby Type:** true, false | **Default Value:** ``false``
@@ -9236,13 +8474,8 @@ This resource has the following properties:
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_notifies
-
    A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
 
-   .. end_tag
-
-   .. tag 5
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timers are available:
 
@@ -9252,17 +8485,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
 
    The syntax for ``notifies`` is:
 
    .. code-block:: ruby
 
      notifies :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``options``
    **Ruby Type:** String
@@ -9292,8 +8520,6 @@ This resource has the following properties:
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_subscribes
-
    A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
 
    Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
@@ -9311,9 +8537,6 @@ This resource has the following properties:
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
 
-   .. end_tag
-
-   .. tag 5
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timers are available:
 
@@ -9323,17 +8546,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
 
    The syntax for ``subscribes`` is:
 
    .. code-block:: ruby
 
       subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``timeout``
    **Ruby Type:** String, Integer
@@ -9349,22 +8567,16 @@ Providers
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 This resource has the following providers:
 
-.. tag resource_package_homebrew_providers
-
 ``Chef::Provider::Package``, ``package``
    When this short name is used, the chef-client will attempt to determine the correct provider during the chef-client run.
 
 ``Chef::Provider::Package::Homebrew``, ``homebrew_package``
    The provider for the macOS platform.
 
-.. end_tag
-
 Example
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **Install a package**
-
-.. tag resource_homebrew_package_install
 
 .. To install a package:
 
@@ -9374,11 +8586,7 @@ Example
      action :install
    end
 
-.. end_tag
-
 **Specify the Homebrew user with a UUID**
-
-.. tag resource_homebrew_package_homebrew_user_as_uuid
 
 .. To specify the Homebrew user as a UUID:
 
@@ -9388,11 +8596,7 @@ Example
      homebrew_user 1001
    end
 
-.. end_tag
-
 **Specify the Homebrew user with a string**
-
-.. tag resource_homebrew_package_homebrew_user_as_string
 
 .. To specify the Homebrew user as a string:
 
@@ -9402,19 +8606,13 @@ Example
      homebrew_user 'user1'
    end
 
-.. end_tag
-
 reboot
 -----------------------------------------------------
-.. tag resource_service_reboot
 
 Use the **reboot** resource to reboot a node, a necessary step with some installations on certain platforms. This resource is supported for use on the Microsoft Windows, macOS, and Linux platforms.
 
-.. end_tag
-
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_service_reboot_syntax
 
 A **reboot** resource block reboots a node:
 
@@ -9445,11 +8643,8 @@ where
 * ``action`` identifies the steps the chef-client will take to bring the node into the desired state
 * ``delay_mins`` and ``reason`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_service_reboot_actions
 
 The reboot resource has the following actions:
 
@@ -9457,19 +8652,14 @@ The reboot resource has the following actions:
    Cancel a reboot request.
 
 ``:nothing``
-   .. tag resources_common_actions_nothing
 
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Client run.
-
-   .. end_tag
 
 ``:reboot_now``
    Reboot a node so that the chef-client may continue the installation process.
 
 ``:request_reboot``
    Reboot a node at the end of a chef-client run.
-
-.. end_tag
 
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -9488,20 +8678,13 @@ This resource has the following properties:
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_notifies
-
    A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_timers_reboot
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timer is available:
 
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
 
 ``reason``
    **Ruby Type:** String
@@ -9521,8 +8704,6 @@ This resource has the following properties:
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_subscribes
-
    A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
 
    Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
@@ -9540,16 +8721,11 @@ This resource has the following properties:
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
 
-   .. end_tag
-
-   .. tag resources_common_notification_timers_reboot
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timer is available:
 
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
 
 Providers
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -9562,8 +8738,6 @@ Example
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **Reboot a node immediately**
-
-.. tag resource_service_reboot_immediately
 
 .. To reboot immediately:
 
@@ -9580,11 +8754,7 @@ Example
      notifies :reboot_now, 'reboot[now]', :immediately
    end
 
-.. end_tag
-
 **Reboot a node at the end of a chef-client run**
-
-.. tag resource_service_reboot_request
 
 .. To reboot a node at the end of the chef-client run:
 
@@ -9596,11 +8766,7 @@ Example
      delay_mins 5
    end
 
-.. end_tag
-
 **Cancel a reboot**
-
-.. tag resource_service_reboot_cancel
 
 .. To cancel a reboot request:
 
@@ -9610,8 +8776,6 @@ Example
      action :cancel
      reason 'Cancel a previous end-of-run reboot request.'
    end
-
-.. end_tag
 
 windows_service
 -----------------------------------------------------
@@ -9661,7 +8825,6 @@ where
 * ``action`` identifies the steps the chef-client will take to bring the node into the desired state
 * ``init_command``, ``pattern``, ``reload_command``, ``restart_command``, ``run_as_password``, ``run_as_user``, ``service_name``, ``start_command``, ``startup_type``, ``status_command``, ``stop_command``, ``supports``, and ``timeout`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -9691,7 +8854,6 @@ This resource has the following actions:
 ``:stop``
    Stop a service.
 
-
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 This resource has the following properties:
@@ -9709,13 +8871,8 @@ This resource has the following properties:
 ``notifies``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_notifies
-
    A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
 
-   .. end_tag
-
-   .. tag 5
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timers are available:
 
@@ -9725,17 +8882,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
 
    The syntax for ``notifies`` is:
 
    .. code-block:: ruby
 
      notifies :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``pattern``
    **Ruby Type:** String
@@ -9800,8 +8952,6 @@ This resource has the following properties:
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
-   .. tag resources_common_notification_subscribes
-
    A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
 
    Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
@@ -9819,9 +8969,6 @@ This resource has the following properties:
 
    In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
 
-   .. end_tag
-
-   .. tag 5
 
    A timer specifies the point during the chef-client run at which a notification is run. The following timers are available:
 
@@ -9831,17 +8978,12 @@ This resource has the following properties:
    ``:immediate``, ``:immediately``
       Specifies that a notification should be run immediately, per resource notified.
 
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
 
    The syntax for ``subscribes`` is:
 
    .. code-block:: ruby
 
       subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
 
 ``supports``
    **Ruby Type:** Hash
@@ -9858,8 +9000,6 @@ Example
 
 **Start a service manually**
 
-.. tag resource_service_windows_manual_start
-
 .. To install a package:
 
 .. code-block:: ruby
@@ -9868,8 +9008,6 @@ Example
      action :configure_startup
      startup_type :manual
    end
-
-.. end_tag
 
 knife bootstrap Settings
 -----------------------------------------------------
@@ -9949,7 +9087,6 @@ The following methods have been added to the Recipe DSL: ``shell_out``, ``shell_
 
 shell_out
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_recipe_method_shell_out
 
 The ``shell_out`` method can be used to run a command against the node, and then display the output to the console when the log level is set to ``debug``.
 
@@ -9961,11 +9098,8 @@ The syntax for the ``shell_out`` method is as follows:
 
 where ``command_args`` is the command that is run against the node.
 
-.. end_tag
-
 shell_out!
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_recipe_method_shell_out_bang
 
 The ``shell_out!`` method can be used to run a command against the node, display the output to the console when the log level is set to ``debug``, and then raise an error when the method returns ``false``.
 
@@ -9977,11 +9111,8 @@ The syntax for the ``shell_out!`` method is as follows:
 
 where ``command_args`` is the command that is run against the node. This method will return ``true`` or ``false``.
 
-.. end_tag
-
 shell_out_with_systems_locale
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag dsl_recipe_method_shell_out_with_systems_locale
 
 The ``shell_out_with_systems_locale`` method can be used to run a command against the node (via the ``shell_out`` method), but using the ``LC_ALL`` environment variable.
 
@@ -9992,8 +9123,6 @@ The syntax for the ``shell_out_with_systems_locale`` method is as follows:
    shell_out_with_systems_locale(command_args)
 
 where ``command_args`` is the command that is run against the node.
-
-.. end_tag
 
 value_for_platform
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -10053,8 +9182,6 @@ The following properties are new for the **user** resource:
 
 **Use SALTED-SHA512 passwords**
 
-.. tag resource_user_password_shadow_hash_salted_sha512
-
 macOS 10.7 calculates the password shadow hash using SALTED-SHA512. The length of the shadow hash value is 68 bytes, the salt value is the first 4 bytes, with the remaining 64 being the shadow hash itself. The following code will calculate password shadow hashes for macOS 10.7:
 
 .. code-block:: ruby
@@ -10072,11 +9199,7 @@ Use the calculated password shadow hash with the **user** resource:
      password 'c9b3bd....d843'  # Length: 136
    end
 
-.. end_tag
-
 **Use SALTED-SHA512-PBKDF2 passwords**
-
-.. tag resource_user_password_shadow_hash_salted_sha512_pbkdf2
 
 macOS 10.8 (and higher) calculates the password shadow hash using SALTED-SHA512-PBKDF2. The length of the shadow hash value is 128 bytes, the salt value is 32 bytes, and an integer specifies the number of iterations. The following code will calculate password shadow hashes for macOS 10.8 (and higher):
 
@@ -10104,8 +9227,6 @@ Use the calculated password shadow hash with the **user** resource:
      salt 'bd1a....fc83'        # Length: 64
      iterations 25000
    end
-
-.. end_tag
 
 chef-client Options
 -----------------------------------------------------
@@ -10188,11 +9309,8 @@ The ``knife search`` subcommand allows filtering search results with a new optio
 
 **execute** Resource, ``path`` Property
 -----------------------------------------------------
-.. tag resources_common_resource_execute_attribute_path
 
 The ``path`` property has been deprecated and will throw an exception in Chef Client 12 or later. We recommend you use the ``environment`` property instead.
-
-.. end_tag
 
 **git** Property
 -----------------------------------------------------
@@ -10211,7 +9329,6 @@ The following property is new for the **git** resource:
 
 Chef::Provider, Custom Resources
 -----------------------------------------------------
-.. tag 16_method_updated_by_last_action_example
 
 If a custom resource was created in the ``/libraries`` directory of a cookbook that also uses a core resource from the chef-client within the custom resource, the base class that is associated with that custom resource must be updated. In previous versions of the chef-client, the ``Chef::Provider`` class was all that was necessary because the Recipe DSL was included in the ``Chef::Provider`` base class.
 
@@ -10260,9 +9377,6 @@ For example, the ``lvm_logical_volume`` custom resource from the `lvm cookbook <
 
 Starting with chef-client 12, the Recipe DSL is removed from the ``Chef::Provider`` base class and is only available by using ``LWRPBase``. Cookbooks that contain custom resources authored for the chef-client 11 version should be inspected and updated.
 
-.. end_tag
-
-.. tag dsl_provider_method_updated_by_last_action_example
 
 Cookbooks that contain custom resources in the ``/libraries`` directory of a cookbook should:
 
@@ -10312,11 +9426,8 @@ For example:
          new_resource.updated_by_last_action(updates.any?)
        end
 
-.. end_tag
-
 SSL Certificates
 -----------------------------------------------------
-.. tag server_security_ssl_cert_client
 
 Chef server 12 enables SSL verification by default for all requests made to the server, such as those made by knife and the chef-client. The certificate that is generated during the installation of the Chef server is self-signed, which means the certificate is not signed by a trusted certificate authority (CA) that ships with the chef-client. The certificate generated by the Chef server must be downloaded to any machine from which knife and/or the chef-client will make requests to the Chef server.
 
@@ -10334,8 +9445,6 @@ responds with an error similar to:
    ERROR: OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 ...
 
 This is by design and will occur until a verifiable certificate is added to the machine from which the request is sent.
-
-.. end_tag
 
 See `SSL Certificates </chef_client_security.html#ssl-certificates>`__ for more information about how knife and the chef-client use SSL certificates generated by the Chef server.
 

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -7458,15 +7458,15 @@ The following client.rb settings are new:
 ``chef_gem_compile_time``
    Controls the phase during which a gem is installed on a node. Set to ``true`` to install a gem while the resource collection is being built (the "compile phase"). Set to ``false`` to install a gem while the chef-client is configuring the node (the "converge phase"). Recommended value: ``false``.
 
-             .. This topic is hooked into client.rb topics, starting with 12.1, in addition to the resource reference pages.
+   .. note:: This topic is hooked into client.rb topics, starting with 12.1, in addition to the resource reference pages.
 
-             To suppress warnings for cookbooks authored prior to chef-client 12.1, use a ``respond_to?`` check to ensure backward compatibility. For example:
+   To suppress warnings for cookbooks authored prior to chef-client 12.1, use a ``respond_to?`` check to ensure backward compatibility. For example:
 
-             .. code-block:: ruby
+   .. code-block:: ruby
 
-                chef_gem 'aws-sdk' do
-                  compile_time false if respond_to?(:compile_time)
-                end
+      chef_gem 'aws-sdk' do
+        compile_time false if respond_to?(:compile_time)
+      end
 
 ``windows_service.watchdog_timeout``
    The maximum amount of time (in seconds) available to the chef-client run when the chef-client is run as a service on the Microsoft Windows platform. If the chef-client run does not complete within the specified timeframe, the chef-client run is terminated. Default value: ``2 * (60 * 60)``.

--- a/chef_master/source/release_notes_chef_automate.rst
+++ b/chef_master/source/release_notes_chef_automate.rst
@@ -121,6 +121,7 @@ Resolved Issues
 * Stale Elasticsearch lock files can be cleaned after a crash with ``automate-ctl delete-elasticsearch-lock --stale-lock-only``
 * Fixed CA certificate path location on SuSE
 * The data collector API now returns a 503 when Automate is in maintenance mode
+* The Elasticsearch API now returns 400 if sent a HTML script tag to prevent XSS attacks
 
 What's New in 1.7.114
 =====================================================

--- a/chef_master/source/release_notes_chef_automate.rst
+++ b/chef_master/source/release_notes_chef_automate.rst
@@ -3,17 +3,12 @@ Release Notes: Chef Automate
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/release_notes_chef_automate.rst>`__
 
-.. tag chef_automate_mark
-
 .. image:: ../../images/a2_docs_banner.svg
    :target: https://automate.chef.io/docs
 
 .. danger:: This documentation covers an outdated version of Chef Automate. See the `Chef Automate site <https://automate.chef.io/docs/quickstart/>`__ for current documentation. The new Chef Automate includes newer out-of-the-box compliance profiles, an improved compliance scanner with total cloud scanning functionality, better visualizations, role-based access control and many other features.
 
-.. end_tag
-
 Chef Automate provides a full suite of enterprise capabilities for workflow, visibility and compliance that allow you to manage and monitor application and cookbook deployments across a cluster of nodes in your environment.
-
 
 What's New in 1.8.96
 =====================================================
@@ -30,7 +25,6 @@ Resolved Issues
 -----------------------------------------------------
 * Resolved an issue with Workflow jobs becoming stuck
 * Corrected the release metadata on a number of profiles so the profiles are compatible with target hosts.
-
 
 What's New in 1.8.85
 =====================================================
@@ -127,7 +121,6 @@ Resolved Issues
 * Stale Elasticsearch lock files can be cleaned after a crash with ``automate-ctl delete-elasticsearch-lock --stale-lock-only``
 * Fixed CA certificate path location on SuSE
 * The data collector API now returns a 503 when Automate is in maintenance mode
-* The Elasticsearch API now returns 400 if sent a HTML script tag to prevent XSS attacks
 
 What's New in 1.7.114
 =====================================================
@@ -222,7 +215,6 @@ Resolved Issues
 * OpsWorks for Chef Automate and the cloud marketplace instances of Chef Automate rely on self-signed SSL certificates. As of Chrome 58, self-signed certificates with x509 version 3 without the SubjectAltName extension are invalid. We added the correct extension for the self-signed cert.
 * Bitbucket integration now works with usernames containing the @ symbol.
 
-
 What's New in 1.7.10
 =====================================================
 
@@ -248,7 +240,6 @@ Chef Automate Statistics
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
 The new ``automate-ctl data-summary`` command gives the total number of Chef client run records and compliance scan records, as well as how much storage is being consumed. For more information, see the `automate-ctl documentation </ctl_automate_server.html#data-summary>`__
 
-
 Command Line Option for Reaper
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
 Override Reaper settings to run a manual Reaper job to remove data from Elasticsearch. Specify a retention period for a single reaper job from the command line. For more details, see `Data Retention Management in Chef Automate <https://docs.chef.io/data_retention_chef_automate.html>`__.
@@ -257,7 +248,6 @@ Removed Legacy Compliance Views
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 The original compliance data views under the Nodes tab have been accessible via the ``legacy`` flag since the release of Chef Automate 1.5 in July.  With this release those views have been removed from the product, and data is no longer written to the underlying data indices.  Both historical and new compliance data is stored in new indices.  To remove the legacy data and reduce storage volume, see `Data Retention Management in Chef Automate <https://docs.chef.io/data_retention_chef_automate.html>`__.
-
 
 Resolved Issues
 -----------------------------------------------------
@@ -291,7 +281,6 @@ Resolved Issues
 * Resolved an issue where ``automate-ctl delete-node`` was not removing nodes from the compliance UI
 * Corrected a regression with the ``mark-nodes-missing`` script; nodes will now be set to missing if they have not checked in for 12 hours
 * Upgraded Ruby to version 2.4.2 to address multiple CVEs
-
 
 What's New in 1.6.99
 =====================================================
@@ -346,7 +335,6 @@ If you plan to upgrade to Chef Automate 1.6.87 by restoring a backup from an exi
    .. code-block:: bash
 
       automate-ctl restore-backup my-backup
-
 
 New Features
 -----------------------------------------------------
@@ -437,7 +425,6 @@ Resolved Issues
 * Fixed an issue that limited the list of compliance profiles in the report to 10
 * Small UI fixes in the compliance view around scan results filter, profile suggestions, and reports with multiple scan results
 
-
 What's New in 1.5.46
 =====================================================
 
@@ -513,7 +500,6 @@ Resolved Issues
 * In **Workflow**, under the **Review** tab, the expandable comments below a change in diff view will now display properly
 * Default permissions for Chef Automate’s primary configuration file ``/etc/delivery/delivery.rb`` have been tightened from 0644 to 0640 so that the file is no longer world readable
 
-
 What's New in 0.8.5
 =====================================================
 
@@ -551,7 +537,6 @@ SUSE Linux Enterprise Server Support
 
 Chef Automate can now be installed on SUSE Linux Enterprise Server (SLES) 11 SP4 and 12 SP2 or above.
 
-
 Resolved Issues
 -----------------------------------------------------
 
@@ -559,7 +544,6 @@ Resolved Issues
 * Added retries to RabbitMQ service on startup to correct a problem reported in OpsWorks for Chef Automate.
 * Corrected a bug with failing to connect to Bitbucket when using a lengthy URL for the Bitbucket server.
 * Corrected an issue with pagination when several pages of run history are displayed.
-
 
 What's New in 0.7.239
 =====================================================

--- a/chef_master/source/release_notes_chefdk.rst
+++ b/chef_master/source/release_notes_chefdk.rst
@@ -444,7 +444,6 @@ What's New in 2.5.3
   * test-kitchen 1.19.2 -> 1.20.0
   * chef-provisioning-azure has been removed as it used deprecated Azure APIs
 
-
 What's New in 2.4.17
 =====================================================
 * **Improved performance downloading cookbooks from a Chef server**
@@ -463,7 +462,6 @@ What's New in 2.4.17
       chef_server_artifact: "https://chef.example/organizations/myorg",
       identifier: "09d43fad354b3efcc5b5836fef5137131f60f974"
 
-
 * **Added include_policy directive**
 
   Policyfile can use the ``include_policy`` directive as described in `RFC097 <https://github.com/chef/chef-rfc/blob/master/rfc097-policyfile-includes.md>`__. This directive's purpose is to allow the inclusion policyfile locks to the current policyfile. In this iteration, we support sourcing lock files from a local path or a Chef server. Below is a simple example of how the ``include_policy`` directive can be used:
@@ -479,7 +477,6 @@ What's New in 2.4.17
      run_list 'motd'
 
      cookbook 'motd', '~> 0.6.0'
-
 
   Run:
 
@@ -510,7 +507,6 @@ What's New in 2.4.17
 
       include_policy 'base', path: './base.lock.json'
 
-
   Run:
 
   .. code-block:: none
@@ -526,7 +522,6 @@ What's New in 2.4.17
 
       Lockfile written to /home/jaym/workspace/chef-dk/users.lock.json
       Policy revision id: 20fac68f987152f62a2761e1cfc7f1dc29b598303bfb2d84a115557e2a4a8f27
-
 
   This will produce a ``users.lock.json`` file that has the ``base`` policyfile lock merged in.
 
@@ -593,7 +588,6 @@ ChefDK 2.2.1 includes:
 * Chef Vault 3.3.0
 * Foodcritic 11.3.1
 * Test Kitchen 1.17.0
-
 
 What's New in 2.1.11
 =====================================================
@@ -668,7 +662,6 @@ Cookstyle 2.0
 -----------------------------------------------------
 Cookstyle 2.0 is based on Rubocop 0.49.1, which changed a large number of rule names.
 
-
 What's New in 1.6.11
 =====================================================
 This release contains only dependency updates, including several security fixes:
@@ -724,7 +717,6 @@ InSpec 1.25.1
 Cookstyle 1.3.1
 ---------------
 * Disabled Style/DoubleNegation rule, which can be necessary in not_if / only_if blocks
-
 
 What's New in 1.3
 =====================================================
@@ -951,7 +943,6 @@ What's New in 1.0
 Version 1.0!
 -----------------------------------------------------
 
-We're recognizing ChefDK's continued stability with the honor of a 1.0 tag. There
 is nothing in this release that breaks backwards compatibility with previous
 installations of ChefDK: it is simply a formal recognition of the stability of
 the product.
@@ -1016,7 +1007,6 @@ Notable Upgraded Gems
 - knife-windows ``1.6.0`` -> ``1.7.0``
 - mixlib-install ``2.0.1`` -> ``2.1.1``
 - winrm ``2.0.3`` -> ``2.1.0``
-
 
 Changelog
 =====================================================

--- a/chef_master/source/release_notes_chefdk.rst
+++ b/chef_master/source/release_notes_chefdk.rst
@@ -943,6 +943,7 @@ What's New in 1.0
 Version 1.0!
 -----------------------------------------------------
 
+We're recognizing ChefDK's continued stability with the honor of a 1.0 tag. There 
 is nothing in this release that breaks backwards compatibility with previous
 installations of ChefDK: it is simply a formal recognition of the stability of
 the product.

--- a/chef_master/source/release_notes_push_jobs.rst
+++ b/chef_master/source/release_notes_push_jobs.rst
@@ -89,7 +89,6 @@ Both the ``knife-push`` library and the Chef Push Jobs API provide options to di
    $ knife job output --channel stdout 26e98ba162fa7ba6fb2793125553c7ae node1
    foobar
 
-
 Environment Control
 =====================================================
 The user has a lot more control over the execution environment of the remote command with three new options available to the ``knife push jobs start`` command.

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -270,7 +270,6 @@ The only supported systems at this time for FIPS mode are RHEL. Packages for
 other systems will be missing the required OpenSSL FIPS module and will fail
 to start if reconfigured with ``fips true``.
 
-
 What's New in 12.12
 =====================================================
 The following items are new for Chef server 12.12:
@@ -308,7 +307,6 @@ You can now set the following options in ``/etc/opscode/chef-server.rb``:
    oc_id['email_from_address'] = "oc_id@example.com"
    # defaults to the api_fqdn
    oc_id['origin'] = "mail.yourco.io"
-
 
 What's New in 12.11
 =====================================================
@@ -437,11 +435,7 @@ About Chef Licenses
 
 All Chef products have a license that governs the entire product and includes links to license files for any third-party software included in Chef packages. The ``/opt/<PRODUCT-NAME>/LICENSES`` directory contains individual copies of all referenced licenses.
 
-.. warning:: .. tag chef_license_note_current
-
              The ``chef-server-ctl install`` command no longer works in the 12.5 (and earlier) versions of the Chef server due to a change in how packages are downloaded from Chef.
-
-             .. end_tag
 
 Apache 2.0
 -----------------------------------------------------
@@ -449,7 +443,6 @@ Apache 2.0
 .. no swaps used for the "such as ..." section to ensure the correct legal name and not the names for these products as otherwise used globally in the documentation.
 
 All open source Chef products---such as the Chef client, the Chef server, or InSpec---are governed by the `Apache 2.0 license <https://www.apache.org/licenses/LICENSE-2.0>`__.
-
 
 What's New in 12.5
 =====================================================
@@ -459,7 +452,6 @@ The following items are new for Chef server 12.5:
 
 public_key_read_access
 -----------------------------------------------------
-.. tag server_rbac_permissions_default_public_key_read_access
 
 The ``public_key_read_access`` group controls which users and clients have `read permissions to the following endpoints </api_chef_server.html>`__:
 
@@ -499,8 +491,6 @@ By default, the ``public_key_read_access`` assigns all members of the ``users`` 
      - yes
      - yes
 
-.. end_tag
-
 What's New in 12.4
 =====================================================
 The following items are new for Chef server 12.4:
@@ -511,17 +501,13 @@ The following items are new for Chef server 12.4:
 
 /universe
 -----------------------------------------------------
-.. tag api_chef_server_endpoint_universe
 
 Use the ``/universe`` endpoint to retrieve the known collection of cookbooks, and then use it with Berkshelf and Chef Supermarket.
 
 The ``/universe`` endpoint has the following methods: ``GET``.
 
-.. end_tag
-
 GET
 -----------------------------------------------------
-.. tag api_chef_server_endpoint_universe_get
 
 The ``GET`` method is used to retrieve the universe data.
 
@@ -579,19 +565,13 @@ The response will return an embedded hash, with the name of each cookbook as a t
    * - ``200``
      - OK. The request was successful. One (or more) cookbooks and associated cookbook version information was returned.
 
-.. end_tag
-
 Server Admins
 -----------------------------------------------------
-.. tag server_rbac_server_admins
 
 The ``server-admins`` group is a global group that grants its members permission to create, read, update, and delete user accounts, with the exception of superuser accounts. The ``server-admins`` group is useful for users who are responsible for day-to-day administration of the Chef server, especially user management via the ``knife user`` subcommand. Before members can be added to the ``server-admins`` group, they must already have a user account on the Chef server.
 
-.. end_tag
-
 Scenario
 -----------------------------------------------------
-.. tag server_rbac_server_admins_scenario
 
 The following user accounts exist on the Chef server: ``pivotal`` (a superuser account), ``alice``, ``bob``, ``carol``, and ``dan``. Run the following command to view a list of users on the Chef server:
 
@@ -667,11 +647,8 @@ For example, Alice runs the following command:
 
 and the $EDITOR opens in which Alice makes changes, and then saves them.
 
-.. end_tag
-
 Superuser Accounts
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag server_rbac_server_admins_superusers
 
 Superuser accounts may not be managed by users who belong to the ``server-admins`` group. For example, Alice attempts to delete the ``pivotal`` superuser account:
 
@@ -689,11 +666,8 @@ and the following error is returned:
 
 Alice's action is unauthorized even with membership in the ``server-admins`` group.
 
-.. end_tag
-
 Manage server-admins Group
 -----------------------------------------------------
-.. tag ctl_chef_server_server_admin
 
 Membership of the ``server-admins`` group is managed with a set of ``chef-server-ctl`` subcommands:
 
@@ -701,11 +675,8 @@ Membership of the ``server-admins`` group is managed with a set of ``chef-server
 * ``chef-server-ctl list-server-admins``
 * ``chef-server-ctl remove-server-admin-permissions``
 
-.. end_tag
-
 Add Members
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag ctl_chef_server_server_admin_grant_user
 
 The ``grant-server-admin-permissions`` subcommand is used to add a user to the ``server-admins`` group. Run the command once per user added.
 
@@ -731,11 +702,8 @@ returns:
    read, and create users (even for orgs they are not members of)
    for this Chef Server.
 
-.. end_tag
-
 Remove Members
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag ctl_chef_server_server_admin_remove_user
 
 The ``remove-server-admin-permissions`` subcommand is used to remove a user from the ``server-admins`` group. Run the command once per user removed.
 
@@ -761,11 +729,8 @@ returns:
    list, read, and create users for this Chef Server except for where
    they have default permissions (such as within an org).
 
-.. end_tag
-
 List Membership
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag ctl_chef_server_server_admin_list
 
 The ``list-server-admins`` subcommand is used to return a list of users who are members of the ``server-admins`` group.
 
@@ -784,8 +749,6 @@ and will return a list of users similar to:
    bob
    carol
    dan
-
-.. end_tag
 
 What's New in 12.3
 =====================================================
@@ -815,13 +778,9 @@ The following configuration settings are new and enable the Nginx ``stub_status`
 
 RabbitMQ Queues
 -----------------------------------------------------
-.. tag server_tuning_rabbitmq_analytics_queue
 
 If the RabbitMQ queue that is used by Chef Analytics stops consuming messages, the Chef server data partition will fill up and may affect the overall performance of the Chef server application itself. The settings for the RabbitMQ queue are tunable, including for queue length monitoring, queue capacity, maximum number of messages that can be in the queue before messages are dropped, the point at which messages are dropped, for settings used by the rabbitmq-management plugin, and so on.
 
-.. end_tag
-
-.. tag server_tuning_rabbitmq_analytics_queue_settings
 
 The following settings may be used for tuning RabbitMQ queues used by Chef Analytics and the Chef server:
 
@@ -888,8 +847,6 @@ The following settings may be used for tuning RabbitMQ queues used by Chef Analy
 ``rabbitmq['ssl_versions']``
    The SSL versions used by the rabbitmq-management plugin. (See `RabbitMQ TLS Support <https://www.rabbitmq.com/ssl.html>`_ for more details.) Default value: ``['tlsv1.2', 'tlsv1.1']``.
 
-.. end_tag
-
 What's New
 -----------------------------------------------------
 The following items are new for Chef server 12.2:
@@ -902,17 +859,13 @@ The following items are new for Chef server 12.2:
 
 Solr => Solr 4 Changes
 -----------------------------------------------------
-.. tag 2_solr_to_solr4
 
 Chef server version 12 is upgraded to Apache Solr 4. If Apache Solr options were added to the private-chef.rb file under ``opscode_solr`` for Enterprise Chef, those configuration options are now stored under ``opscode_solr4`` in the chef-server.rb file for Chef server version 12.
 
 Some ``opscode_solr`` settings are imported automatically, such as heap, new size, and Java options, but many settings are ignored. If your Enterprise Chef configuration is highly tuned for Apache Solr, review `these configuration settings </config_rb_server_optional_settings.html#opscode-solr4>`__ before re-tuning Apache Solr for Chef server version 12.
 
-.. end_tag
-
 External PostgreSQL
 -----------------------------------------------------
-.. tag server_ha_external_postgresql
 
 The following diagram highlights the specific changes that occur when PostgreSQL is configured and managed independently of the Chef server configuration.
 
@@ -930,15 +883,9 @@ The following table describes the components in an external PostgreSQL configura
    * - Chef Server
      - The Chef server configuration file is updated to point to an independently configured set of servers for PostgreSQL.
    * - PostgreSQL
-     - .. tag chef_server_component_postgresql
-
-       PostgreSQL is the data storage repository for the Chef server.
-
-       .. end_tag
+     - PostgreSQL is the data storage repository for the Chef server.
 
        This represents the independently configured set of servers that are running PostgreSQL and are configured to act as the data store for the Chef server.
-
-.. end_tag
 
 .. note:: The following ``chef-server-ctl`` subcommands for managing services are disabled when an external PostgreSQL database is configured for the Chef server: ``hup``, ``int``, ``kill``, ``once``, ``restart``, ``start``, ``stop``, ``tail``, and ``term``.
 
@@ -970,7 +917,6 @@ Use the following commands to manage backups of Chef server data, and then to re
 
 backup
 -----------------------------------------------------
-.. tag ctl_chef_server_backup
 
 The ``backup`` subcommand is used to back up all Chef server data. This subcommand:
 
@@ -979,22 +925,14 @@ The ``backup`` subcommand is used to back up all Chef server data. This subcomma
 * Should not be run in a Chef server configuration with an external PostgreSQL database; `use knife ec backup <https://github.com/chef/knife-ec-backup>`__ instead
 * Puts the initial backup in the ``/var/opt/chef-backup`` directory as a tar.gz file; move this backup to a new location for safe keeping
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_backup_options
 
 This subcommand has the following options:
 
 ``-y``, ``--yes``
    Use to specify if the Chef server can go offline during tar.gz-based backups.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_backup_syntax
 
 This subcommand has the following syntax:
 
@@ -1002,11 +940,8 @@ This subcommand has the following syntax:
 
    $ chef-server-ctl backup
 
-.. end_tag
-
 restore
 -----------------------------------------------------
-.. tag ctl_chef_server_restore
 
 The ``restore`` subcommand is used to restore Chef server data from a backup that was created by the ``backup`` subcommand. This subcommand may also be used to add Chef server data to a newly-installed server. This subcommand:
 
@@ -1016,11 +951,7 @@ The ``restore`` subcommand is used to restore Chef server data from a backup tha
 
 .. note :: The ``restore`` command does not support transferring backups across different versions of Chef server. Backups taken with the ``backup`` command must restore to the same version of Chef server that was in use when they were created.
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_restore_options
 
 This subcommand has the following options:
 
@@ -1030,19 +961,13 @@ This subcommand has the following options:
 ``-d DIRECTORY``, ``--staging-dir DIRECTORY``
    Use to specify that the path to an empty directory to be used during the restore process. This directory must have enough disk space to expand all data in the backup archive.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_restore_syntax
 
 This subcommand has the following syntax:
 
 .. code-block:: bash
 
    $ chef-server-ctl restore PATH_TO_BACKUP (options)
-
-.. end_tag
 
 **Examples**
 
@@ -1052,7 +977,6 @@ This subcommand has the following syntax:
 
 psql
 -----------------------------------------------------
-.. tag ctl_chef_server_psql
 
 The ``psql`` subcommand is used to log into the PostgreSQL database associated with the named service. This subcommand:
 
@@ -1061,11 +985,7 @@ The ``psql`` subcommand is used to log into the PostgreSQL database associated w
 * Is the recommended way to interact with any PostgreSQL database that is part of the Chef server
 * Automatically handles authentication
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_psql_syntax
 
 This subcommand has the following syntax:
 
@@ -1073,22 +993,15 @@ This subcommand has the following syntax:
 
    $ chef-server-ctl psql SERVICE_NAME (options)
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_psql_options
 
 This subcommand has the following options:
 
 ``--write``
    Use to enable write access to the PostgreSQL database.
 
-.. end_tag
-
 reindex Options
 -----------------------------------------------------
-.. tag ctl_chef_server_reindex_options
 
 This subcommand has the following options:
 
@@ -1104,19 +1017,14 @@ This subcommand has the following options:
 ``-w``, ``--wait``
    Use to wait for the reindexing queue to clear before exiting. This option only works when run on a standalone Chef server, or on a primary backend Chef server within a legacy tier or DRBD HA system. This option should not be used on a HA frontend.
 
-.. end_tag
-
 Chef server API Endpoints
 -----------------------------------------------------
 The following endpoints have been added to the Chef server API:
 
 /policy_groups/NAME
 -----------------------------------------------------
-.. tag api_chef_server_endpoint_policy_groups
 
 The ``/policy_groups`` endpoint has the following methods: ``GET``.
-
-.. end_tag
 
 DELETE
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -1516,23 +1424,16 @@ The ``knife user`` and ``knife client`` subcommands support key rotation. Use th
 
 X-Ops-Server-API-Version
 -----------------------------------------------------
-.. tag api_chef_server_headers_x_ops_server_api_version
 
 Use ``X-Ops-Server-API-Version`` to specify the version of the Chef server API. For example: ``X-Ops-Server-API-Version: 1``. ``X-Ops-Server-API-Version: 0`` is supported for use with the version 12 Chef server, but will be deprecated as part of the next major release.
 
-.. end_tag
-
 /clients/CLIENT/keys/
 -----------------------------------------------------
-.. tag api_chef_server_endpoint_keys_clients
 
 The ``/clients/CLIENT/keys`` endpoint has the following methods: ``GET`` and ``POST``.
 
-.. end_tag
-
 GET
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag api_chef_server_endpoint_keys_clients_get
 
 The ``GET`` method is used to retrieve all of the named client's key identifiers, associated URIs, and expiry states.
 
@@ -1576,11 +1477,8 @@ The response is similar to:
    * - ``404``
      - Not found. The requested object does not exist.
 
-.. end_tag
-
 POST
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag api_chef_server_endpoint_keys_clients_post
 
 The ``POST`` method is used to add a key for the specified client.
 
@@ -1629,19 +1527,13 @@ The response is similar to:
    * - ``404``
      - Not found. The requested object does not exist.
 
-.. end_tag
-
 /clients/CLIENT/keys/KEY
 -----------------------------------------------------
-.. tag api_chef_server_endpoint_key_client
 
 The ``/clients/CLIENT/keys/KEY`` endpoint has the following methods: ``DELETE``, ``GET``, and ``PUT``.
 
-.. end_tag
-
 DELETE
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag api_chef_server_endpoint_key_client_delete
 
 The ``DELETE`` method is used to delete the specified key for the specified client.
 
@@ -1682,11 +1574,8 @@ The response returns the information about the deleted key and is similar to:
    * - ``404``
      - Not found. The requested object does not exist.
 
-.. end_tag
-
 GET
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag api_chef_server_endpoint_key_client_get
 
 The ``GET`` method is used to return details for a specific key for a specific client.
 
@@ -1727,11 +1616,8 @@ The response is similar to:
    * - ``404``
      - Not found. The requested object does not exist.
 
-.. end_tag
-
 PUT
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag api_chef_server_endpoint_key_client_put
 
 The ``PUT`` method is used to update one or more properties for a specific key for a specific client.
 
@@ -1784,19 +1670,13 @@ The response contains the updated inforamtion for the key, and is similar to:
    * - ``404``
      - Not found. The requested object does not exist.
 
-.. end_tag
-
 /user/USER/keys/
 -----------------------------------------------------
-.. tag api_chef_server_endpoint_keys_users
 
 The ``/users/USER/keys`` endpoint has the following methods: ``GET`` and ``POST``.
 
-.. end_tag
-
 GET
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag api_chef_server_endpoint_keys_users_get
 
 The ``GET`` method is used to retrieve all of the named user's key identifiers, associated URIs, and expiry states.
 
@@ -1840,11 +1720,8 @@ The response is similar to:
    * - ``404``
      - Not found. The requested object does not exist.
 
-.. end_tag
-
 POST
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag api_chef_server_endpoint_keys_users_post
 
 The ``POST`` method is used to add a key for the specified user.
 
@@ -1893,19 +1770,13 @@ The response is similar to:
    * - ``404``
      - Not found. The requested object does not exist.
 
-.. end_tag
-
 /user/USER/keys/KEY
 -----------------------------------------------------
-.. tag api_chef_server_endpoint_key_user
 
 The ``/users/USER/keys/KEY`` endpoint has the following methods: ``DELETE``, ``GET``, and ``PUT``.
 
-.. end_tag
-
 DELETE
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag api_chef_server_endpoint_key_user_delete
 
 The ``DELETE`` method is used to delete the specified key for the specified user.
 
@@ -1946,11 +1817,8 @@ The response returns the information about the deleted key and is similar to:
    * - ``404``
      - Not found. The requested object does not exist.
 
-.. end_tag
-
 GET
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag api_chef_server_endpoint_key_user_get
 
 The ``GET`` method is used to return details for a specific key for a specific user.
 
@@ -1991,11 +1859,8 @@ The response is similar to:
    * - ``404``
      - Not found. The requested object does not exist.
 
-.. end_tag
-
 PUT
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag api_chef_server_endpoint_key_user_put
 
 The ``PUT`` method is used to update one or more properties for a specific key for a specific user.
 
@@ -2048,19 +1913,13 @@ The response contains the updated inforamtion for the key, and is similar to:
    * - ``404``
      - Not found. The requested object does not exist.
 
-.. end_tag
-
 /policies
 -----------------------------------------------------
-.. tag api_chef_server_endpoint_policies
 
 The ``/policies`` endpoint has the following methods: ``GET``.
 
-.. end_tag
-
 GET
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag api_chef_server_endpoint_policies_get
 
 The ``GET`` method is used to get a list of policies (including policy revisions) from the Chef server.
 
@@ -2116,24 +1975,16 @@ The response groups policies by name and revision and is similar to:
    * - ``403``
      - Forbidden. The user who made the request is not authorized to perform the action.
 
-.. end_tag
-
 /policy_groups
 -----------------------------------------------------
-.. tag api_chef_server_endpoint_policy_groups
 
 The ``/policy_groups`` endpoint has the following methods: ``GET``.
 
-.. end_tag
-
-.. tag policy_group_relates_to_nodes
 
 Each node has a 1:many relationship with policy settings stored on the Chef server. This relationship is based on the policy group to which the node is associated, and then the policy settings assigned to that group:
 
 * A policy is typically named after the functional role ahost performs, such as "application server", "chat server", "load balancer", and so on
 * A policy group defines a set of hosts in a deployed units, typically mapped to organizational requirements such as "dev", "test", "staging", and "production", but can also be mapped to more detailed requirements as needed
-
-.. end_tag
 
 GET
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -2196,14 +2047,10 @@ The response is similar to:
 -----------------------------------------------------
 The ``/policies/NAME`` endpoint has the following methods: ``DELETE``, ``GET``, and ``PUT``. These endpoints enable the management of policies as they relate to a specific policy group.
 
-.. tag policy_group_relates_to_nodes
-
 Each node has a 1:many relationship with policy settings stored on the Chef server. This relationship is based on the policy group to which the node is associated, and then the policy settings assigned to that group:
 
 * A policy is typically named after the functional role ahost performs, such as "application server", "chat server", "load balancer", and so on
 * A policy group defines a set of hosts in a deployed units, typically mapped to organizational requirements such as "dev", "test", "staging", and "production", but can also be mapped to more detailed requirements as needed
-
-.. end_tag
 
 Each policy group and individual policy are separate objects for the purposes of authentication. This enables each policy and policy group to have restricted access, such as for specific nodes that handle sensitive data or for specific production groups that require sign-off as part of organizational requirements.
 
@@ -2628,7 +2475,6 @@ Upgrades to Chef server 12 are supported for both Enterprise Chef and Open Sourc
 
 HA using AWS
 -----------------------------------------------------
-.. tag server_ha_aws
 
 Amazon Web Services (AWS) is a supported high availability configuration option for the Chef server.
 
@@ -2640,21 +2486,14 @@ Backend servers make use of a single Amazon Elastic Block Store (EBS) volume.
 
 For more information about Amazon Elastic Block Store (EBS), see http://aws.amazon.com/ebs/.
 
-.. end_tag
-
 View the topic `High Availability: AWS </install_server_ha_aws.html>`__ for more information about how to set up the Chef server for high availability in Amazon Web Services (AWS).
 
 Chef Replication
 -----------------------------------------------------
-.. tag server_replication_summary
 
 Chef replication provides a way to asynchronously distribute cookbook, environment, role, and data bag data from a single, primary Chef server to one (or more) replicas of that Chef server.
 
-.. end_tag
-
 **Scenarios**
-
-.. tag server_replication_scenarios
 
 Replication is configured on a per-organization and also a per-replica basis. Each organization must be configured to synchronize with each replica instance. Each organization may be configured to synchronize with all, some, or none of the available replica instances.
 
@@ -2672,17 +2511,11 @@ Chef replication should not be used for:
 * Synchronizing a replica instance with another replica instance
 * Node re-registration. A node may be associated only with a single Chef server
 
-.. end_tag
-
 **How Replication Works**
-
-.. tag server_replication_how_it_works
 
 A daemon named **ec-syncd** runs on each of the replica instances of the Chef server and periodically polls the primary Chef server via the ``updated_since`` endpoint in the Chef server API. The **ec-syncd** daemon requests a list of objects that have been updated since the last successful synchronization time. If there are updates, the **ec-syncd** daemon then pulls down the updated data from the primary Chef server to the replica.
 
 .. image:: ../../images/chef_server_replication_sequence.png
-
-.. end_tag
 
 View the topic `Chef Replication </server_replication.html>`__ for more information about how to set up the Chef server for replication.
 
@@ -2698,15 +2531,10 @@ In addition, the ``install`` subcommand is added, plus two new subcommand groupi
 
 install Command
 -----------------------------------------------------
-.. tag ctl_chef_server_install
 
 The ``install`` subcommand is used to install premium features of the Chef server: Chef management console and chef-client run reporting, high availability configurations, Chef push jobs, and Chef server replication.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_install_syntax
 
 This subcommand has the following syntax:
 
@@ -2716,22 +2544,14 @@ This subcommand has the following syntax:
 
 where ``name_of_addon`` represents the command line value associated with the add-on or premium feature.
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_install_options
 
 This subcommand has the following options:
 
 ``--path PATH``
    Use to specify the location of a package. This option is not required when packages are downloaded from https://packages.chef.io/.
 
-.. end_tag
-
 **Use Downloads**
-
-.. tag ctl_chef_server_install_features_download
 
 The ``install`` subcommand downloads packages from https://packages.chef.io/ by default. For systems that are not behind a firewall (and have connectivity to https://packages.chef.io/), these packages can be installed as described below.
 
@@ -2762,17 +2582,10 @@ The ``install`` subcommand downloads packages from https://packages.chef.io/ by 
 
           $ sudo chef-manage-ctl reconfigure
 
-       .. note:: .. tag chef_license_reconfigure_manage
-
                  Starting with the Chef management console 2.3.0, the `Chef MLSA </chef_license.html>`__ must be accepted when reconfiguring the product. If the Chef MLSA has not already been accepted, the reconfigure process will prompt for a ``yes`` to accept it. Or run ``chef-manage-ctl reconfigure --accept-license`` to automatically accept the license.
 
-                 .. end_tag
-
-.. end_tag
 
 **Use Local Packages**
-
-.. tag ctl_chef_server_install_features_manual
 
 The ``install`` subcommand downloads packages from https://packages.chef.io/ by default. For systems that are behind a firewall (and may not have connectivity to packages.chef.io), these packages can be downloaded from https://downloads.chef.io/chef-manage/, and then installed manually. First download the package that is appropriate for the platform, save it to a local path, and then run the ``install`` command using the ``--path`` option to specify the directory in which the package is located:
 
@@ -2788,11 +2601,8 @@ For example:
 
 The ``chef-server-ctl`` command will install the first ``chef-manage`` package found in the ``/root/packages`` directory.
 
-.. end_tag
-
 gather-logs Command
 -----------------------------------------------------
-.. tag ctl_chef_server_gather_logs
 
 The ``gather-logs`` subcommand is used to gather the Chef server log files into a tarball that contains all of the important log files and system information.
 
@@ -2802,23 +2612,16 @@ This subcommand has the following syntax:
 
    $ chef-server-ctl gather-logs
 
-.. end_tag
-
 user-* Commands
 -----------------------------------------------------
 The following subcommands can be used to manage users:
 
 user-create
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag ctl_chef_server_user_create
 
 The ``user-create`` subcommand is used to create a user. (The validation key for the organization may be returned to ``STDOUT`` when creating a user with this command.)
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_user_create_syntax
 
 This subcommand has the following syntax:
 
@@ -2826,18 +2629,12 @@ This subcommand has the following syntax:
 
    $ chef-server-ctl user-create USER_NAME FIRST_NAME [MIDDLE_NAME] LAST_NAME EMAIL 'PASSWORD' (options)
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_user_create_options
 
 This subcommand has the following options:
 
 ``-f FILE_NAME``, ``--filename FILE_NAME``
    Write the USER.pem to a file instead of ``STDOUT``.
-
-.. end_tag
 
 **Examples**
 
@@ -2855,23 +2652,16 @@ This subcommand has the following options:
 
 user-delete
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag ctl_chef_server_user_delete
 
 The ``user-delete`` subcommand is used to delete a user.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_user_delete_syntax
 
 This subcommand has the following syntax:
 
 .. code-block:: bash
 
    $ chef-server-ctl user-delete USER_NAME
-
-.. end_tag
 
 **Examples**
 
@@ -2885,23 +2675,16 @@ This subcommand has the following syntax:
 
 user-edit
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag ctl_chef_server_user_edit
 
 The ``user-edit`` subcommand is used to edit the details for a user. The data will be made available in the $EDITOR for editing.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_user_edit_syntax
 
 This subcommand has the following syntax:
 
 .. code-block:: bash
 
    $ chef-server-ctl user-edit USER_NAME
-
-.. end_tag
 
 **Examples**
 
@@ -2915,15 +2698,10 @@ This subcommand has the following syntax:
 
 user-list
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag ctl_chef_server_user_list
 
 The ``user-list`` subcommand is used to view a list of users.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_user_list_syntax
 
 This subcommand has the following syntax:
 
@@ -2931,30 +2709,19 @@ This subcommand has the following syntax:
 
    $ chef-server-ctl user-list (options)
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_user_list_options
 
 This subcommand has the following options:
 
 ``-w``, ``--with-uri``
    Show the corresponding URIs.
 
-.. end_tag
-
 user-show
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag ctl_chef_server_user_show
 
 The ``user-show`` subcommand is used to show the details for a user.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_user_show_syntax
 
 This subcommand has the following syntax:
 
@@ -2962,18 +2729,12 @@ This subcommand has the following syntax:
 
    $ chef-server-ctl user-show USER_NAME (options)
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_user_show_options
 
 This subcommand has the following options:
 
 ``-l``, ``--with-orgs``
    Show all organizations.
-
-.. end_tag
 
 org-* Commands
 -----------------------------------------------------
@@ -2981,15 +2742,10 @@ The following subcommands can be used to manage organizations:
 
 org-create
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag ctl_chef_server_org_create
 
 The ``org-create`` subcommand is used to create an organization. (The validation key for the organization is returned to ``STDOUT`` when creating an organization with this command.)
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_org_create_syntax
 
 This subcommand has the following syntax:
 
@@ -3002,11 +2758,7 @@ where:
 * The name must begin with a lower-case letter or digit, may only contain lower-case letters, digits, hyphens, and underscores, and must be between 1 and 255 characters. For example: ``chef``.
 * The full name must begin with a non-white space character and must be between 1 and 1023 characters. For example: ``"Chef Software, Inc."``.
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_org_create_options
 
 This subcommand has the following options:
 
@@ -3015,8 +2767,6 @@ This subcommand has the following options:
 
 ``-f FILE_NAME``, ``--filename FILE_NAME``
    Write the ORGANIZATION-validator.pem to ``FILE_NAME`` instead of printing it to ``STDOUT``.
-
-.. end_tag
 
 **Examples**
 
@@ -3034,23 +2784,16 @@ This subcommand has the following options:
 
 org-delete
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag ctl_chef_server_org_delete
 
 The ``org-delete`` subcommand is used to delete an organization.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_org_delete_syntax
 
 This subcommand has the following syntax:
 
 .. code-block:: bash
 
    $ chef-server-ctl org-delete ORG_NAME
-
-.. end_tag
 
 **Examples**
 
@@ -3064,15 +2807,10 @@ This subcommand has the following syntax:
 
 org-list
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag ctl_chef_server_org_list
 
 The ``org-list`` subcommand is used to list all of the organizations currently present on the Chef server.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_org_list_syntax
 
 This subcommand has the following syntax:
 
@@ -3080,11 +2818,7 @@ This subcommand has the following syntax:
 
    $ chef-server-ctl org-list (options)
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_org_list_options
 
 This subcommand has the following options:
 
@@ -3094,19 +2828,12 @@ This subcommand has the following options:
 ``-w``, ``--with-uri``
    Show the corresponding URIs.
 
-.. end_tag
-
 org-show
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag ctl_chef_server_org_show
 
 The ``org-show`` subcommand is used to show the details for an organization.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_org_show_syntax
 
 This subcommand has the following syntax:
 
@@ -3114,21 +2841,13 @@ This subcommand has the following syntax:
 
    $ chef-server-ctl org-show ORG_NAME
 
-.. end_tag
-
 org-user-add
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. warning:: Early RC candidates for the Chef server 12 release named this command ``org-associate``. This is the same command, with the exception of the ``--admin`` flag, which is added to the command (along with the rename) for the upcoming final release of Chef server 12.
 
-.. tag ctl_chef_server_org_user_add
-
 The ``org-user-add`` subcommand is used to add a user to an organization.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_org_user_add_syntax
 
 This subcommand has the following syntax:
 
@@ -3136,18 +2855,12 @@ This subcommand has the following syntax:
 
    $ chef-server-ctl org-user-add ORG_NAME USER_NAME (options)
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_org_user_add_options
 
 This subcommand has the following options:
 
 ``--admin``
    Add the user to the ``admins`` group.
-
-.. end_tag
 
 **Examples**
 
@@ -3167,23 +2880,15 @@ org-user-remove
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. warning:: Early RC candidates for the Chef server 12 release named this command ``org-disociate``. This is the same command, but renamed for the upcoming final release of Chef server 12.
 
-.. tag ctl_chef_server_org_user_remove
-
 The ``org-user-remove`` subcommand is used to remove a user from an organization.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_org_user_remove_syntax
 
 This subcommand has the following syntax:
 
 .. code-block:: bash
 
    $ chef-server-ctl org-user-remove ORG_NAME USER_NAME (options)
-
-.. end_tag
 
 **Examples**
 
@@ -3238,13 +2943,9 @@ The following configuration settings are new in Chef server version 12.0.5:
 
 oc_chef_authz
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag server_services_authz
 
 The **opscode-authz** service is used to handle authorization requests to the Chef server.
 
-.. end_tag
-
-.. tag config_rb_server_settings_oc_chef_authz
 
 This configuration file has the following settings for ``oc_chef_authz``:
 
@@ -3265,8 +2966,6 @@ This configuration file has the following settings for ``oc_chef_authz``:
 
 ``oc_chef_authz['ibrowse_options']``
    The amount of time (in milliseconds) to wait for a connection to be established. Default value: ``'[{connect_timeout, 5000}]'``.
-
-.. end_tag
 
 Data Bag Policy Changes
 -----------------------------------------------------
@@ -3319,15 +3018,10 @@ Use the following commands to manage public and private key rotation for users a
 
 add-client-key
 -----------------------------------------------------
-.. tag ctl_chef_server_add_client_key
 
 Use the ``add-client-key`` subcommand to add a client key.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_add_client_key_syntax
 
 This subcommand has the following syntax:
 
@@ -3337,11 +3031,7 @@ This subcommand has the following syntax:
 
 .. warning:: All options for this subcommand must follow all arguments.
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_add_client_key_options
 
 This subcommand has the following options:
 
@@ -3360,19 +3050,12 @@ This subcommand has the following options:
 ``-p PATH`` ``--public-key-path PATH``
    The location to a file containing valid PKCS#1 public key to be added. If not passed, then the server will generate a new one for you and return the private key to STDOUT.
 
-.. end_tag
-
 add-user-key
 -----------------------------------------------------
-.. tag ctl_chef_server_add_user_key
 
 Use the ``add-user-key`` subcommand to add a user key.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_add_user_key_syntax
 
 This subcommand has the following syntax:
 
@@ -3382,11 +3065,7 @@ This subcommand has the following syntax:
 
 .. warning:: All options for this subcommand must follow all arguments.
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_add_user_key_options
 
 This subcommand has the following options:
 
@@ -3402,19 +3081,12 @@ This subcommand has the following options:
 ``USER_NAME``
    The user name for the user for which a key is added.
 
-.. end_tag
-
 delete-client-key
 -----------------------------------------------------
-.. tag ctl_chef_server_delete_client_key
 
 Use the ``delete-client-key`` subcommand to delete a client key.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_delete_client_key_syntax
 
 This subcommand has the following syntax:
 
@@ -3422,11 +3094,7 @@ This subcommand has the following syntax:
 
    $ chef-server-ctl delete-client-key ORG_NAME CLIENT_NAME KEY_NAME
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_delete_client_key_options
 
 This subcommand has the following arguments:
 
@@ -3439,19 +3107,12 @@ This subcommand has the following arguments:
 ``KEY_NAME``
    The unique name to be assigned to the key you wish to delete.
 
-.. end_tag
-
 delete-user-key
 -----------------------------------------------------
-.. tag ctl_chef_server_delete_user_key
 
 Use the ``delete-user-key`` subcommand to delete a user key.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_delete_user_key_syntax
 
 This subcommand has the following syntax:
 
@@ -3461,11 +3122,7 @@ This subcommand has the following syntax:
 
 .. warning:: The parameters for this subcommand must be in the order specified above.
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_delete_user_key_options
 
 This subcommand has the following arguments:
 
@@ -3475,19 +3132,12 @@ This subcommand has the following arguments:
 ``KEY_NAME``
    The unique name to be assigned to the key you wish to delete.
 
-.. end_tag
-
 list-client-key
 -----------------------------------------------------
-.. tag ctl_chef_server_list_client_keys
 
 Use the ``list-client-keys`` subcommand to list client keys.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_list_client_keys_syntax
 
 This subcommand has the following syntax:
 
@@ -3497,11 +3147,7 @@ This subcommand has the following syntax:
 
 .. warning::  All options for this subcommand must follow all arguments.
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_list_client_keys_options
 
 This subcommand has the following options:
 
@@ -3514,19 +3160,12 @@ This subcommand has the following options:
 ``--verbose``
    Use to show the full public key strings in command output.
 
-.. end_tag
-
 list-user-key
 -----------------------------------------------------
-.. tag ctl_chef_server_list_user_keys
 
 Use the ``list-user-keys`` subcommand to list client keys.
 
-.. end_tag
-
 **Syntax**
-
-.. tag ctl_chef_server_list_user_keys_syntax
 
 This subcommand has the following syntax:
 
@@ -3536,11 +3175,7 @@ This subcommand has the following syntax:
 
 .. warning:: All options for this subcommand must follow all arguments.
 
-.. end_tag
-
 **Options**
-
-.. tag ctl_chef_server_list_user_keys_options
 
 This subcommand has the following options:
 
@@ -3549,8 +3184,6 @@ This subcommand has the following options:
 
 ``--verbose``
    Use to show the full public key strings in command output.
-
-.. end_tag
 
 **Example**
 

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -435,7 +435,7 @@ About Chef Licenses
 
 All Chef products have a license that governs the entire product and includes links to license files for any third-party software included in Chef packages. The ``/opt/<PRODUCT-NAME>/LICENSES`` directory contains individual copies of all referenced licenses.
 
-             The ``chef-server-ctl install`` command no longer works in the 12.5 (and earlier) versions of the Chef server due to a change in how packages are downloaded from Chef.
+.. warning:: The ``chef-server-ctl install`` command no longer works in the 12.5 (and earlier) versions of the Chef server due to a change in how packages are downloaded from Chef.
 
 Apache 2.0
 -----------------------------------------------------
@@ -2581,8 +2581,8 @@ The ``install`` subcommand downloads packages from https://packages.chef.io/ by 
        .. code-block:: bash
 
           $ sudo chef-manage-ctl reconfigure
-
-                 Starting with the Chef management console 2.3.0, the `Chef MLSA </chef_license.html>`__ must be accepted when reconfiguring the product. If the Chef MLSA has not already been accepted, the reconfigure process will prompt for a ``yes`` to accept it. Or run ``chef-manage-ctl reconfigure --accept-license`` to automatically accept the license.
+          
+       .. note:: Starting with the Chef management console 2.3.0, the `Chef MLSA </chef_license.html>`__ must be accepted when reconfiguring the product. If the Chef MLSA has not already been accepted, the reconfigure process will prompt for a ``yes`` to accept it. Or run ``chef-manage-ctl reconfigure --accept-license`` to automatically accept the license.
 
 
 **Use Local Packages**


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### Description

Dtags in release notes have been a constant source of pain. This PR removes all dtags and consecutive blank likes from release notes in this repo.

### Check List

- [ ] Spell Check
- [x] Local build
- [x] Examine the local build
- [ ] All tests pass
