### PR TITLE
Update server_security.rst

### DIFF
--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -7,7 +7,7 @@ This guide covers the security features available in Chef Infra Server.
 
 SSL Certificates
 =====================================================
-Initial configuration of the Chef Infra Server is done automatically using a self-signed certificate to create the certificate and private key files for Nginx. This section details the process for updating a Chef server's SSL certificate.
+Initial configuration of the Chef Infra Server is done automatically using a self-signed certificate to create the certificate and private key files for Nginx. This section details the process for updating a Chef server s SSL certificate.
 
 Automatic Installation (recommended)
 -----------------------------------------------------
@@ -313,7 +313,7 @@ While the file does not contain passwords in plaintext, it is not safe to share 
 SSL Encryption Between Chef Infra Server and External PostgreSQL
 ================================================================
 
-**New in Chef Server X.Y:**  Chef Server X.Y introduces the capability to encrypt traffic between Chef Infra Server and an external PostgreSQL configuration over SSL.  These instructions are not all-encompassing and assume familiarity with PostgreSQL administration, configuration, and troubleshooting.  Consult the appropriate PostgreSQL documentation as necessary, e.g. https://www.postgresql.org/docs/9.6/ssl-tcp.html.
+**New in Chef Server 13.1.13:**  Chef Server 13.1.13 introduces the capability to encrypt traffic between Chef Infra Server and an external PostgreSQL configuration over SSL.  These instructions are not all-encompassing and assume familiarity with PostgreSQL administration, configuration, and troubleshooting.  Consult the appropriate PostgreSQL documentation as necessary, e.g. https://www.postgresql.org/docs/9.6/ssl-tcp.html.
 
 To enable this encryption (typical scenario):
 
@@ -336,9 +336,9 @@ To enable this encryption (typical scenario):
    #ssl_cert_file='<PATH/TO/CERT/FILE>'
    #ssl_key_file='<PATH/TO/KEY/FILE>'
 
-5. Consider forcing the use of SSL connections from the PostgreSQL side, otherwise non-SSL connections could be used.  This can be achieved by editing `pg_hba.conf` on the PostgreSQL machine, and changing the relevant Chef Server connections to `hostssl`.
+5. Consider forcing the use of SSL connections from the PostgreSQL side, otherwise non-SSL connections could be used.  This can be achieved by editing `pg_hba.conf` on the PostgreSQL machine, and changing the relevant Chef Infra Server connections to `hostssl`.
 
-   Here is a sample `pg_hba.conf` file with `hostssl` connections for Chef Server (the contents of your `pg_hba.conf` will be different):
+   Here is a sample `pg_hba.conf` file with `hostssl` connections for Chef Infra Server (the contents of your `pg_hba.conf` will be different):
 
 .. code-block:: bash
 
@@ -360,19 +360,19 @@ To enable this encryption (typical scenario):
 
    $ /<PATH/TO/POSTGRESQL>/postgresql restart
 
-7. Edit /etc/opscode/chef-server.rb on the Chef Server machine and add the following line:
+7. Edit /etc/opscode/chef-server.rb on the Chef Infra Server machine and add the following line:
 
 .. code-block:: ruby
 
    postgresql['sslmode']='require'
 
-8. Run the following command on the Chef Server machine:
+8. Run the following command on the Chef Infra Server machine:
 
 .. code-block:: bash
 
    $ chef-server-ctl reconfigure
 
-9. Verify that SSL is enabled and that SSL connections are up between Chef Server and your running PostgreSQL instance.  One way to do this is by using psql on the PostgreSQL machine:
+9. Verify that SSL is enabled and that SSL connections are up between Chef Infra Server and your running PostgreSQL instance.  One way to do this is by using `chef-server-ctl psql` on the Chef Infra Server machine:
 
 .. code-block:: bash
 

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -313,7 +313,7 @@ While the file does not contain passwords in plaintext, it is not safe to share 
 SSL Encryption Between Chef Infra Server and External PostgreSQL
 ================================================================
 
