### PR TITLE
Add detail about chef-client package contents

### DIFF
--- a/chef_master/source/auth.rst
+++ b/chef_master/source/auth.rst
@@ -44,7 +44,7 @@ Chef Infra Client
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. tag security_key_pairs_chef_client
 
-RSA public key-pairs are used to authenticate Chef Infra Client with the Chef Infra Server every time a Chef Infra Client needs access to data that is stored on the Chef Infra Server. This prevents any node from accessing data that it shouldn't and it ensures that only nodes that are properly registered with the Chef Infra Server can be managed.
+Chef Infra Client authenticates with the Chef Infra Server using RSA public key-pairs each time a Chef Infra Client needs access to data that is stored on the Chef Infra Server. This prevents any node from accessing data that it shouldn't and it ensures that only nodes that are properly registered with the Chef Infra Server can be managed.
 
 .. end_tag
 

--- a/chef_master/source/chef_client_overview.rst
+++ b/chef_master/source/chef_client_overview.rst
@@ -15,7 +15,8 @@ Chef Infra Client Overview
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install
+       and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it        will perform all of the steps that are required to bring the node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object

--- a/chef_master/source/chef_client_overview.rst
+++ b/chef_master/source/chef_client_overview.rst
@@ -15,7 +15,7 @@ Chef Infra Client Overview
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, perform sall of the steps required for brining a node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object
@@ -28,7 +28,7 @@ Chef Infra Client Overview
 
        .. tag security_key_pairs_chef_client
 
-       RSA public key-pairs are used to authenticate Chef Infra Client with the Chef Infra Server every time a Chef Infra Client needs access to data that is stored on the Chef Infra Server. This prevents any node from accessing data that it shouldn't and it ensures that only nodes that are properly registered with the Chef Infra Server can be managed.
+       Chef Infra Client authenticates with the Chef Infra Server using RSA public key-pairs each time a Chef Infra Client needs access to data that is stored on the Chef Infra Server. This prevents any node from accessing data that it shouldn't and it ensures that only nodes that are properly registered with the Chef Infra Server can be managed.
 
        .. end_tag
 

--- a/chef_master/source/chef_client_overview.rst
+++ b/chef_master/source/chef_client_overview.rst
@@ -15,8 +15,7 @@ Chef Infra Client Overview
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install
-       and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it        will perform all of the steps that are required to bring the node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object

--- a/chef_master/source/chef_client_overview.rst
+++ b/chef_master/source/chef_client_overview.rst
@@ -15,7 +15,7 @@ Chef Infra Client Overview
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, perform sall of the steps required for brining a node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for brining a node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object

--- a/chef_master/source/chef_client_overview.rst
+++ b/chef_master/source/chef_client_overview.rst
@@ -15,7 +15,7 @@ Chef Infra Client Overview
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for brining a node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for bringing a node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -390,8 +390,7 @@ The key components of nodes that are under management by Chef include:
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install
-       and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it        will perform all of the steps that are required to bring the node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -390,7 +390,7 @@ The key components of nodes that are under management by Chef include:
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, perform sall of the steps required for brining a node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object
@@ -403,7 +403,7 @@ The key components of nodes that are under management by Chef include:
 
        .. tag security_key_pairs_chef_client
 
-       RSA public key-pairs are used to authenticate Chef Infra Client with the Chef Infra Server every time a Chef Infra Client needs access to data that is stored on the Chef Infra Server. This prevents any node from accessing data that it shouldn't and it ensures that only nodes that are properly registered with the Chef Infra Server can be managed.
+       Chef Infra Client authenticates with the Chef Infra Server using RSA public key-pairs each time a Chef Infra Client needs access to data that is stored on the Chef Infra Server. This prevents any node from accessing data that it shouldn't and it ensures that only nodes that are properly registered with the Chef Infra Server can be managed.
 
        .. end_tag
 

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -390,7 +390,8 @@ The key components of nodes that are under management by Chef include:
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install
+       and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it        will perform all of the steps that are required to bring the node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -390,7 +390,7 @@ The key components of nodes that are under management by Chef include:
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, perform sall of the steps required for brining a node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for brining a node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -390,7 +390,7 @@ The key components of nodes that are under management by Chef include:
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for brining a node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for bringing a node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object

