### PR TITLE
Drop SLES 11

### DIFF
--- a/chef_master/source/install_server.rst
+++ b/chef_master/source/install_server.rst
@@ -33,7 +33,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``6.x``, ``7.x``
    * - SUSE Enterprise Linux Server
      - ``x86_64``
-     - ``11 SP4``, ``12 SP1+``, ``15``
+     - ``12 SP1+``, ``15``
    * - Ubuntu
      - ``x86_64``
      - ``16.04``, ``18.04``

--- a/chef_master/source/install_server_pre.rst
+++ b/chef_master/source/install_server_pre.rst
@@ -29,7 +29,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``6.x``, ``7.x``
    * - SUSE Enterprise Linux Server
      - ``x86_64``
-     - ``11 SP4``, ``12 SP1+``, ``15``
+     - ``12 SP1+``, ``15``
    * - Ubuntu
      - ``x86_64``
      - ``16.04``, ``18.04``

--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -63,7 +63,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``11.2``, ``11.3``, ``11.4``
    * - SUSE Enterprise Linux Server
      - ``x86_64``, ``s390x``, ``ppc64le``, ``ppc64``
-     - ``11 SP4``, ``12 SP1+``, ``15``
+     - ``12 SP1+``, ``15``
    * - Ubuntu (LTS releases)
      - ``i386``, ``x86_64``
      - ``16.04``, ``18.04``
@@ -159,7 +159,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``6.x``, ``7.x``, ``8.x``
    * - SUSE Enterprise Linux Server
      - ``x86_64``
-     - ``11 SP4``, ``12 SP1+``, ``15``
+     - ``12 SP1+``, ``15``
    * - Ubuntu
      - ``x86_64``
      - ``16.04``, ``18.04``
@@ -195,7 +195,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``6.x``, ``7.x``
    * - SUSE Enterprise Linux Server
      - ``x86_64``
-     - ``11 SP4``, ``12 SP1+``
+     - ``12 SP1+``
    * - Ubuntu
      - ``x86_64``
      - ``16.04``, ``18.04``
@@ -245,7 +245,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``6.x``, ``7.x``
    * - SUSE Enterprise Linux Server
      - ``x86_64``
-     - ``11 SP4``, ``12 SP1+``, ``15``
+     - ``12 SP1+``, ``15``
    * - Ubuntu
      - ``x86_64``
      - ``16.04``, ``18.04``
@@ -285,7 +285,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``6.x``, ``7.x``
    * - SUSE Enterprise Linux Server
      - ``x86_64``
-     - ``11 SP4``, ``12 SP2``
+     - ``12 SP2``
    * - Ubuntu
      - ``x86_64``
      - ``16.04``, ``18.04``


### PR DESCRIPTION
### Description

SLES 11 went EOL on 3/31/19, and per our policy that makes it an EOL platform for us.