### PR TITLE
Kg/resource common actions nothing

### DIFF
--- a/chef_master/source/ctl_chef.rst
+++ b/chef_master/source/ctl_chef.rst
@@ -711,16 +711,24 @@ None.
 
 chef provision
 =====================================================
+.. tag EOL_provisioning
+
+This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
+
+Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
+
+.. end_tag
+
 .. tag ctl_chef_provision
 
-Use the ``chef provision`` subcommand to invoke an embedded Chef Infra Client run to provision machines using Chef provisioning. By default, this subcommand expects to find a cookbook named ``provision`` in the current working directory. The Chef Infra Client run will run a recipe in this cookbook that uses Chef provisioning to create one (or more) machines.
+Use the ``chef provision`` subcommand to invoke an embedded Chef Infra Client run to provision machines using Chef Provisioning. By default, this subcommand expects to find a cookbook named ``provision`` in the current working directory. The Chef Infra Client run will run a recipe in this cookbook that uses Chef Provisioning to create one (or more) machines.
 
 The ``chef provision`` subcommand is intended to:
 
 * Provide a provisioning mechanism that supports using ``Policyfile.rb`` files
-* Support naming conventions within Chef provisioning
-* Integrate Chef provisioning steps with the command-line tools that are packaged with ChefDK
-* Separate the configuration of provisioned machines from running Chef provisioning
+* Support naming conventions within Chef Provisioning
+* Integrate Chef Provisioning steps with the command-line tools that are packaged with ChefDK
+* Separate the configuration of provisioned machines from running Chef Provisioning
 * Allow provisioning to be managed as code and versioned (via ``Policyfile.rb`` files), as opposed to the legacy ``knife bootstrap`` behavior, which is primarily driven by command-line options
 
 .. end_tag
@@ -1516,14 +1524,14 @@ chef provision
 -----------------------------------------------------
 .. tag ctl_chef_provision
 
-Use the ``chef provision`` subcommand to invoke an embedded Chef Infra Client run to provision machines using Chef provisioning. By default, this subcommand expects to find a cookbook named ``provision`` in the current working directory. The Chef Infra Client run will run a recipe in this cookbook that uses Chef provisioning to create one (or more) machines.
+Use the ``chef provision`` subcommand to invoke an embedded Chef Infra Client run to provision machines using Chef Provisioning. By default, this subcommand expects to find a cookbook named ``provision`` in the current working directory. The Chef Infra Client run will run a recipe in this cookbook that uses Chef Provisioning to create one (or more) machines.
 
 The ``chef provision`` subcommand is intended to:
 
 * Provide a provisioning mechanism that supports using ``Policyfile.rb`` files
-* Support naming conventions within Chef provisioning
-* Integrate Chef provisioning steps with the command-line tools that are packaged with ChefDK
-* Separate the configuration of provisioned machines from running Chef provisioning
+* Support naming conventions within Chef Provisioning
+* Integrate Chef Provisioning steps with the command-line tools that are packaged with ChefDK
+* Separate the configuration of provisioned machines from running Chef Provisioning
 * Allow provisioning to be managed as code and versioned (via ``Policyfile.rb`` files), as opposed to the legacy ``knife bootstrap`` behavior, which is primarily driven by command-line options
 
 .. end_tag

--- a/chef_master/source/policyfile.rst
+++ b/chef_master/source/policyfile.rst
@@ -904,16 +904,24 @@ A ``Policyfile.lock.json`` file is similar to:
 
 chef provision
 -----------------------------------------------------
+.. tag EOL_provisioning
+
+This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
+
+Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
+
+.. end_tag
+
 .. tag ctl_chef_provision
 
-Use the ``chef provision`` subcommand to invoke an embedded Chef Infra Client run to provision machines using Chef provisioning. By default, this subcommand expects to find a cookbook named ``provision`` in the current working directory. The Chef Infra Client run will run a recipe in this cookbook that uses Chef provisioning to create one (or more) machines.
+Use the ``chef provision`` subcommand to invoke an embedded Chef Infra Client run to provision machines using Chef Provisioning. By default, this subcommand expects to find a cookbook named ``provision`` in the current working directory. The Chef Infra Client run will run a recipe in this cookbook that uses Chef Provisioning to create one (or more) machines.
 
 The ``chef provision`` subcommand is intended to:
 
 * Provide a provisioning mechanism that supports using ``Policyfile.rb`` files
-* Support naming conventions within Chef provisioning
-* Integrate Chef provisioning steps with the command-line tools that are packaged with ChefDK
-* Separate the configuration of provisioned machines from running Chef provisioning
+* Support naming conventions within Chef Provisioning
+* Integrate Chef Provisioning steps with the command-line tools that are packaged with ChefDK
+* Separate the configuration of provisioned machines from running Chef Provisioning
 * Allow provisioning to be managed as code and versioned (via ``Policyfile.rb`` files), as opposed to the legacy ``knife bootstrap`` behavior, which is primarily driven by command-line options
 
 .. end_tag

--- a/chef_master/source/provisioning.rst
+++ b/chef_master/source/provisioning.rst
@@ -3,23 +3,29 @@ Chef Provisioning
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/provisioning.rst>`__
 
+.. tag EOL_provisioning
+
+This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
+
+Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
+
+.. end_tag
+
 .. tag provisioning_summary
 
-Chef provisioning is a collection of resources that enable the creation of machines and machine infrastructures using the Chef Infra Client. It has a plugin model that allows bootstrap operations to be done against any infrastructure, such as VirtualBox, DigitalOcean, Amazon EC2, LXC, bare metal, and more.
+Chef Provisioning is a collection of resources that enable the creation of machines and machine infrastructures using the Chef Infra Client. It has a plugin model that allows bootstrap operations to be done against any infrastructure, such as VirtualBox, DigitalOcean, Amazon EC2, LXC, bare metal, and more.
 
-Chef provisioning is built around two major components: the **machine** resource and drivers.
+Chef Provisioning is built around two major components: the **machine** resource and drivers.
 
-Chef provisioning is packaged in ChefDK. Chef provisioning is a framework that allows clusters to be managed by the Chef Infra Client and the Chef Infra Server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+Chef Provisioning is packaged in ChefDK. Chef Provisioning is a framework that allows clusters to be managed by the Chef Infra Client and the Chef Infra Server in the same way nodes are managed: with recipes. Use Chef Provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
 
 .. end_tag
 
 In-Parallel Processing
 =====================================================
-.. tag provisioning_parallel
+In certain situations Chef Provisioning will run multiple **machine** processes in-parallel, as long as each of the individual **machine** resources have the same declared action. The **machine_batch** resource is used to run in-parallel processes.
 
-In certain situations Chef provisioning will run multiple **machine** processes in-parallel, as long as each of the individual **machine** resources have the same declared action. The **machine_batch** resource is used to run in-parallel processes.
-
-Chef provisioning will processes resources in-parallel automatically, unless:
+Chef Provisioning will processes resources in-parallel automatically, unless:
 
 * The recipe contains complex scripts, such as when a **file** resource sits in-between two **machine** resources in a single recipe. In this situation, the resources will be run sequentially
 * The actions specified for each individual **machine** resource are not identical; for example, if resource A is set to ``:converge`` and resource B is set to ``:destroy``, then they may not be processed in-parallel
@@ -83,11 +89,9 @@ will show output similar to:
 
 At the end, it shows ``1/1 resources updated``. The three **machine** resources are replaced with a single **machine_batch** resource, which then runs each of the individual **machine** processes in-parallel.
 
-.. end_tag
-
 Drivers
 =====================================================
-The following drivers are available for Chef provisioning:
+The following drivers are available for Chef Provisioning:
 
 .. list-table::
    :widths: 120 400
@@ -96,34 +100,28 @@ The following drivers are available for Chef provisioning:
    * - Driver
      - Description
    * - `Amazon Web Services <https://github.com/chef/chef-provisioning-aws>`__
-     - A Chef provisioning driver for Amazon Web Services (AWS).
+     - A Chef Provisioning driver for Amazon Web Services (AWS).
    * - `Fog <https://github.com/chef/chef-provisioning-fog>`__
-     - A Chef provisioning driver for Fog.
+     - A Chef Provisioning driver for Fog.
    * - `OpenNebula <https://github.com/blackberry/chef-provisioning-opennebula>`__
-     - A Chef provisioning driver for OpenNebula.
+     - A Chef Provisioning driver for OpenNebula.
    * - `SSH <https://github.com/chef/chef-provisioning-ssh>`__
-     - A Chef provisioning driver for SSH.
+     - A Chef Provisioning driver for SSH.
    * - `vSphere <https://github.com/chef-partners/chef-provisioning-vsphere>`__
-     - A Chef provisioning driver for VMware vSphere.
+     - A Chef Provisioning driver for VMware vSphere.
 
 Driver-specific Resources
 -----------------------------------------------------
-.. tag resources_provisioning
-
 A driver-specific resource is a statement of configuration policy that:
 
-* Describes the desired state for a configuration item that is created using Chef provisioning
+* Describes the desired state for a configuration item that is created using Chef Provisioning
 * Declares the steps needed to bring that item to the desired state
 * Specifies a resource type---such as ``package``, ``template``, or ``service``
 * Lists additional details (also known as properties), as necessary
 * Are grouped into recipes, which describe working configurations
 
-.. end_tag
-
 Machine Resources
 =====================================================
