### PR TITLE
Add more detailed general follower recovery process

### DIFF
--- a/chef_master/source/backend_failure_recovery.rst
+++ b/chef_master/source/backend_failure_recovery.rst
@@ -157,26 +157,31 @@ Once you've resolved the issue and can run the ``pgsql-follow`` command successf
 General Follower Recovery Process
 =====================================
 
-Initial attempts to recover should follow this general pattern and use the scenarios and tools shown above to assist in the recovery steps
+Initial attempts to recover should follow this general pattern and use the scenarios and tools shown above to assist in the recovery steps:
 
-1. Take a filesystem level backup of all backend nodes with the cluster down
-2. Check the health of the leader and repair if necessary. If the /var/log/chef-backend/leaderl/current logs do not show leadership changes and the `chef-backend-ctl cluster-status` shows a solid etcd/pgsql leader, then you are good to go. Any leadership repair process often involves removing an internal pgsql lock file that prevents promotion of what we think was the last leader. This file is placed automatically by leaderl when it demotes a leader `/var/opt/chef-backend/leaderl/data/no-start-pgsql`. Refer to the Promoting a Previous Leader section above for more detail. This is a very dangerous step that can result in data loss. We recommend opening a ticket with Support to go over any cluster leadership issue. www.chef.io/support/get-started
-3. If necessary, promote what we think was the most recent leader. Refer to the Promoting a Previous Leader section above for more detail
-4. Sync the followers from the leader using a full basebackup because the WAL entries have likely already rotated. When this happens, the followers will complain in /var/log/chef-backend/postgresql/X.Y/current about being unable to synch and just the `--recovery` flag will result in timeouts of the `chef-backend-ctl join-cluster` command. It's impossible for a follower to sync and rejoin while in this state. It doesn't have current enough info.
+#. With the cluster down, take a filesystem level backup of all backend nodes.
+#. Check the health of the leader and repair if necessary. If the `/var/log/chef-backend/leaderl/current` logs do not show leadership changes and the ``chef-backend-ctl cluster-status`` shows a solid etcd/pgsql leader, then you are good to continue. 
 
-.. code-block:: none
+   **Note**: Any leadership repair process is a very dangerous step that can result in data loss. We recommend `opening a ticket with Support <www.chef.io/support/get-started>`__ to go over any cluster leadership issue.
+   
+   Any leadership repair process often involves removing an internal pgsql lock file that prevents promotion of what is thought as the last leader. This file is placed automatically by leaderl when it demotes a leader ``/var/opt/chef-backend/leaderl/data/no-start-pgsql``. Refer to the `Promoting a Previous Leader section </backend_failure_recovery.html#promoting-a-previous-leader>`__ for more details. 
+#. If necessary, promote what is thought as the most recent leader. Refer to the `Promoting a Previous Leader section </backend_failure_recovery.html#promoting-a-previous-leader>`__ for more detail.
+#. Sync the followers from the leader using a full basebackup because the WAL entries have likely already rotated. When this happens, the followers will complain in ``/var/log/chef-backend/postgresql/X.Y/current`` about being unable to sync. Using just the `--recovery` flag will result in timeouts of the ``chef-backend-ctl join-cluster`` command. It's impossible for a follower to sync and rejoin while in this state because it doesn't have current enough info.
 
-   2018-04-25_16:36:29.42242 FATAL:  the database system is starting up
-   2018-04-25_16:36:30.90058 LOG:  started streaming WAL from primary at 16F3/2D000000 on timeline 88
-   2018-04-25_16:36:30.90124 FATAL:  could not receive data from WAL stream: ERROR:  requested WAL segment     00000058000016F30000002D has already been removed
-   2018-04-25_16:36:30.90125
+    .. code-block:: none
+
+       2018-04-25_16:36:29.42242 FATAL:  the database system is starting up
+       2018-04-25_16:36:30.90058 LOG:  started streaming WAL from primary at 16F3/2D000000 on timeline 88
+       2018-04-25_16:36:30.90124 FATAL:  could not receive data from WAL stream: ERROR:  requested WAL segment      00000058000016F30000002D has already been removed
+       2018-04-25_16:36:30.90125
  
+    In a Chef Backend High Availability deployment, the etcd service is extremely sensitive and can get into a bad state across backend nodes due to disk and/or network latency. When this happens, it is common for the cluster to be unable to automatically failover/recover. 
 
-In a Chef Backend High Availability deployment, the etcd service is extremely sensitive and can get into a bad state across backend nodes due to disk and/or network latency. When this happens, it is common for the cluster to be unable to automatically failover/recover. To attempt manual recovery on a follower that exhibits the symptoms previously shown, try issuing the following commands on problematic followers that will not sync. Do this on one follower at a time. You can check `chef-backend cluster-status` output periodically to watch the state of the cluster change:
+    To attempt manual recovery on a follower that exhibits the symptoms previously shown, try issuing the following commands on problematic followers that will not sync. **Do this on one follower at a time.** You can check output from the ``chef-backend cluster-status`` command periodically to watch the state of the cluster change:
 
-.. code-block:: none
+    .. code-block:: bash
 
-    chef-backend-ctl stop leaderl
-    chef-backend-ctl cluster-status
-    PSQL_INTERNAL_OK=true chef-backend-ctl pgsql-follow --force-basebackup --verbose LAST_LEADER_IP
-    chef-backend-ctl start
+       chef-backend-ctl stop leaderl
+       chef-backend-ctl cluster-status
+       PSQL_INTERNAL_OK=true chef-backend-ctl pgsql-follow --force-basebackup --verbose LAST_LEADER_IP
+       chef-backend-ctl start

--- a/chef_master/source/backend_failure_recovery.rst
+++ b/chef_master/source/backend_failure_recovery.rst
@@ -166,7 +166,7 @@ Initial attempts to recover should follow this general pattern and use the scena
    
    Any leadership repair process often involves removing an internal pgsql lock file that prevents promotion of what is thought as the last leader. This file is placed automatically by leaderl when it demotes a leader ``/var/opt/chef-backend/leaderl/data/no-start-pgsql``. Refer to the `Promoting a Previous Leader section </backend_failure_recovery.html#promoting-a-previous-leader>`__ for more details. 
 #. If necessary, promote what is thought as the most recent leader. Refer to the `Promoting a Previous Leader section </backend_failure_recovery.html#promoting-a-previous-leader>`__ for more detail.
-#. Sync the followers from the leader using a full basebackup because the WAL entries have likely already rotated. When this happens, the followers will complain in ``/var/log/chef-backend/postgresql/X.Y/current`` about being unable to sync. Using just the `--recovery` flag will result in timeouts of the ``chef-backend-ctl join-cluster`` command. It's impossible for a follower to sync and rejoin while in this state because it doesn't have current enough info.
+#. Sync the followers from the leader using a full basebackup because the WAL entries have likely already rotated. When the WAL entries have already roated away, the followers will complain in the ``/var/log/chef-backend/postgresql/X.Y/current`` logfile about being unable to sync. Using just the `--recovery` flag will result in timeouts of the ``chef-backend-ctl join-cluster`` command. It's impossible for a follower to sync and rejoin while in this state because it doesn't have current enough info. Below is an example error message highlighting followers being unable to rejoin:
 
     .. code-block:: none
 


### PR DESCRIPTION
We have a lot of separate scenarios here. Let's try to make a unified one, then refer to the separate scenarios from it.

A common scenario are followers that have fallen so far out of sync, the `chef-server-ctl join-cluster IPADDRESS --recovery` command no longer works to rejoin a follower to the cluster.

Signed-off-by: Sean Horn sean_horn@chef.io