### PR TITLE
Better specifying how to accept the chef license

### DIFF
--- a/chef_master/source/chef_license_accept.rst
+++ b/chef_master/source/chef_license_accept.rst
@@ -67,7 +67,7 @@ Chef Workstation
 Chef Workstation contains multiple Chef Software products.
 When invoking the ``chef`` command line tool and accepting the license, users are required to accept the license for all the embedded products as well.
 The same license applies to all products, but each product must have its own license acceptance.
-``chef <command> --chef-license accept`` will accept the license for Chef Workstation, Chef Infra Client, Chef InSpec, and Push Jobs Client.
+``chef <command> --chef-license accept`` will accept the license for Chef Workstation, Chef Infra Client, Chef InSpec, and Push Jobs Client. For example, `chef env --chef-license accept`
 
 Chef Infra Client
 -----------------------------------------------------

--- a/chef_master/source/chef_license_accept.rst
+++ b/chef_master/source/chef_license_accept.rst
@@ -67,7 +67,7 @@ Chef Workstation
 Chef Workstation contains multiple Chef Software products.
 When invoking the ``chef`` command line tool and accepting the license, users are required to accept the license for all the embedded products as well.
 The same license applies to all products, but each product must have its own license acceptance.
-``chef --chef-license accept`` will accept the license for Chef Workstation, Chef Infra Client, Chef InSpec, and Push Jobs Client.
+``chef <command> --chef-license accept`` will accept the license for Chef Workstation, Chef Infra Client, Chef InSpec, and Push Jobs Client.
 
 Chef Infra Client
 -----------------------------------------------------


### PR DESCRIPTION
### Description

Customer reported this issue - you need to actually specify a command to `chef`

### Definition of Done

### Issues Resolved

N/A

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
