### PR TITLE
Update knife_ssh.rst

### DIFF
--- a/chef_master/source/knife_ssh.rst
+++ b/chef_master/source/knife_ssh.rst
@@ -47,7 +47,7 @@ This subcommand has the following options:
 
    *New in Chef Client 13.0.*
 
-``-i IDENTITY_FILE``, ``--identity-file IDENTIFY_FILE``
+``-i IDENTITY_FILE``, ``--ssh-identity-file IDENTIFY_FILE``
    The SSH identity file used for authentication. Key-based authentication is recommended.
 
 ``-m``, ``--manual-list``


### PR DESCRIPTION
Current versions of knife ssh use --ssh-identity-file, and are not backwards compatible.

This applies the documentation made in remote fork of #1900 made by @zmalone in chef-web-docs.

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass