### PR TITLE
Fixes nested tags notes_registry_key_resource_recursive

### DIFF
--- a/chef_master/source/resource_examples.rst
+++ b/chef_master/source/resource_examples.rst
@@ -4665,13 +4665,13 @@ or a single-quoted string:
      action :delete_key
    end
 
+.. end_tag
+
 .. note:: .. tag notes_registry_key_resource_recursive
 
           Be careful when using the ``:delete_key`` action with the ``recursive`` attribute. This will delete the registry key, all of its values and all of the names, types, and data associated with them. This cannot be undone by the Chef Infra Client.
 
           .. end_tag
-
-.. end_tag
 
 **Use re-directed keys**
 

--- a/chef_master/source/resource_registry_key.rst
+++ b/chef_master/source/resource_registry_key.rst
@@ -302,7 +302,7 @@ The registry_key resource has the following actions:
    Delete the specified values for a registry key.
 
 ``:delete_key``
-   Delete the specified registry key and all of its subkeys. Be careful when using the ``:delete_key`` action with the ``recursive`` attribute. This will delete the registry key, all of its values and all of the names, types, and data associated with them. This cannot be undone by the Chef Infra Client.
+   Delete the specified registry key and all of its subkeys. The ``:delete_key`` action with the ``recursive`` attribute will delete the registry key, all of its values and all of the names, types, and data associated with them. This cannot be undone by the Chef Infra Client.
 
 ``:nothing``
    .. tag resources_common_actions_nothing
@@ -335,7 +335,7 @@ The registry_key resource has the following properties:
 ``recursive``
    **Ruby Type:** true, false | **Default Value:** ``false``
 
-   When creating a key, this value specifies that the required keys for the specified path are to be created. When using the ``:delete_key`` action in a recipe, and if the registry key has subkeys, then set the value for this property to ``true``. Be careful when using the ``:delete_key`` action with the ``recursive`` attribute. This will delete the registry key, all of its values and all of the names, types, and data associated with them. This cannot be undone by the Chef Infra Client.
+   When creating a key, this value specifies that the required keys for the specified path are to be created. When using the ``:delete_key`` action in a recipe, and if the registry key has subkeys, then set the value for this property to ``true``. The ``:delete_key`` action with the ``recursive`` attribute will delete the registry key, all of its values and all of the names, types, and data associated with them. This cannot be undone by the Chef Infra Client.
 
 ``values``
    **Ruby Type:** Hash, Array

--- a/chef_master/source/resource_registry_key.rst
+++ b/chef_master/source/resource_registry_key.rst
@@ -302,7 +302,7 @@ The registry_key resource has the following actions:
    Delete the specified values for a registry key.
 
 ``:delete_key``
-   Delete the specified registry key and all of its subkeys.
+   Delete the specified registry key and all of its subkeys. Be careful when using the ``:delete_key`` action with the ``recursive`` attribute. This will delete the registry key, all of its values and all of the names, types, and data associated with them. This cannot be undone by the Chef Infra Client.
 
 ``:nothing``
    .. tag resources_common_actions_nothing
@@ -310,12 +310,6 @@ The registry_key resource has the following actions:
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Infra Client run.
 
    .. end_tag
-
-.. note:: .. tag notes_registry_key_resource_recursive
-
-          Be careful when using the ``:delete_key`` action with the ``recursive`` attribute. This will delete the registry key, all of its values and all of the names, types, and data associated with them. This cannot be undone by the Chef Infra Client.
-
-          .. end_tag
 
 .. end_tag
 
@@ -341,13 +335,7 @@ The registry_key resource has the following properties:
 ``recursive``
    **Ruby Type:** true, false | **Default Value:** ``false``
 
-   When creating a key, this value specifies that the required keys for the specified path are to be created. When using the ``:delete_key`` action in a recipe, and if the registry key has subkeys, then set the value for this property to ``true``.
-
-   .. note:: .. tag notes_registry_key_resource_recursive
-
-             Be careful when using the ``:delete_key`` action with the ``recursive`` attribute. This will delete the registry key, all of its values and all of the names, types, and data associated with them. This cannot be undone by the Chef Infra Client.
-
-             .. end_tag
+   When creating a key, this value specifies that the required keys for the specified path are to be created. When using the ``:delete_key`` action in a recipe, and if the registry key has subkeys, then set the value for this property to ``true``. Be careful when using the ``:delete_key`` action with the ``recursive`` attribute. This will delete the registry key, all of its values and all of the names, types, and data associated with them. This cannot be undone by the Chef Infra Client.
 
 ``values``
    **Ruby Type:** Hash, Array
@@ -458,13 +446,13 @@ or a single-quoted string:
      action :delete_key
    end
 
+.. end_tag
+
 .. note:: .. tag notes_registry_key_resource_recursive
 
           Be careful when using the ``:delete_key`` action with the ``recursive`` attribute. This will delete the registry key, all of its values and all of the names, types, and data associated with them. This cannot be undone by the Chef Infra Client.
 
           .. end_tag
-
-.. end_tag
 
 **Use re-directed keys**
 


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### Description

Fixes nested tags notes_registry_key_resource_recursive by removing the note & adding content to definitions where possible. Keeps two uses in code examples.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
