### PR TITLE
Remove duplicate item in Constructs to Avoid

### DIFF
--- a/chef_master/source/ruby.rst
+++ b/chef_master/source/ruby.rst
@@ -618,7 +618,6 @@ Constructs to Avoid
 Avoid the following patterns:
 
 * ``node.normal`` - Avoid using attributes at normal precedence since they are set directly on the node object itself, rather than implied (computed) at runtime.
-* ``node.normal`` - Avoid using attributes at normal precedence since they are set directly on the node object itself, rather than implied (computed) at runtime.
 * if ``node.run_list.include?('foo')`` i.e. branching in recipes based on what's in the node's run-list. Better and more readable to use a feature flag and set its precedence appropriately.
 
 Recipes


### PR DESCRIPTION
Signed-off-by: Ric Caliolio <riccaliolio@gmail.com>

### Description

This will remove the duplicate `node.normal` in the section "Constructs to Avoid".

Obvious fix.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
