### PR TITLE
Update AIX platform support

### DIFF
--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -524,7 +524,7 @@ This approach can work very well on a case-by-case basis. The challenge with thi
 
 Run on IBM AIX
 =====================================================
-The Chef Infra Client may now be used to configure nodes that are running on the AIX platform, versions 6.1 (TL6 or higher, recommended) and 7.1 (TL0 SP3 or higher, recommended). The **service** resource supports starting, stopping, and restarting services that are managed by System Resource Controller (SRC), as well as managing all service states with BSD-based init systems.
+The Chef Infra Client may now be used to configure nodes that are running on the AIX platform, versions 7.1 (TL5 SP2 or higher, recommended) and 7.2. The **service** resource supports starting, stopping, and restarting services that are managed by System Resource Controller (SRC), as well as managing all service states with BSD-based init systems.
 
 
 

--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -36,7 +36,7 @@ The following table lists the commercially-supported platforms and versions for 
      - Version
    * - AIX
      - ``powerpc``
-     - ``7.1`` (TL0 SP3 or higher, recommended), ``7.2``
+     - ``7.1`` (TL5 SP2 or higher, recommended), ``7.2``
    * - Amazon Linux
      -
      - 2013+ and 2.0

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -8464,7 +8464,7 @@ Use an array to match any of the platforms within the array:
 AIX Platform Support
 -----------------------------------------------------
 
-Chef Client may now be used to configure nodes that are running on the AIX platform, versions 6.1 (TL6 or higher, recommended) and 7.1 (TL0 SP3 or higher, recommended). The **service** resource supports starting, stopping, and restarting services that are managed by System Resource Controller (SRC), as well as managing all service states with BSD-based init systems.
+Chef Client may now be used to configure nodes that are running on the AIX platform, versions 7.1 (TL5 SP2 or higher, recommended) and 7.2. The **service** resource supports starting, stopping, and restarting services that are managed by System Resource Controller (SRC), as well as managing all service states with BSD-based init systems.
 
 **System Requirements**
 


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

We now support AIX versions 7.1 (TL5 SP2 or higher, recommended) and 7.2

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