-.. tag resources_common
-
 A resource is a statement of configuration policy that:
 
 * Describes the desired state for a configuration item
@@ -132,20 +130,12 @@ A resource is a statement of configuration policy that:
 * Lists additional details (also known as resource properties), as necessary
 * Are grouped into recipes, which describe working configurations
 
-.. end_tag
-
 load_balancer
 -----------------------------------------------------
-.. tag resource_load_balancer_summary
-
 Use the **load_balancer** resource to create or destroy a load balancer.
-
-.. end_tag
 
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_load_balancer_syntax
-
 The syntax for using the **load_balancer** resource in a recipe is as follows:
 
 .. code-block:: ruby
@@ -163,12 +153,8 @@ where
 * ``attribute`` is zero (or more) of the properties that are available for this resource
 * ``action`` identifies which steps the Chef Infra Client will take to bring the node into the desired state
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_load_balancer_actions
-
 This resource has the following actions:
 
 ``:create``
@@ -183,12 +169,8 @@ This resource has the following actions:
 
    .. end_tag
 
-.. end_tag
-
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_load_balancer_attributes
-
 This resource has the following properties:
 
 ``driver``
@@ -207,22 +189,14 @@ This resource has the following properties:
 
    The name of the load balancer.
 
-.. end_tag
-
 machine
 -----------------------------------------------------
-.. tag resource_machine_summary
-
 Use the **machine** resource to define one (or more) machines, and then converge entire clusters of machines. This allows clusters to be maintained in a version control system and to be defined using multi-machine orchestration scenarios. For example, spinning up small test clusters and using them for continuous integration and local testing, building clusters that auto-scale, moving a set of machines in one cluster to another, building images, and so on.
 
 Each machine is declared as a separate application topology, defined using operating system- and provisioner-independent files. Recipes (defined in cookbooks) are used to manage them. The Chef Infra Client is used to converge the individual nodes (machines) within the cluster.
 
-.. end_tag
-
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_syntax
-
 The syntax for using the **machine** resource in a recipe is as follows:
 
 .. code-block:: ruby
@@ -240,12 +214,8 @@ where
 * ``attribute`` is zero (or more) of the properties that are available for this resource
 * ``action`` identifies which steps the Chef Infra Client will take to bring the node into the desired state
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_actions
-
 This resource has the following actions:
 
 ``:allocate``
@@ -276,12 +246,8 @@ This resource has the following actions:
 ``:stop``
    Use to stop a machine.
 
-.. end_tag
-
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_attributes
-
 This resource has the following properties:
 
 ``admin``
@@ -496,14 +462,10 @@ This resource has the following properties:
 
    Use to specify if the Chef Infra Client is a chef-validator.
 
-.. end_tag
-
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **Build machines dynamically**
-
-.. tag resource_machines_build_machines_dynamically
 
 .. To build machines dynamically:
 
@@ -524,11 +486,7 @@ Examples
      end
    end
 
-.. end_tag
-
 **Get a remote file onto a new machine**
-
-.. tag resource_machine_file_get_remote_file
 
 A deployment process requires more than just setting up machines. For example, files may need to be copied to machines from remote locations. The following example shows how to use the **remote_file** resource to grab a tarball from a URL, create a machine, copy that tarball to the machine, and then get that machine running by using a recipe that installs and configures that tarball on the machine:
 
@@ -553,11 +511,7 @@ A deployment process requires more than just setting up machines. For example, f
      action :converge
    end
 
-.. end_tag
-
 **Build machines that depend on each other**
-
-.. tag resource_machines_codependent_servers
 
 The following example shows how to create two identical machines, both of which cannot exist without the other. The first **machine** resource block creates the first machine by omitting the recipe that requires the other machine to be defined. The second resource block creates the second machine; because the first machine exists, both recipes can be run. The third resource block applies the second recipe to the first machine:
 
@@ -576,11 +530,7 @@ The following example shows how to create two identical machines, both of which 
      recipe 'theserver'
    end
 
-.. end_tag
-
 **Use a loop to build many machines**
-
-.. tag resource_machines_use_a_loop_to_create_many_machines
 
 .. To create multiple machines using a loop:
 
@@ -592,11 +542,7 @@ The following example shows how to create two identical machines, both of which 
      end
    end
 
-.. end_tag
-
 **Converge multiple machine types, in-parallel**
-
-.. tag resource_machine_batch_multiple_machine_types
 
 The **machine_batch** resource can be used to converge multiple machine types, in-parallel, even if each machine type has different drivers. For example:
 
@@ -613,11 +559,7 @@ The **machine_batch** resource can be used to converge multiple machine types, i
      end
    end
 
-.. end_tag
-
 **Build a machine from a machine image**
-
-.. tag resource_machine_image_add_apache_to_image
 
 .. To add Apache to a machine image, and then build a machine:
 
@@ -631,20 +573,12 @@ The **machine_batch** resource can be used to converge multiple machine types, i
     from_image 'web_image'
    end
 
-.. end_tag
-
 machine_batch
 -----------------------------------------------------
-.. tag resource_machine_batch_summary
-
 Use the **machine_batch** resource to explicitly declare a parallel process when building machines.
-
-.. end_tag
 
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_batch_syntax
-
 The syntax for using the **machine_batch** resource in a recipe is as follows:
 
 .. code-block:: ruby
@@ -662,12 +596,8 @@ where
 * ``attribute`` is zero (or more) of the properties that are available for this resource
 * ``action`` identifies which steps the Chef Infra Client will take to bring the node into the desired state
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_batch_actions
-
 This resource has the following actions:
 
 ``:allocate``
@@ -692,12 +622,8 @@ This resource has the following actions:
 
 ``:stop``
 
-.. end_tag
-
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_batch_attributes
-
 This resource has the following attributes:
 
 ``chef_server``
@@ -725,14 +651,10 @@ This resource has the following attributes:
 ``max_simultaneous``
    ...
 
-.. end_tag
-
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **Set up multiple machines, in-parallel**
-
-.. tag resource_machine_batch_setup_n_machines
 
 .. To setup multiple machines in-parallel:
 
@@ -743,11 +665,7 @@ Examples
      machines 'a', 'b', 'c', 'd', 'e'
    end
 
-.. end_tag
-
 **Converge multiple machines, in-parallel**
-
-.. tag resource_machine_batch_converge_n_machines
 
 .. To converge multiple machines in-parallel:
 
@@ -758,11 +676,7 @@ Examples
      machines 'a', 'b', 'c', 'd', 'e'
    end
 
-.. end_tag
-
 **Stop multiple machines, in-parallel**
-
-.. tag resource_machine_batch_stop_n_machines
 
 .. To stop multiple machines in-parallel:
 
@@ -773,11 +687,7 @@ Examples
      machines 'a', 'b', 'c', 'd', 'e'
    end
 
-.. end_tag
-
 **Destroy multiple machines, in-parallel**
-
-.. tag resource_machine_batch_destroy_n_machines
 
 .. To delete multiple machines in-parallel:
 
@@ -788,11 +698,7 @@ Examples
      machines 'a', 'b', 'c', 'd', 'e'
    end
 
-.. end_tag
-
 **Converge multiple machine types, in-parallel**
-
-.. tag resource_machine_batch_multiple_machine_types
 
 The **machine_batch** resource can be used to converge multiple machine types, in-parallel, even if each machine type has different drivers. For example:
 
@@ -809,20 +715,12 @@ The **machine_batch** resource can be used to converge multiple machine types, i
      end
    end
 
-.. end_tag
-
 machine_execute
 -----------------------------------------------------
-.. tag resource_machine_execute_summary
-
 Use the **machine_execute** resource to run a command on a remote machine in much the same way the **execute** resource is used to run a command on a local machine.
-
-.. end_tag
 
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_execute_syntax
-
 The syntax for using the **machine_execute** resource in a recipe is as follows:
 
 .. code-block:: ruby
@@ -840,12 +738,8 @@ where
 * ``attribute`` is zero (or more) of the properties that are available for this resource
 * ``action`` identifies which steps the Chef Infra Client will take to bring the node into the desired state
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_execute_actions
-
 This resource has the following actions:
 
 ``:nothing``
@@ -858,12 +752,8 @@ This resource has the following actions:
 ``:run``
    Default. Use to run a machine.
 
-.. end_tag
-
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_execute_attributes
-
 This resource has the following properties:
 
 ``chef_server``
@@ -889,20 +779,12 @@ This resource has the following properties:
 
    Use to specify the machine type.
 
-.. end_tag
-
 machine_file
 -----------------------------------------------------
-.. tag resource_machine_file_summary
-
 Use the **machine_file** resource to manage a file on a remote machine in much the same way the **file** resource is used to manage a file on a local machine.
-
-.. end_tag
 
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_file_syntax
-
 The syntax for using the **machine_file** resource in a recipe is as follows:
 
 .. code-block:: ruby
@@ -920,12 +802,8 @@ where
 * ``attribute`` is zero (or more) of the properties that are available for this resource
 * ``action`` identifies which steps the Chef Infra Client will take to bring the node into the desired state
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_file_actions
-
 This resource has the following actions:
 
 ``:delete``
@@ -944,12 +822,8 @@ This resource has the following actions:
 ``:upload``
    Default. Use to upload a file to a machine.
 
-.. end_tag
-
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_file_attributes
-
 This resource has the following properties:
 
 ``chef_server``
