### PR TITLE
Removes nested uses of this dtag.

### DIFF
--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -378,8 +378,6 @@ The types of nodes that can be managed by Chef include, but are not limited to, 
 
 Chef on Nodes
 -----------------------------------------------------
-.. tag node_components
-
 The key components of nodes that are under management by Chef include:
 
 .. list-table::
@@ -435,8 +433,6 @@ The key components of nodes that are under management by Chef include:
        Attributes that are collected by Ohai are automatic level attributes, in that these attributes are used by the Chef Infra Client to ensure that these attributes remain unchanged after the Chef Infra Client is done configuring the node.
 
        .. end_tag
-
-.. end_tag
 
 The Chef Server
 =====================================================

--- a/chef_master/source/nodes.rst
+++ b/chef_master/source/nodes.rst
@@ -47,8 +47,6 @@ The types of nodes that can be managed by Chef include, but are not limited to, 
 
 .. end_tag
 
-.. tag node_components
-
 The key components of nodes that are under management by Chef include:
 
 .. list-table::
@@ -104,8 +102,6 @@ The key components of nodes that are under management by Chef include:
        Attributes that are collected by Ohai are automatic level attributes, in that these attributes are used by the Chef Infra Client to ensure that these attributes remain unchanged after the Chef Infra Client is done configuring the node.
 
        .. end_tag
-
-.. end_tag
 
 About Run-lists
 -----------------------------------------------------

--- a/chef_master/source/resource_chef_acl.rst
+++ b/chef_master/source/resource_chef_acl.rst
@@ -5,22 +5,11 @@ chef_acl
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
-
-.. tag chef_client_summary
-
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
-
-* Registering and authenticating the node with the Chef Infra Server
-* Building the node object
-* Synchronizing cookbooks
-* Compiling the resource collection by loading each of the required cookbooks, including recipes, attributes, and all other dependencies
-* Taking the appropriate and required actions to configure the node
-* Looking for exceptions and notifications, handling each as required
-
-.. end_tag
 
 Use the **chef_acl** resource to interact with access control lists (ACLs) that exist on the Chef server.
 

--- a/chef_master/source/resource_chef_client.rst
+++ b/chef_master/source/resource_chef_client.rst
@@ -5,7 +5,9 @@ chef_client
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_chef_container.rst
+++ b/chef_master/source/resource_chef_container.rst
@@ -5,22 +5,11 @@ chef_container
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
-
-.. tag chef_client_summary
-
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
-
-* Registering and authenticating the node with the Chef Infra Server
-* Building the node object
-* Synchronizing cookbooks
-* Compiling the resource collection by loading each of the required cookbooks, including recipes, attributes, and all other dependencies
-* Taking the appropriate and required actions to configure the node
-* Looking for exceptions and notifications, handling each as required
-
-.. end_tag
 
 Use the **chef_container** resource to interact with container objects that exist on the Chef server.
 

--- a/chef_master/source/resource_chef_data_bag.rst
+++ b/chef_master/source/resource_chef_data_bag.rst
@@ -5,7 +5,9 @@ chef_data_bag
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_chef_data_bag_item.rst
+++ b/chef_master/source/resource_chef_data_bag_item.rst
@@ -5,7 +5,9 @@ chef_data_bag_item
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_chef_environment.rst
+++ b/chef_master/source/resource_chef_environment.rst
@@ -5,7 +5,9 @@ chef_environment
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_chef_group.rst
+++ b/chef_master/source/resource_chef_group.rst
@@ -5,22 +5,11 @@ chef_group
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
-
-.. tag chef_client_summary
-
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
-
-* Registering and authenticating the node with the Chef Infra Server
-* Building the node object
-* Synchronizing cookbooks
-* Compiling the resource collection by loading each of the required cookbooks, including recipes, attributes, and all other dependencies
-* Taking the appropriate and required actions to configure the node
-* Looking for exceptions and notifications, handling each as required
-
-.. end_tag
 
 Use the **chef_group** resource to interact with group objects that exist on the Chef server.
 

--- a/chef_master/source/resource_chef_mirror.rst
+++ b/chef_master/source/resource_chef_mirror.rst
@@ -5,22 +5,11 @@ chef_mirror
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
-
-.. tag chef_client_summary
-
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
-
-* Registering and authenticating the node with the Chef Infra Server
-* Building the node object
-* Synchronizing cookbooks
-* Compiling the resource collection by loading each of the required cookbooks, including recipes, attributes, and all other dependencies
-* Taking the appropriate and required actions to configure the node
-* Looking for exceptions and notifications, handling each as required
-
-.. end_tag
 
 Use the **chef_mirror** resource to mirror objects in the chef-repo to a specified location.
 

--- a/chef_master/source/resource_chef_node.rst
+++ b/chef_master/source/resource_chef_node.rst
@@ -5,7 +5,9 @@ chef_node
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_chef_organization.rst
+++ b/chef_master/source/resource_chef_organization.rst
@@ -5,22 +5,11 @@ chef_organization
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
-
-.. tag chef_client_summary
-
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
-
-* Registering and authenticating the node with the Chef Infra Server
-* Building the node object
-* Synchronizing cookbooks
-* Compiling the resource collection by loading each of the required cookbooks, including recipes, attributes, and all other dependencies
-* Taking the appropriate and required actions to configure the node
-* Looking for exceptions and notifications, handling each as required
-
-.. end_tag
 
 Use the **chef_organization** resource to interact with organization objects that exist on the Chef server.
 

--- a/chef_master/source/resource_chef_role.rst
+++ b/chef_master/source/resource_chef_role.rst
@@ -5,7 +5,9 @@ chef_role
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_chef_user.rst
+++ b/chef_master/source/resource_chef_user.rst
@@ -5,7 +5,9 @@ chef_user
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_load_balancer.rst
+++ b/chef_master/source/resource_load_balancer.rst
@@ -5,7 +5,9 @@ load_balancer
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_machine.rst
+++ b/chef_master/source/resource_machine.rst
@@ -13,7 +13,9 @@ Each machine is declared as a separate application topology, defined using opera
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_machine_batch.rst
+++ b/chef_master/source/resource_machine_batch.rst
@@ -11,7 +11,9 @@ Use the **machine_batch** resource to explicitly declare a parallel process when
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_machine_execute.rst
+++ b/chef_master/source/resource_machine_execute.rst
@@ -11,7 +11,9 @@ Use the **machine_execute** resource to run a command on a remote machine in muc
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_machine_file.rst
+++ b/chef_master/source/resource_machine_file.rst
@@ -11,7 +11,9 @@ Use the **machine_file** resource to manage a file on a remote machine in much t
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_machine_image.rst
+++ b/chef_master/source/resource_machine_image.rst
@@ -11,7 +11,9 @@ Use the **machine_image** resource to define a machine image. This image may the
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_private_key.rst
+++ b/chef_master/source/resource_private_key.rst
@@ -5,7 +5,9 @@ private_key
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 

--- a/chef_master/source/resource_public_key.rst
+++ b/chef_master/source/resource_public_key.rst
@@ -5,7 +5,9 @@ public_key
 
 .. warning:: .. tag notes_provisioning
 
-             This functionality is available with Chef provisioning and is packaged in the Chef development kit. Chef provisioning is a framework that allows clusters to be managed by the chef-client and the Chef server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+
+             Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
              .. end_tag
 


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### Description

Removes the tag containers that nested `tag chef_client_summary`. Also removes uses of this tag where it added minimal context. Revises a Provisioning waring to include EOL.

### Definition of Done

### Issues Resolved

Simplifying docs for migration.

### Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
