### PR TITLE
More resource cleanup to match reality

### DIFF
--- a/chef_master/source/azure_portal.rst
+++ b/chef_master/source/azure_portal.rst
@@ -12,6 +12,11 @@ Microsoft Azure is a cloud hosting platform from Microsoft that provides virtual
 Virtual Machines running Chef Infra Client
 =====================================================
 
+.. warning:: When the Chef VM extension is provisioned as part of a scale operation for a VM Scale Set, we suggest not using the Chef Infra Client extension and instead pre-install Chef Infra Client onto the VM and/or use an image-based deployment process, such as `Packer <https://docs.microsoft.com/en-us/azure/virtual-machines/windows/build-image-with-packer>`_, to create the base VM disk image.
+
+  The Microsoft VM agent on the machine executes all installations in parallel and these extensions can call 'locking' installation mechanisms such as Windows Installer (via installation of an MSI) or Apt updates. A timeout can occur if the total time for all of these activities exceeds 5 minutes and in some regions that is not enough time to get the Chef Infra Client package and enable the Chef Infra Client extension.
+
+
 Through the Azure portal, you can provision a virtual machine with Chef Infra Client running as a background service. Once provisioned, these virtual machines are ready to be managed by a Chef Infra Server.
 
 .. note:: Virtual machines running on Microsoft Azure can also be provisioned from the command-line using the ``knife azure`` plugin for knife. This approach is ideal for cases that require automation or for users who are more suited to command-line interfaces.

--- a/chef_master/source/debug.rst
+++ b/chef_master/source/debug.rst
@@ -122,7 +122,7 @@ The log resource has the following properties:
 ``level``
    **Ruby Type:** Symbol | **Default Value:** ``:info``
 
-   The logging level for displaying this message.. Options (in order of priority): ``:debug``, ``:info``, ``:warn``, ``:error``, and ``:fatal``.
+   The logging level for displaying this message. Options (in order of priority): ``:debug``, ``:info``, ``:warn``, ``:error``, and ``:fatal``.
 
 ``message``
    **Ruby Type:** String | **Default Value:** ``The resource block's name``

--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -56,8 +56,8 @@ The following table lists the commercially-supported platforms and versions for 
      - ``x86_64``
      - ``6.x``, ``7.x``
    * - Red Hat Enterprise Linux
-     - ``x86_64``, ``s390x``, ``ppc64le`` (7.x only), ``ppc64`` (7.x only)
-     - ``6.x``, ``7.x``
+     - ``x86_64``, ``s390x``(6.x and 7.x only), ``ppc64le`` (7.x only), ``ppc64`` (7.x only)
+     - ``6.x``, ``7.x``, ``8.x``
    * - Solaris
      - ``sparc``, ``i86pc``
      - ``11.2``, ``11.3``, ``11.4``
@@ -65,7 +65,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``x86_64``, ``s390x``, ``ppc64le``, ``ppc64``
      - ``12 SP1+``, ``15``
    * - Ubuntu (LTS releases)
-     - ``i386``, ``x86_64``
+     - ``x86_64``
      - ``16.04``, ``18.04``
    * - Microsoft Windows
      - ``x86``, ``x64``
@@ -165,7 +165,7 @@ The following table lists the commercially-supported platforms and versions for 
      - ``16.04``, ``18.04``
    * - Microsoft Windows
      - ``x86_64``
-     - ``7``, ``8.1``, ``2008 R2``, ``2012``, ``2012 R2``, ``2016``, ``10 (all channels except "insider" builds)``, ``2019``
+     - ``2012``, ``2012 R2``, ``2016``, ``10 (all channels except "insider" builds)``, ``2019``
 
 Chef InSpec Target Mode (``inspec --target``) may be functional on additional platforms, versions, and architectures but are not validated by Chef Software, Inc.
 
@@ -195,13 +195,13 @@ The following table lists the commercially-supported platforms and versions for 
      - ``6.x``, ``7.x``
    * - SUSE Enterprise Linux Server
      - ``x86_64``
-     - ``12 SP1+``
+     - ``12 SP1+``, ``15``
    * - Ubuntu
      - ``x86_64``
      - ``16.04``, ``18.04``
    * - Microsoft Windows
      - ``x86``, ``x64``
-     - ``7``, ``8.1``, ``2008 R2``, ``2012``, ``2012 R2``, ``2016``, ``10 (all channels except "insider" builds)``, ``2019 (Long-term servicing channel (LTSC), Desktop Experience only)``
+     - ``2008 R2``, ``2012``, ``2012 R2``, ``2016``, ``10 (all channels except "insider" builds)``, ``2019 (Long-term servicing channel (LTSC), Desktop Experience only)``
 
 Community Support
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -214,6 +214,9 @@ The following platforms are supported only via the community:
    * - Platform
      - Architecture
      - Version
+   * - openSUSE
+     -
+     - ``42.x``
    * - Scientific Linux
      - ``x86_64``
      - ``6.x``, ``7.x``

--- a/chef_master/source/resource_apt_package.rst
+++ b/chef_master/source/resource_apt_package.rst
@@ -29,17 +29,17 @@ The full syntax for all of the properties that are available to the **apt_packag
 
 .. code-block:: ruby
 
-   apt_package 'name' do
-     default_release            String
-     options                    String, Array
-     overwrite_config_files     true, false # default value: false
-     package_name               String, Array # defaults to 'name' if not specified
-     response_file              String
-     response_file_variables    Hash
-     timeout                    String, Integer
-     version                    String, Array
-     action                     Symbol # defaults to :install if not specified
-   end
+  apt_package 'name' do
+    default_release              String
+    options                      String, Array
+    overwrite_config_files       true, false # default value: false
+    package_name                 String, Array
+    response_file                String
+    response_file_variables      Hash
+    timeout                      String, Integer
+    version                      String, Array
+    action                       Symbol # defaults to :install if not specified
+  end
 
 where:
 
@@ -80,6 +80,13 @@ The apt_package resource has the following actions:
 
 ``:upgrade``
    Install a package and/or ensure that a package is the latest version.
+
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of a Chef Infra Client run.
+
+   .. end_tag
 
 Properties
 =====================================================
@@ -164,6 +171,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_apt_preference.rst
+++ b/chef_master/source/resource_apt_preference.rst
@@ -9,6 +9,7 @@ The **apt_preference** resource allows for the creation of APT `preference files
 
 Syntax
 =====================================================
+
 The apt_preference resource has the following syntax:
 
 .. code-block:: ruby
@@ -39,6 +40,13 @@ The apt_preference resource has the following actions:
 ``remove``
   Removes the preferences file, thus unpinning the package.
 
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of a Chef Infra Client run.
+
+   .. end_tag
+
 Properties
 =====================================================
 
@@ -63,7 +71,6 @@ The apt_preference resource has the following properties:
    **Ruby Type:** String, Integer | ``REQUIRED``
 
    Sets the ``Pin-Priority`` for a package. See the `APT pinning documentation <https://wiki.debian.org/AptPreferences>`__ for more details.
-
 
 Common Resource Functionality
 =====================================================
@@ -101,6 +108,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_apt_repository.rst
+++ b/chef_master/source/resource_apt_repository.rst
@@ -61,6 +61,13 @@ The apt_repository resource has the following actions:
 ``:remove``
    Removes the repository listing.
 
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of a Chef Infra Client run.
+
+   .. end_tag
+
 Properties
 =====================================================
 
@@ -164,6 +171,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_apt_update.rst
+++ b/chef_master/source/resource_apt_update.rst
@@ -11,7 +11,8 @@ Use the **apt_update** resource to manage APT repository updates on Debian and U
 
 Syntax
 =====================================================
-An **apt_update** resource block defines the update frequency for APT repositories:
+
+The apt_update resource has the following syntax:
 
 .. code-block:: ruby
 
@@ -26,8 +27,6 @@ where:
 * ``name`` is the name given to the resource block.
 * ``action`` identifies which steps Chef Infra Client will take to bring the node into the desired state.
 * ``frequency`` is the property available to this resource.
-
-
 
 Nameless
 =====================================================
@@ -61,8 +60,6 @@ The apt_update resource has the following actions:
 ``:update``
    Update the Apt repository at the start of a Chef Infra Client run.
 
-
-
 Properties
 =====================================================
 
@@ -72,8 +69,6 @@ The apt_update resource has the following properties:
    **Ruby Type:** Integer | **Default Value:** ``86400``
 
    Determines how frequently (in seconds) APT repository updates are made. Use this property when the ``:periodic`` action is specified.
-
-
 
 Common Resource Functionality
 =====================================================
@@ -111,6 +106,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_archive_file.rst
+++ b/chef_master/source/resource_archive_file.rst
@@ -9,6 +9,7 @@ Use the **archive_file** resource to extract archive files to disk. This resourc
 
 Syntax
 =====================================================
+
 The archive_file resource has the following syntax:
 
 .. code-block:: ruby
@@ -122,6 +123,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_build_essential.rst
+++ b/chef_master/source/resource_build_essential.rst
@@ -9,6 +9,7 @@ Use the **build_essential** resource to install the packages required for compil
 
 Syntax
 =====================================================
+
 The build_essential resource has the following syntax:
 
 .. code-block:: ruby
@@ -49,7 +50,7 @@ The build_essential resource has the following properties:
    **Ruby Type:** true, false | **Default Value:** ``false``
 
    Install the build essential packages at compile time.
-   
+
 Common Resource Functionality
 =====================================================
 
