### PR TITLE
Warn about client_key config.rb relative path spec

### DIFF
--- a/chef_master/source/config_rb.rst
+++ b/chef_master/source/config_rb.rst
@@ -49,7 +49,7 @@ This configuration file has the following settings:
    A directory that contains additional configuration scripts to load for Chef Infra Client.
 
 ``client_key``
-   The location of the file that contains the client key. Default value: ``/etc/chef/client.pem``. For example:
+   Warning: This config item should always be specified as an absolute path. The location of the file that contains the client key. Default value: ``/etc/chef/client.pem``. For example:
 
    .. code-block:: ruby
 

--- a/chef_master/source/config_rb.rst
+++ b/chef_master/source/config_rb.rst
@@ -49,7 +49,7 @@ This configuration file has the following settings:
    A directory that contains additional configuration scripts to load for Chef Infra Client.
 
 ``client_key``
-   Warning: This config item should always be specified as an absolute path. The location of the file that contains the client key. Default value: ``/etc/chef/client.pem``. For example:
+   The location of the file that contains the client key, as an absolute path. Default value: ``/etc/chef/client.pem``. For example:
 
    .. code-block:: ruby
 


### PR DESCRIPTION
Signed-off-by: Sean Horn <sean_horn@chef.io>

### Description

knife/chef commands using config.rb in most cases may not be aware of what the shorthand `~` should mean. This can result in failure to read the file like this

```
2019-08-13T18:13:36+00:00] WARN: Failed to read the private key ~/.chef/jenkins.pem: #<Errno::ENOENT: No such file or directory @ rb_sysopen - ~/.chef/jenkins.pem>

Error: Failed to upload policy to policy group test

Reason: (Chef::Exceptions::PrivateKeyMissing) I cannot read ~/.chef/jenkins.pem, which you told me to use to sign requests!
```

### Issues Resolved

Let's instead change the docs to warn explicitly that the path to the client_key file be specified as an absolute path from the root.

### Check List

- [X] Spell Check
