### PR TITLE
Add ohai plugin directory to cookbooks, clean up a little

### DIFF
--- a/chef_master/source/attributes.rst
+++ b/chef_master/source/attributes.rst
@@ -259,7 +259,7 @@ Recipes
 A recipe is the most fundamental configuration element within the organization. A recipe:
 
 * Is authored using Ruby, which is a programming language designed to read and behave in a predictable manner
-* Is mostly a collection of resources, defined using patterns (resource names, attribute-value pairs, and actions); helper code is added around this using Ruby, when needed
+* Is mostly a collection of `resources </resources.html>`__, defined using patterns (resource names, attribute-value pairs, and actions); helper code is added around this using Ruby, when needed
 * Must define everything that is required to configure part of a system
 * Must be stored in a cookbook
 * May be included in another recipe

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -274,7 +274,7 @@ Cookbooks are comprised of the following components:
        A recipe is the most fundamental configuration element within the organization. A recipe:
 
        * Is authored using Ruby, which is a programming language designed to read and behave in a predictable manner
-       * Is mostly a collection of resources, defined using patterns (resource names, attribute-value pairs, and actions); helper code is added around this using Ruby, when needed
+       * Is mostly a collection of `resources </resources.html>`__, defined using patterns (resource names, attribute-value pairs, and actions); helper code is added around this using Ruby, when needed
        * Must define everything that is required to configure part of a system
        * Must be stored in a cookbook
        * May be included in another recipe

--- a/chef_master/source/cookbook_repo.rst
+++ b/chef_master/source/cookbook_repo.rst
@@ -1,21 +1,11 @@
 =====================================================
-Cookbook Directories and Metadata
+Cookbook Directory
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/cookbook_repo.rst>`__
 
-The ``cookbooks/`` directory is used to store the cookbooks that Chef Infra Client uses in configuring the various systems in the organization. This directory contains the cookbooks that are used to configure systems in the infrastructure. Each cookbook can be configured to contain cookbook-specific copyright, email, and license data.
+The ``cookbooks/`` directory of your Chef Infra repository is used to store the cookbooks that Chef Infra Client uses in configuring the various systems in the organization.
 
-To configure cookbook-specific copyright, email, and license data, add the following to the config.rb file in the chef-repo:
-
-.. code-block:: bash
-
-   cookbook_copyright "Example, Com."
-   cookbook_email     "cookbooks@example.com"
-   cookbook_license   "apachev2"
-
-where the ``cookbook_copyright`` and ``cookbook_email`` are specific to the organization and ``cookbook_license`` is either ``apachev2`` or ``none``. These settings will be used in the default recipe and in corresponding values in the metadata.rb file, but can be modified in those locations as well (if they should be different from the default values contained in the config.rb file.)
-
-Work with Cookbooks
+Working with Cookbooks
 =====================================================
 Use the following knife subcommands to create, install, and/or download cookbooks.
 
@@ -59,21 +49,22 @@ where ``COOKBOOK_NAME`` is the name of a cookbook on `Chef Supermarket <https://
 
 Cookbook Metadata
 =====================================================
-
 .. tag cookbooks_metadata
 
 Every cookbook requires a small amount of metadata. A file named metadata.rb is located at the top of every cookbook directory structure. The contents of the metadata.rb file provides information that helps Chef Infra Client and Server correctly deploy cookbooks to each node.
 
 .. end_tag
 
-A metadata.rb file is:
+Each cookbook can be configured to contain cookbook-specific copyright, email, and license data which is stored in the `metadata.rb </config_rb_metadata.html>`__ file.
 
-* Located at the top level of a cookbook's directory structure.
-* Compiled whenever a cookbook is uploaded to the Chef Infra Server or when the ``knife cookbook metadata`` subcommand is run, and then stored as JSON data.
-* Created automatically by knife whenever the ``knife cookbook create`` subcommand is run.
-* Edited using a text editor, and then re-uploaded to the Chef Infra Server as part of a cookbook upload.
+You can configure default values for the copyright, email, and license of new cookbooks by adding the following to the config.rb file in the chef-repo:
 