@@ -86,6 +87,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_cab_package.rst
+++ b/chef_master/source/resource_cab_package.rst
@@ -7,6 +7,7 @@ Use the **cab_package** resource to install or remove Microsoft Windows cabinet 
 
 Syntax
 =====================================================
+
 The cab_package resource has the following syntax:
 
 .. code-block:: ruby
@@ -81,6 +82,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_chocolatey_config.rst
+++ b/chef_master/source/resource_chocolatey_config.rst
@@ -9,6 +9,7 @@ Use the **chocolatey_config** resource to add or remove Chocolatey configuration
 
 Syntax
 =====================================================
+
 The chocolatey_config resource has the following syntax:
 
 .. code-block:: ruby
@@ -95,6 +96,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_chocolatey_feature.rst
+++ b/chef_master/source/resource_chocolatey_feature.rst
@@ -9,14 +9,14 @@ Use the **chocolatey_feature** resource to enable and disable Chocolatey feature
 
 Syntax
 =====================================================
+
 The chocolatey_feature resource has the following syntax:
 
 .. code-block:: ruby
 
   chocolatey_feature 'name' do
-    feature_name       String # default value: 'name' unless specified
-    feature_state      true, false # default value: false
-    action             Symbol # defaults to :enable if not specified
+    feature_name      String # default value: 'name' unless specified
+    action            Symbol # defaults to :enable if not specified
   end
 
 where:
@@ -24,7 +24,7 @@ where:
 * ``chocolatey_feature`` is the resource.
 * ``name`` is the name given to the resource block.
 * ``action`` identifies which steps Chef Infra Client will take to bring the node into the desired state.
-* ``feature_name`` and ``feature_state`` are the properties available to this resource.
+* ``feature_name`` is the property available to this resource.
 
 Actions
 =====================================================
@@ -90,6 +90,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_chocolatey_package.rst
+++ b/chef_master/source/resource_chocolatey_package.rst
@@ -47,8 +47,6 @@ where:
 * ``action`` identifies which steps Chef Infra Client will take to bring the node into the desired state.
 * ``options``, ``package_name``, ``returns``, ``source``, ``timeout``, and ``version`` are the properties available to this resource.
 
-
-
 Actions
 =====================================================
 
@@ -81,9 +79,9 @@ The chocolatey_package resource has the following actions:
 ``:upgrade``
    Install a package and/or ensure that a package is the latest version.
 
-
 Properties
 =====================================================
+
 The chocolatey_package resource has the following properties:
 
 ``options``
@@ -94,7 +92,7 @@ The chocolatey_package resource has the following properties:
 ``package_name``
    **Ruby Type:** String, Array
 
-   The name of the package. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
+   The name of the package. Default value: the name of the resource block.
 
 ``returns``
    **Ruby Type:** Integer, Array | **Default Value:** ``[0]``
@@ -121,9 +119,6 @@ The chocolatey_package resource has the following properties:
    **Ruby Type:** String, Array
 
    The version of a package to be installed or upgraded.
-
-
-
 
 Common Resource Functionality
 =====================================================
@@ -161,6 +156,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_chocolatey_source.rst
+++ b/chef_master/source/resource_chocolatey_source.rst
@@ -9,6 +9,7 @@ Use the **chocolatey_source** resource to add, remove, enable, or disable Chocol
 
 Syntax
 =====================================================
+
 The chocolatey_source resource has the following syntax:
 
 .. code-block:: ruby
@@ -133,6 +134,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_cron.rst
+++ b/chef_master/source/resource_cron.rst
@@ -79,7 +79,7 @@ The cron resource has the following actions:
 
    .. end_tag
 
-.. note:: Chef can only reliably manage crontab entries that it creates. To remove existing system entries we may use **execute** resource with a guard like:
+.. note:: Chef Infra Client can only reliably manage crontab entries that it creates. To remove existing system entries we may use **execute** resource with a guard like:
 
   .. code-block:: ruby
 
@@ -218,6 +218,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_cron_access.rst
+++ b/chef_master/source/resource_cron_access.rst
@@ -9,6 +9,7 @@ Use the **cron_access** resource to manage the /etc/cron.allow and /etc/cron.den
 
 Syntax
 =====================================================
+
 The cron_access resource has the following syntax:
 
 .. code-block:: ruby
@@ -52,7 +53,7 @@ The cron_access resource has the following properties:
    **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    An optional property to set the user name if it differs from the resource block's name.
-   
+
 Common Resource Functionality
 =====================================================
 
@@ -89,6 +90,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
@@ -201,7 +203,7 @@ The following properties can be used to define a guard that is evaluated during 
 .. end_tag
 
 Examples
-=====================================================
+==========================================
 
 The following examples demonstrate various approaches for using resources in recipes:
 

--- a/chef_master/source/resource_cron_d.rst
+++ b/chef_master/source/resource_cron_d.rst
@@ -152,7 +152,6 @@ The cron_d resource has the following properties:
 
    The hour at which the cron entry is to run (``0 - 23``).
 
-
 ``mailto``
    **Ruby Type:** String
 
@@ -239,6 +238,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_dmg_package.rst
+++ b/chef_master/source/resource_dmg_package.rst
@@ -9,6 +9,7 @@ Use the **dmg_package** resource to install a package from a ``.dmg`` file. The 
 
 Syntax
 =====================================================
+
 The dmg_package resource has the following syntax:
 
 .. code-block:: ruby
@@ -135,6 +136,7 @@ Chef resources include common properties, notifications, and resource guards.
 
 Common Properties
 -----------------------------------------------------
+
 .. tag resources_common_properties
 
 The following properties are common to every resource:
@@ -163,6 +165,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_dnf_package.rst
+++ b/chef_master/source/resource_dnf_package.rst
@@ -238,6 +238,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_dpkg_package.rst
+++ b/chef_master/source/resource_dpkg_package.rst
@@ -83,7 +83,6 @@ The dpkg_package resource has the following properties:
 
    An optional property to set the package name if it differs from the resource block's name.
 
-
 ``response_file``
    **Ruby Type:** String
 
@@ -108,7 +107,7 @@ The dpkg_package resource has the following properties:
    **Ruby Type:** String, Array
 
    The version of a package to be installed or upgraded.
-   
+
 Common Resource Functionality
 =====================================================
 
@@ -145,6 +144,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_execute.rst
+++ b/chef_master/source/resource_execute.rst
@@ -108,7 +108,6 @@ The execute resource has the following properties:
 
    The current working directory from which the command will be run.
 
-
 ``default_env``
    **Ruby Type:** true, false | **Default Value:** ``false``
 
@@ -172,7 +171,7 @@ The execute resource has the following properties:
 ``user``
    **Ruby Type:** String, Integer
 
-   The user name of the user identity with which to launch the new process. The user name may optionally be specifed with a domain, i.e. domainuser or user@my.dns.domain.com via Universal Principal Name (UPN)format. It can also be specified without a domain simply as user if the domain is instead specified using the domain attribute. On Windows only, if this property is specified, the password property must be specified.
+   The user name of the user identity with which to launch the new process. The user name may optionally be specifed with a domain, i.e. domainuser or user@my.dns.domain.com via Universal Principal Name (UPN)format. It can also be specified without a domain simply as user if the domain is instead specified using the domain property. On Windows only, if this property is specified, the password property must be specified.
 
 Common Resource Functionality
 =====================================================
@@ -210,6 +209,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_freebsd_package.rst
+++ b/chef_master/source/resource_freebsd_package.rst
@@ -29,14 +29,14 @@ The full syntax for all of the properties that are available to the **freebsd_pa
 
 .. code-block:: ruby
 
-   freebsd_package 'name' do
-     options                    String
-     package_name               String, Array
-     source                     String
-     timeout                    String, Integer
-     version                    String, Array
-     action                     Symbol # defaults to :install if not specified
-   end
+  freebsd_package 'name' do
+    options           String
+    package_name      String
+    source            String
+    timeout           String, Integer
+    version           String
+    action            Symbol # defaults to :install if not specified
+  end
 
 where:
 
@@ -71,18 +71,17 @@ The freebsd_package resource has the following properties:
 ``options``
    **Ruby Type:** String
 
-   One (or more) additional options that are passed to the command.
+   One (or more) additional command options that are passed to the command.
 
 ``package_name``
-   **Ruby Type:** String, Array
+   **Ruby Type:** String
 
-   The name of the package. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
+   An optional property to set the package name if it differs from the resource block's name.
 
 ``source``
    **Ruby Type:** String
 
-   Optional. The path to a package in the local file system.
-
+   The optional path to a package on the local file system.
 
 ``timeout``
    **Ruby Type:** String, Integer
@@ -90,7 +89,7 @@ The freebsd_package resource has the following properties:
    The amount of time (in seconds) to wait before timing out.
 
 ``version``
-   **Ruby Type:** String, Array
+   **Ruby Type:** String
 
    The version of a package to be installed or upgraded.
 
@@ -130,6 +129,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_group.rst
+++ b/chef_master/source/resource_group.rst
@@ -11,6 +11,7 @@ Use the **group** resource to manage a local group.
 
 Syntax
 =====================================================
+
 The group resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_homebrew_cask.rst
+++ b/chef_master/source/resource_homebrew_cask.rst
@@ -9,6 +9,7 @@ Use the **homebrew_cask** resource to install binaries distributed via the Homeb
 
 Syntax
 =====================================================
+
 The homebrew_cask resource has the following syntax:
 
 .. code-block:: ruby
@@ -113,6 +114,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_homebrew_package.rst
+++ b/chef_master/source/resource_homebrew_package.rst
@@ -32,10 +32,10 @@ The full syntax for all of the properties that are available to the **homebrew_p
    homebrew_package 'name' do
      homebrew_user              String, Integer
      options                    String