@@ -991,14 +865,10 @@ This resource has the following properties:
 
    Microsoft Windows: A quoted 3-5 character string that defines the octal mode that is translated into rights for Microsoft Windows security. For example: ``'755'``, ``'0755'``, or ``00755``. Values up to ``'0777'`` are allowed (no sticky bits) and mean the same in Microsoft Windows as they do in UNIX, where ``4`` equals ``GENERIC_READ``, ``2`` equals ``GENERIC_WRITE``, and ``1`` equals ``GENERIC_EXECUTE``. This property cannot be used to set ``:full_control``. This property has no effect if not specified, but when it and ``rights`` are both specified, the effects are cumulative.
 
-.. end_tag
-
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **Get a remote file onto a new machine**
-
-.. tag resource_machine_file_get_remote_file
 
 A deployment process requires more than just setting up machines. For example, files may need to be copied to machines from remote locations. The following example shows how to use the **remote_file** resource to grab a tarball from a URL, create a machine, copy that tarball to the machine, and then get that machine running by using a recipe that installs and configures that tarball on the machine:
 
@@ -1023,20 +893,12 @@ A deployment process requires more than just setting up machines. For example, f
      action :converge
    end
 
-.. end_tag
-
 machine_image
 -----------------------------------------------------
-.. tag resource_machine_image_summary
-
 Use the **machine_image** resource to define a machine image. This image may then be used by the **machine** resource when building machines.
-
-.. end_tag
 
 Syntax
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_image_syntax
-
 The syntax for using the **machine_image** resource in a recipe is as follows:
 
 .. code-block:: ruby
@@ -1054,12 +916,8 @@ where
 * ``attribute`` is zero (or more) of the properties that are available for this resource
 * ``action`` identifies which steps the Chef Infra Client will take to bring the node into the desired state
 
-.. end_tag
-
 Actions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_image_actions
-
 This resource has the following actions:
 
 ``:archive``
@@ -1078,12 +936,8 @@ This resource has the following actions:
 
    .. end_tag
 
-.. end_tag
-
 Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. tag resource_machine_image_attributes
-
 This resource has the following properties:
 
 ``attributes``
@@ -1130,14 +984,10 @@ This resource has the following properties:
 ``tags``
    Use to specify the list of tags to be applied to the machine image. Any tag not specified in this list will be removed.
 
-.. end_tag
-
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **Build a machine from a machine image**
-
-.. tag resource_machine_image_add_apache_to_image
 
 .. To add Apache to a machine image, and then build a machine:
 
@@ -1151,23 +1001,17 @@ Examples
     from_image 'web_image'
    end
 
-.. end_tag
-
 AWS Driver Resources
 =====================================================
-.. tag resources_provisioning
-
 A driver-specific resource is a statement of configuration policy that:
 
-* Describes the desired state for a configuration item that is created using Chef provisioning
+* Describes the desired state for a configuration item that is created using Chef Provisioning
 * Declares the steps needed to bring that item to the desired state
 * Specifies a resource type---such as ``package``, ``template``, or ``service``
 * Lists additional details (also known as properties), as necessary
 * Are grouped into recipes, which describe working configurations
 
-.. end_tag
-
-The following Chef provisioning driver-specific resources are available for Amazon Web Services (AWS):
+The following Chef Provisioning driver-specific resources are available for Amazon Web Services (AWS):
 
 * ``aws_auto_scaling_group``
 * ``aws_cache_cluster``
@@ -1200,19 +1044,15 @@ For more information about these driver-specific resources, see `AWS Driver Reso
 
 Fog Driver Resources
 =====================================================
-.. tag resources_provisioning
-
 A driver-specific resource is a statement of configuration policy that:
 
-* Describes the desired state for a configuration item that is created using Chef provisioning
+* Describes the desired state for a configuration item that is created using Chef Provisioning
 * Declares the steps needed to bring that item to the desired state
 * Specifies a resource type---such as ``package``, ``template``, or ``service``
 * Lists additional details (also known as properties), as necessary
 * Are grouped into recipes, which describe working configurations
 
-.. end_tag
-
-The following Chef provisioning driver-specific resources are available for Fog:
+The following Chef Provisioning driver-specific resources are available for Fog:
 
 * ``fog_key_pair``
 

--- a/chef_master/source/provisioning_aws.rst
+++ b/chef_master/source/provisioning_aws.rst
@@ -3,13 +3,22 @@ AWS Driver Resources
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/provisioning_aws.rst>`__
 
+.. tag EOL_provisioning
+
+This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
+
+Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
+
+.. end_tag
+
+
 .. tag provisioning_summary
 
-Chef provisioning is a collection of resources that enable the creation of machines and machine infrastructures using the Chef Infra Client. It has a plugin model that allows bootstrap operations to be done against any infrastructure, such as VirtualBox, DigitalOcean, Amazon EC2, LXC, bare metal, and more.
+Chef Provisioning is a collection of resources that enable the creation of machines and machine infrastructures using the Chef Infra Client. It has a plugin model that allows bootstrap operations to be done against any infrastructure, such as VirtualBox, DigitalOcean, Amazon EC2, LXC, bare metal, and more.
 
-Chef provisioning is built around two major components: the **machine** resource and drivers.
+Chef Provisioning is built around two major components: the **machine** resource and drivers.
 
-Chef provisioning is packaged in ChefDK. Chef provisioning is a framework that allows clusters to be managed by the Chef Infra Client and the Chef Infra Server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+Chef Provisioning is packaged in ChefDK. Chef Provisioning is a framework that allows clusters to be managed by the Chef Infra Client and the Chef Infra Server in the same way nodes are managed: with recipes. Use Chef Provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
 
 .. end_tag
 
@@ -17,7 +26,7 @@ Chef provisioning is packaged in ChefDK. Chef provisioning is a framework that a
 
 A driver-specific resource is a statement of configuration policy that:
 
-* Describes the desired state for a configuration item that is created using Chef provisioning
+* Describes the desired state for a configuration item that is created using Chef Provisioning
 * Declares the steps needed to bring that item to the desired state
 * Specifies a resource type---such as ``package``, ``template``, or ``service``
 * Lists additional details (also known as properties), as necessary
@@ -25,7 +34,7 @@ A driver-specific resource is a statement of configuration policy that:
 
 .. end_tag
 
-The following driver-specific resources are available for Amazon Web Services (AWS) and Chef provisioning:
+The following driver-specific resources are available for Amazon Web Services (AWS) and Chef Provisioning:
 
 * ``aws_auto_scaling_group``
 * ``aws_cache_cluster``