-**New in Chef Server 13.1.13:**  Chef Server 13.1.13 introduces the capability to encrypt traffic between Chef Infra Server and an external PostgreSQL server over SSL.  These instructions are not all-encompassing and assume familiarity with PostgreSQL administration, configuration, and troubleshooting.  Consult the appropriate PostgreSQL documentation as necessary, e.g. https://www.postgresql.org/docs/9.6/ssl-tcp.html.
+**New in Chef Infra Server 13.1.13:**  Chef Infra Server 13.1.13 introduces the ability to encrypt traffic between Chef Infra Server and an external PostgreSQL server over SSL.  These instructions are not all-encompassing and assume some familiarity with PostgreSQL administration, configuration, and troubleshooting. Consult the `PostgreSQL documentation <https://www.postgresql.org/docs/9.6/ssl-tcp.html>`_ for more information.
 
 Here is a walkthrough of a typical scenario for enabling encryption between a Chef Infra Server machine and an external PostgreSQL machine.  It is assumed that both machines are networked together and user-accessible.
 
@@ -323,13 +323,13 @@ Here is a walkthrough of a typical scenario for enabling encryption between a Ch
     
       sudo -i
 
-#. Ensure that `OpenSSL <https://www.openssl.org>` is installed on the PostgreSQL machine.
+#. Ensure that `OpenSSL <https://www.openssl.org>`_ is installed on the PostgreSQL machine.
 
 #. Ensure that PostgreSQL is installed on the PostgreSQL machine and has SSL support compiled-in.  This applies whether you are compiling your own source or using a pre-compiled binary.
 
 #. Place SSL certificates in the proper directories on the PostgreSQL machine, and ensure they have correct filenames, ownerships, and permissions.
 
-#. Enable SSL on PostgreSQL, and specify paths to the SSL certificates.  This can be done by editing the `postgresql.conf` file on the PostgreSQL machine and ensuring the relevant entries are present (substitute the appropriate paths):
+#. Enable SSL on PostgreSQL, and specify paths to the SSL certificates.  This can be done by editing ``postgresql.conf`` on the PostgreSQL machine and ensuring the relevant entries are present (substitute the appropriate paths):
 
    .. code-block:: bash
    
@@ -338,9 +338,9 @@ Here is a walkthrough of a typical scenario for enabling encryption between a Ch
       ssl_cert_file='/path/to/cert/file'
       ssl_key_file='/path/to/key/file'
 
-#. Consider forcing the use of SSL connections from the PostgreSQL side, otherwise non-SSL connections could be used.  This can be achieved by editing `pg_hba.conf` on the PostgreSQL machine, and changing the relevant Chef Infra Server connections to `hostssl`.
+#. To prevent PostgreSQL from accepting non-SSL connections, edit ``pg_hba.conf`` on the PostgreSQL machine and change the relevant Chef Infra Server connections to `hostssl`.
 
-   Here is a sample `pg_hba.conf` file with `hostssl` connections for Chef Infra Server (the contents of your `pg_hba.conf` will be different):
+   Here is a sample ``pg_hba.conf`` file with `hostssl` connections for Chef Infra Server (the contents of your ``pg_hba.conf`` will be different):
 
    .. code-block:: bash
    
@@ -362,7 +362,7 @@ Here is a walkthrough of a typical scenario for enabling encryption between a Ch
    
       $ /path/to/postgresql/postgresql restart
 
-#. Edit `/etc/opscode/chef-server.rb` on the Chef Infra Server machine and add the following line:
+#. Edit ``/etc/opscode/chef-server.rb`` on the Chef Infra Server machine and add the following line:
 
    .. code-block:: ruby
    
@@ -374,7 +374,7 @@ Here is a walkthrough of a typical scenario for enabling encryption between a Ch
    
       $ chef-server-ctl reconfigure
 
-#. Verify that SSL is enabled and that SSL connections are up between Chef Infra Server and your running PostgreSQL instance.  One way to do this is by running `chef-server-ctl psql` on the Chef Infra Server machine and confirming that most connections in the ssl column are marked 't' (true):
+#. Verify that SSL is enabled and that SSL connections are up between Chef Infra Server and your running PostgreSQL instance.  One way to do this is by running ``chef-server-ctl psql`` on the Chef Infra Server machine and confirming that most connections in the ssl column are marked 't' (true):
 
    .. code-block:: bash
    