-     package_name               String, Array
+     package_name               String
      source                     String
      timeout                    String, Integer
-     version                    String, Array
+     version                    String
      action                     Symbol # defaults to :install if not specified
    end
 
@@ -43,7 +43,7 @@ where:
 
 * ``homebrew_package`` is the resource.
 * ``name`` is the name given to the resource block.
-* ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
+* ``action`` identifies which steps Chef Infra Client will take to bring the node into the desired state.
 * ``homebrew_user``, ``options``, ``package_name``, ``source``, ``timeout``, and ``version`` are the properties available to this resource.
 
 Actions
@@ -93,7 +93,7 @@ The homebrew_package resource has the following properties:
    One (or more) additional command options that are passed to the command.
 
 ``package_name``
-   **Ruby Type:** String, Array
+   **Ruby Type:** String
 
    An optional property to set the package name if it differs from the resource block's name.
 
@@ -108,7 +108,7 @@ The homebrew_package resource has the following properties:
    The amount of time (in seconds) to wait before timing out.
 
 ``version``
-   **Ruby Type:** String, Array
+   **Ruby Type:** String
 
    The version of a package to be installed or upgraded.
 

--- a/chef_master/source/resource_homebrew_tap.rst
+++ b/chef_master/source/resource_homebrew_tap.rst
@@ -9,6 +9,7 @@ Use the **homebrew_tap** resource to add additional formula repositories to the 
 
 Syntax
 =====================================================
+
 The homebrew_tap resource has the following syntax:
 
 .. code-block:: ruby
@@ -113,6 +114,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_hostname.rst
+++ b/chef_master/source/resource_hostname.rst
@@ -9,6 +9,7 @@ Use the **hostname** resource to set the system's hostname, configure hostname a
 
 Syntax
 =====================================================
+
 The hostname resource has the following syntax:
 
 .. code-block:: ruby
@@ -110,6 +111,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 
@@ -222,7 +224,7 @@ The following properties can be used to define a guard that is evaluated during 
 .. end_tag
 
 Examples
-=====================================================
+==========================================
 
 **Set the hostname**
 

--- a/chef_master/source/resource_http_request.rst
+++ b/chef_master/source/resource_http_request.rst
@@ -126,6 +126,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_ifconfig.rst
+++ b/chef_master/source/resource_ifconfig.rst
@@ -107,7 +107,7 @@ The ifconfig resource has the following properties:
 ``ethtool_opts``
    **Ruby Type:** String
 
-   Options to be passed to ethtool(8). For example: ``-A eth0 autoneg off rx off tx off``
+   Options to be passed to ethtool(8). For example: ``-A eth0 autoneg off rx off tx off``.
 
    *New in Chef Client 13.4.*
 
@@ -227,6 +227,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_kernel_module.rst
+++ b/chef_master/source/resource_kernel_module.rst
@@ -9,6 +9,7 @@ Use the **kernel_module** resource to manage kernel modules on Linux systems. Th
 
 Syntax
 =====================================================
+
 The kernel_module resource has the following syntax:
 
 .. code-block:: ruby
@@ -34,6 +35,11 @@ The kernel_module resource has the following actions:
 
 ``:blacklist``
    Blacklist a kernel module.
+
+``:disable``
+   Disable a kernel module
+
+**New in Chef Client 15.2.**
 
 ``:install``
    Default. Load kernel module, and ensure it loads on reboot.
@@ -110,6 +116,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_launchd.rst
+++ b/chef_master/source/resource_launchd.rst
@@ -9,6 +9,7 @@ Use the **launchd** resource to manage system-wide services (daemons) and per-us
 
 Syntax
 =====================================================
+
 The launchd resource has the following syntax:
 
 .. code-block:: ruby
@@ -74,11 +75,12 @@ where:
 
 * ``launchd`` is the resource.
 * ``name`` is the name given to the resource block.
-* ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
+* ``action`` identifies which steps Chef Infra Client will take to bring the node into the desired state.
 * ``abandon_process_group``, ``backup``, ``cookbook``, ``debug``, ``disabled``, ``enable_globbing``, ``enable_transactions``, ``environment_variables``, ``exit_timeout``, ``group``, ``hard_resource_limits``, ``inetd_compatibility``, ``init_groups``, ``keep_alive``, ``label``, ``launch_events``, ``launch_only_once``, ``ld_group``, ``limit_load_from_hosts``, ``limit_load_to_hosts``, ``limit_load_to_session_type``, ``low_priority_io``, ``mach_services``, ``mode``, ``nice``, ``on_demand``, ``owner``, ``path``, ``plist_hash``, ``process_type``, ``program``, ``program_arguments``, ``queue_directories``, ``root_directory``, ``run_at_load``, ``session_type``, ``sockets``, ``soft_resource_limits``, ``source``, ``standard_error_path``, ``standard_in_path``, ``standard_out_path``, ``start_calendar_interval``, ``start_interval``, ``start_on_mount``, ``throttle_interval``, ``time_out``, ``type``, ``umask``, ``username``, ``wait_for_debugger``, ``watch_paths``, and ``working_directory`` are the properties available to this resource.
 
 Actions
 =====================================================
+
 The launchd resource has the following actions:
 
 ``:create``
@@ -105,8 +107,6 @@ The launchd resource has the following actions:
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of a Chef Infra Client run.
 
    .. end_tag
-
-
 
 Properties
 =====================================================
@@ -191,7 +191,7 @@ The following resource properties may be used to define keys in the XML property
    Sets the log mask to ``LOG_DEBUG`` for this job.
 
 ``disabled``
-   **Ruby Type:** true, false| **Default Value:** ``false``
+   **Ruby Type:** true, false | **Default Value:** ``false``
 
    Hints to ``launchctl`` to not submit this job to launchd.
 

--- a/chef_master/source/resource_link.rst
+++ b/chef_master/source/resource_link.rst
@@ -79,7 +79,7 @@ The link resource has the following properties:
 ``group``
    **Ruby Type:** String, Integer
 
-   A string or ID that identifies the group associated with a symbolic link.
+   A group name or ID number that identifies the group associated with a symbolic link.
 
 ``link_type``
    **Ruby Type:** String, Symbol | **Default Value:** ``:symbolic``
@@ -148,6 +148,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_locale.rst
+++ b/chef_master/source/resource_locale.rst
@@ -9,6 +9,7 @@ Use the **locale** resource to set the system's locale.
 
 Syntax
 =====================================================
+
 The locale resource has the following syntax:
 
 .. code-block:: ruby
@@ -104,6 +105,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_log.rst
+++ b/chef_master/source/resource_log.rst
@@ -70,7 +70,7 @@ The log resource has the following properties:
 ``level``
    **Ruby Type:** Symbol | **Default Value:** ``:info``
 
-   The logging level for displaying this message.. Options (in order of priority): ``:debug``, ``:info``, ``:warn``, ``:error``, and ``:fatal``.
+   The logging level for displaying this message. Options (in order of priority): ``:debug``, ``:info``, ``:warn``, ``:error``, and ``:fatal``.
 
 ``message``
    **Ruby Type:** String | **Default Value:** ``The resource block's name``

