### PR TITLE
Remove some older / broken knife plugins from our list

### DIFF
--- a/chef_master/source/plugin_community.rst
+++ b/chef_master/source/plugin_community.rst
@@ -20,7 +20,7 @@ knife is a command-line tool that provides an interface between a local chef-rep
 
 .. end_tag
 
-knife plugins for cloud hosting platforms--- `knife azure <https://github.com/chef/knife-azure>`_, `knife bluebox <https://github.com/chef-boneyard/knife-bluebox>`_, `knife ec2 <https://github.com/chef/knife-ec2>`_, `knife eucalyptus <https://github.com/chef-boneyard/knife-eucalyptus>`_, `knife google <https://github.com/chef/knife-google>`_, `knife linode <https://github.com/chef/knife-linode>`_, `knife openstack <https://github.com/chef/knife-openstack>`_, and `knife rackspace <https://github.com/chef/knife-rackspace>`_, ---are built and maintained by Chef.
+knife plugins for cloud hosting platforms--- `knife azure <https://github.com/chef/knife-azure>`_, `knife ec2 <https://github.com/chef/knife-ec2>`_, `knife google <https://github.com/chef/knife-google>`_, and `knife openstack <https://github.com/chef/knife-openstack>`_, ---are built and maintained by Chef.
 
 The following table lists knife plugins built by the Chef community.
 
@@ -32,8 +32,6 @@ The following table lists knife plugins built by the Chef community.
      - Description
    * - `knife-audit <https://github.com/jbz/knife-audit>`_
      - Adds the ability to see how many (and which) nodes have a cookbook in its run-list.
-   * - `knife-baremetalcloud <https://github.com/baremetalcloud/knife-baremetalcloud>`_
-     - Adds the ability to manage compute nodes in baremetalcloud.
    * - `knife-batch <https://github.com/imeyer/knife-batch>`_
      - Adds the ability to execute commands like ``knife ssh``, but in groups of N with a sleep between execution iterations.
    * - `knife-block <https://github.com/greenandsecure/knife-block>`_
@@ -54,8 +52,6 @@ The following table lists knife plugins built by the Chef community.
      - Adds the ability to create, bootstrap, and manage instances in CloudStack using Fog, a Ruby gem for interacting with various cloud providers.
    * - `knife-cloudstack <https://github.com/CloudStack-extras/knife-cloudstack>`_
      - Adds the ability to create, bootstrap, and manage CloudStack instances.
-   * - `knife-community <https://github.com/miketheman/knife-community>`_
-     - Adds the ability to assist with deploying completed cookbooks to the community web site.
    * - `knife-crawl <https://github.com/jgoulah/knife-crawl>`_
      - Adds the ability to display the roles that are included recursively within a role and (optionally) all of the roles that include it.
    * - `knife-digital_ocean <https://github.com/rmoriz/knife-digital_ocean>`_
@@ -134,8 +130,6 @@ The following table lists knife plugins built by the Chef community.
      - Adds extra features to be used with SSH.
    * - `knife-ucs <https://github.com/velankanisys/knife-ucs>`_
      - Adds the ability to provision, list, and manage Cisco UCS servers.
-   * - `knife-voxel <https://github.com/warwickp/knife-voxel>`_
-     - Adds the ability to provision instances in the Voxel cloud.
    * - `knife-whisk <https://github.com/Banno/knife-whisk>`_
      - Adds the ability to create new servers in a team environment.
    * - `knife-xapi <https://github.com/spheromak/knife-xapi>`_


### PR DESCRIPTION
Remove the Chef written plugins that we don't maintain anymore
Remove knife-voxel as the company is no more
Remove knife-community as knife supermarket is built into chef now
Remove knife-baremetalcloud as it hasn't been updated in 7 years

Signed-off-by: Tim Smith <tsmith@chef.io>