### PR TITLE
Stop the sidebars from scrolling

### DIFF
--- a/_themes/chefv3/static/scss/_nav.scss
+++ b/_themes/chefv3/static/scss/_nav.scss
@@ -6,6 +6,7 @@ $nav-border: 3px solid lighten($chef-grey, 30%);
 
 .downloads .nav-main {
   margin-bottom: 20px;
+  position: fixed;
 }
 
 // Top Bar

--- a/_themes/chefv3/static/scss/_sphinx.scss
+++ b/_themes/chefv3/static/scss/_sphinx.scss
@@ -113,6 +113,7 @@ div.related ul li a:hover {
 
 div.sphinxsidebarwrapper {
     padding: 0;
+    position: fixed;
 }
 
 div.sphinxsidebarwrapper > ul > li {


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### Description

Pins the left-nav and the page TOC in place. The center text moves while the sides stay in place.

### Definition of Done

Review & style with @magwalk 

### Issues Resolved

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