-Metadata Settings
------------------------------------------------------
+.. code-block:: bash
+
+   cookbook_copyright "Example, Com."
+   cookbook_email     "cookbooks@example.com"
+   cookbook_license   "apachev2"
+
+where the ``cookbook_copyright`` and ``cookbook_email`` are specific to the organization and ``cookbook_license`` is either ``apachev2`` or ``none``. These settings will be used in the default recipe and in corresponding values in the metadata.rb file, but can be modified in those locations as well (if they should be different from the default values contained in the config.rb file.)
 
 For a full explanation of working with cookbook metadata, see `metadata.rb </config_rb_metadata.html>`__.

--- a/chef_master/source/cookbooks.rst
+++ b/chef_master/source/cookbooks.rst
@@ -17,30 +17,27 @@ A cookbook is the fundamental unit of configuration and policy distribution. A c
 
 Chef Infra Client uses Ruby as its reference language for creating cookbooks and defining recipes, with an extended DSL for specific resources. Chef Infra Client provides a reasonable set of resources, enough to support many of the most common infrastructure automation scenarios; however, this DSL can also be extended when additional resources and capabilities are required.
 
+Chef Infra Client will run a recipe only when asked. When Chef Infra Client runs the same recipe more than once, the results will be the same system state each time. When a recipe is run against a system, but nothing has changed on either the system or in the recipe, Chef Infra Client won't change anything.
+
 Components
 =====================================================
-Some important components of cookbooks include:
+A cookbook is comprised of recipes and other optional components as files or directories.
 
 .. list-table::
-   :widths: 60 420
+   :widths: 100 50 450
    :header-rows: 1
 
-   * - Feature
+   * - Component
+     - File/Directory Name
      - Description
-   * - `Attributes </attributes.html>`__
-     - .. tag cookbooks_attribute
-
-       An attribute can be defined in a cookbook (or a recipe) and then used to override the default settings on a node. When a cookbook is loaded during a Chef Infra Client run, these attributes are compared to the attributes that are already present on the node. Attributes that are defined in attribute files are first loaded according to cookbook order. For each cookbook, attributes in the ``default.rb`` file are loaded first, and then additional attribute files (if present) are loaded in lexical sort order. When the cookbook attributes take precedence over the default attributes, Chef Infra Client applies those new settings and values during a Chef Infra Client run on the node.
-
-       .. end_tag
-
    * - `Recipes </recipes.html>`__
+     - recipes/
      - .. tag cookbooks_recipe
 
        A recipe is the most fundamental configuration element within the organization. A recipe:
 
        * Is authored using Ruby, which is a programming language designed to read and behave in a predictable manner
-       * Is mostly a collection of resources, defined using patterns (resource names, attribute-value pairs, and actions); helper code is added around this using Ruby, when needed
+       * Is mostly a collection of `resources </resources.html>`__, defined using patterns (resource names, attribute-value pairs, and actions); helper code is added around this using Ruby, when needed
        * Must define everything that is required to configure part of a system
        * Must be stored in a cookbook
        * May be included in another recipe
@@ -50,37 +47,31 @@ Some important components of cookbooks include:
        * Is always executed in the same order as listed in a run-list
 
        .. end_tag
+   * - `Attributes </attributes.html>`__
+     - attributes/
+     - .. tag cookbooks_attribute
 
