### PR TITLE
fix typo reference to revision

### DIFF
--- a/chef_master/source/resource_bash.rst
+++ b/chef_master/source/resource_bash.rst
@@ -370,7 +370,7 @@ The following example shows how Bash can be used to install a plug-in for rbenv 
 
    git "#{Chef::Config[:file_cache_path]}/ruby-build" do
      repository 'git://github.com/sstephenson/ruby-build.git'
-     reference 'master'
+     revision 'master'
      action :sync
    end
 

--- a/chef_master/source/resource_examples.rst
+++ b/chef_master/source/resource_examples.rst
@@ -706,7 +706,7 @@ The following example shows how Bash can be used to install a plug-in for rbenv 
 
    git "#{Chef::Config[:file_cache_path]}/ruby-build" do
      repository 'git://github.com/sstephenson/ruby-build.git'
-     reference 'master'
+     revision 'master'
      action :sync
    end
 
@@ -2835,7 +2835,7 @@ The following example shows how Bash can be used to install a plug-in for rbenv 
 
    git "#{Chef::Config[:file_cache_path]}/ruby-build" do
      repository 'git://github.com/sstephenson/ruby-build.git'
-     reference 'master'
+     revision 'master'
      action :sync
    end
 
@@ -5434,7 +5434,7 @@ The following example shows how Bash can be used to install a plug-in for rbenv 
 
    git "#{Chef::Config[:file_cache_path]}/ruby-build" do
      repository 'git://github.com/sstephenson/ruby-build.git'
-     reference 'master'
+     revision 'master'
      action :sync
    end
 

--- a/chef_master/source/resource_git.rst
+++ b/chef_master/source/resource_git.rst
@@ -365,7 +365,7 @@ The following example shows how Bash can be used to install a plug-in for rbenv 
 
    git "#{Chef::Config[:file_cache_path]}/ruby-build" do
      repository 'git://github.com/sstephenson/ruby-build.git'
-     reference 'master'
+     revision 'master'
      action :sync
    end
 

--- a/chef_master/source/resource_script.rst
+++ b/chef_master/source/resource_script.rst
@@ -567,7 +567,7 @@ The following example shows how Bash can be used to install a plug-in for rbenv 
 
    git "#{Chef::Config[:file_cache_path]}/ruby-build" do
      repository 'git://github.com/sstephenson/ruby-build.git'
-     reference 'master'
+     revision 'master'
      action :sync
    end
 


### PR DESCRIPTION
probably a typo, because no talk about `reference` anywhere else in the repo

### Description

Typo in documentation.

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
