### PR TITLE
Fix nested dtag ohai_notes

### DIFF
--- a/chef_master/source/knife_azure.rst
+++ b/chef_master/source/knife_azure.rst
@@ -452,39 +452,7 @@ This argument has the following options:
    The host name for the virtual machine.
 
 ``--hint HINT_NAME[=HINT_FILE]``
-   An Ohai hint to be set on the target node.
-
-   .. tag ohai_hints
-
-   Ohai hints are used to tell Ohai something about the system that it is running on that it would not be able to discover itself. An Ohai hint exists if a JSON file exists in the hint directory with the same name as the hint. For example, calling ``hint?('antarctica')`` in an Ohai plugin would return an empty hash if the file ``antarctica.json`` existed in the hints directory, and return nil if the file does not exist.
-
-   .. end_tag
-
-   .. tag ohai_hints_json
-
-   If the hint file contains JSON content, it will be returned as a hash from the call to ``hint?``.
-
-   .. code-block:: javascript
-
-      {
-        "snow": true,
-        "penguins": "many"
-      }
-
-   .. code-block:: ruby
-
-      antarctica_hint = hint?('antarctica')
-      if antarctica_hint['snow']
-        "There are #{antarctica_hint['penguins']} penguins here."
-      else
-        'There is no snow here, and penguins like snow.'
-      end
-
-   Hint files are located in the ``/etc/chef/ohai/hints/`` directory by default. Use the ``Ohai.config[:hints_path]`` setting in the ``client.rb`` file to customize this location.
-
-   .. end_tag
-
-   ``HINT_FILE`` is the name of the JSON file. ``HINT_NAME`` is the name of a hint in a JSON file. Use multiple ``--hint`` options to specify multiple hints.
+   An Ohai hint to be set on the target node. See the `Ohai </ohai.html#hints>`__ documentation for more information. ``HINT_FILE`` is the name of the JSON file. ``HINT_NAME`` is the name of a hint in a JSON file. Use multiple ``--hint`` options to specify multiple hints.
 
 ``--host-name HOST_NAME``
    The host name for the Microsoft Azure environment.

--- a/chef_master/source/knife_bootstrap.rst
+++ b/chef_master/source/knife_bootstrap.rst
@@ -108,39 +108,7 @@ This subcommand has the following options:
    The SSH tunnel or gateway that is used to run a bootstrap action on a machine that is not accessible from the workstation.
 
 ``--hint HINT_NAME[=HINT_FILE]``
-   An Ohai hint to be set on the target node.
-
-   .. tag ohai_hints
-
-   Ohai hints are used to tell Ohai something about the system that it is running on that it would not be able to discover itself. An Ohai hint exists if a JSON file exists in the hint directory with the same name as the hint. For example, calling ``hint?('antarctica')`` in an Ohai plugin would return an empty hash if the file ``antarctica.json`` existed in the hints directory, and return nil if the file does not exist.
-
-   .. end_tag
-
-   .. tag ohai_hints_json
-
-   If the hint file contains JSON content, it will be returned as a hash from the call to ``hint?``.
-
-   .. code-block:: javascript
-
-      {
-        "snow": true,
-        "penguins": "many"
-      }
-
-   .. code-block:: ruby
-
-      antarctica_hint = hint?('antarctica')
-      if antarctica_hint['snow']
-        "There are #{antarctica_hint['penguins']} penguins here."
-      else
-        'There is no snow here, and penguins like snow.'
-      end
-
-   Hint files are located in the ``/etc/chef/ohai/hints/`` directory by default. Use the ``Ohai.config[:hints_path]`` setting in the ``client.rb`` file to customize this location.
-
-   .. end_tag
-
-   ``HINT_FILE`` is the name of the JSON file. ``HINT_NAME`` is the name of a hint in a JSON file. Use multiple ``--hint`` options to specify multiple hints.
+   An Ohai hint to be set on the target node. See the `Ohai </ohai.html#hints>`__ documentation for more information. ``HINT_FILE`` is the name of the JSON file. ``HINT_NAME`` is the name of a hint in a JSON file. Use multiple ``--hint`` options to specify multiple hints.
 
 ``-i IDENTITY_FILE``, ``--ssh-identity-file IDENTITY_FILE``
    The SSH identity file used for authentication. Key-based authentication is recommended.

--- a/chef_master/source/ohai.rst
+++ b/chef_master/source/ohai.rst
@@ -364,13 +364,8 @@ Custom Ohai plugins can be written to collect additional information from system
 
 Hints
 =====================================================
-.. tag ohai_hints
 
 Ohai hints are used to tell Ohai something about the system that it is running on that it would not be able to discover itself. An Ohai hint exists if a JSON file exists in the hint directory with the same name as the hint. For example, calling ``hint?('antarctica')`` in an Ohai plugin would return an empty hash if the file ``antarctica.json`` existed in the hints directory, and return nil if the file does not exist.
-
-.. end_tag
-
-.. tag ohai_hints_json
 
 If the hint file contains JSON content, it will be returned as a hash from the call to ``hint?``.
 
@@ -392,7 +387,6 @@ If the hint file contains JSON content, it will be returned as a hash from the c
 
 Hint files are located in the ``/etc/chef/ohai/hints/`` directory by default. Use the ``Ohai.config[:hints_path]`` setting in the ``client.rb`` file to customize this location.
 
-.. end_tag
 
 ohai Resource
 =====================================================


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### Description

Fix nested dtag ohai_notes by removing explanatory content from reference docs and adding a link instead.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