--- a/chef_master/source/resource_macos_userdefaults.rst
+++ b/chef_master/source/resource_macos_userdefaults.rst
@@ -9,6 +9,7 @@ Use the **macos_userdefaults** resource to manage the macOS `user defaults <http
 
 Syntax
 =====================================================
+
 The macos_userdefaults resource has the following syntax:
 
 .. code-block:: ruby
@@ -65,7 +66,6 @@ The macos_userdefaults resource has the following properties:
    **Ruby Type:** String
 
    The preference key.
-   
 
 ``sudo``
    **Ruby Type:** true, false | **Default Value:** ``false``

--- a/chef_master/source/resource_macports_package.rst
+++ b/chef_master/source/resource_macports_package.rst
@@ -82,13 +82,12 @@ The macports_package resource has the following properties:
 ``package_name``
    **Ruby Type:** String, Array
 
-   The name of the package. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
-
+   An optional property to set the package name if it differs from the resource block's name.
 
 ``source``
    **Ruby Type:** String
 
-   Optional. The path to a package in the local file system.
+   The optional path to a package on the local file system.
 
 ``timeout``
    **Ruby Type:** String, Integer

--- a/chef_master/source/resource_mdadm.rst
+++ b/chef_master/source/resource_mdadm.rst
@@ -7,6 +7,7 @@ Use the **mdadm** resource to manage RAID devices in a Linux environment using t
 
 Syntax
 =====================================================
+
 The mdadm resource has the following syntax:
 
 .. code-block:: ruby
@@ -85,13 +86,10 @@ The mdadm resource has the following properties:
 
    The superblock type for RAID metadata.
 
-
 ``raid_device``
    **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
-   Optional property to specify the name of the RAID device if it differs from the resource block's name.
-
-
+   An optional property to specify the name of the RAID device if it differs from the resource block's name.
 
 Common Resource Functionality
 =====================================================
@@ -242,7 +240,7 @@ The following properties can be used to define a guard that is evaluated during 
 .. end_tag
 
 Examples
-=====================================================
+==========================================
 The following examples demonstrate various approaches for using resources in recipes:
 
 **Create and assemble a RAID 0 array**

--- a/chef_master/source/resource_mount.rst
+++ b/chef_master/source/resource_mount.rst
@@ -7,6 +7,7 @@ Use the **mount** resource to manage a mounted file system.
 
 Syntax
 =====================================================
+
 The mount resource has the following syntax:
 
 .. code-block:: ruby
@@ -82,7 +83,6 @@ The mount resource has the following properties:
 
    The type of device: :device, :label, or :uuid
 
-
 ``domain``
    **Ruby Type:** String
 
@@ -103,7 +103,6 @@ The mount resource has the following properties:
 
    Solaris only: The fsck device.
 
-
 ``fstype``
    **Ruby Type:** String | **Default Value:** ``"auto"``
 
@@ -113,7 +112,6 @@ The mount resource has the following properties:
    **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    The directory (or path) in which the device is to be mounted. Defaults to the name of the resource block if not provided.
-
 
 ``options``
    **Ruby Type:** Array, String | **Default Value:** ``["defaults"]``
@@ -289,7 +287,7 @@ The following properties can be used to define a guard that is evaluated during 
 .. end_tag
 
 Examples
-=====================================================
+==========================================
 The following examples demonstrate various approaches for using resources in recipes:
 
 **Mount a labeled file system**

--- a/chef_master/source/resource_msu_package.rst
+++ b/chef_master/source/resource_msu_package.rst
@@ -9,11 +9,13 @@ Use the **msu_package** resource to install Microsoft Update(MSU) packages on Mi
 
 Syntax
 =====================================================
+
 The msu_package resource has the following syntax:
 
 .. code-block:: ruby
 
    msu_package 'name' do
+     package_name               String
      source                     String
      action                     Symbol
    end
@@ -45,6 +47,13 @@ The msu_package resource has the following actions:
 :remove
    Uninstalls the MSU package from its location on disk.
 
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of a Chef Infra Client run.
+
+   .. end_tag
+
 Properties
 =====================================================
 
@@ -54,6 +63,12 @@ The msu_package resource has the following properties:
    **Ruby Type:** String
 
    SHA-256 digest used to verify the checksum of the downloaded MSU package.
+
+
+``package_name``
+   **Ruby Type:** String, Array
+
+   An optional property to set the package name if it differs from the resource block's name.
 
 ``source``
    **Ruby Type:** String
@@ -209,7 +224,7 @@ The following properties can be used to define a guard that is evaluated during 
 .. end_tag
 
 Examples
-=====================================================
+==========================================
 
 **Using local path in source**
 

--- a/chef_master/source/resource_ohai.rst
+++ b/chef_master/source/resource_ohai.rst
@@ -7,6 +7,7 @@ Use the **ohai** resource to reload the Ohai configuration on a node. This allow
 
 Syntax
 =====================================================
+
 The ohai resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_ohai_hint.rst
+++ b/chef_master/source/resource_ohai_hint.rst
@@ -9,6 +9,7 @@ Use the **ohai_hint** resource to aid in configuration detection by passing hint
 
 Syntax
 =====================================================
+
 The ohai_hint resource has the following syntax:
 
 .. code-block:: ruby
@@ -39,7 +40,11 @@ The ohai_hint resource has the following actions:
    Delete an Ohai hint file.
 
 ``:nothing``
-   Define this resource block to do nothing until notified by another resource to take action. When this resource is notified, the resource block is either run immediately or it is queued up to be run at the end of a Chef Infra Client run.
+   .. tag resources_common_actions_nothing
+
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of a Chef Infra Client run.
+
+   .. end_tag
 
 Properties
 =====================================================
@@ -210,7 +215,7 @@ The following properties can be used to define a guard that is evaluated during 
 .. end_tag
 
 Examples
-=====================================================
+==========================================
 
 **Create a hint file**
 

--- a/chef_master/source/resource_openbsd_package.rst
+++ b/chef_master/source/resource_openbsd_package.rst
@@ -29,26 +29,25 @@ The full syntax for all of the properties that are available to the **openbsd_pa
 
 .. code-block:: ruby
 
-   openbsd_package 'name' do
-     options                    String
-     package_name               String, Array # defaults to 'name' if not specified
-     source                     String
-     timeout                    String, Integer
-     version                    String, Array
-     action                     Symbol # defaults to :install if not specified
-   end
+  openbsd_package 'name' do
+    options           String
+    package_name      String
+    source            String
+    timeout           String, Integer
+    version           String, Array
+    action            Symbol # defaults to :install if not specified
+  end
 
 where:
 
 * ``openbsd_package`` is the resource.
 * ``name`` is the name given to the resource block.
-* ``action`` identifies which steps Chef Infra Client will take to bring the node into the desired state
-* ``options``, ``package_name``, ``source``, ``timeout``, and ``version`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
-
-
+* ``action`` identifies which steps Chef Infra Client will take to bring the node into the desired state.
+* ``options``, ``package_name``, ``source``, ``timeout``, and ``version`` are the properties available to this resource.
 
 Actions
 =====================================================
+
 The openbsd_package resource has the following actions:
 
 ``:install``
@@ -64,8 +63,6 @@ The openbsd_package resource has the following actions:
 ``:remove``
    Remove a package.
 
-
-
 Properties
 =====================================================
 
@@ -79,61 +76,12 @@ The openbsd_package resource has the following properties:
 ``package_name``
    **Ruby Type:** String, Array
 
-   The name of the package. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
+   An optional property to set the package name if it differs from the resource block's name.
 
 ``source``
    **Ruby Type:** String
 
-   Optional. The path to a package in the local file system.
-
-``subscribes``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_subscribes
-
-   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
-
-   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
-
-   .. code-block:: ruby
-
-    file '/etc/nginx/ssl/example.crt' do
-      mode '0600'
-      owner 'root'
-    end
-
-    service 'nginx' do
-      subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
-    end
-
-   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during a Chef Infra Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of a Chef Infra Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
-
-   The syntax for ``subscribes`` is:
-
-   .. code-block:: ruby
-
-      subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
+   The optional path to a package on the local file system.
 
 ``timeout``
    **Ruby Type:** String, Integer
@@ -294,7 +242,7 @@ The following properties can be used to define a guard that is evaluated during 
 .. end_tag
 
 Examples
-=====================================================
+==========================================
 The following examples demonstrate various approaches for using resources in recipes:
 
 **Install a package**

--- a/chef_master/source/resource_openssl_dhparam.rst
+++ b/chef_master/source/resource_openssl_dhparam.rst
@@ -9,6 +9,7 @@ Use the **openssl_dhparam** resource to generate ``dhparam.pem`` files. If a val
 
 Syntax
 =====================================================
+
 The openssl_dhparam resource has the following syntax:
 
 .. code-block:: ruby
@@ -69,7 +70,6 @@ The openssl_dhparam resource has the following properties:
    **Ruby Type:** Integer, String | **Default Value:** ``0640``
 
    The permission mode applied to all files created by the resource.
-
 
 ``owner``
    **Ruby Type:** String, Integer
@@ -230,7 +230,7 @@ The following properties can be used to define a guard that is evaluated during 
 .. end_tag
 
 Examples
-=====================================================
+==========================================
 
 **Create a dhparam file**
 

--- a/chef_master/source/resource_openssl_ec_private_key.rst
+++ b/chef_master/source/resource_openssl_ec_private_key.rst
@@ -9,6 +9,7 @@ Use the **openssl_ec_private_key** resource to generate an elliptic curve (EC) p
 
 Syntax
 =====================================================
+
 The openssl_ec_private_key resource has the following syntax:
 
 .. code-block:: ruby
@@ -81,7 +82,6 @@ The openssl_ec_private_key resource has the following properties:
    **Ruby Type:** Integer, String | **Default Value:** ``"0600"``
 
    The permission mode applied to all files created by the resource.
-
 
 ``owner``
    **Ruby Type:** String, Integer

--- a/chef_master/source/resource_openssl_ec_public_key.rst
+++ b/chef_master/source/resource_openssl_ec_public_key.rst
@@ -9,6 +9,7 @@ Use the **openssl_ec_public_key** resource to generate elliptic curve (EC) publi
 
 Syntax
 =====================================================
+
 The openssl_ec_public_key resource has the following syntax:
 
 .. code-block:: ruby
@@ -234,9 +235,8 @@ The following properties can be used to define a guard that is evaluated during 
 
 .. end_tag
 
-
 Examples
-=====================================================
+==========================================
 
 **Create a public key from a private key file**
 

--- a/chef_master/source/resource_openssl_rsa_private_key.rst
+++ b/chef_master/source/resource_openssl_rsa_private_key.rst
@@ -11,6 +11,7 @@ Use the **openssl_rsa_private_key** resource to generate RSA private key files. 
 
 Syntax
 =====================================================
+
 The openssl_rsa_private_key resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_openssl_rsa_public_key.rst
+++ b/chef_master/source/resource_openssl_rsa_public_key.rst
@@ -9,6 +9,7 @@ Use the **openssl_rsa_public_key** resource to generate RSA public key files for
 
 Syntax
 =====================================================
+
 The openssl_rsa_public_key resource has the following syntax:
 
 .. code-block:: ruby
@@ -234,9 +235,8 @@ The following properties can be used to define a guard that is evaluated during 
 
 .. end_tag
 
-
 Examples
-=====================================================
+==========================================
 **Create a public key from a private key file**
 
 .. code-block:: ruby

--- a/chef_master/source/resource_openssl_x509_certificate.rst
+++ b/chef_master/source/resource_openssl_x509_certificate.rst
@@ -9,6 +9,7 @@ Use the **openssl_x509_certificate** resource to generate signed or self-signed,
 
 Syntax
 =====================================================
+
 The openssl_x509_certificate resource has the following syntax:
 
 .. code-block:: ruby