@@ -412,6 +412,8 @@ Here is a walkthrough of a typical scenario for enabling encryption between a Ch
        16102 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
        16119 | f   |         |                             |      |             |
       (21 rows)
+
+      postgres=# \q
 
 Key Rotation
 =====================================================

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -325,7 +325,7 @@ The following is a typical scenario for enabling encryption between a machine ru
 
 #. Ensure that `OpenSSL <https://www.openssl.org>`_ is installed on the PostgreSQL machine.
 
-#. Ensure that PostgreSQL is installed on the PostgreSQL machine and has SSL support compiled-in.  This applies whether you are compiling your own source or using a pre-compiled binary.
+#. Ensure that SSL support is compiled in on PostgreSQL.  This applies whether you are compiling your own source or using a pre-compiled binary.
 
 #. Place SSL certificates in the proper directories on the PostgreSQL machine and ensure they have correct filenames, ownerships, and permissions.
 

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -372,7 +372,7 @@ The following is a typical scenario for enabling encryption between a machine ru
 
    .. code-block:: bash
    
-      $ chef-server-ctl reconfigure
+      chef-server-ctl reconfigure
 
 #. Verify that SSL is enabled and that SSL connections are up between Chef Infra Server and your running PostgreSQL instance.  One way to do this is to log into the PostgreSQL database from the Chef Infra Server by runnning ``chef-server-ctl psql`` and examine the SSL state using SQL queries.
 

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -7,7 +7,7 @@ This guide covers the security features available in Chef Infra Server.
 
 SSL Certificates
 =====================================================
-Initial configuration of the Chef Infra Server is done automatically using a self-signed certificate to create the certificate and private key files for Nginx. This section details the process for updating a Chef server s SSL certificate.
+Initial configuration of the Chef Infra Server is done automatically using a self-signed certificate to create the certificate and private key files for Nginx. This section details the process for updating a Chef Infra Server's SSL certificate.
 
 Automatic Installation (recommended)
 -----------------------------------------------------

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -329,7 +329,7 @@ The following is a typical scenario for enabling encryption between a machine ru
 
 #. Place SSL certificates in the proper directories on the PostgreSQL machine and ensure they have correct filenames, ownerships, and permissions.
 
-#. Enable SSL on PostgreSQL, and specify paths to the SSL certificates.  This can be done by editing ``postgresql.conf`` on the PostgreSQL machine and ensuring the relevant entries are present (substitute the appropriate paths):
+#. Enable SSL on PostgreSQL by editing the ``postgresql.conf`` file. Set ``ssl = on`` and specify the paths to the SSL certificates:
 
    .. code-block:: text
    

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -362,7 +362,7 @@ The following is a typical scenario for enabling encryption between a machine ru
    
       $ /path/to/postgresql/postgresql restart
 
-#. Edit ``/etc/opscode/chef-server.rb`` on the Chef Infra Server machine and add the following line:
+#. Edit ``/etc/opscode/chef-server.rb`` on the Chef Infra Server and add the following line:
 
    .. code-block:: ruby
    

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -327,7 +327,7 @@ Here is a walkthrough of a typical scenario for enabling encryption between a Ch
 
 #. Ensure that PostgreSQL is installed on the PostgreSQL machine and has SSL support compiled-in.  This applies whether you are compiling your own source or using a pre-compiled binary.
 
-#. Place SSL certificates in the proper directories on the PostgreSQL machine, and ensure they have correct filenames, ownerships, and permissions.
+#. Place SSL certificates in the proper directories on the PostgreSQL machine and ensure they have correct filenames, ownerships, and permissions.
 
 #. Enable SSL on PostgreSQL, and specify paths to the SSL certificates.  This can be done by editing ``postgresql.conf`` on the PostgreSQL machine and ensuring the relevant entries are present (substitute the appropriate paths):
 

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -315,7 +315,7 @@ SSL Encryption Between Chef Infra Server and External PostgreSQL
 
 **New in Chef Infra Server 13.1.13:**  Chef Infra Server 13.1.13 introduces the ability to encrypt traffic between Chef Infra Server and an external PostgreSQL server over SSL.  These instructions are not all-encompassing and assume some familiarity with PostgreSQL administration, configuration, and troubleshooting. Consult the `PostgreSQL documentation <https://www.postgresql.org/docs/9.6/ssl-tcp.html>`_ for more information.
 
