### PR TITLE
Replace Chef Style Guide with Ruby Guide

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -1475,7 +1475,7 @@
             "url": "/cookbook_versioning.html"
           },
           {
-            "title": "Ruby",
+            "title": "Ruby Guide",
             "hasSubItems": false,
             "url": "/ruby.html"
           }

--- a/chef_master/source/dsl_recipe.rst
+++ b/chef_master/source/dsl_recipe.rst
@@ -9,7 +9,7 @@ The Recipe DSL is a Ruby DSL that is primarily used to declare resources from wi
 
 .. end_tag
 
-Because the Recipe DSL is a Ruby DSL, anything that can be done using Ruby can also be done in a recipe or custom resource, including ``if`` and ``case`` statements, using the ``include?`` Ruby method, including recipes in recipes, and checking for dependencies. See the `Ruby </ruby.html>`_ guide for further information on built-in Ruby functionality.
+Because the Recipe DSL is a Ruby DSL, anything that can be done using Ruby can also be done in a recipe or custom resource, including ``if`` and ``case`` statements, using the ``include?`` Ruby method, including recipes in recipes, and checking for dependencies. See the `Ruby Guide </ruby.html>`_ for further information on built-in Ruby functionality.
 
 Include Recipes
 =====================================================

--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -280,7 +280,7 @@ Cookbook Reference
 `Cookbook Repo </cookbook_repo.html>`__ |
 `metadata.rb </config_rb_metadata.html>`__ |
 `Cookbook Versioning </cookbook_versioning.html>`__ |
-`Ruby </ruby.html>`__
+`Ruby Guide </ruby.html>`__
 
 **Chef Automate Cookbooks**: `build-cookbook (cookbook) </delivery_build_cookbook.html>`__ | `delivery-truck (cookbook) </delivery_truck.html>`__ | `Publish Cookbooks to Multiple Chef Servers </publish_cookbooks_multiple_servers.html>`__
 

--- a/chef_master/source/ruby.rst
+++ b/chef_master/source/ruby.rst
@@ -1,5 +1,5 @@
 =====================================================
-Chef Style Guide
+Ruby Guide
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/ruby.rst>`__
 


### PR DESCRIPTION
Signed-off-by: Mary Jinglewski <mjinglewski@chef.io>

### Description

By changing "Chef Style Guide" with "Ruby Guide," this PR deals with outstanding work left over from https://github.com/chef/chef-web-docs/pull/1665

### Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