@@ -65,7 +74,7 @@ The following driver-specific resources are available for Amazon Web Services (A
 
 Common Actions
 =====================================================
-Every Chef provisioning Amazon Web Services (AWS) driver-specific resource has the following actions:
+Every Chef Provisioning Amazon Web Services (AWS) driver-specific resource has the following actions:
 
 .. list-table::
    :widths: 150 450
@@ -84,7 +93,7 @@ Every Chef provisioning Amazon Web Services (AWS) driver-specific resource has t
 
 aws_auto_scaling_group
 =====================================================
-The ``aws_auto_scaling_group`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_auto_scaling_group`` resource to manage auto scaling groups for Amazon EC2 instances. Auto Scaling ensures that the correct number of Amazon EC2 instances are available. Each auto scaling group is set to a minimum size, along with a maximum that a group does not exceed.
+The ``aws_auto_scaling_group`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_auto_scaling_group`` resource to manage auto scaling groups for Amazon EC2 instances. Auto Scaling ensures that the correct number of Amazon EC2 instances are available. Each auto scaling group is set to a minimum size, along with a maximum that a group does not exceed.
 
 Syntax
 -----------------------------------------------------
@@ -124,7 +133,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -166,7 +175,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``launch_configuration``
      - **Ruby Type:** String
 
@@ -252,7 +261,7 @@ The following example destroys an auto scaling group and the associated launch c
 
 aws_cache_cluster
 =====================================================
-The ``aws_cache_cluster`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_cache_cluster`` resource to manage `cache clusters <http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/WhatIs.html>`__ in Amazon ElastiCache.
+The ``aws_cache_cluster`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_cache_cluster`` resource to manage `cache clusters <http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/WhatIs.html>`__ in Amazon ElastiCache.
 
 Syntax
 -----------------------------------------------------
@@ -299,7 +308,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -341,7 +350,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``engine``
      - **Ruby Type:** String
 
@@ -434,7 +443,7 @@ Examples
 
 aws_cache_replication_group
 =====================================================
-The ``aws_cache_replication_group`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_cache_replication_group`` resource to manage `replication groups for cache clusters <http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/WhatIs.html>`__ in Amazon ElastiCache. A replication group is a collection of nodes, with a primary read/write cluster and up to five secondary, read-only clusters.
+The ``aws_cache_replication_group`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_cache_replication_group`` resource to manage `replication groups for cache clusters <http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/WhatIs.html>`__ in Amazon ElastiCache. A replication group is a collection of nodes, with a primary read/write cluster and up to five secondary, read-only clusters.
 
 Syntax
 -----------------------------------------------------
@@ -482,7 +491,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -524,7 +533,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``engine``
      - **Ruby Type:** String
 
@@ -595,7 +604,7 @@ Examples
 
 aws_cache_subnet_group
 =====================================================
-The ``aws_cache_subnet_group`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_cache_subnet_group`` resource to manage a `cache subnet group <http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingVPC.CreatingSubnetGroup.html>`__, which is a collection of subnets that may be designated for cache clusters in Amazon Virtual Private Cloud (VPC).
+The ``aws_cache_subnet_group`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_cache_subnet_group`` resource to manage a `cache subnet group <http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingVPC.CreatingSubnetGroup.html>`__, which is a collection of subnets that may be designated for cache clusters in Amazon Virtual Private Cloud (VPC).
 
 Syntax
 -----------------------------------------------------
@@ -626,7 +635,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -664,7 +673,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``group_name``
      - **Ruby Type:** String
 
@@ -724,7 +733,7 @@ Examples
 
 aws_cloudsearch_domain
 =====================================================
-The ``aws_cloudsearch_domain`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_cloudsearch_domain`` resource to manage `full-text searching for domains <https://aws.amazon.com/cloudsearch/>`__ in Amazon CloudSearch.
+The ``aws_cloudsearch_domain`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_cloudsearch_domain`` resource to manage `full-text searching for domains <https://aws.amazon.com/cloudsearch/>`__ in Amazon CloudSearch.
 
 Syntax
 -----------------------------------------------------
@@ -761,7 +770,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -780,7 +789,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``index_fields``
      - **Ruby Type:** Array
 
@@ -828,7 +837,7 @@ Examples
 
 aws_cloudwatch_alarm
 =====================================================
-The ``aws_cloudwatch_alarm`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_cloudwatch_alarm`` resource to manage `CloudWatch alarm <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-createalarm.html/>`__ in Amazon CloudWatch.
+The ``aws_cloudwatch_alarm`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_cloudwatch_alarm`` resource to manage `CloudWatch alarm <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-createalarm.html/>`__ in Amazon CloudWatch.
 
 Syntax
 -----------------------------------------------------
@@ -874,7 +883,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -893,7 +902,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``metric_name``
      - **Ruby Type:** String
 
@@ -971,7 +980,7 @@ Examples
 
 aws_dhcp_options
 =====================================================
-The ``aws_dhcp_options`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_dhcp_options`` resource to manage the `option sets <http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html>`__ for the Dynamic Host Configuration Protocol (DHCP) protocol. Option sets are associated with the Amazon Web Services (AWS) account and may be used across all instances in Amazon Virtual Private Cloud (VPC).
+The ``aws_dhcp_options`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_dhcp_options`` resource to manage the `option sets <http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html>`__ for the Dynamic Host Configuration Protocol (DHCP) protocol. Option sets are associated with the Amazon Web Services (AWS) account and may be used across all instances in Amazon Virtual Private Cloud (VPC).
 
 Syntax
 -----------------------------------------------------
@@ -1009,7 +1018,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -1055,7 +1064,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``managed_entry_store``
      - **Ruby Type:** Chef::Provisioning::ManagedEntryStore
 
@@ -1105,7 +1114,7 @@ Examples
 
 aws_ebs_volume
 =====================================================
-The ``aws_ebs_volume`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_ebs_volume`` resource to manage a `block-level storage device <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumes.html>`__ that is attached to an Amazon EC2 instance.
+The ``aws_ebs_volume`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_ebs_volume`` resource to manage a `block-level storage device <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumes.html>`__ that is attached to an Amazon EC2 instance.
 
 Syntax
 -----------------------------------------------------
@@ -1148,7 +1157,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -1190,7 +1199,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``encrypted``
      - **Ruby Type:** true, false
 
@@ -1210,7 +1219,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``name``
      - **Ruby Type:** String
 
-       Use to specify the name of the block-level storage device. Because the name of a Amazon Virtual Private Cloud (VPC) instance is not guaranteed to be unique for an account at Amazon Web Services (AWS), Chef provisioning will store the associated identifier on the Chef Infra Server using the ``data/aws_ebs_volume/<name>`` data bag.
+       Use to specify the name of the block-level storage device. Because the name of a Amazon Virtual Private Cloud (VPC) instance is not guaranteed to be unique for an account at Amazon Web Services (AWS), Chef Provisioning will store the associated identifier on the Chef Infra Server using the ``data/aws_ebs_volume/<name>`` data bag.
    * - ``size``
      - **Ruby Type:** Integer
 
@@ -1336,7 +1345,7 @@ The following example destroys an Amazon Elastic Block Store (EBS) volume for th
 
 aws_eip_address
 =====================================================
-The ``aws_eip_address`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_eip_address`` resource to manage `an elastic IP address <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html>`__, a static IP address designed for dynamic cloud computing that is associated with an Amazon Web Services (AWS) account.
+The ``aws_eip_address`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_eip_address`` resource to manage `an elastic IP address <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html>`__, a static IP address designed for dynamic cloud computing that is associated with an Amazon Web Services (AWS) account.
 
 Syntax
 -----------------------------------------------------
@@ -1368,7 +1377,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -1387,7 +1396,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``machine``
      - **Ruby Type:** String, false
 
@@ -1451,7 +1460,7 @@ Examples
 
 aws_elasticsearch_domain
 =====================================================
-The ``aws_elasticsearch_domain`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_elasticsearch_domain`` resource to manage `an Elasticsearch domain <http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html>`__, an Amazon Elasticsearch Service (Amazon ES) domain that encapsulates the Amazon ES engine instances associated with an Amazon Web Services (AWS) account.
+The ``aws_elasticsearch_domain`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_elasticsearch_domain`` resource to manage `an Elasticsearch domain <http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html>`__, an Amazon Elasticsearch Service (Amazon ES) domain that encapsulates the Amazon ES engine instances associated with an Amazon Web Services (AWS) account.
 
 Syntax
 -----------------------------------------------------
@@ -1487,7 +1496,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -1506,7 +1515,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``ebs_enabled``
      - **Ruby Type:** true, false
 
@@ -1542,7 +1551,7 @@ Examples
 
 aws_iam_instance_profile
 =====================================================
-The ``aws_iam_instance_profile`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_iam_instance_profile`` resource to manage `an IAM instance profile <http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html>`__, An instance profile is a container for an IAM role that you can use to pass role information to an EC2 instance when the instance starts.
+The ``aws_iam_instance_profile`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_iam_instance_profile`` resource to manage `an IAM instance profile <http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html>`__, An instance profile is a container for an IAM role that you can use to pass role information to an EC2 instance when the instance starts.
 
 Syntax
 -----------------------------------------------------
@@ -1572,7 +1581,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -1591,7 +1600,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``role``
      - **Ruby Type:** String, AwsIamRole, ::Aws::IAM::Role
 
@@ -1618,7 +1627,7 @@ Examples
 
 aws_iam_role
 =====================================================
-The ``aws_iam_role`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_iam_role`` resource to manage `an IAM Role <http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html>`__, An IAM role is similar to a user, in that it is an AWS identity with permission policies that determine what the identity can and cannot do in AWS. However, instead of being uniquely associated with one person, a role is intended to be assumable by anyone who needs it. Also, a role does not have any credentials (password or access keys) associated with it. Instead, if a user is assigned to a role, access keys are created dynamically and provided to the user.
+The ``aws_iam_role`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_iam_role`` resource to manage `an IAM Role <http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html>`__, An IAM role is similar to a user, in that it is an AWS identity with permission policies that determine what the identity can and cannot do in AWS. However, instead of being uniquely associated with one person, a role is intended to be assumable by anyone who needs it. Also, a role does not have any credentials (password or access keys) associated with it. Instead, if a user is assigned to a role, access keys are created dynamically and provided to the user.
 
 Syntax
 -----------------------------------------------------
@@ -1650,7 +1659,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -1669,7 +1678,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``assume_role_policy_document``
      - **Ruby Type:** String
 
@@ -1766,7 +1775,7 @@ Examples
 
 machine_image
 =====================================================
-The ``machine_image`` resource is a driver-specific resource used by Chef provisioning. Use the ``machine_image`` resource to manage Amazon Machine Images (AMI) `images <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html>`__ that exist in Amazon EC2. An image includes a template for the root volume of an instance (operating system, application server, application, for example), launch permissions, and a block mapping device that attaches volumes to the instance when it is launched.
+The ``machine_image`` resource is a driver-specific resource used by Chef Provisioning. Use the ``machine_image`` resource to manage Amazon Machine Images (AMI) `images <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html>`__ that exist in Amazon EC2. An image includes a template for the root volume of an instance (operating system, application server, application, for example), launch permissions, and a block mapping device that attaches volumes to the instance when it is launched.
 
 Syntax
 -----------------------------------------------------
@@ -1794,7 +1803,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -1828,7 +1837,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``image_id``
      - **Ruby Type:** String
 
@@ -1895,7 +1904,7 @@ Examples
 
 machine
 =====================================================
-The ``machine`` resource is a driver-specific resource used by Chef provisioning. Use the ``machine`` resource to manage an instance in Amazon EC2.
+The ``machine`` resource is a driver-specific resource used by Chef Provisioning. Use the ``machine`` resource to manage an instance in Amazon EC2.
 
 Syntax
 -----------------------------------------------------
@@ -1923,7 +1932,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -1957,7 +1966,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``instance_id``
      - **Ruby Type:** String
 
@@ -2029,7 +2038,7 @@ Examples
 
 aws_internet_gateway
 =====================================================
-The ``aws_internet_gateway`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_internet_gateway`` resource to configure an internet gateway for a defined virtual network within Amazon Virtual Private Cloud (VPC) (the networking layer of Amazon EC2).
+The ``aws_internet_gateway`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_internet_gateway`` resource to configure an internet gateway for a defined virtual network within Amazon Virtual Private Cloud (VPC) (the networking layer of Amazon EC2).
 
 An internet gateway is a horizontally scaled, redundant, and highly available component within Amazon Virtual Private Cloud (VPC) that enables communication between instances within a defined virtual network and the Internet.
 
@@ -2060,7 +2069,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -2090,7 +2099,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``internet_gateway_id``
      - **Ruby Type:** String
 
@@ -2134,7 +2143,7 @@ Examples
 
 aws_key_pair
 =====================================================
-The ``aws_key_pair`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_key_pair`` resource to manage key pairs in Amazon EC2.
+The ``aws_key_pair`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_key_pair`` resource to manage key pairs in Amazon EC2.
 
 Syntax
 -----------------------------------------------------
@@ -2170,7 +2179,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -2208,7 +2217,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``managed_entry_store``
      - **Ruby Type:** Chef::Provisioning::ManagedEntryStore
 
@@ -2304,7 +2313,7 @@ The following example destroys an Amazon Elastic Block Store (EBS) volume for th
 
 aws_launch_configuration
 =====================================================
-The ``aws_launch_configuration`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_launch_configuration`` resource to manage Amazon Machine Images (AMI) `instance types <http://aws.amazon.com/amazon-linux-ami/instance-type-matrix/>`__, also known as pre-configured templates for instances in Amazon EC2.
+The ``aws_launch_configuration`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_launch_configuration`` resource to manage Amazon Machine Images (AMI) `instance types <http://aws.amazon.com/amazon-linux-ami/instance-type-matrix/>`__, also known as pre-configured templates for instances in Amazon EC2.
 
 Syntax
 -----------------------------------------------------
@@ -2336,7 +2345,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -2370,7 +2379,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``image``
      - **Ruby Type:** String, AWS::EC2::Image
 
@@ -2462,7 +2471,7 @@ The following example destroys an auto scaling group and the associated launch c
 
 aws_load_balancer
 =====================================================
-The ``aws_load_balancer`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_load_balancer`` resource to manage load balancers that exist in Amazon Elastic Load Balancing (ELB).
+The ``aws_load_balancer`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_load_balancer`` resource to manage load balancers that exist in Amazon Elastic Load Balancing (ELB).
 
 Syntax
 -----------------------------------------------------
@@ -2490,7 +2499,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -2524,7 +2533,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``load_balancer_id``
      - **Ruby Type:** String
 
@@ -2589,7 +2598,7 @@ Examples
 
 aws_nat_gateway
 =====================================================
-The ``aws_nat_gateway`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_nat_gateway`` resource to configure a NAT gateway for a defined virtual network within Amazon Virtual Private Cloud (VPC) (the networking layer of Amazon EC2).
+The ``aws_nat_gateway`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_nat_gateway`` resource to configure a NAT gateway for a defined virtual network within Amazon Virtual Private Cloud (VPC) (the networking layer of Amazon EC2).
 
 An AWS nat gateway, enable instances in a private subnet to connect to the Internet or other AWS services, but prevent the Internet from initiating a connection with those instances.
 
@@ -2622,7 +2631,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -2652,7 +2661,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** ``Chef::Provisioning::Driver``
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``nat_gateway_id``
      - **Ruby Type:** String
 
@@ -2701,7 +2710,7 @@ Examples
 
 aws_network_acl
 =====================================================
-The ``aws_network_acl`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_network_acl`` resource to manage network ACLs.
+The ``aws_network_acl`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_network_acl`` resource to manage network ACLs.
 
 Syntax
 -----------------------------------------------------
@@ -2737,7 +2746,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -2771,7 +2780,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``inbound_rules``
      - **Ruby Type:** Array, Hash
 
@@ -3001,7 +3010,7 @@ Examples
 
 aws_network_interface
 =====================================================
-The ``aws_network_interface`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_network_interface`` resource to manage a network interface in Amazon EC2.
+The ``aws_network_interface`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_network_interface`` resource to manage a network interface in Amazon EC2.
 
 Syntax
 -----------------------------------------------------
@@ -3039,7 +3048,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -3081,7 +3090,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``machine``
      - **Ruby Type:** String, false, AwsInstance, AWS::EC2::Instance
 
@@ -3130,7 +3139,7 @@ Examples
 
 aws_rds_instance
 =====================================================
-The ``aws_rds_instance`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_rds_instance`` resource to manage `a database instance <https://aws.amazon.com/rds/>`__ using Amazon Relational Database Service (RDS).
+The ``aws_rds_instance`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_rds_instance`` resource to manage `a database instance <https://aws.amazon.com/rds/>`__ using Amazon Relational Database Service (RDS).
 
 Syntax
 -----------------------------------------------------
@@ -3177,7 +3186,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -3216,7 +3225,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``engine``
      - **Ruby Type:** String
 
@@ -3280,7 +3289,7 @@ Examples
 
 aws_rds_parameter_group
 =====================================================
-The ``aws_rds_parameter_group`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_rds_parameter_group`` resource to manage `a database parameter group <http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html>`__ using Amazon Relational Database Service (RDS).
+The ``aws_rds_parameter_group`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_rds_parameter_group`` resource to manage `a database parameter group <http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html>`__ using Amazon Relational Database Service (RDS).
 
 Syntax
 -----------------------------------------------------
@@ -3312,7 +3321,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -3335,7 +3344,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``managed_entry_store``
      - **Ruby Type:** Chef::Provisioning::ManagedEntryStore
 
@@ -3363,7 +3372,7 @@ Examples
 
 aws_rds_subnet_group
 =====================================================
-The ``aws_rds_subnet_group`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_rds_subnet_group`` resource to manage `a collection of subnets <http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.html>`__ that exist in an Amazon Virtual Private Cloud (VPC) that is passed to the Amazon Relational Database Service (RDS) instance. At least two subnets must be specified.
+The ``aws_rds_subnet_group`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_rds_subnet_group`` resource to manage `a collection of subnets <http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.html>`__ that exist in an Amazon Virtual Private Cloud (VPC) that is passed to the Amazon Relational Database Service (RDS) instance. At least two subnets must be specified.
 
 Syntax
 -----------------------------------------------------
@@ -3393,7 +3402,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -3412,7 +3421,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``managed_entry_store``
      - **Ruby Type:** Chef::Provisioning::ManagedEntryStore
 
@@ -3443,7 +3452,7 @@ Examples
 
 aws_route53_hosted_zone
 =====================================================
-The ``aws_route53_hosted_zone`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_route53_hosted_zone`` resource to manage `a route53 hosted zone <http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/AboutHZWorkingWith.html>`__ for a domain (such as example.com), and then you create resource record sets to tell the Domain Name System how you want traffic to be routed for that domain.
+The ``aws_route53_hosted_zone`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_route53_hosted_zone`` resource to manage `a route53 hosted zone <http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/AboutHZWorkingWith.html>`__ for a domain (such as example.com), and then you create resource record sets to tell the Domain Name System how you want traffic to be routed for that domain.
 
 Syntax
 -----------------------------------------------------
@@ -3472,7 +3481,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -3491,7 +3500,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``managed_entry_store``
      - **Ruby Type:** Chef::Provisioning::ManagedEntryStore
 
@@ -3521,7 +3530,7 @@ Examples
 
 aws_route53_record_set
 =====================================================
-The ``aws_route53_record_set`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_route53_record_set`` resource to manage `a route53 record sets <http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/rrsets-working-with.html>`__ for a hosted zone.
+The ``aws_route53_record_set`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_route53_record_set`` resource to manage `a route53 record sets <http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/rrsets-working-with.html>`__ for a hosted zone.
 
 Syntax
 -----------------------------------------------------
@@ -3563,7 +3572,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -3582,7 +3591,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``managed_entry_store``
      - **Ruby Type:** Chef::Provisioning::ManagedEntryStore
 
@@ -3619,7 +3628,7 @@ Examples
 
 aws_route_table
 =====================================================
-The ``aws_route_table`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_route_table`` resource to `define a route table <http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Route_Tables.html>`__ within Amazon Virtual Private Cloud (VPC) (the networking layer of Amazon EC2).
+The ``aws_route_table`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_route_table`` resource to `define a route table <http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Route_Tables.html>`__ within Amazon Virtual Private Cloud (VPC) (the networking layer of Amazon EC2).
 
 Syntax
 -----------------------------------------------------
@@ -3653,7 +3662,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -3687,7 +3696,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``ignore_route_targets``
      - **Ruby Type:** String, Array
 
@@ -3707,7 +3716,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``routes``
      - **Ruby Type:** Hash
 
-       Use to specify a Hash that contains all of the routes associated with a route table. The destination (on the left side of the ``=>``) must be a classless inter-domain routing (CIDR) block. The target (on the right side of the ``=>``) may be the identifier for an internet gateway, an instance name, the identifier for network interface, a Chef provisioning machine name, or a Chef provisioning resource. For example:
+       Use to specify a Hash that contains all of the routes associated with a route table. The destination (on the left side of the ``=>``) must be a classless inter-domain routing (CIDR) block. The target (on the right side of the ``=>``) may be the identifier for an internet gateway, an instance name, the identifier for network interface, a Chef Provisioning machine name, or a Chef Provisioning resource. For example:
 
        .. code-block:: ruby
 
@@ -3777,7 +3786,7 @@ Examples
 
 aws_s3_bucket
 =====================================================
-The ``aws_s3_bucket`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_s3_bucket`` resource to create an Amazon Simple Storage Service (S3) bucket in which any amount of data is stored, retrievable at any time from anywhere.
+The ``aws_s3_bucket`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_s3_bucket`` resource to create an Amazon Simple Storage Service (S3) bucket in which any amount of data is stored, retrievable at any time from anywhere.
 
 Syntax
 -----------------------------------------------------
@@ -3810,7 +3819,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -3844,7 +3853,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``enable_website_hosting``
      - **Ruby Type:** true, false | **Default Value:** ``false``
 
@@ -3904,7 +3913,7 @@ Examples
 
 aws_security_group
 =====================================================
-The ``aws_security_group`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_security_group`` resource to define and manage a security group in Amazon Web Services (AWS).
+The ``aws_security_group`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_security_group`` resource to define and manage a security group in Amazon Web Services (AWS).
 
 Syntax
 -----------------------------------------------------
@@ -3942,7 +3951,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -3972,7 +3981,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``inbound_rules``
      - **Ruby Type:** Array, Hash
 
@@ -4323,7 +4332,7 @@ Examples
 
 aws_server_certificate
 =====================================================
-The ``aws_server_certificate`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_server_certificate`` resource to `manage server certificates <http://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingServerCerts.html>`__ in Amazon EC2.
+The ``aws_server_certificate`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_server_certificate`` resource to `manage server certificates <http://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingServerCerts.html>`__ in Amazon EC2.
 
 Syntax
 -----------------------------------------------------
@@ -4353,7 +4362,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -4391,7 +4400,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``managed_entry_store``
      - **Ruby Type:** Chef::Provisioning::ManagedEntryStore
 
@@ -4486,7 +4495,7 @@ Examples
 
 aws_sns_topic
 =====================================================
-The ``aws_sns_topic`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_sns_topic`` resource to create a topic in Amazon Simple Notification Service (SNS). A topic is a communication channel through which messages are sent and an access point through which publishers and subscribers communicate.
+The ``aws_sns_topic`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_sns_topic`` resource to create a topic in Amazon Simple Notification Service (SNS). A topic is a communication channel through which messages are sent and an access point through which publishers and subscribers communicate.
 
 Syntax
 -----------------------------------------------------
@@ -4514,7 +4523,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -4552,7 +4561,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``managed_entry_store``
      - **Ruby Type:** Chef::Provisioning::ManagedEntryStore
 
@@ -4588,7 +4597,7 @@ Examples
 
 aws_sqs_queue
 =====================================================
-The ``aws_sqs_queue`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_sqs_queue`` resource to create a queue in Amazon Simple Queue Service (SQS). Amazon Simple Queue Service (SQS) offers reliable and scalable hosted queues for storing messages as they travel between distributed components of applications and without requiring each component to be always available.
+The ``aws_sqs_queue`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_sqs_queue`` resource to create a queue in Amazon Simple Queue Service (SQS). Amazon Simple Queue Service (SQS) offers reliable and scalable hosted queues for storing messages as they travel between distributed components of applications and without requiring each component to be always available.
 
 Syntax
 -----------------------------------------------------
@@ -4616,7 +4625,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -4650,7 +4659,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``managed_entry_store``
      - **Ruby Type:** Chef::Provisioning::ManagedEntryStore
 
@@ -4692,7 +4701,7 @@ Examples
 
 aws_subnet
 =====================================================
-The ``aws_subnet`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_subnet`` resource to configure a subnet within a defined virtual network in Amazon Virtual Private Cloud (VPC) (the networking layer of Amazon EC2).
+The ``aws_subnet`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_subnet`` resource to configure a subnet within a defined virtual network in Amazon Virtual Private Cloud (VPC) (the networking layer of Amazon EC2).
 
 This defined virtual network is dedicated to a specific Amazon Web Services (AWS) account and is logically isolated from other defined virtual network in Amazon Web Services (AWS). One (or more) subnets may exist within this defined virtual network.
 
@@ -4732,7 +4741,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -4774,7 +4783,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``managed_entry_store``
      - **Ruby Type:** Chef::Provisioning::ManagedEntryStore
 
@@ -4936,7 +4945,7 @@ Examples
 
 aws_vpc
 =====================================================
-The ``aws_vpc`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_vpc`` resource to `launch resources into a defined virtual network <http://aws.amazon.com/documentation/vpc/>`__ with Amazon Virtual Private Cloud (VPC) (the networking layer of Amazon EC2).
+The ``aws_vpc`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_vpc`` resource to `launch resources into a defined virtual network <http://aws.amazon.com/documentation/vpc/>`__ with Amazon Virtual Private Cloud (VPC) (the networking layer of Amazon EC2).
 
 This defined virtual network is dedicated to a specific Amazon Web Services (AWS) account and is logically isolated from other defined virtual network in Amazon Web Services (AWS). Amazon EC2 instances may be launched into the defined virtual network and it may be configured for specific IP address ranges, subnets, routing tables, network gateways, and security settings.
 
@@ -4987,7 +4996,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -5029,7 +5038,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``enable_dns_hostnames``
      - **Ruby Type:** true
 
@@ -5055,7 +5064,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``main_routes``
      - **Ruby Type:** Hash
 
-       Use to specify a Hash that defines the routes for the main route table. The destination (on the left side of the ``=>``) must be a classless inter-domain routing (CIDR) block. The target (on the right side of the ``=>``) may be the identifier for an internet gateway, an instance name, the identifier for network interface, a Chef provisioning machine name, or a Chef provisioning resource.
+       Use to specify a Hash that defines the routes for the main route table. The destination (on the left side of the ``=>``) must be a classless inter-domain routing (CIDR) block. The target (on the right side of the ``=>``) may be the identifier for an internet gateway, an instance name, the identifier for network interface, a Chef Provisioning machine name, or a Chef Provisioning resource.
 
        For example:
 
@@ -5074,7 +5083,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``name``
      - **Ruby Type:** String
 
-       Use to specify the name of the defined virtual network. Because the name of a Amazon Virtual Private Cloud (VPC) instance is not guaranteed to be unique for an account at Amazon Web Services (AWS), Chef provisioning will store the associated identifier on the Chef Infra Server using the ``data/aws_vpc/<name>`` data bag.
+       Use to specify the name of the defined virtual network. Because the name of a Amazon Virtual Private Cloud (VPC) instance is not guaranteed to be unique for an account at Amazon Web Services (AWS), Chef Provisioning will store the associated identifier on the Chef Infra Server using the ``data/aws_vpc/<name>`` data bag.
    * - ``vpc_id``
      - **Ruby Type:** String
 
@@ -5264,7 +5273,7 @@ An Amazon Virtual Private Cloud (VPC) cannot be deleted when it has a non-main r
 
 aws_vpc_peering_connection
 =====================================================
-The ``aws_vpc_peering_connection`` resource is a driver-specific resource used by Chef provisioning. Use the ``aws_vpc_peering_connection`` resource to create a connection between two VPCs that enables you to route traffic between them using private IPv4 addresses or IPv6 addresses.
+The ``aws_vpc_peering_connection`` resource is a driver-specific resource used by Chef Provisioning. Use the ``aws_vpc_peering_connection`` resource to create a connection between two VPCs that enables you to route traffic between them using private IPv4 addresses or IPv6 addresses.
 
 Syntax
 -----------------------------------------------------
@@ -5296,7 +5305,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -5334,7 +5343,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``managed_entry_store``
      - **Ruby Type:** Chef::Provisioning::ManagedEntryStore
 

--- a/chef_master/source/provisioning_fog.rst
+++ b/chef_master/source/provisioning_fog.rst
@@ -3,13 +3,22 @@ Fog Driver Resources
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/provisioning_fog.rst>`__
 
+.. tag EOL_provisioning
+
+This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
+
+Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
+
+.. end_tag
+
+
 .. tag provisioning_summary
 
-Chef provisioning is a collection of resources that enable the creation of machines and machine infrastructures using the Chef Infra Client. It has a plugin model that allows bootstrap operations to be done against any infrastructure, such as VirtualBox, DigitalOcean, Amazon EC2, LXC, bare metal, and more.
+Chef Provisioning is a collection of resources that enable the creation of machines and machine infrastructures using the Chef Infra Client. It has a plugin model that allows bootstrap operations to be done against any infrastructure, such as VirtualBox, DigitalOcean, Amazon EC2, LXC, bare metal, and more.
 
-Chef provisioning is built around two major components: the **machine** resource and drivers.
+Chef Provisioning is built around two major components: the **machine** resource and drivers.
 
-Chef provisioning is packaged in ChefDK. Chef provisioning is a framework that allows clusters to be managed by the Chef Infra Client and the Chef Infra Server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+Chef Provisioning is packaged in ChefDK. Chef Provisioning is a framework that allows clusters to be managed by the Chef Infra Client and the Chef Infra Server in the same way nodes are managed: with recipes. Use Chef Provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
 
 .. end_tag
 
@@ -17,7 +26,7 @@ Chef provisioning is packaged in ChefDK. Chef provisioning is a framework that a
 
 A driver-specific resource is a statement of configuration policy that:
 
-* Describes the desired state for a configuration item that is created using Chef provisioning
+* Describes the desired state for a configuration item that is created using Chef Provisioning
 * Declares the steps needed to bring that item to the desired state
 * Specifies a resource type---such as ``package``, ``template``, or ``service``
 * Lists additional details (also known as properties), as necessary
@@ -25,13 +34,13 @@ A driver-specific resource is a statement of configuration policy that:
 
 .. end_tag
 
-The following driver-specific resources are available for Fog and Chef provisioning:
+The following driver-specific resources are available for Fog and Chef Provisioning:
 
 * ``fog_key_pair``
 
 fog_key_pair
 =====================================================
-The ``fog_key_pair`` resource is a driver-specific resource used by Chef provisioning for use with Fog, a Ruby gem for interacting with various cloud providers, such as Amazon EC2, CloudStack, DigitalOcean, Google Cloud Platform, Joyent, OpenStack, Rackspace, SoftLayer, and vCloud Air.
+The ``fog_key_pair`` resource is a driver-specific resource used by Chef Provisioning for use with Fog, a Ruby gem for interacting with various cloud providers, such as Amazon EC2, CloudStack, DigitalOcean, Google Cloud Platform, Joyent, OpenStack, Rackspace, SoftLayer, and vCloud Air.
 
 Syntax
 -----------------------------------------------------
@@ -68,7 +77,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -83,7 +92,7 @@ This Chef provisioning driver-specific resource has the following properties:
    * - ``driver``
      - **Ruby Type:** Chef::Provisioning::Driver
 
-       The Chef provisioning driver.
+       The Chef Provisioning driver.
    * - ``private_key_options``
      - **Ruby Type:** Hash
 

--- a/chef_master/source/provisioning_vagrant.rst
+++ b/chef_master/source/provisioning_vagrant.rst
@@ -3,6 +3,15 @@ Vagrant Driver Resources
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/provisioning_vagrant.rst>`__
 
+.. tag EOL_provisioning
+
+This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
+
+Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
+
+.. end_tag
+
+
 .. warning:: ..
 
   The Vagrant driver for Chef Provisioning has been deprecated and is no longer supported or recommended for use.
@@ -10,11 +19,11 @@ Vagrant Driver Resources
 
 .. tag provisioning_summary
 
-Chef provisioning is a collection of resources that enable the creation of machines and machine infrastructures using the Chef Infra Client. It has a plugin model that allows bootstrap operations to be done against any infrastructure, such as VirtualBox, DigitalOcean, Amazon EC2, LXC, bare metal, and more.
+Chef Provisioning is a collection of resources that enable the creation of machines and machine infrastructures using the Chef Infra Client. It has a plugin model that allows bootstrap operations to be done against any infrastructure, such as VirtualBox, DigitalOcean, Amazon EC2, LXC, bare metal, and more.
 
-Chef provisioning is built around two major components: the **machine** resource and drivers.
+Chef Provisioning is built around two major components: the **machine** resource and drivers.
 
-Chef provisioning is packaged in ChefDK. Chef provisioning is a framework that allows clusters to be managed by the Chef Infra Client and the Chef Infra Server in the same way nodes are managed: with recipes. Use Chef provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
+Chef Provisioning is packaged in ChefDK. Chef Provisioning is a framework that allows clusters to be managed by the Chef Infra Client and the Chef Infra Server in the same way nodes are managed: with recipes. Use Chef Provisioning to describe, version, deploy, and manage clusters of any size and complexity using a common set of tools.
 
 .. end_tag
 
@@ -22,7 +31,7 @@ Chef provisioning is packaged in ChefDK. Chef provisioning is a framework that a
 
 A driver-specific resource is a statement of configuration policy that:
 
-* Describes the desired state for a configuration item that is created using Chef provisioning
+* Describes the desired state for a configuration item that is created using Chef Provisioning
 * Declares the steps needed to bring that item to the desired state
 * Specifies a resource type---such as ``package``, ``template``, or ``service``
 * Lists additional details (also known as properties), as necessary
@@ -30,14 +39,14 @@ A driver-specific resource is a statement of configuration policy that:
 
 .. end_tag
 
-The following driver-specific resources are available for Vagrant and Chef provisioning:
+The following driver-specific resources are available for Vagrant and Chef Provisioning:
 
 * ``vagrant_box``
 * ``vagrant_cluster``
 
 vagrant_box
 =====================================================
-The ``vagrant_box`` resource is a driver-specific resource used by Chef provisioning. Use the ``vagrant_box`` resource to add and remove machines that are running in Vagrant and using VirtualBox by default.
+The ``vagrant_box`` resource is a driver-specific resource used by Chef Provisioning. Use the ``vagrant_box`` resource to add and remove machines that are running in Vagrant and using VirtualBox by default.
 
 Syntax
 -----------------------------------------------------
@@ -68,7 +77,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450
@@ -99,7 +108,7 @@ None.
 
 vagrant_cluster
 =====================================================
-The ``vagrant_cluster`` resource is a driver-specific resource used by Chef provisioning. Use the ``vagrant_cluster`` resource to build a group of boxes in Vagrant using a single Vagrantfile that defines each of the boxes in the group. The ``vagrant list`` command will show all of the boxes that are configured with the Vagrantfile.
+The ``vagrant_cluster`` resource is a driver-specific resource used by Chef Provisioning. Use the ``vagrant_cluster`` resource to build a group of boxes in Vagrant using a single Vagrantfile that defines each of the boxes in the group. The ``vagrant list`` command will show all of the boxes that are configured with the Vagrantfile.
 
 Syntax
 -----------------------------------------------------
@@ -129,7 +138,7 @@ where
 
 Properties
 -----------------------------------------------------
-This Chef provisioning driver-specific resource has the following properties:
+This Chef Provisioning driver-specific resource has the following properties:
 
 .. list-table::
    :widths: 150 450

--- a/chef_master/source/resource_batch.rst
+++ b/chef_master/source/resource_batch.rst
@@ -59,7 +59,6 @@ where:
 
 Actions
 =====================================================
-.. tag resource_batch_actions
 
 The batch resource has the following actions:
 
@@ -72,8 +71,6 @@ The batch resource has the following actions:
 
 ``:run``
    Run a batch file.
-
-.. end_tag
 
 Properties
 =====================================================
@@ -156,7 +153,6 @@ The batch resource has the following properties:
 .. note:: See https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmd for more information about the cmd.exe interpreter.
 
 .. end_tag
-
 
 Common Resource Functionality
 =====================================================

--- a/chef_master/source/resource_breakpoint.rst
+++ b/chef_master/source/resource_breakpoint.rst
@@ -25,7 +25,7 @@ where
 
 * ``:break`` will tell the Chef Infra Client to stop running a recipe; can only be used when the Chef Infra Client is being run in chef-shell mode
 
-.. end_tag 
+.. end_tag
 
 Actions
 =====================================================

--- a/chef_master/source/resource_chef_acl.rst
+++ b/chef_master/source/resource_chef_acl.rst
@@ -3,9 +3,9 @@ chef_acl
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chef_acl.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_chef_client.rst
+++ b/chef_master/source/resource_chef_client.rst
@@ -3,9 +3,9 @@ chef_client
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chef_client.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_chef_container.rst
+++ b/chef_master/source/resource_chef_container.rst
@@ -3,9 +3,9 @@ chef_container
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chef_container.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_chef_data_bag.rst
+++ b/chef_master/source/resource_chef_data_bag.rst
@@ -3,9 +3,9 @@ chef_data_bag
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chef_data_bag.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_chef_data_bag_item.rst
+++ b/chef_master/source/resource_chef_data_bag_item.rst
@@ -3,9 +3,9 @@ chef_data_bag_item
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chef_data_bag_item.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_chef_environment.rst
+++ b/chef_master/source/resource_chef_environment.rst
@@ -3,9 +3,9 @@ chef_environment
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chef_environment.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_chef_group.rst
+++ b/chef_master/source/resource_chef_group.rst
@@ -3,9 +3,9 @@ chef_group
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chef_group.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_chef_mirror.rst
+++ b/chef_master/source/resource_chef_mirror.rst
@@ -3,9 +3,9 @@ chef_mirror
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chef_mirror.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_chef_node.rst
+++ b/chef_master/source/resource_chef_node.rst
@@ -3,9 +3,9 @@ chef_node
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chef_node.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_chef_organization.rst
+++ b/chef_master/source/resource_chef_organization.rst
@@ -3,9 +3,9 @@ chef_organization
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chef_organization.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_chef_role.rst
+++ b/chef_master/source/resource_chef_role.rst
@@ -3,9 +3,9 @@ chef_role
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chef_role.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_chef_user.rst
+++ b/chef_master/source/resource_chef_user.rst
@@ -3,9 +3,9 @@ chef_user
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chef_user.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_dsc_script.rst
+++ b/chef_master/source/resource_dsc_script.rst
@@ -77,8 +77,6 @@ where:
 
 Actions
 =====================================================
-.. tag resource_dsc_script_actions
-
 The dsc_script resource has the following actions:
 
 ``:nothing``
@@ -91,8 +89,6 @@ The dsc_script resource has the following actions:
 
 ``:run``
    Default. Use to run the DSC configuration defined as defined in this resource.
-
-.. end_tag
 
 Properties
 =====================================================

--- a/chef_master/source/resource_load_balancer.rst
+++ b/chef_master/source/resource_load_balancer.rst
@@ -3,9 +3,9 @@ load_balancer
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_load_balancer.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
@@ -42,8 +42,6 @@ where
 
 Actions
 =====================================================
-.. tag resource_load_balancer_actions
-
 This resource has the following actions:
 
 ``:create``
@@ -57,8 +55,6 @@ This resource has the following actions:
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Infra Client run.
 
    .. end_tag
-
-.. end_tag
 
 Properties
 =====================================================

--- a/chef_master/source/resource_machine.rst
+++ b/chef_master/source/resource_machine.rst
@@ -11,9 +11,9 @@ Each machine is declared as a separate application topology, defined using opera
 
 .. end_tag
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
@@ -44,8 +44,6 @@ where
 
 Actions
 =====================================================
-.. tag resource_machine_actions
-
 This resource has the following actions:
 
 ``:allocate``
@@ -76,15 +74,13 @@ This resource has the following actions:
 ``:stop``
    Use to stop a machine.
 
-.. end_tag
-
 In-Parallel Processing
 -----------------------------------------------------
 .. tag provisioning_parallel
 
-In certain situations Chef provisioning will run multiple **machine** processes in-parallel, as long as each of the individual **machine** resources have the same declared action. The **machine_batch** resource is used to run in-parallel processes.
+In certain situations Chef Provisioning will run multiple **machine** processes in-parallel, as long as each of the individual **machine** resources have the same declared action. The **machine_batch** resource is used to run in-parallel processes.
 
-Chef provisioning will processes resources in-parallel automatically, unless:
+Chef Provisioning will processes resources in-parallel automatically, unless:
 
 * The recipe contains complex scripts, such as when a **file** resource sits in-between two **machine** resources in a single recipe. In this situation, the resources will be run sequentially
 * The actions specified for each individual **machine** resource are not identical; for example, if resource A is set to ``:converge`` and resource B is set to ``:destroy``, then they may not be processed in-parallel

--- a/chef_master/source/resource_machine_batch.rst
+++ b/chef_master/source/resource_machine_batch.rst
@@ -9,9 +9,9 @@ Use the **machine_batch** resource to explicitly declare a parallel process when
 
 .. end_tag
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
@@ -42,8 +42,6 @@ where
 
 Actions
 =====================================================
-.. tag resource_machine_batch_actions
-
 This resource has the following actions:
 
 ``:allocate``
@@ -68,15 +66,13 @@ This resource has the following actions:
 
 ``:stop``
 
-.. end_tag
-
 In-Parallel Processing
 -----------------------------------------------------
 .. tag provisioning_parallel
 
-In certain situations Chef provisioning will run multiple **machine** processes in-parallel, as long as each of the individual **machine** resources have the same declared action. The **machine_batch** resource is used to run in-parallel processes.
+In certain situations Chef Provisioning will run multiple **machine** processes in-parallel, as long as each of the individual **machine** resources have the same declared action. The **machine_batch** resource is used to run in-parallel processes.
 
-Chef provisioning will processes resources in-parallel automatically, unless:
+Chef Provisioning will processes resources in-parallel automatically, unless:
 
 * The recipe contains complex scripts, such as when a **file** resource sits in-between two **machine** resources in a single recipe. In this situation, the resources will be run sequentially
 * The actions specified for each individual **machine** resource are not identical; for example, if resource A is set to ``:converge`` and resource B is set to ``:destroy``, then they may not be processed in-parallel

--- a/chef_master/source/resource_machine_execute.rst
+++ b/chef_master/source/resource_machine_execute.rst
@@ -9,9 +9,9 @@ Use the **machine_execute** resource to run a command on a remote machine in muc
 
 .. end_tag
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
@@ -42,8 +42,6 @@ where
 
 Actions
 =====================================================
-.. tag resource_machine_execute_actions
-
 This resource has the following actions:
 
 ``:nothing``
@@ -55,8 +53,6 @@ This resource has the following actions:
 
 ``:run``
    Default. Use to run a machine.
-
-.. end_tag
 
 Properties
 =====================================================

--- a/chef_master/source/resource_machine_file.rst
+++ b/chef_master/source/resource_machine_file.rst
@@ -9,9 +9,9 @@ Use the **machine_file** resource to manage a file on a remote machine in much t
 
 .. end_tag
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
@@ -42,8 +42,6 @@ where
 
 Actions
 =====================================================
-.. tag resource_machine_file_actions
-
 This resource has the following actions:
 
 ``:delete``
@@ -61,8 +59,6 @@ This resource has the following actions:
 
 ``:upload``
    Default. Use to upload a file to a machine.
-
-.. end_tag
 
 Properties
 =====================================================

--- a/chef_master/source/resource_machine_image.rst
+++ b/chef_master/source/resource_machine_image.rst
@@ -9,9 +9,9 @@ Use the **machine_image** resource to define a machine image. This image may the
 
 .. end_tag
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 
@@ -42,8 +42,6 @@ where
 
 Actions
 =====================================================
-.. tag resource_machine_image_actions
-
 This resource has the following actions:
 
 ``:archive``
@@ -61,8 +59,6 @@ This resource has the following actions:
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Infra Client run.
 
    .. end_tag
-
-.. end_tag
 
 Properties
 =====================================================

--- a/chef_master/source/resource_private_key.rst
+++ b/chef_master/source/resource_private_key.rst
@@ -3,9 +3,9 @@ private_key
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_private_key.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_public_key.rst
+++ b/chef_master/source/resource_public_key.rst
@@ -3,9 +3,9 @@ public_key
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_public_key.rst>`__
 
-.. warning:: .. tag notes_provisioning
+.. warning:: .. tag EOL_provisioning
 
-             This functionality was available with Chef provisioning and was packaged in the Chef development kit.
+             This functionality was available with Chef Provisioning and was packaged in the Chef development kit.
 
              Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019.  The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard organization. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
 

--- a/chef_master/source/resource_windows_env.rst
+++ b/chef_master/source/resource_windows_env.rst
@@ -36,8 +36,6 @@ where:
 
 Actions
 =====================================================
-.. tag resource_env_actions
-
 The windows_env resource has the following actions:
 
 ``:create``
@@ -55,8 +53,6 @@ The windows_env resource has the following actions:
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Infra Client run.
 
    .. end_tag
-
-.. end_tag
 
 Properties
 =====================================================

--- a/chef_master/source/resource_windows_package.rst
+++ b/chef_master/source/resource_windows_package.rst
@@ -49,8 +49,6 @@ where:
 
 Actions
 =====================================================
-.. tag resource_package_windows_actions
-
 The windows_package resource has the following actions:
 
 ``:install``
@@ -65,8 +63,6 @@ The windows_package resource has the following actions:
 
 ``:remove``
    Remove a package.
-
-.. end_tag
 
 Properties
 =====================================================

--- a/chef_master/source/resource_windows_service.rst
+++ b/chef_master/source/resource_windows_service.rst
@@ -59,8 +59,6 @@ where:
 
 Actions
 =====================================================
-.. tag resource_service_windows_actions
-
 The windows_service resource has the following actions:
 
 ``:configure``
@@ -108,8 +106,6 @@ The windows_service resource has the following actions:
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Infra Client run.
 
    .. end_tag
-
-.. end_tag
 
 Properties
 =====================================================

--- a/chef_master/source/workflow.rst
+++ b/chef_master/source/workflow.rst
@@ -140,7 +140,7 @@ Acceptance Stage
 -----------------------------------------------------
 Beginning with the Acceptance stage, the pipeline switches from analyzing the project's source code to verifying the set of artifacts that were produced in the Build stage. The goal of the Acceptance stage is for the team to make a decision about whether the change should go all the way out to production or not. There are four phases in Acceptance:
 
-* **Provision**. Provision infrastructure needed to test the artifact(s). Examples include instantiating new infrastructure with Chef provisioning (or another API-accessible mechanism) and manipulating Chef Infra Server environments to designate the nodes used by the current stage. Of course, what executes in any phase is up to you and determined by the project's build cookbook.
+* **Provision**. Provision infrastructure needed to test the artifact(s). Examples include instantiating new infrastructure with Chef Provisioning (or another API-accessible mechanism) and manipulating Chef Infra Server environments to designate the nodes used by the current stage. Of course, what executes in any phase is up to you and determined by the project's build cookbook.
 * **Deploy**. Deploy the artifacts published in the Build stage to the portion of your infrastructure that has been set aside for acceptance testing.
 * **Smoke**. Smoke tests should be relatively short-running tests that verify that the code that should have been deployed has indeed been deployed and that the system passes minimal health checks.
 * **Functional**. The functional tests should give you confidence that the system is meeting its business requirements.


### PR DESCRIPTION
### Description

Fixes nesting of dtag `resourse_common_actions_nothing` in most cases by removing containing tags. 
- Removed all containing tags from `provisioning.rst`, which turned many tags into single-use.
- Removed single-use tags
- s/Chef provisioning/Chef Provisioning
- Changed `tag note_provisioning` to `tag EOL_provisioning`

Nested dtags for this tag still exist in:
- `tag resource_breakpoint_actions`
- `tag resource_log_actions`
- `tag resource_ohai_actions` 

Two of these uses are located on `debug.rst`. However, the debug page is ranked #53 for 12-month use and requires further examination of user behavior before refactoring.


### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
