### PR TITLE
Update resource_directory.rst

### DIFF
--- a/chef_master/source/resource_directory.rst
+++ b/chef_master/source/resource_directory.rst
@@ -461,7 +461,7 @@ The following examples demonstrate various approaches for using resources in rec
 
 .. code-block:: ruby
 
-   directory "C:\\tmp\\something.txt" do
+   directory "C:\\tmp\\something" do
      rights :full_control, "DOMAIN\\User"
      inherits false
      action :create
@@ -471,7 +471,7 @@ or:
 
 .. code-block:: ruby
 
-   directory 'C:\tmp\something.txt' do
+   directory 'C:\tmp\something' do
      rights :full_control, 'DOMAIN\User'
      inherits false
      action :create

--- a/chef_master/source/resource_examples.rst
+++ b/chef_master/source/resource_examples.rst
@@ -1508,7 +1508,7 @@ Use the **directory** resource to manage a directory, which is a hierarchy of fo
 
 .. code-block:: ruby
 
-   directory "C:\\tmp\\something.txt" do
+   directory "C:\\tmp\\something" do
      rights :full_control, "DOMAIN\\User"
      inherits false
      action :create
@@ -1518,7 +1518,7 @@ or:
 
 .. code-block:: ruby
 
-   directory 'C:\tmp\something.txt' do
+   directory 'C:\tmp\something' do
      rights :full_control, 'DOMAIN\User'
      inherits false
      action :create


### PR DESCRIPTION
### Description

The examples for Windows directories were .txt files instead of directories.

Obvious fix.

### Definition of Done

### Issues Resolved

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
