### PR TITLE
Missing text from resource_chef_handler.rst

### DIFF
--- a/chef_master/source/resource_chef_handler.rst
+++ b/chef_master/source/resource_chef_handler.rst
@@ -508,7 +508,7 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
 
 Optional Interfaces
 -----------------------------------------------------
-The following interfaces may be used in a handler in the same way as the ``report`` interface to override the default handler behavior in . That said, the following interfaces are not typically used in a handler and, for the most part, are completely unnecessary for a handler to work properly and/or as desired.
+The following interfaces may be used in a handler in the same way as the ``report`` interface to override the default handler behavior in Chef Infra Client. That said, the following interfaces are not typically used in a handler and, for the most part, are completely unnecessary for a handler to work properly and/or as desired.
 
 data
 +++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

Missing text `Chef Infra Client` from resource_chef_handler.rst.
From #1997 

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
