### PR TITLE
Rename Chef to Chef Infra in the nav bar

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -87,7 +87,7 @@
     ]
   },
   {
-    "title": "Chef",
+    "title": "Chef Infra",
     "image": "chef-logo-gray.svg",
     "subItems": [
       {


### PR DESCRIPTION
The other product have the new naming, but not Chef Infra.

Signed-off-by: Tim Smith <tsmith@chef.io>