--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -5,8 +5,7 @@ Chef Infra Client (executable)
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install
-and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it        will perform all of the steps that are required to bring the node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -5,7 +5,8 @@ Chef Infra Client (executable)
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install
+and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it        will perform all of the steps that are required to bring the node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -5,7 +5,7 @@ Chef Infra Client (executable)
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, perform sall of the steps required for brining a node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -5,7 +5,7 @@ Chef Infra Client (executable)
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, perform sall of the steps required for brining a node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for brining a node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -5,7 +5,7 @@ Chef Infra Client (executable)
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for brining a node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for bringing a node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/install_dk.rst
+++ b/chef_master/source/install_dk.rst
@@ -8,7 +8,7 @@ Install ChefDK
 The ChefDK package is produced by the `Chef Omnibus <https://github.com/chef/omnibus>`__ tool for installation on a workstation. ChefDK includes:
 
 * Chef Infra Client
-* An embedded version of Ruby, RubyGems, and the Ruby interpreter, all of which are build from the source. (The Ruby interpreter is not available for Windows)
+* Embedded versions of Ruby, RubyGems, and the Ruby interpreter, all of which are build from the source. (The Ruby interpreter is not available for Windows)
 * An embedded version of OpenSSL
 * Test Kitchen
 * Cookstyle

--- a/chef_master/source/install_dk.rst
+++ b/chef_master/source/install_dk.rst
@@ -16,7 +16,7 @@ The ChefDK package is produced by the `Chef Omnibus <https://github.com/chef/omn
 * ChefSpec
 
 
-ChefDK installs to ``/opt/chefdk/`` on macOS / Linux and ``C:\opscode\chefdk\`` on Windows, in order to avoid conflicts between these components and other applications that may be running on the target machine.
+ChefDK installs to ``/opt/chefdk/`` on macOS / Linux and ``C:\opscode\chefdk\`` on Windows. These file locations should help avoid interference between these components and other applications that may be running on the target machine.
 
 Install
 =====================================================

--- a/chef_master/source/install_dk.rst
+++ b/chef_master/source/install_dk.rst
@@ -3,20 +3,29 @@ Install ChefDK
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/install_dk.rst>`__
 
-Use the ChefDK installer to set up ChefDK on a workstation. ChefDK includes Chef Infra Client, an embedded version of Ruby, RubyGems, and OpenSSL, as well as our tools: Test Kitchen, Cookstyle, and ChefSpec. The Chef installer puts everything into a unique directory (``/opt/chefdk/`` on macOS / Linux and ``C:\opscode\chefdk\`` on Windows) so that these components will not interfere with other applications that may be running on the target machine.
-
-.. note:: The Chef installer must run as a privileged user.
-
 .. note:: `Chef Workstation <https://downloads.chef.io/chef-workstation/>`__ gives you everything you need to get started with Chef — ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software — all in one easy-to-install package. Chef Workstation replaces ChefDK, combining all the existing features with new features, such as ad-hoc task support and the new Chef Workstation desktop application. Chef will continue to maintain ChefDK, but new development will take place in Chef Workstation without backporting features.
+
+The ChefDK package is produced by the `Chef Omnibus <https://github.com/chef/omnibus>`__ tool for installation on a workstation. ChefDK includes:
+
+* Chef Infra Client
+* An embedded version of Ruby, RubyGems, and the Ruby interpreter, all of which are build from the source. (The Ruby interpreter is not available for Windows)
+* An embedded version of OpenSSL
+* Test Kitchen
+* Cookstyle
+* Foodcritic
+* ChefSpec
+
+
+ChefDK installs to ``/opt/chefdk/`` on macOS / Linux and ``C:\opscode\chefdk\`` on Windows, in order to avoid conflicts between these components and other applications that may be running on the target machine.
 
 Install
 =====================================================
+The ChefDK installer must run as a privileged user.
 
 macOS
 -----------------------------------------------------
 
-.. note:: ChefDK works without installing Xcode, but Xcode is required for native Ruby Gem installation. Run ``xcode-select --install`` from the terminal to install Xcode.
-
+#. Dependency: Xcode is recommended for running ChefDK on OSX. While ChefDK works without Xcode, it is required for native Ruby Gem installation. Run ``xcode-select --install`` from the terminal to install Xcode.
 #. Visit the `ChefDK downloads page <https://downloads.chef.io/chefdk#mac_os_x>`__ and select the appropriate package for your macOS version. Click on the **Download** button.
 #. Follow the steps to accept the license and install ChefDK. You will have the option to change your install location; by default the installer uses the ``/opt/chefdk/`` directory.
 

--- a/chef_master/source/nodes.rst
+++ b/chef_master/source/nodes.rst
@@ -61,8 +61,7 @@ The key components of nodes that are under management by Chef include:
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install
-       and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it        will perform all of the steps that are required to bring the node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object

--- a/chef_master/source/nodes.rst
+++ b/chef_master/source/nodes.rst
@@ -61,7 +61,8 @@ The key components of nodes that are under management by Chef include:
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install
+       and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it        will perform all of the steps that are required to bring the node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object

