### PR TITLE
Fix description of :create action

### DIFF
--- a/chef_master/source/resource_cron_d.rst
+++ b/chef_master/source/resource_cron_d.rst
@@ -70,7 +70,7 @@ Actions
 The cron_d resource has the following actions:
 
 ``:create``
-   Default. "Add a cron definition file to /etc/cron.d, but do not update an existing file.
+   Default. Add a cron definition file to /etc/cron.d, and update an existing file.
 
 ``:delete``
    Remove a cron definition file from /etc/cron.d if it exists.

--- a/chef_master/source/resource_cron_d.rst
+++ b/chef_master/source/resource_cron_d.rst
@@ -70,7 +70,7 @@ Actions
 The cron_d resource has the following actions:
 
 ``:create``
-   Default. Add a cron definition file to /etc/cron.d, and update an existing file.
+   Default. Add a cron definition file to /etc/cron.d.
 
 ``:delete``
    Remove a cron definition file from /etc/cron.d if it exists.


### PR DESCRIPTION
Fixed description of :create action.  It was the same as :create_if_missing.

Obvious fix (invoking the "obvious fix" rule)