### PR TITLE
Fix dtag `node_ctl_attribute`

### DIFF
--- a/chef_master/source/chef_shell.rst
+++ b/chef_master/source/chef_shell.rst
@@ -54,8 +54,6 @@ This command has the following options:
 ``-j PATH``, ``--json-attributes PATH``
    The path to a file that contains JSON data.
 
-   .. tag node_ctl_run_list
-
    Use this option to define a ``run_list`` object. For example, a JSON file similar to:
 
    .. code-block:: javascript
@@ -70,8 +68,6 @@ This command has the following options:
    may be used by running ``chef-client -j path/to/file.json``.
 
    In certain situations this option may be used to update ``normal`` attributes.
-
-   .. end_tag
 
    .. warning:: .. tag node_ctl_attribute
 

--- a/chef_master/source/chef_solo.rst
+++ b/chef_master/source/chef_solo.rst
@@ -245,8 +245,6 @@ This command has the following options:
 ``-j PATH``, ``--json-attributes PATH``
    The path to a file that contains JSON data.
 
-   .. tag node_ctl_run_list
-
    Use this option to define a ``run_list`` object. For example, a JSON file similar to:
 
    .. code-block:: javascript
@@ -261,8 +259,6 @@ This command has the following options:
    may be used by running ``chef-client -j path/to/file.json``.
 
    In certain situations this option may be used to update ``normal`` attributes.
-
-   .. end_tag
 
    .. warning:: .. tag node_ctl_attribute
 

--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -115,8 +115,6 @@ This command has the following options:
 
    **Run-lists**
 
-   .. tag node_ctl_run_list
-
    Use this option to define a ``run_list`` object. For example, a JSON file similar to:
 
    .. code-block:: javascript
@@ -131,8 +129,6 @@ This command has the following options:
    may be used by running ``chef-client -j path/to/file.json``.
 
    In certain situations this option may be used to update ``normal`` attributes.
-
-   .. end_tag
 
    **Environments**
 

--- a/chef_master/source/ctl_chef_solo.rst
+++ b/chef_master/source/ctl_chef_solo.rst
@@ -79,8 +79,6 @@ This command has the following options:
 ``-j PATH``, ``--json-attributes PATH``
    The path to a file that contains JSON data.
 
-   .. tag node_ctl_run_list
-
    Use this option to define a ``run_list`` object. For example, a JSON file similar to:
 
    .. code-block:: javascript
@@ -95,8 +93,6 @@ This command has the following options:
    may be used by running ``chef-client -j path/to/file.json``.
 
    In certain situations this option may be used to update ``normal`` attributes.
-
-   .. end_tag
 
    .. warning:: .. tag node_ctl_attribute
 

--- a/chef_master/source/debug.rst
+++ b/chef_master/source/debug.rst
@@ -871,8 +871,6 @@ This command has the following options:
 ``-j PATH``, ``--json-attributes PATH``
    The path to a file that contains JSON data.
 
-   .. tag node_ctl_run_list
-
    Use this option to define a ``run_list`` object. For example, a JSON file similar to:
 
    .. code-block:: javascript
@@ -887,8 +885,6 @@ This command has the following options:
    may be used by running ``chef-client -j path/to/file.json``.
 
    In certain situations this option may be used to update ``normal`` attributes.
-
-   .. end_tag
 
    .. warning:: .. tag node_ctl_attribute
 


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### Description

Removes nesting of `node_ctl_attribute` by removing containing dtag, which was used consistently in 4 docs.
Earlier PRs should fix remaining nesting.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
