### PR TITLE
Remove duplicate Guards section from resource_windows_env.rst

### DIFF
--- a/chef_master/source/resource_windows_env.rst
+++ b/chef_master/source/resource_windows_env.rst
@@ -202,32 +202,6 @@ The syntax for ``subscribes`` is:
 
 Guards
 -----------------------------------------------------
-
-.. tag resources_common_guards
-
-A guard property can be used to evaluate the state of a node during the execution phase of a Chef Infra Client run. Based on the results of this evaluation, a guard property is then used to tell Chef Infra Client if it should continue executing a resource. A guard property accepts either a string value or a Ruby block value:
-
-* A string is executed as a shell command. If the command returns ``0``, the guard is applied. If the command returns any other value, then the guard property is not applied. String guards in a **powershell_script** run Windows PowerShell commands and may return ``true`` in addition to ``0``.
-* A block is executed as Ruby code that must return either ``true`` or ``false``. If the block returns ``true``, the guard property is applied. If the block returns ``false``, the guard property is not applied.
-
-A guard property is useful for ensuring that a resource is idempotent by allowing that resource to test for the desired state as it is being executed, and then if the desired state is present, for Chef Infra Client to do nothing.
-
-.. end_tag
-
-.. tag resources_common_guards_properties
-
-The following properties can be used to define a guard that is evaluated during the execution phase of a Chef Infra Client run:
-
-``not_if``
-  Prevent a resource from executing when the condition returns ``true``.
-
-``only_if``
-  Allow a resource to execute only if the condition returns ``true``.
-
-.. end_tag
-
-Guards
------------------------------------------------------
 .. tag resources_common_guards
 
 A guard property can be used to evaluate the state of a node during the execution phase of a Chef Infra Client run. Based on the results of this evaluation, a guard property is then used to tell Chef Infra Client if it should continue executing a resource. A guard property accepts either a string value or a Ruby block value:


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

Removes a duplicate **Guards** section from `resource_windows_env.rst` 

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
