### PR TITLE
Fix instructions for chef infra acceptance

### DIFF
--- a/chef_master/source/chef_license_accept.rst
+++ b/chef_master/source/chef_license_accept.rst
@@ -71,7 +71,7 @@ The same license applies to all products, but each product must have its own lic
 
 Chef Infra Client
 -----------------------------------------------------
-In addition to the above methods, users can specify ``chef_license = 'accept'`` in their Chef Infra Client and Chef Infra Server config.
+In addition to the above methods, users can specify ``chef_license 'accept'`` in their Chef Infra Client and Chef Infra Server config.
 On a workstation, this can be specified in ``~/.chef/config.rb`` or ``~/.chef/knife.rb``, and on a node, it can be specified in ``/etc/chef/client.rb``.
 This method of license acceptance is backwards-compatible to non-EULA versions of Chef Infra Client.
 


### PR DESCRIPTION
The original instructions said to put an equals sign in your client.rb file, but this doesn't work. However, putting `chef_license 'accept'` without an equals sign does work, and also matches the format for the rest of the configuration.