--- a/chef_master/source/nodes.rst
+++ b/chef_master/source/nodes.rst
@@ -61,7 +61,7 @@ The key components of nodes that are under management by Chef include:
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, perform sall of the steps required for brining a node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object
@@ -74,7 +74,7 @@ The key components of nodes that are under management by Chef include:
 
        .. tag security_key_pairs_chef_client
 
-       RSA public key-pairs are used to authenticate Chef Infra Client with the Chef Infra Server every time a Chef Infra Client needs access to data that is stored on the Chef Infra Server. This prevents any node from accessing data that it shouldn't and it ensures that only nodes that are properly registered with the Chef Infra Server can be managed.
+       Chef Infra Client authenticates with the Chef Infra Server using RSA public key-pairs each time a Chef Infra Client needs access to data that is stored on the Chef Infra Server. This prevents any node from accessing data that it shouldn't and it ensures that only nodes that are properly registered with the Chef Infra Server can be managed.
 
        .. end_tag
 

--- a/chef_master/source/nodes.rst
+++ b/chef_master/source/nodes.rst
@@ -61,7 +61,7 @@ The key components of nodes that are under management by Chef include:
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for brining a node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for bringing a node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object

--- a/chef_master/source/nodes.rst
+++ b/chef_master/source/nodes.rst
@@ -61,7 +61,7 @@ The key components of nodes that are under management by Chef include:
 
      - .. tag chef_client_summary
 
-       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, perform sall of the steps required for brining a node into the expected state, including:
+       Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for brining a node into the expected state, including:
 
        * Registering and authenticating the node with Chef Infra Server
        * Building the node object

--- a/chef_master/source/resource_chef_client.rst
+++ b/chef_master/source/resource_chef_client.rst
@@ -16,8 +16,7 @@ chef_client
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install
-and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it        will perform all of the steps that are required to bring the node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/resource_chef_client.rst
+++ b/chef_master/source/resource_chef_client.rst
@@ -16,7 +16,7 @@ chef_client
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, perform sall of the steps required for brining a node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/resource_chef_client.rst
+++ b/chef_master/source/resource_chef_client.rst
@@ -16,7 +16,8 @@ chef_client
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install
+and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it        will perform all of the steps that are required to bring the node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/resource_chef_client.rst
+++ b/chef_master/source/resource_chef_client.rst
@@ -16,7 +16,7 @@ chef_client
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, perform sall of the steps required for brining a node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for brining a node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/resource_chef_client.rst
+++ b/chef_master/source/resource_chef_client.rst
@@ -16,7 +16,7 @@ chef_client
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for brining a node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for bringing a node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -26,8 +26,7 @@ Install Chef Infra Client on Windows Nodes
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install
-and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it        will perform all of the steps that are required to bring the node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -26,7 +26,7 @@ Install Chef Infra Client on Windows Nodes
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, perform sall of the steps required for brining a node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -26,7 +26,8 @@ Install Chef Infra Client on Windows Nodes
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When a Chef Infra Client is run, it will perform all of the steps that are required to bring the node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. The chef-client install package includes a self-contained ruby install
+and the chef-client code, which runs in the included ruby interpreter runtime. All components of the chef-client live in /opt/chef or c:\\opscode. When a Chef Infra Client is run, it        will perform all of the steps that are required to bring the node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -26,7 +26,7 @@ Install Chef Infra Client on Windows Nodes
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, perform sall of the steps required for brining a node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for brining a node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/chef_master/source/windows.rst
+++ b/chef_master/source/windows.rst
@@ -26,7 +26,7 @@ Install Chef Infra Client on Windows Nodes
 
 .. tag chef_client_summary
 
-Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for brining a node into the expected state, including:
+Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra Server. When Chef Infra Client runs, performs all of the steps required for bringing a node into the expected state, including:
 
 * Registering and authenticating the node with Chef Infra Server
 * Building the node object

--- a/doctools/dictionary.rb
+++ b/doctools/dictionary.rb
@@ -1,0 +1,11 @@
+require 'nokogiri'
+require 'open-uri'
+
+index_url = "https://docs.chef.io"
+
+def get_doc(index_url)
+  open(index_url) #OpenURI to get the HTML doc
+  @doc = Nokogiri::HTML(open(index_url))# Get Nokogiri data structure
+end
+
+


### PR DESCRIPTION
Signed-off-by: Sean Horn <sean_horn@chef.io>

### Description

dtags update/replicate of chef_client_summary tag

Added more detail about what is in a chef-client package and where those contents live on the system with the package installed.

### Check List

- [X] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass

### Issues Resolved

Customer asking for more detail about what's in the chef-client package.