-Chef Infra Client will run a recipe only when asked. When Chef Infra Client runs the same recipe more than once, the results will be the same system state each time. When a recipe is run against a system, but nothing has changed on either the system or in the recipe, Chef Infra Client won't change anything.
-
-In addition to attributes and recipes, the following items are also part of cookbooks:
-
-.. list-table::
-   :widths: 150 450
-   :header-rows: 1
-
-   * - Components
-     - Description
-   * - `Files </files.html>`__
-     - A file distribution is a specific type of resource that tells a cookbook how to distribute files, including by node, by platform, or by file version.
-   * - `Libraries </libraries.html>`__
-     - A library allows the use of arbitrary Ruby code in a cookbook, either as a way to extend the Chef Infra Client language or to implement a new class.
-   * - `Custom Resources </custom_resources.html>`__
-     - A custom resource is an abstract approach for defining a set of actions and (for each action) a set of properties and validation parameters.
-   * - `Metadata </cookbook_repo.html>`__
-     - A metadata file is used to ensure that each cookbook is correctly deployed to each node.\
-   * - `Resources </resource.html>`__
-     - A resource instructs Chef Infra Client to complete various tasks like installing packages, running Ruby code, or accessing directories and file systems. Chef Infra Client includes built-in resources that cover many common scenarios. For the full list of resources that are built-in to Chef Infra Client, see our `Resources Reference </resource_reference.html>`__.
-   * - `Templates </templates.html>`__
-     - A template is a file written in markup language that uses Ruby statements to solve complex configuration scenarios.
-   * - `Cookbook Versioning </cookbook_versioning.html>`__
-     - .. tag cookbooks_version
-
-       A cookbook version represents a set of functionality that is different from the cookbook on which it is based. A version may exist for many reasons, such as ensuring the correct use of a third-party component, updating a bug fix, or adding an improvement. A cookbook version is defined using syntax and operators, may be associated with environments, cookbook metadata, and/or run-lists, and may be frozen (to prevent unwanted updates from being made).
-
-       A cookbook version is maintained just like a cookbook, with regard to source control, uploading it to the Chef Infra Server, and how Chef Infra Client applies that cookbook when configuring nodes.
+       An attribute can be defined in a cookbook (or a recipe) and then used to override the default settings on a node. When a cookbook is loaded during a Chef Infra Client run, these attributes are compared to the attributes that are already present on the node. Attributes that are defined in attribute files are first loaded according to cookbook order. For each cookbook, attributes in the ``default.rb`` file are loaded first, and then additional attribute files (if present) are loaded in lexical sort order. When the cookbook attributes take precedence over the default attributes, Chef Infra Client applies those new settings and values during a Chef Infra Client run on the node.
 
        .. end_tag
+   * - `Files </files.html>`__
+     - files/
+     - A file distribution is a specific type of resource that tells a cookbook how to distribute files, including by node, by platform, or by file version.
+   * - `Libraries </libraries.html>`__
+     - libraries/
+     - A library allows the use of arbitrary Ruby code in a cookbook, either as a way to extend the Chef Infra Client language or to implement a new class.
+   * - `Custom Resources </custom_resources.html>`__
+     - resources/
+     - A custom resource is an abstract approach for defining a set of actions and (for each action) a set of properties and validation parameters.
+   * - `Templates </templates.html>`__
+     - templates/
+     - A template is a file written in markup language that uses Ruby statements to solve complex configuration scenarios.
+   * - `Ohai Plugins </ohai_custom.html>`__
+     - ohai/
+     - Custom Ohai plugins can be written to load additional information about your nodes to be used in recipes.
+   * - `Metadata </config_rb_metadata.html>`__
+     - metadata.rb
+     - This file contains information about the cookbook such as the cookbook name, description, and `version </cookbook_versioning.html>`__.
 
 Community Cookbooks
 =====================================================

--- a/chef_master/source/recipes.rst
+++ b/chef_master/source/recipes.rst
@@ -8,7 +8,7 @@ About Recipes
 A recipe is the most fundamental configuration element within the organization. A recipe:
 
 * Is authored using Ruby, which is a programming language designed to read and behave in a predictable manner
-* Is mostly a collection of resources, defined using patterns (resource names, attribute-value pairs, and actions); helper code is added around this using Ruby, when needed
+* Is mostly a collection of `resources </resources.html>`__, defined using patterns (resource names, attribute-value pairs, and actions); helper code is added around this using Ruby, when needed
 * Must define everything that is required to configure part of a system
 * Must be stored in a cookbook
 * May be included in another recipe

--- a/chef_master/source/server_manage_cookbooks.rst
+++ b/chef_master/source/server_manage_cookbooks.rst
@@ -84,7 +84,7 @@ A cookbook can contain the following types of files:
        A recipe is the most fundamental configuration element within the organization. A recipe:
 
        * Is authored using Ruby, which is a programming language designed to read and behave in a predictable manner
-       * Is mostly a collection of resources, defined using patterns (resource names, attribute-value pairs, and actions); helper code is added around this using Ruby, when needed
+       * Is mostly a collection of `resources </resources.html>`__, defined using patterns (resource names, attribute-value pairs, and actions); helper code is added around this using Ruby, when needed
        * Must define everything that is required to configure part of a system
        * Must be stored in a cookbook
        * May be included in another recipe


### PR DESCRIPTION
Chef cookbooks may contain custom ohai plugins in the 'ohai' directory which
will be installed and loaded as part of a client run.

Also, cleaned up some confusion and duplication. There's still more to
do but this is better.
