### PR TITLE
Fix typo in resource_breakpoint.rst

### DIFF
--- a/chef_master/source/resource_breakpoint.rst
+++ b/chef_master/source/resource_breakpoint.rst
@@ -112,7 +112,7 @@ and then add them to the chef-shell.rb file. Other configuration possibilities i
 
 .. end_tag
 
-Run as a Chhef Infra Client
+Run as a Chef Infra Client
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. tag chef_shell_run_as_chef_client
 


### PR DESCRIPTION
### Description

Fix typo in resource_breakpoint.rst

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