-Here is a walkthrough of a typical scenario for enabling encryption between a Chef Infra Server machine and an external PostgreSQL machine.  It is assumed that both machines are networked together and user-accessible.
+The following is a typical scenario for enabling encryption between a machine running Chef Infra Server and an external machine running PostgreSQL.  Both machines must be networked together and accessible to the user.
 
 #. Run the following command on both machines to gain root access:
 

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -374,19 +374,20 @@ The following is a typical scenario for enabling encryption between a machine ru
    
       chef-server-ctl reconfigure
 
-#. Verify that SSL is enabled and that SSL connections are up between Chef Infra Server and your running PostgreSQL instance.  One way to do this is to log into the PostgreSQL database from the Chef Infra Server by runnning ``chef-server-ctl psql`` and examine the SSL state using SQL queries.
+#. Verify that SSL is enabled and that SSL connections are up between Chef Infra Server and your running PostgreSQL instance.  One way to do this is to log into the PostgreSQL database from the Chef Infra Server by running ``chef-server-ctl psql`` and then examine the SSL state using SQL queries.
 
    Start a psql session:
 
    .. code-block:: bash
    
-      $ chef-server-ctl psql opscode_chef 
+      chef-server-ctl psql opscode_chef 
 
-   From the ``psql`` session, enter ``postgres=# show ssl;`` which will show if ssl is enabled:
+   From the psql session, enter ``postgres=# show ssl;`` which will show if ssl is enabled:
 
    .. code-block:: sql
 
       postgres=# show ssl;
+			
        ssl
       -----
        on

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -360,7 +360,7 @@ The following is a typical scenario for enabling encryption between a machine ru
 
    .. code-block:: bash
    
-      $ /path/to/postgresql/postgresql restart
+      /path/to/postgresql/postgresql restart
 
 #. Edit ``/etc/opscode/chef-server.rb`` on the Chef Infra Server and add the following line:
 

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -356,7 +356,7 @@ The following is a typical scenario for enabling encryption between a machine ru
       # nonlocal connections
       hostssl    all             all            192.168.33.100/32        md5
 
-#. Restart PostgreSQL.  This can typically be done with the following command on the PostgreSQL machine (substitute the appropriate path):
+#. Restart PostgreSQL.  This can typically be done with the following command on the PostgreSQL machine:
 
    .. code-block:: bash
    

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -374,7 +374,7 @@ The following is a typical scenario for enabling encryption between a machine ru
    
       $ chef-server-ctl reconfigure
 
-#. Verify that SSL is enabled and that SSL connections are up between Chef Infra Server and your running PostgreSQL instance.  One way to do this is to log into the PostgreSQL database from the Chef Infra Server machine by runnning ``chef-server-ctl psql`` and examine the SSL state using SQL queries.
+#. Verify that SSL is enabled and that SSL connections are up between Chef Infra Server and your running PostgreSQL instance.  One way to do this is to log into the PostgreSQL database from the Chef Infra Server by runnning ``chef-server-ctl psql`` and examine the SSL state using SQL queries.
 
    Start a psql session:
 

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -313,7 +313,7 @@ While the file does not contain passwords in plaintext, it is not safe to share 
 SSL Encryption Between Chef Infra Server and External PostgreSQL
 ================================================================
 
-**New in Chef Server 13.1.13:**  Chef Server 13.1.13 introduces the capability to encrypt traffic between Chef Infra Server and an external PostgreSQL configuration over SSL.  These instructions are not all-encompassing and assume familiarity with PostgreSQL administration, configuration, and troubleshooting.  Consult the appropriate PostgreSQL documentation as necessary, e.g. https://www.postgresql.org/docs/9.6/ssl-tcp.html.
+**New in Chef Server 13.1.13:**  Chef Server 13.1.13 introduces the capability to encrypt traffic between Chef Infra Server and an external PostgreSQL server over SSL.  These instructions are not all-encompassing and assume familiarity with PostgreSQL administration, configuration, and troubleshooting.  Consult the appropriate PostgreSQL documentation as necessary, e.g. https://www.postgresql.org/docs/9.6/ssl-tcp.html.
 
 To enable this encryption (typical scenario):
 