@@ -179,7 +180,7 @@ The openssl_x509_certificate resource has the following properties:
 
 ``subject_alt_name``
    **Ruby Type:** Array
-   
+
    Array of Subject Alternative Name entries, in format DNS:example.com or IP:1.2.3.4.
 
 Common Resource Functionality
@@ -330,9 +331,8 @@ The following properties can be used to define a guard that is evaluated during 
 
 .. end_tag
 
-
 Examples
-=====================================================
+==========================================
 
 **Create a simple self-signed certificate file**
 

--- a/chef_master/source/resource_openssl_x509_crl.rst
+++ b/chef_master/source/resource_openssl_x509_crl.rst
@@ -9,6 +9,7 @@ Use the **openssl_x509_crl** resource to generate PEM-formatted x509 certificate
 
 Syntax
 =====================================================
+
 The openssl_x509_crl resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_openssl_x509_request.rst
+++ b/chef_master/source/resource_openssl_x509_request.rst
@@ -9,6 +9,7 @@ Use the **openssl_x509_request** resource to generate PEM-formatted x509 certifi
 
 Syntax
 =====================================================
+
 The openssl_x509_request resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_osx_profile.rst
+++ b/chef_master/source/resource_osx_profile.rst
@@ -11,6 +11,7 @@ Use the **osx_profile** resource to manage configuration profiles (``.mobileconf
 
 Syntax
 =====================================================
+
 The osx_profile resource has the following syntax:
 
 .. code-block:: ruby
@@ -75,8 +76,6 @@ The osx_profile resource has the following properties:
    **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
    Use to specify the name of the profile, if different from the name of the resource block.
-
-
 
 Common Resource Functionality
 =====================================================
@@ -226,9 +225,8 @@ The following properties can be used to define a guard that is evaluated during 
 
 .. end_tag
 
-
 Examples
-=====================================================
+==========================================
 
 The following examples demonstrate various approaches for using resources in recipes:
 

--- a/chef_master/source/resource_pacman_package.rst
+++ b/chef_master/source/resource_pacman_package.rst
@@ -31,7 +31,7 @@ The full syntax for all of the properties that are available to the **pacman_pac
 
   pacman_package 'name' do
     options           String
-    package_name      String, Array
+    package_name      String
     source            String
     timeout           String, Integer
     version           String, Array
@@ -80,7 +80,7 @@ The pacman_package resource has the following properties:
    One (or more) additional command options that are passed to the command.
 
 ``package_name``
-   **Ruby Type:** String, Array
+   **Ruby Type:** String
 
    An optional property to set the package name if it differs from the resource block's name.
 

--- a/chef_master/source/resource_paludis_package.rst
+++ b/chef_master/source/resource_paludis_package.rst
@@ -31,10 +31,10 @@ The full syntax for all of the properties that are available to the **paludis_pa
 
   paludis_package 'name' do
     options           String
-    package_name      String, Array
+    package_name      String
     source            String
     timeout           Integer # default value: 3600
-    version           String, Array
+    version           String
     action            Symbol # defaults to :install if not specified
   end
 
@@ -45,10 +45,9 @@ where:
 * ``action`` identifies which steps Chef Infra Client will take to bring the node into the desired state.
 * ``options``, ``package_name``, ``source``, ``timeout``, and ``version`` are the properties available to this resource.
 
-
-
 Actions
 =====================================================
+
 The paludis_package resource has the following actions:
 
 ``:install``
@@ -79,7 +78,7 @@ The paludis_package resource has the following properties:
    One (or more) additional command options that are passed to the command.
 
 ``package_name``
-   **Ruby Type:** String, Array
+   **Ruby Type:** String
 
    An optional property to set the package name if it differs from the resource block's name.
 
@@ -94,7 +93,7 @@ The paludis_package resource has the following properties:
    The amount of time (in seconds) to wait before timing out.
 
 ``version``
-   **Ruby Type:** String, Array
+   **Ruby Type:** String
 
    The version of a package to be installed or upgraded.
 

--- a/chef_master/source/resource_portage_package.rst
+++ b/chef_master/source/resource_portage_package.rst
@@ -71,133 +71,184 @@ The portage_package resource has the following actions:
 
 Properties
 =====================================================
-This resource has the following properties:
 
-``ignore_failure``
-   **Ruby Type:** true, false | **Default Value:** ``false``
-
-   Continue running a recipe if a resource fails for any reason.
-
-``notifies``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_notifies
-
-   A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during a Chef Infra Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of a Chef Infra Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_notifies_syntax
-
-   The syntax for ``notifies`` is:
-
-   .. code-block:: ruby
-
-     notifies :action, 'resource[name]', :timer
-
-   .. end_tag
+The portage_package resource has the following properties:
 
 ``options``
    **Ruby Type:** String
 
-   One (or more) additional options that are passed to the command.
+   One (or more) additional command options that are passed to the command.
 
 ``package_name``
    **Ruby Type:** String, Array
 
-   The name of the package. Default value: the ``name`` of the resource block. See "Syntax" section above for more information.
-
-``retries``
-   **Ruby Type:** Integer | **Default Value:** ``0``
-
-   The number of attempts to catch exceptions and retry the resource.
-
-``retry_delay``
-   **Ruby Type:** Integer | **Default Value:** ``2``
-
-   The retry delay (in seconds).
+   An optional property to set the package name if it differs from the resource block's name.
 
 ``source``
    **Ruby Type:** String
 
-   Optional. The path to a package in the local file system.
-
-``subscribes``
-   **Ruby Type:** Symbol, 'Chef::Resource[String]'
-
-   .. tag resources_common_notification_subscribes
-
-   A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
-
-   Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
-
-   .. code-block:: ruby
-
-    file '/etc/nginx/ssl/example.crt' do
-      mode '0600'
-      owner 'root'
-    end
-
-    service 'nginx' do
-      subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
-    end
-
-   In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
-
-   .. end_tag
-
-   .. tag resources_common_notification_timers
-
-   A timer specifies the point during a Chef Infra Client run at which a notification is run. The following timers are available:
-
-   ``:before``
-      Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-   ``:delayed``
-      Default. Specifies that a notification should be queued up, and then executed at the end of a Chef Infra Client run.
-
-   ``:immediate``, ``:immediately``
-      Specifies that a notification should be run immediately, per resource notified.
-
-   .. end_tag
-
-   .. tag resources_common_notification_subscribes_syntax
-
-   The syntax for ``subscribes`` is:
-
-   .. code-block:: ruby
-
-      subscribes :action, 'resource[name]', :timer
-
-   .. end_tag
+   The optional path to a package on the local file system.
 
 ``timeout``
-   **Ruby Type:** String, Integer
+   **Ruby Type:** String, Integer | **Default Value:** ``3600``
 
    The amount of time (in seconds) to wait before timing out.
 
 ``version``
-   **Ruby Type:** String, Array
+   **Ruby Type:** String
 
    The version of a package to be installed or upgraded.
 
-Examples
+Common Resource Functionality
 =====================================================
+
+Chef resources include common properties, notifications, and resource guards.
+
+Common Properties
+-----------------------------------------------------
+
+.. tag resources_common_properties
+
+The following properties are common to every resource:
+
+``ignore_failure``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Continue running a recipe if a resource fails for any reason.
+
+``retries``
+  **Ruby Type:** Integer | **Default Value:** ``0``
+
+  The number of attempts to catch exceptions and retry the resource.
+
+``retry_delay``
+  **Ruby Type:** Integer | **Default Value:** ``2``
+
+  The retry delay (in seconds).
+
+``sensitive``
+  **Ruby Type:** true, false | **Default Value:** ``false``
+
+  Ensure that sensitive resource data is not logged by Chef Infra Client.
+
+.. end_tag
+
+Notifications
+-----------------------------------------------------
+
+``notifies``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+  .. tag resources_common_notification_notifies
+
+  A resource may notify another resource to take action when its state changes. Specify a ``'resource[name]'``, the ``:action`` that resource should take, and then the ``:timer`` for that action. A resource may notify more than one resource; use a ``notifies`` statement for each resource to be notified.
+
+  .. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during a Chef Infra Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of a Chef Infra Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_notifies_syntax
+
+The syntax for ``notifies`` is:
+
+.. code-block:: ruby
+
+  notifies :action, 'resource[name]', :timer
+
+.. end_tag
+
+``subscribes``
+  **Ruby Type:** Symbol, 'Chef::Resource[String]'
+
+.. tag resources_common_notification_subscribes
+
+A resource may listen to another resource, and then take action if the state of the resource being listened to changes. Specify a ``'resource[name]'``, the ``:action`` to be taken, and then the ``:timer`` for that action.
+
+Note that ``subscribes`` does not apply the specified action to the resource that it listens to - for example:
+
+.. code-block:: ruby
+
+ file '/etc/nginx/ssl/example.crt' do
+   mode '0600'
+   owner 'root'
+ end
+
+ service 'nginx' do
+   subscribes :reload, 'file[/etc/nginx/ssl/example.crt]', :immediately
+ end
+
+In this case the ``subscribes`` property reloads the ``nginx`` service whenever its certificate file, located under ``/etc/nginx/ssl/example.crt``, is updated. ``subscribes`` does not make any changes to the certificate file itself, it merely listens for a change to the file, and executes the ``:reload`` action for its resource (in this example ``nginx``) when a change is detected.
+
+.. end_tag
+
+.. tag resources_common_notification_timers
+
+A timer specifies the point during a Chef Infra Client run at which a notification is run. The following timers are available:
+
+``:before``
+   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
+
+``:delayed``
+   Default. Specifies that a notification should be queued up, and then executed at the end of a Chef Infra Client run.
+
+``:immediate``, ``:immediately``
+   Specifies that a notification should be run immediately, per resource notified.
+
+.. end_tag
+
+.. tag resources_common_notification_subscribes_syntax
+
+The syntax for ``subscribes`` is:
+
+.. code-block:: ruby
+
+   subscribes :action, 'resource[name]', :timer
+
+.. end_tag
+
+Guards
+-----------------------------------------------------
+
+.. tag resources_common_guards
+
+A guard property can be used to evaluate the state of a node during the execution phase of a Chef Infra Client run. Based on the results of this evaluation, a guard property is then used to tell Chef Infra Client if it should continue executing a resource. A guard property accepts either a string value or a Ruby block value:
+
+* A string is executed as a shell command. If the command returns ``0``, the guard is applied. If the command returns any other value, then the guard property is not applied. String guards in a **powershell_script** run Windows PowerShell commands and may return ``true`` in addition to ``0``.
+* A block is executed as Ruby code that must return either ``true`` or ``false``. If the block returns ``true``, the guard property is applied. If the block returns ``false``, the guard property is not applied.
+
+A guard property is useful for ensuring that a resource is idempotent by allowing that resource to test for the desired state as it is being executed, and then if the desired state is present, for Chef Infra Client to do nothing.
+
+.. end_tag
+
+**Properties**
+
+.. tag resources_common_guards_properties
+
+The following properties can be used to define a guard that is evaluated during the execution phase of a Chef Infra Client run:
+
+``not_if``
+  Prevent a resource from executing when the condition returns ``true``.
+
+``only_if``
+  Allow a resource to execute only if the condition returns ``true``.
+
+.. end_tag
+
+Examples
+==========================================
 The following examples demonstrate various approaches for using resources in recipes:
 
 **Install a package**

--- a/chef_master/source/resource_powershell_package.rst
+++ b/chef_master/source/resource_powershell_package.rst
@@ -22,6 +22,7 @@ The powershell_package resource has the following syntax:
 .. code-block:: ruby
 
   powershell_package 'name' do
+    options                   String, Array
     package_name              String, Array
     skip_publisher_check      true, false # default value: false
     source                    String
@@ -35,7 +36,7 @@ where:
 * ``powershell_package`` is the resource.
 * ``name`` is the name given to the resource block.
 * ``action`` identifies which steps Chef Infra Client will take to bring the node into the desired state.
-* ``package_name``, ``skip_publisher_check``, ``source``, ``timeout``, and ``version`` are the properties available to this resource.
+* ``options``, ``package_name``, ``skip_publisher_check``, ``source``, ``timeout``, and ``version`` are the properties available to this resource.
 
 Actions
 =====================================================
@@ -52,6 +53,11 @@ Properties
 =====================================================
 
 The powershell_package resource has the following properties:
+
+``options``
+   **Ruby Type:** String, Array
+
+   One (or more) additional command options that are passed to the command.
 
 ``package_name``
    **Ruby Type:** String, Array
@@ -76,7 +82,6 @@ The powershell_package resource has the following properties:
    **Ruby Type:** String, Integer
 
    The amount of time (in seconds) to wait before timing out.
-
 
 ``version``
    **Ruby Type:** String, Array
@@ -119,6 +124,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_powershell_package_source.rst
+++ b/chef_master/source/resource_powershell_package_source.rst
@@ -9,6 +9,7 @@ Use the **powershell_package_source** resource to register a PowerShell package 
 
 Syntax
 =====================================================
+
 The powershell_package_source resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_powershell_script.rst
+++ b/chef_master/source/resource_powershell_script.rst
@@ -59,7 +59,7 @@ where:
 * ``powershell_script`` is the resource.
 * ``name`` is the name given to the resource block.
 * ``command`` is the command to be run and ``cwd`` is the location from which the command is run.
-* ``action`` identifies the steps Chef Infra Client will take to bring the node into the desired state.
+* ``action`` identifies which steps Chef Infra Client will take to bring the node into the desired state.
 * ``architecture``, ``code``, ``command``, ``convert_boolean_return``, ``creates``, ``cwd``, ``environment``, ``flags``, ``group``, ``guard_interpreter``, ``interpreter``, ``returns``, ``sensitive``, ``timeout``, ``user``, ``password``, ``domain`` and ``elevated`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
 .. end_tag

--- a/chef_master/source/resource_python.rst
+++ b/chef_master/source/resource_python.rst
@@ -13,6 +13,7 @@ Use the **python** resource to execute scripts using the Python interpreter. Thi
 
 Syntax
 =====================================================
+
 The python resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_reboot.rst
+++ b/chef_master/source/resource_reboot.rst
@@ -11,6 +11,7 @@ Use the **reboot** resource to reboot a node, a necessary step with some install
 
 Syntax
 =====================================================
+
 The reboot resource has the following syntax:
 
 .. code-block:: ruby
@@ -63,7 +64,6 @@ The reboot resource has the following properties:
    **Ruby Type:** String | **Default Value:** ``"Reboot by Chef Infra Client"``
 
    A string that describes the reboot action.
-
 
 Common Resource Functionality
 =====================================================

--- a/chef_master/source/resource_registry_key.rst
+++ b/chef_master/source/resource_registry_key.rst
@@ -49,7 +49,7 @@ Use multiple registry key entries with key values that are based on node attribu
      action :create
    end
 
-The full syntax for all of the properties that are available to the **registry_key** resource is:
+The registry_key resource has the following syntax:
 
 .. code-block:: ruby
 

--- a/chef_master/source/resource_rhsm_errata.rst
+++ b/chef_master/source/resource_rhsm_errata.rst
@@ -9,6 +9,7 @@ Use the **rhsm_errata** resource to install packages associated with a given Red
 
 Syntax
 =====================================================
+
 The rhsm_errata resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_rhsm_errata_level.rst
+++ b/chef_master/source/resource_rhsm_errata_level.rst
@@ -11,6 +11,7 @@ The available errata levels are: ``critical``, ``moderate``, ``important``, and 
 
 Syntax
 =====================================================
+
 The rhsm_errata_level resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_rhsm_register.rst
+++ b/chef_master/source/resource_rhsm_register.rst
@@ -9,6 +9,7 @@ Use the **rhsm_register** resource to register a node with the Red Hat Subscript
 
 Syntax
 =====================================================
+
 The rhsm_register resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_rhsm_repo.rst
+++ b/chef_master/source/resource_rhsm_repo.rst
@@ -9,6 +9,7 @@ Use the **rhsm_repo** resource to enable or disable Red Hat Subscription Manager
 
 Syntax
 =====================================================
+
 The rhsm_repo resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_rhsm_subscription.rst
+++ b/chef_master/source/resource_rhsm_subscription.rst
@@ -9,6 +9,7 @@ Use the **rhsm_subscription** resource to add or remove Red Hat Subscription Man
 
 Syntax
 =====================================================
+
 The rhsm_subscription resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_rpm_package.rst
+++ b/chef_master/source/resource_rpm_package.rst
@@ -102,7 +102,6 @@ The rpm_package resource has the following properties:
 
    The version of a package to be installed or upgraded.
 
-
 Common Resource Functionality
 =====================================================
 

--- a/chef_master/source/resource_ruby_block.rst
+++ b/chef_master/source/resource_ruby_block.rst
@@ -37,7 +37,7 @@ where:
 * ``ruby_block`` is the resource.
 * ``name`` is the name given to the resource block.
 * ``block`` is the block of Ruby code to be executed.
-* ``action`` identifies the steps Chef Infra Client will take to bring the node into the desired state
+* ``action`` identifies which steps Chef Infra Client will take to bring the node into the desired state.
 * ``block`` and ``block_name`` are properties of this resource, with the Ruby type shown. See "Properties" section below for more information about all of the properties that may be used with this resource.
 
 Actions

--- a/chef_master/source/resource_script.rst
+++ b/chef_master/source/resource_script.rst
@@ -104,7 +104,8 @@ The script resource has the following actions:
 
 Properties
 =====================================================
-This resource has the following attributes:
+
+The script resource has the following properties:
 
 ``code``
    **Ruby Type:** String
@@ -119,7 +120,7 @@ This resource has the following attributes:
 ``cwd``
    **Ruby Type:** String
 
-   The current working directory.
+   The current working directory from which the command will be run.
 
 ``environment``
    **Ruby Type:** Hash

--- a/chef_master/source/resource_service.rst
+++ b/chef_master/source/resource_service.rst
@@ -81,7 +81,7 @@ The service resource has the following actions:
    This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of a Chef Infra Client run.
 
    .. end_tag
-   
+
 Properties
 =====================================================
 
@@ -148,7 +148,7 @@ The service resource has the following properties:
    The command used to stop a service.
 
 ``supports``
-   **Ruby Type:** Hash
+   **Ruby Type:** Hash | **Default Value:** ``{"restart" => nil, "reload" => nil, "status" => nil}``
 
    A list of properties that controls how Chef Infra Client is to attempt to manage a service: ``:restart``, ``:reload``, ``:status``. For ``:restart``, the init script or other service provider can use a restart command; if ``:restart`` is not specified, Chef Infra Client attempts to stop and then start a service. For ``:reload``, the init script or other service provider can use a reload command. For ``:status``, the init script or other service provider can use a status command to determine if the service is running; if ``:status`` is not specified, Chef Infra Client attempts to match the ``service_name`` against the process table as a regular expression, unless a pattern is specified as a parameter property. Default value: ``{ restart: false, reload: false, status: false }`` for all platforms (except for the Red Hat platform family, which defaults to ``{ restart: false, reload: false, status: true }``.)
 

--- a/chef_master/source/resource_smartos_package.rst
+++ b/chef_master/source/resource_smartos_package.rst
@@ -42,7 +42,7 @@ where:
 
 * ``smartos_package`` is the resource.
 * ``name`` is the name given to the resource block.
-* ``action`` identifies which steps the chef-client will take to bring the node into the desired state.
+* ``action`` identifies which steps Chef Infra Client will take to bring the node into the desired state.
 * ``options``, ``package_name``, ``source``, ``timeout``, and ``version`` are the properties available to this resource.
 
 Actions

--- a/chef_master/source/resource_snap_package.rst
+++ b/chef_master/source/resource_snap_package.rst
@@ -5,8 +5,11 @@ snap_package resource
 
 Use the **snap_package** resource to manage snap packages on Debian and Ubuntu platforms.
 
+**New in Chef Infra Client 15.0.**
+
 Syntax
 =====================================================
+
 The snap_package resource has the following syntax:
 
 .. code-block:: ruby
@@ -132,6 +135,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_solaris_package.rst
+++ b/chef_master/source/resource_solaris_package.rst
@@ -79,6 +79,11 @@ The solaris_package resource has the following properties:
 
    An optional property to set the package name if it differs from the resource block's name.
 
+``source``
+   **Ruby Type:** String
+
+   The optional path to a package on the local file system.
+
 ``timeout``
    **Ruby Type:** String, Integer
 

--- a/chef_master/source/resource_ssh_known_hosts_entry.rst
+++ b/chef_master/source/resource_ssh_known_hosts_entry.rst
@@ -9,6 +9,7 @@ Use the **ssh_known_hosts_entry** resource to add an entry for the specified hos
 
 Syntax
 =====================================================
+
 The ssh_known_hosts_entry resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_subversion.rst
+++ b/chef_master/source/resource_subversion.rst
@@ -9,6 +9,7 @@ Use the **subversion** resource to manage source control resources that exist in
 
 Syntax
 =====================================================
+
 The subversion resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_sudo.rst
+++ b/chef_master/source/resource_sudo.rst
@@ -9,6 +9,7 @@ Use the **sudo** resource to add or remove individual sudo entries using ``sudoe
 
 Syntax
 =====================================================
+
 The sudo resource has the following syntax:
 
 .. code-block:: ruby
@@ -70,12 +71,10 @@ The sudo resource has the following properties:
 
    Command aliases that can be used as allowed commands later in the configuration.
 
-
 ``commands``
    **Ruby Type:** Array | **Default Value:** ``["ALL"]``
 
    An array of commands this sudoer can execute.
-
 
 ``config_prefix``
    **Ruby Type:** String | **Default Value:** ``Prefix values based on the node's platform``
@@ -122,7 +121,6 @@ The sudo resource has the following properties:
 
    Allow sudo to be run without specifying a password.
 
-
 ``runas``
    **Ruby Type:** String | **Default Value:** ``"ALL"``
 
@@ -132,7 +130,6 @@ The sudo resource has the following properties:
    **Ruby Type:** true, false | **Default Value:** ``false``
 
    Determines whether or not to permit preservation of the environment with ``sudo -E``.
-
 
 ``template``
    **Ruby Type:** String

--- a/chef_master/source/resource_swap_file.rst
+++ b/chef_master/source/resource_swap_file.rst
@@ -9,6 +9,7 @@ Use the **swap_file** resource to create or delete swap files on Linux systems, 
 
 Syntax
 =====================================================
+
 The swap_file resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_sysctl.rst
+++ b/chef_master/source/resource_sysctl.rst
@@ -9,6 +9,7 @@ Use the **sysctl** resource to set or remove kernel parameters using the ``sysct
 
 Syntax
 =====================================================
+
 The sysctl resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_systemd_unit.rst
+++ b/chef_master/source/resource_systemd_unit.rst
@@ -9,6 +9,7 @@ Use the **systemd_unit** resource to create, manage, and run `systemd units <htt
 
 Syntax
 =====================================================
+
 The systemd_unit resource has the following syntax:
 
 .. code-block:: ruby
@@ -125,7 +126,7 @@ The systemd_unit resource has the following properties:
 ``unit_name``
    **Ruby Type:** String | **Default Value:** ``The resource block's name``
 
-   The name of the unit file if it differs from the resource block name.
+   The name of the unit file if it differs from the resource block's name.
 
    *New in Chef Client 13.7.*
 

--- a/chef_master/source/resource_timezone.rst
+++ b/chef_master/source/resource_timezone.rst
@@ -5,7 +5,7 @@ timezone resource
 
 Use the **timezone** resource to change the system **timezone** on Windows, Linux, and macOS hosts. Timezones are specified in tz database format, with a complete list of available TZ values for Linux and macOS here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones and for Windows here: https://ss64.com/nt/timezones.html.
 
- **New in Chef Client 14.6.**
+**New in Chef Client 14.6.**
 
 Syntax
 =====================================================

--- a/chef_master/source/resource_windows_ad_join.rst
+++ b/chef_master/source/resource_windows_ad_join.rst
@@ -9,6 +9,7 @@ Use the **windows_ad_join** resource to join a Windows Active Directory domain.
 
 Syntax
 =====================================================
+
 The windows_ad_join resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_windows_auto_run.rst
+++ b/chef_master/source/resource_windows_auto_run.rst
@@ -9,6 +9,7 @@ Use the **windows_auto_run** resource to set applications to run at login.
 
 Syntax
 =====================================================
+
 The windows_auto_run resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_windows_certificate.rst
+++ b/chef_master/source/resource_windows_certificate.rst
@@ -9,6 +9,7 @@ Use the **windows_certificate** resource to install a certificate into the Windo
 
 Syntax
 =====================================================
+
 The windows_certificate resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_windows_dfs_folder.rst
+++ b/chef_master/source/resource_windows_dfs_folder.rst
@@ -9,6 +9,7 @@ The **windows_dfs_folder** resources creates a folder within dfs as many levels 
 
 Syntax
 =====================================================
+
 The windows_dfs_folder resource has the following syntax:
 
 .. code-block:: ruby
@@ -107,6 +108,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_windows_dfs_namespace.rst
+++ b/chef_master/source/resource_windows_dfs_namespace.rst
@@ -119,6 +119,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_windows_dfs_server.rst
+++ b/chef_master/source/resource_windows_dfs_server.rst
@@ -9,6 +9,7 @@ The **windows_dfs_server** resource sets system-wide DFS settings.
 
 Syntax
 =====================================================
+
 The windows_dfs_server resource has the following syntax:
 
 .. code-block:: ruby
@@ -102,6 +103,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_windows_dns_record.rst
+++ b/chef_master/source/resource_windows_dns_record.rst
@@ -9,6 +9,7 @@ The **windows_dns_record** resource creates a DNS record for the given domain.
 
 Syntax
 =====================================================
+
 The windows_dns_record resource has the following syntax:
 
 .. code-block:: ruby
@@ -107,6 +108,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_windows_dns_zone.rst
+++ b/chef_master/source/resource_windows_dns_zone.rst
@@ -9,6 +9,7 @@ The **windows_dns_zone** resource creates an Active Directory Integrated DNS Zon
 
 Syntax
 =====================================================
+
 The windows_dns_zone resource has the following syntax:
 
 .. code-block:: ruby
@@ -101,6 +102,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_windows_env.rst
+++ b/chef_master/source/resource_windows_env.rst
@@ -15,6 +15,7 @@ This resource was previously called the **env** resource; its name was updated i
 
 Syntax
 =====================================================
+
 The windows_env resource has the following syntax:
 
 .. code-block:: ruby
@@ -36,6 +37,7 @@ where:
 
 Actions
 =====================================================
+
 The windows_env resource has the following actions:
 
 ``:create``
@@ -202,6 +204,7 @@ The syntax for ``subscribes`` is:
 
 Guards
 -----------------------------------------------------
+
 .. tag resources_common_guards
 
 A guard property can be used to evaluate the state of a node during the execution phase of a Chef Infra Client run. Based on the results of this evaluation, a guard property is then used to tell Chef Infra Client if it should continue executing a resource. A guard property accepts either a string value or a Ruby block value:

--- a/chef_master/source/resource_windows_feature.rst
+++ b/chef_master/source/resource_windows_feature.rst
@@ -9,6 +9,7 @@ Use the **windows_feature** resource to add, remove or entirely delete Windows f
 
 Syntax
 =====================================================
+
 The windows_feature resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_windows_feature_dism.rst
+++ b/chef_master/source/resource_windows_feature_dism.rst
@@ -33,14 +33,21 @@ Actions
 
 The windows_feature_dism resource has the following actions:
 
+``:delete``
+   Delete a Windows role / feature from the image using DISM.
+
 ``:install``
    Default. Install a Windows role / feature using DISM.
 
 ``:remove``
    Remove a Windows role / feature using DISM.
 
-``:delete``
-   Delete a Windows role / feature from the image using DISM.
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of a Chef Infra Client run.
+
+   .. end_tag
 
 Properties
 =====================================================

--- a/chef_master/source/resource_windows_feature_powershell.rst
+++ b/chef_master/source/resource_windows_feature_powershell.rst
@@ -9,6 +9,7 @@ Use the **windows_feature_powershell** resource to add, remove or entirely delet
 
 Syntax
 =====================================================
+
 The windows_feature_powershell resource has the following syntax:
 
 .. code-block:: ruby
@@ -34,14 +35,15 @@ Actions
 
 The windows_feature_powershell resource has the following actions:
 
+``:delete``
+   Delete a Windows role / feature from the image using PowerShell.
+
 ``:install``
    Default. Install a Windows role / feature using PowerShell.
 
 ``:remove``
    Remove a Windows role / feature using PowerShell.
 
-``:delete``
-   Delete a Windows role / feature from the image using PowerShell.
 
 ``:nothing``
    .. tag resources_common_actions_nothing

--- a/chef_master/source/resource_windows_firewall_rule.rst
+++ b/chef_master/source/resource_windows_firewall_rule.rst
@@ -9,6 +9,7 @@ Use the **windows_firewall_rule** resource to create, change or remove windows f
 
 Syntax
 =====================================================
+
 The windows_firewall_rule resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_windows_font.rst
+++ b/chef_master/source/resource_windows_font.rst
@@ -9,6 +9,7 @@ Use the **windows_font** resource to install font files on Windows. By default, 
 
 Syntax
 =====================================================
+
 The windows_font resource has the following syntax:
 
 .. code-block:: ruby
@@ -28,6 +29,9 @@ where:
 
 Actions
 =====================================================
+
+The windows_font resource has the following actions:
+
 ``:install``
    Default. Install the font to the system fonts directory.
 

--- a/chef_master/source/resource_windows_pagefile.rst
+++ b/chef_master/source/resource_windows_pagefile.rst
@@ -39,7 +39,7 @@ The windows_pagefile resource has the following actions:
    Deletes the specified pagefile.
 
 ``:set``
-   Default. Configures the default pagefile, creating if it doesn't exist.
+   Default. Configures the default pagefile, creating it if it doesn't exist.
 
 ``:nothing``
    .. tag resources_common_actions_nothing

--- a/chef_master/source/resource_windows_pagefile.rst
+++ b/chef_master/source/resource_windows_pagefile.rst
@@ -9,6 +9,7 @@ Use the **windows_pagefile** resource to configure pagefile settings on Windows.
 
 Syntax
 =====================================================
+
 The windows_pagefile resource has the following syntax:
 
 .. code-block:: ruby
@@ -34,11 +35,11 @@ Actions
 
 The windows_pagefile resource has the following actions:
 
-``:set``
-   Default. Configures the default pagefile, creating if it doesn't exist.
-
 ``:delete``
    Deletes the specified pagefile.
+
+``:set``
+   Default. Configures the default pagefile, creating if it doesn't exist.
 
 ``:nothing``
    .. tag resources_common_actions_nothing
@@ -73,7 +74,6 @@ The windows_pagefile resource has the following properties:
    An optional property to set the pagefile name if it differs from the resource block's name.
 
 ``system_managed``
-
    **Ruby Type:** true, false
 
    Configures whether the system manages the pagefile size.

--- a/chef_master/source/resource_windows_path.rst
+++ b/chef_master/source/resource_windows_path.rst
@@ -9,6 +9,7 @@ Use the **windows_path** resource to manage the path environment variable on Mic
 
 Syntax
 =====================================================
+
 The windows_path resource has the following syntax:
 
 .. code-block:: ruby
@@ -35,6 +36,13 @@ The windows_path resource has the following actions:
 
 ``:remove``
    Remove an item from the system path
+
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of a Chef Infra Client run.
+
+   .. end_tag
 
 Properties
 =====================================================

--- a/chef_master/source/resource_windows_printer.rst
+++ b/chef_master/source/resource_windows_printer.rst
@@ -9,6 +9,7 @@ Use the **windows_printer** resource to setup Windows printers. Note that this d
 
 Syntax
 =====================================================
+
 The windows_printer resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_windows_printer_port.rst
+++ b/chef_master/source/resource_windows_printer_port.rst
@@ -9,6 +9,7 @@ Use the **windows_printer_port** resource to create and delete TCP/IPv4 printer 
 
 Syntax
 =====================================================
+
 The windows_printer_port resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_windows_share.rst
+++ b/chef_master/source/resource_windows_share.rst
@@ -9,6 +9,7 @@ Use the **windows_share** resource to create, modify and remove Windows shares.
 
 Syntax
 =====================================================
+
 The windows_share resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_windows_shortcut.rst
+++ b/chef_master/source/resource_windows_shortcut.rst
@@ -9,6 +9,7 @@ Use the **windows_shortcut** resource to create shortcut files on Windows.
 
 Syntax
 =====================================================
+
 The windows_shortcut resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_windows_task.rst
+++ b/chef_master/source/resource_windows_task.rst
@@ -11,6 +11,7 @@ Use the **windows_task** resource to create, delete or run a Windows scheduled t
 
 Syntax
 =====================================================
+
 The windows_task resource has the following syntax:
 
 .. code-block:: ruby
@@ -61,17 +62,18 @@ The windows_task resource has the following actions:
 ``:delete``
    Deletes a task.
 
-``:run``
-   Runs a task.
 
-``:end``
-   Ends a task.
+``:disable``
+   Disables a task.
 
 ``:enable``
    Enables a task.
 
-``:disable``
-   Disables a task.
+``:end``
+   Ends a task.
+
+``:run``
+   Runs a task.
 
 ``:nothing``
    .. tag resources_common_actions_nothing
@@ -186,7 +188,7 @@ The windows_task resource has the following properties:
    Delays the task up to a given time (in seconds).
 
 ``run_level``
-  **Ruby Type:** Symbol | **Default Value:** ``:limited``
+   **Ruby Type:** Symbol | **Default Value:** ``:limited``
 
   Run with ``:limited`` or ``:highest`` privileges.
 

--- a/chef_master/source/resource_windows_uac.rst
+++ b/chef_master/source/resource_windows_uac.rst
@@ -9,6 +9,7 @@ The **windows_uac** resource configures UAC on Windows hosts by setting registry
 
 Syntax
 =====================================================
+
 The windows_uac resource has the following syntax:
 
 .. code-block:: ruby
@@ -116,6 +117,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/chef_master/source/resource_windows_workgroup.rst
+++ b/chef_master/source/resource_windows_workgroup.rst
@@ -9,6 +9,7 @@ Use the **windows_workgroup** resource to join or change the workgroup of a Wind
 
 Syntax
 =====================================================
+
 The windows_workgroup resource has the following syntax:
 
 .. code-block:: ruby

--- a/chef_master/source/resource_yum_package.rst
+++ b/chef_master/source/resource_yum_package.rst
@@ -81,6 +81,13 @@ The yum_package resource has the following actions:
 ``:upgrade``
    Install a package and/or ensure that a package is the latest version. This action will ignore the ``version`` attribute.
 
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of a Chef Infra Client run.
+
+   .. end_tag
+
 Properties
 =====================================================
 

--- a/chef_master/source/resource_yum_repository.rst
+++ b/chef_master/source/resource_yum_repository.rst
@@ -9,6 +9,7 @@ Use the **yum_repository** resource to manage a Yum repository configuration fil
 
 Syntax
 =====================================================
+
 The yum_repository resource has the following syntax:
 
 .. code-block:: ruby
@@ -80,6 +81,12 @@ The yum_repository resource has the following actions:
 :makecache
    Updates the yum cache.
 
+``:nothing``
+   .. tag resources_common_actions_nothing
+
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of a Chef Infra Client run.
+
+   .. end_tag
 
 Properties
 =====================================================

--- a/chef_master/source/resource_zypper_repository.rst
+++ b/chef_master/source/resource_zypper_repository.rst
@@ -9,6 +9,7 @@ Use the **zypper_repository** resource to create Zypper package repositories on 
 
 Syntax
 =====================================================
+
 The zypper_repository resource has the following syntax:
 
 .. code-block:: ruby
@@ -50,13 +51,20 @@ The zypper_repository resource has the following actions:
 
    Default action. Add a new Zypper repository.
 
+``:refresh``
+
+   Refresh a Zypper repository.
+
 ``:remove``
 
    Remove a Zypper repository.
 
-``:refresh``
+``:nothing``
+   .. tag resources_common_actions_nothing
 
-   Refresh a Zypper repository.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Infra Client run.
+
+   .. end_tag
 
 Properties
 =====================================================
@@ -92,6 +100,7 @@ The zypper_repository resource has the following properties:
    **Ruby Type:** true, false | **Default Value:** ``true``
 
    Automatically import the specified key when setting up the repository.
+
 ``gpgcheck``
    **Ruby Type:** true, false | **Default Value:** ``true``
 
@@ -141,7 +150,6 @@ The zypper_repository resource has the following properties:
    **Ruby Type:** String
 
    The name of the template for the repository file. Only necessary if you're not using the built in template.
-
 
 ``type``
    **Ruby Type:** String | **Default Value:** ``"NONE"``

--- a/chef_master/source/resource_zypper_repository.rst
+++ b/chef_master/source/resource_zypper_repository.rst
@@ -62,7 +62,7 @@ The zypper_repository resource has the following actions:
 ``:nothing``
    .. tag resources_common_actions_nothing
 
-   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of the Chef Infra Client run.
+   This resource block does not act unless notified by another resource to take action. Once notified, this resource block either runs immediately or is queued up to run at the end of a Chef Infra Client run.
 
    .. end_tag
 


### PR DESCRIPTION
Fix spacing
Remove some bogus properties
Fix some package resources that don't support multipackage so we can't tell folks to pass in arrays
Add the :nothing action where it was missing
Redo a few of the resource pages that had never received the new format

Signed-off-by: Tim Smith <tsmith@chef.io>