### PR TITLE
Updates links to section headings

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -2408,7 +2408,7 @@
       {
         "title": "Chef Client Plugins",
         "hasSubItems": false,
-        "url": "/plugin_community.html#chef-client"
+        "url": "/plugin_community.html#chef-infra-client"
       }
     ]
   }

--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -533,7 +533,7 @@ The Chef Infra Client may now be used to configure nodes that are running on the
 
 **System Requirements**
 
-The Chef Infra Client has the `same system requirements </chef_system_requirements.html#chef-client>`_ on the AIX platform as any other platform, with the following notes:
+The Chef Infra Client has the `same system requirements </chef_system_requirements.html#chef-infra-client>`_ on the AIX platform as any other platform, with the following notes:
 
 * Expand the file system on the AIX platform using ``chfs`` or by passing the ``-X`` flag to ``installp`` to automatically expand the logical partition (LPAR)
 * The EN_US (UTF-8) character set should be installed on the logical partition prior to installing the Chef Infra Client

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -449,7 +449,7 @@ Ohai Plugins
 Chef Infra Client Plugins
 -----------------------------------------------------
 
-`Chef Infra Client Plugins </plugin_community.html#chef-client>`_
+`Chef Infra Client Plugins </plugin_community.html#chef-infra-client>`_
 
 Addenda
 =====================================================

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -8453,7 +8453,7 @@ The chef-client may now be used to configure nodes that are running on the AIX p
 
 **System Requirements**
 
-The chef-client has the `same system requirements </chef_system_requirements.html#chef-client>`_ on the AIX platform as any other platform, with the following notes:
+The chef-client has the `same system requirements </chef_system_requirements.html#chef-infra-client>`_ on the AIX platform as any other platform, with the following notes:
 
 * Expand the file system on the AIX platform using ``chfs`` or by passing the ``-X`` flag to ``installp`` to automatically expand the logical partition (LPAR)
 * The EN_US (UTF-8) character set should be installed on the logical partition prior to installing the chef-client

--- a/chef_master/source/release_notes_push_jobs.rst
+++ b/chef_master/source/release_notes_push_jobs.rst
@@ -30,7 +30,7 @@ What's New in 2.2
 =====================================================
 The following items are new for Chef Push Jobs:
 
-* Uses Chef Server >12.14.0 `consolidated credentials <https://docs.chef.io/server_security.html#chef-server-credentials-management>`_ removing credentials stored in Push Server's configuration files.
+* Uses Chef Server >12.14.0 `consolidated credentials <https://docs.chef.io/server_security.html#chef-infra-server-credentials-management>`_ removing credentials stored in Push Server's configuration files.
 
 Important Notes
 -----------------------------------------------------

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -233,7 +233,7 @@ If you are using LDAP integration, external postgresql, or other Chef server fea
 
 For further information see:
 
-See `Chef Server Credentials Management </server_security.html#chef-server-credentials-management>`_ for more details.
+See `Chef Server Credentials Management </server_security.html#chef-infra-server-credentials-management>`_ for more details.
 
 What's New in 12.13
 =====================================================

--- a/chef_master/source/upgrade_server.rst
+++ b/chef_master/source/upgrade_server.rst
@@ -17,7 +17,7 @@ There are three upgrade scenarios for upgrades from earlier versions of Chef Ser
 
 .. note:: As of version 12.14, Chef Server will not render passwords outside of the ``/etc/opscode`` directory by default. If you are not using any Chef Infra Server add-ons, or you're using the latest add-on versions, you can set ``insecure_addon_compat`` to ``false`` in ``/etc/opscode/chef-server.rb``. With this option set to ``false``, Chef Infra Server writes all credentials to a single location. Note that this setting should only be applied after both the Chef Infra Server and its add-ons have been upgraded to compatible versions.
 
-        For additional information on this change, including a list of supported add-on versions, see `Chef Infra Server Credentials Management </server_security.html#chef-server-credentials-management>`_.
+        For additional information on this change, including a list of supported add-on versions, see `Chef Infra Server Credentials Management </server_security.html#chef-infra-server-credentials-management>`_.
 
 Standalone
 -----------------------------------------------------


### PR DESCRIPTION
Signed-off-by: IanMadd <maddaus@protonmail.com>

In #1902 headings that had the words Chef Client or Chef Server were changed to Chef Infra Client or Chef Infra Server, but the links to those headings weren't updated. This corrects links to those headings.

### Check List

- [ ] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