@@ -362,7 +362,7 @@ To enable this encryption (typical scenario):
    
       postgresql['sslmode']='require'
 
-#. Run the following command on the Chef Infra Server machine:
+#. Run reconfigure on the Chef Infra Server machine:
 
    .. code-block:: bash
    

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -317,100 +317,95 @@ SSL Encryption Between Chef Infra Server and External PostgreSQL
 
 To enable this encryption (typical scenario):
 
-1. Ensure that OpenSSL is installed on the PostgreSQL machine (consult appropriate documentation as necessary, e.g. https://www.openssl.org/).
+#. Ensure that `OpenSSL <https://www.openssl.org>` is installed on the PostgreSQL machine.
 
-2. Ensure that PostgreSQL has SSL support compiled-in (this applies whether you are compiling your own or using a pre-compiled binary).
+#. Ensure that PostgreSQL has SSL support compiled-in.  This applies whether you are compiling your own source or using a pre-compiled binary.
 
-3. Place SSL certificates in the proper directories on the PostgreSQL machine, and ensure correct filenames, ownerships and permissions.
+#. Place SSL certificates in the proper directories on the PostgreSQL machine, and ensure they have correct filenames, ownerships, and permissions.
 
-4. Enable SSL support on PostgreSQL, and specify paths to the SSL certificates, if necessary.
+#. Enable SSL on PostgreSQL, and specify paths to the SSL certificates.  This can be done by editing the `postgresql.conf` file on the PostgreSQL machine and ensuring the relevant entries are present (substitute the appropriate paths):
 
-   Edit the postgresql.conf file on the PostgreSQL machine and ensure the relevant entries are present and not commented out (substitute the appropriate paths):
+   .. code-block:: bash
+   
+      ssl=on
+   
+      ssl_cert_file='/path/to/cert/file'
+      ssl_key_file='/path/to/key/file'
 
-.. code-block:: bash
-
-   # mandatory
-   ssl=on
-
-   # optional - uncomment accordingly
-   #ssl_cert_file='<PATH/TO/CERT/FILE>'
-   #ssl_key_file='<PATH/TO/KEY/FILE>'
-
-5. Consider forcing the use of SSL connections from the PostgreSQL side, otherwise non-SSL connections could be used.  This can be achieved by editing `pg_hba.conf` on the PostgreSQL machine, and changing the relevant Chef Infra Server connections to `hostssl`.
+#. Consider forcing the use of SSL connections from the PostgreSQL side, otherwise non-SSL connections could be used.  This can be achieved by editing `pg_hba.conf` on the PostgreSQL machine, and changing the relevant Chef Infra Server connections to `hostssl`.
 
    Here is a sample `pg_hba.conf` file with `hostssl` connections for Chef Infra Server (the contents of your `pg_hba.conf` will be different):
 
-.. code-block:: bash
+   .. code-block:: bash
+   
+      # "local" is for Unix domain socket connections only
+      local      all             all                                     peer
+   
+      # IPv4 local connections:
+      hostssl    all             all             127.0.0.1/32            md5
+   
+      # IPv6 local connections:
+      hostssl    all             all             ::1/128                 md5
+   
+      # nonlocal connections
+      hostssl    all             all            192.168.33.100/32        md5
 
-   # "local" is for Unix domain socket connections only
-   local      all             all                                     peer
+#. Restart PostgreSQL.  This can typically be done with the following command on the PostgreSQL machine (substitute the appropriate path):
 
-   # IPv4 local connections:
-   hostssl    all             all             127.0.0.1/32            md5
+   .. code-block:: bash
+   
+      $ /path/to/postgresql/postgresql restart
 
-   # IPv6 local connections:
-   hostssl    all             all             ::1/128                 md5
+#. Edit `/etc/opscode/chef-server.rb` on the Chef Infra Server machine and add the following line:
 
-   # nonlocal connections
-   hostssl    all             all            192.168.33.100/32        md5
+   .. code-block:: ruby
+   
+      postgresql['sslmode']='require'
 
-6. Restart PostgreSQL.  This can typically be done with the following command on the PostgreSQL machine (substitute the appropriate path):
+#. Run the following command on the Chef Infra Server machine:
 
-.. code-block:: bash
+   .. code-block:: bash
+   
+      $ chef-server-ctl reconfigure
 
-   $ /<PATH/TO/POSTGRESQL>/postgresql restart
+#. Verify that SSL is enabled and that SSL connections are up between Chef Infra Server and your running PostgreSQL instance.  One way to do this is by running `chef-server-ctl psql` on the Chef Infra Server machine and confirming that most connections in the ssl column are marked 't' (true):
 
-7. Edit /etc/opscode/chef-server.rb on the Chef Infra Server machine and add the following line:
-
-.. code-block:: ruby
-
-   postgresql['sslmode']='require'
-
-8. Run the following command on the Chef Infra Server machine:
-
-.. code-block:: bash
-
-   $ chef-server-ctl reconfigure
-
-9. Verify that SSL is enabled and that SSL connections are up between Chef Infra Server and your running PostgreSQL instance.  One way to do this is by using `chef-server-ctl psql` on the Chef Infra Server machine:
-
-.. code-block:: bash
-
-   $ su - postgres
-   $ psql
-
-   postgres=# show ssl;
-    ssl
-   -----
-    on
-   (1 row)
-
-   postgres=# select * from pg_stat_ssl;
-
-     pid  | ssl | version |           cipher            | bits | compression | clientdn
-   -------+-----+---------+-----------------------------+------+-------------+----------
-    16083 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16084 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16085 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16086 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16087 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16088 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16089 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16090 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16091 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16092 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16093 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16094 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16095 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16096 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16097 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16098 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16099 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16100 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16101 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16102 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
-    16119 | f   |         |                             |      |             |
-   (21 rows)
+   .. code-block:: bash
+   
+      $ chef-server-ctl psql opscode_chef 
+   
+      postgres=# show ssl;
+       ssl
+      -----
+       on
+      (1 row)
+   
+      postgres=# select * from pg_stat_ssl;
+   
+        pid  | ssl | version |           cipher            | bits | compression | clientdn
+      -------+-----+---------+-----------------------------+------+-------------+----------
+       16083 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16084 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16085 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16086 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16087 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16088 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16089 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16090 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16091 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16092 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16093 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16094 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16095 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16096 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16097 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16098 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16099 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16100 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16101 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16102 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
+       16119 | f   |         |                             |      |             |
+      (21 rows)
 
 Key Rotation
 =====================================================

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -368,7 +368,7 @@ The following is a typical scenario for enabling encryption between a machine ru
    
       postgresql['sslmode']='require'
 
-#. Run reconfigure on the Chef Infra Server machine:
+#. Run reconfigure on the Chef Infra Server:
 
    .. code-block:: bash
    

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -315,11 +315,17 @@ SSL Encryption Between Chef Infra Server and External PostgreSQL
 
 **New in Chef Server 13.1.13:**  Chef Server 13.1.13 introduces the capability to encrypt traffic between Chef Infra Server and an external PostgreSQL server over SSL.  These instructions are not all-encompassing and assume familiarity with PostgreSQL administration, configuration, and troubleshooting.  Consult the appropriate PostgreSQL documentation as necessary, e.g. https://www.postgresql.org/docs/9.6/ssl-tcp.html.
 
-To enable this encryption (typical scenario):
+Here is a walkthrough of a typical scenario for enabling encryption between a Chef Infra Server machine and an external PostgreSQL machine.  It is assumed that both machines are networked together and user-accessible.
+
+#. Run the following command on both machines to gain root access:
+
+   .. code-block:: bash
+    
+      sudo -i
 
 #. Ensure that `OpenSSL <https://www.openssl.org>` is installed on the PostgreSQL machine.
 
-#. Ensure that PostgreSQL has SSL support compiled-in.  This applies whether you are compiling your own source or using a pre-compiled binary.
+#. Ensure that PostgreSQL is installed on the PostgreSQL machine and has SSL support compiled-in.  This applies whether you are compiling your own source or using a pre-compiled binary.
 
 #. Place SSL certificates in the proper directories on the PostgreSQL machine, and ensure they have correct filenames, ownerships, and permissions.
 

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -331,7 +331,7 @@ Here is a walkthrough of a typical scenario for enabling encryption between a Ch
 
 #. Enable SSL on PostgreSQL, and specify paths to the SSL certificates.  This can be done by editing ``postgresql.conf`` on the PostgreSQL machine and ensuring the relevant entries are present (substitute the appropriate paths):
 
-   .. code-block:: bash
+   .. code-block:: text
    
       ssl=on
    
@@ -342,7 +342,7 @@ Here is a walkthrough of a typical scenario for enabling encryption between a Ch
 
    Here is a sample ``pg_hba.conf`` file with `hostssl` connections for Chef Infra Server (the contents of your ``pg_hba.conf`` will be different):
 
-   .. code-block:: bash
+   .. code-block:: text
    
       # "local" is for Unix domain socket connections only
       local      all             all                                     peer
@@ -374,18 +374,28 @@ Here is a walkthrough of a typical scenario for enabling encryption between a Ch
    
       $ chef-server-ctl reconfigure
 
-#. Verify that SSL is enabled and that SSL connections are up between Chef Infra Server and your running PostgreSQL instance.  One way to do this is by running ``chef-server-ctl psql`` on the Chef Infra Server machine and confirming that most connections in the ssl column are marked 't' (true):
+#. Verify that SSL is enabled and that SSL connections are up between Chef Infra Server and your running PostgreSQL instance.  One way to do this is to log into the PostgreSQL database from the Chef Infra Server machine by runnning ``chef-server-ctl psql`` and examine the SSL state using SQL queries.
+
+   Start a psql session:
 
    .. code-block:: bash
    
       $ chef-server-ctl psql opscode_chef 
-   
+
+   From the ``psql`` session, enter ``postgres=# show ssl;`` which will show if ssl is enabled:
+
+   .. code-block:: sql
+
       postgres=# show ssl;
        ssl
       -----
        on
       (1 row)
    
+   Then enter ``postgres=# select * from pg_stat_ssl;`` which will return true (``t``) in rows with SSL connections:
+   
+   .. code-block:: sql
+
       postgres=# select * from pg_stat_ssl;
    
         pid  | ssl | version |           cipher            | bits | compression | clientdn
@@ -412,8 +422,6 @@ Here is a walkthrough of a typical scenario for enabling encryption between a Ch
        16102 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
        16119 | f   |         |                             |      |             |
       (21 rows)
-
-      postgres=# \q
 
 Key Rotation
 =====================================================

--- a/chef_master/source/server_security.rst
+++ b/chef_master/source/server_security.rst
@@ -338,7 +338,7 @@ The following is a typical scenario for enabling encryption between a machine ru
       ssl_cert_file='/path/to/cert/file'
       ssl_key_file='/path/to/key/file'
 
-#. To prevent PostgreSQL from accepting non-SSL connections, edit ``pg_hba.conf`` on the PostgreSQL machine and change the relevant Chef Infra Server connections to `hostssl`.
+#. To prevent PostgreSQL from accepting non-SSL connections, edit ``pg_hba.conf`` on the PostgreSQL machine and change the relevant Chef Infra Server connections to ``hostssl``.
 
    Here is a sample ``pg_hba.conf`` file with `hostssl` connections for Chef Infra Server (the contents of your ``pg_hba.conf`` will be different):
 


### PR DESCRIPTION
### NOTES

My default presumption in creating these docs was that an external PostgreSQL instance is mainly the responsibility of the user and is not mainly the responsibility of Chef.  Therefore I didn't want to get into heavy or detailed instructions on how to setup an external PostgreSQL instance.  I have a note that these docs assume familiarity with PostgreSQL administration, configuration, and troubleshooting, and to consult the appropriate PostgreSQL documentation as necessary.  My presumption was that we didn't want to, in essence, recreate PostgreSQL docs within our docs.  Having said that, I thought we should at the very least have brief numbered steps ('boxes to check off') in setting up external PostgreSQL so that the user would know what they needed to do on the PostgreSQL side to have it communicate with Chef Server.  Basically, the user needs to know what Chef Server needs and expects of the PostgreSQL setup.

Beyond that, naturally I thought that instructions on configuring the Chef Server side of things *IS* our responsibility.

SSL Encryption Between Chef Infra Server and External PostgreSQL
================================================================

**New in Chef Infra Server 13.1.13:**  Chef Infra Server 13.1.13 introduces the ability to encrypt traffic between Chef Infra Server and an external PostgreSQL server over SSL.  These instructions are not all-encompassing and assume some familiarity with PostgreSQL administration, configuration, and troubleshooting. Consult the `PostgreSQL documentation <https://www.postgresql.org/docs/9.6/ssl-tcp.html>`_ for more information.

Here is a walkthrough of a typical scenario for enabling encryption between a Chef Infra Server machine and an external PostgreSQL machine.  It is assumed that both machines are networked together and user-accessible.

#. Run the following command on both machines to gain root access:

   .. code-block:: bash

      sudo -i

#. Ensure that `OpenSSL <https://www.openssl.org>`_ is installed on the PostgreSQL machine.

#. Ensure that PostgreSQL is installed on the PostgreSQL machine and has SSL support compiled-in.  This applies whether you are compiling your own source or using a pre-compiled binary.

#. Place SSL certificates in the proper directories on the PostgreSQL machine, and ensure they have correct filenames, ownerships, and permissions.

#. Enable SSL on PostgreSQL, and specify paths to the SSL certificates.  This can be done by editing ``postgresql.conf`` on the PostgreSQL machine and ensuring the relevant entries are present (substitute the appropriate paths):

   .. code-block:: text

      ssl=on

      ssl_cert_file='/path/to/cert/file'
      ssl_key_file='/path/to/key/file'

#. To prevent PostgreSQL from accepting non-SSL connections, edit ``pg_hba.conf`` on the PostgreSQL machine and change the relevant Chef Infra Server connections to `hostssl`.

   Here is a sample ``pg_hba.conf`` file with `hostssl` connections for Chef Infra Server (the contents of your ``pg_hba.conf`` will be different):

   .. code-block:: text

      # "local" is for Unix domain socket connections only
      local      all             all                                     peer

      # IPv4 local connections:
      hostssl    all             all             127.0.0.1/32            md5

      # IPv6 local connections:
      hostssl    all             all             ::1/128                 md5

      # nonlocal connections
      hostssl    all             all            192.168.33.100/32        md5

#. Restart PostgreSQL.  This can typically be done with the following command on the PostgreSQL machine (substitute the appropriate path):

   .. code-block:: bash

      $ /path/to/postgresql/postgresql restart

#. Edit ``/etc/opscode/chef-server.rb`` on the Chef Infra Server machine and add the following line:

   .. code-block:: ruby

      postgresql['sslmode']='require'

#. Run reconfigure on the Chef Infra Server machine:

   .. code-block:: bash

      $ chef-server-ctl reconfigure

#. Verify that SSL is enabled and that SSL connections are up between Chef Infra Server and your running PostgreSQL instance.  One way to do this is to log into the PostgreSQL database from the Chef Infra Server machine by runnning ``chef-server-ctl psql`` and examine the SSL state using SQL queries.

   Start a psql session:

   .. code-block:: bash

      $ chef-server-ctl psql opscode_chef

   From the ``psql`` session, enter ``postgres=# show ssl;`` which will show if ssl is enabled:

   .. code-block:: sql

      postgres=# show ssl;
       ssl
      -----
       on
      (1 row)

   Then enter ``postgres=# select * from pg_stat_ssl;`` which will return true (``t``) in rows with SSL connections:

   .. code-block:: sql

      postgres=# select * from pg_stat_ssl;

        pid  | ssl | version |           cipher            | bits | compression | clientdn
      -------+-----+---------+-----------------------------+------+-------------+----------
       16083 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16084 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16085 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16086 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16087 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16088 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16089 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16090 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16091 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16092 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16093 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16094 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16095 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16096 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16097 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16098 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16099 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16100 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16101 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16102 | t   | TLSv1.2 | ECDHE-RSA-AES256-GCM-SHA384 |  256 | f           |
       16119 | f   |         |                             |      |             |
      (21 rows)