### PR TITLE
Update the location of the _status api end point

### DIFF
--- a/chef_master/source/api_chef_server.rst
+++ b/chef_master/source/api_chef_server.rst
@@ -520,6 +520,59 @@ The response will return the JSON for the updated organization.
    * - ``410``
      - Gone. Unable to update private key.
 
+_status
+----------------------------------------------------
+The ``/_status`` endpoint can be used to check the status of communications between the front and back end servers. This endpoint is located at ``/_status`` on the front end servers.
+
+**Request**
+
+.. code-block:: none
+
+   api.get("https://chef_server.front_end.url/_status")
+
+This method has no request body.
+
+**Response**
+
+The response will return something like the following:
+
+.. code-block:: javascript
+
+   {
+     "status": "pong",
+     "upstreams":
+       {
+         "service_name": "pong",
+         "service_name": "pong",
+         ...
+       }
+    }
+
+**Response Codes**
+
+.. list-table::
+   :widths: 200 300
+   :header-rows: 1
+
+   * - Response Code
+     - Description
+   * - ``200``
+     - All communications are OK.
+   * - ``500``
+     - One (or more) services are down. For example:
+
+       .. code-block:: javascript
+
+          {
+            "status":"fail",
+            "upstreams":
+              {
+                "service_name": "fail",
+                "service_name": "pong",
+                ...
+              }
+          }
+	  
 /users
 -----------------------------------------------------
 A user is an individual account that is created to allow access to the Chef Infra Server. For example:
@@ -4903,59 +4956,6 @@ The response is similar to:
      - Forbidden. The user who made the request is not authorized to perform the action.
    * - ``413``
      - Request entity too large. A request may not be larger than 1000000 bytes.
-
-_status
-----------------------------------------------------
-The ``/_status`` endpoint can be used to check the status of communications between the front and back end servers. This endpoint is located at ``/_status`` on the front end servers.
-
-**Request**
-
-.. code-block:: none
-
-   api.get("https://chef_server.front_end.url/_status")
-
-This method has no request body.
-
-**Response**
-
-The response will return something like the following:
-
-.. code-block:: javascript
-
-   {
-     "status": "pong",
-     "upstreams":
-       {
-         "service_name": "pong",
-         "service_name": "pong",
-         ...
-       }
-    }
-
-**Response Codes**
-
-.. list-table::
-   :widths: 200 300
-   :header-rows: 1
-
-   * - Response Code
-     - Description
-   * - ``200``
-     - All communications are OK.
-   * - ``500``
-     - One (or more) services are down. For example:
-
-       .. code-block:: javascript
-
-          {
-            "status":"fail",
-            "upstreams":
-              {
-                "service_name": "fail",
-                "service_name": "pong",
-                ...
-              }
-          }
 
 
 


### PR DESCRIPTION
The _status check is not an /organizations check.  It is a global check and belongs in the global section.

### Description

Fixes the location of the _status endpoint.  Without this fix people would probably assume the endpoint was /organizations/NAME/_status instead of /_status.

The readme for updating the documentation suggests doing the pull request inside the repository.  I don't have write access so it pushes me to my fork.  If you would rather I submit changes inside the original repository  I may need an access change. I'll have quite a few changes for the API documentation in the next couple months.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
