### PR TITLE
Add back git to build environment

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -7,6 +7,7 @@ pkg_description="HTML for docs.chef.io"
 pkg_upstream_url="https://docs.chef.io"
 pkg_build_deps=(
   core/hugo
+  core/git
   core/make
   core/node
 )


### PR DESCRIPTION
Signed-off-by: Tom Duffield <tom@chef.io>

### Description

I removed git because I thought we only needed it to pull in the theme. Turns out that hugo also needs it for asset pipelines. 

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
