### PR TITLE
Update Chef Server release notes from 12.19.26 - 13.0.11

### DIFF
--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -1,9 +1,90 @@
 =====================================================
-Release Notes: Chef Server 12.0 - 12.18.14
+Release Notes: Chef Infra Server 12.0 - 13.0.11
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/release_notes_server.rst>`__
 
 Chef Server acts as a hub for configuration data by storing cookbooks, the policies that are applied to nodes, and metadata that describes each registered node that is managed by the chef-client.
+
+What's New in 13.0.11
+=====================================================
+
+Chef Server is now Chef Infra Server
+-----------------------------------------------------
+
+Chef Server has a new name, but don’t worry, it’s the same Chef Server you’ve grown used to. You’ll notice new branding throughout the application and documentation but the command `chef-server-ctl` remains the same.
+
+Chef EULA
+-----------------------------------------------------
+
+Chef Infra Server requires an EULA to be accepted by users before it can be installed. Users can accept the EULA in a variety of ways:
+
+* `chef-server-ctl reconfigure --chef-license accept`
+* `chef-server-ctl reconfigure --chef-license accept-no-persist`
+* `CHEF_LICENSE="accept" chef-server-ctl reconfigure`
+* `CHEF_LICENSE="accept-no-persist" chef-server-ctl reconfigure`
+
+Finally, if users run `chef-server-ctl reconfigure` without any of these options, they will receive an interactive prompt asking for license acceptance. If the license is accepted, a marker file will be written to the filesystem unless `accept-no-persist` is specified. Once this marker file is persisted, users no longer need to set any of these flags.
+
+See our `Frequently Asked Questions document <https://www.chef.io/bmc-faq/>`__ for more information on the EULA and license acceptance.
+
+Deprecation notice
+-----------------------------------------------------
+
+* `Deprecated PowerPC and s390x platforms <https://blog.chef.io/2018/11/01/end-of-life-announcement-for-chef-server-for-linux-on-ibm-z-and-linux-on-ibm-power-systems/>`__
+* `Deprecated Keepalived/DRBD-based HA <https://blog.chef.io/2018/10/02/end-of-life-announcement-for-drbd-based-ha-support-in-chef-server/>`__
+* Deprecated Ubuntu 14.04 support. (Ubuntu 14 was EoL’d at the end of April 2019)
+
+Updates and Improvements
+-----------------------------------------------------
+
+* Updated OpenResty to 1.13.6.2
+
+  * This fixes two CVEs: CVE-2018-9230 and CVE-2017-7529.
+  * This version cannot be built on PowerPC and s390x because those platforms are not supported in mainline luajit.
+  
+* Updated Ruby version to 2.5.5
+* Updated Chef Infra Client to 14.11.21
+* Updated runit cookbook to 5.1.1
+* Migrated unit tests from Travis to Buildkite. Reorganized them for improved speed, stability and portability.
+* Added some Habitat packaging improvements with parameterized search_server.
+* Erchef request size increased from 1,000,000 to 2,000,000 bytes to better support inspec scanning via the audit cookbook.
+* Nginx error logs no longer log 404s. In the Chef API, 404s are typically not errors as they are often the expected response about an object that doesn't exist. The logs will continue to show 404s in the request logs.
+* Profiles and data-collector upstreams now render correctly if their root_url is configured. If the data_collector token secret is not set, a 401 response code and an error message will be seen instead of 404.
+
+What's New in 12.19.31
+=====================================================
+
+This release was triggered by the update to Habitat base plans. (https://blog.chef.io/2019/01/28/base-plans-refresh-is-coming-to-habitat-core-plans/)
+Omnibus release was done to keep in sync with the Habitat release.
+
+* `chef-server-ctl` leverages HAB_LISTEN_CTL envvar if available.
+
+
+What's New in 12.19.26
+=====================================================
+
+This release contains some minor improvements and updates to include software:
+
+* Added request id to nginx log to easily track the Chef request through the logs.
+* Bundler pinned to 1.17 to avoid taking the 2.0 upgrade.
+* Erlang updated to 18.3.4.9
+
+  * Fixed two CVEs CVE-2017-1000385 and CVE-2016-10253. SSL headers got stricter which unfortunately broke LDAP. (Issue #1642)
+  * Removed `et`, `debugger`, `gs`, and `observer` as they depend on `wx`, which is not available on all platforms.
+  
+* Ruby updated to 2.5.3.
+* Chef Client updated to 14.5.
+* Erchef and Bookshelf can optionally use mTLS protocol for their internal communications.
+* Added configuration for pedant SSL-signed requests to include mTLS support.
+* Habitat package improvements:
+
+  * Increased `authn:keygen_timeout` amount for `oc_erchef` hab pkg.
+  * Removed `do_end` function from `chef-server-ctl` hab plan.
+  * Enhanced `chef-server-ctl` to function in more habitat environments.
+  * `chef-server-ctl` commands pass relevant TLS options during bifrost API calls.
+  
+* Used standard ruby-cleanup definition, which shrinks install size by ~5% on disk.
+* Removed unused couchdb configurables.
 
 What's New in 12.18.14
 =====================================================


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Updates Infra Server release notes to include changes from 12.19.26 - 13.0.11

### Check List

- [ ] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
