### PR TITLE
Use the correct name for the openssl_x509_certificate example

### DIFF
--- a/chef_master/source/resource_openssl_x509_certificate.rst
+++ b/chef_master/source/resource_openssl_x509_certificate.rst
@@ -338,7 +338,7 @@ Examples
 
 .. code-block:: ruby
 
-  openssl_x509 '/etc/httpd/ssl/mycert.pem' do
+  openssl_x509_certificate '/etc/httpd/ssl/mycert.pem' do
     common_name 'www.f00bar.com'
     org 'Foo Bar'
     org_unit 'Lab'


### PR DESCRIPTION
Technically the name here works, but that's the legacy name we don't
want folks to use anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>