### PR TITLE
Add more resource examples

### DIFF
--- a/chef_master/source/resource_apt_package.rst
+++ b/chef_master/source/resource_apt_package.rst
@@ -349,7 +349,7 @@ Notifications, via an implicit name:
 Examples
 =====================================================
 
-The following examples demonstrate various approaches for using apt_update in recipes.
+The following examples demonstrate various approaches for using resources in recipes:
 
 **Install a package using package manager**
 

--- a/chef_master/source/resource_apt_preference.rst
+++ b/chef_master/source/resource_apt_preference.rst
@@ -223,6 +223,8 @@ The following properties can be used to define a guard that is evaluated during 
 Examples
 =====================================================
 
+The following examples demonstrate various approaches for using resources in recipes:
+
 **Pin a package to a specific version**
 
 This example pins the ``libmysqlclient16`` package to ``version 5.1.49-3``:

--- a/chef_master/source/resource_apt_repository.rst
+++ b/chef_master/source/resource_apt_repository.rst
@@ -6,7 +6,7 @@ apt_repository resource
 Use the **apt_repository** resource to specify additional APT repositories. Adding a new repository will update the APT package cache immediately.
 
 Syntax
-==========================================
+=====================================================
 An **apt_repository** resource specifies APT repository information and adds an additional APT repository to the existing list of repositories:
 
 .. code-block:: ruby
@@ -285,6 +285,8 @@ The following properties can be used to define a guard that is evaluated during 
 
 Examples
 =====================================================
+
+The following examples demonstrate various approaches for using resources in recipes:
 
 **Add repository with basic settings**
 

--- a/chef_master/source/resource_apt_update.rst
+++ b/chef_master/source/resource_apt_update.rst
@@ -45,6 +45,7 @@ will behave the same as:
 
 Actions
 =====================================================
+
 The apt_update resource has the following actions:
 
 ``:nothing``
@@ -220,11 +221,8 @@ The following properties can be used to define a guard that is evaluated during 
 
 Examples
 =====================================================
-.. tag resources_common_examples_intro
 
 The following examples demonstrate various approaches for using resources in recipes:
-
-.. end_tag
 
 **Update the Apt repository at a specified interval**
 

--- a/chef_master/source/resource_archive_file.rst
+++ b/chef_master/source/resource_archive_file.rst
@@ -236,7 +236,9 @@ The following properties can be used to define a guard that is evaluated during 
 .. end_tag
 
 Examples
-==========================================
+=====================================================
+
+The following examples demonstrate various approaches for using resources in recipes:
 
 **Extract a zip file to a specified directory**
 

--- a/chef_master/source/resource_bash.rst
+++ b/chef_master/source/resource_bash.rst
@@ -292,6 +292,7 @@ The following properties can be used to define a guard that is evaluated during 
 
 Examples
 =====================================================
+
 The following examples demonstrate various approaches for using resources in recipes:
 
 **Use a named provider to run a script**

--- a/chef_master/source/resource_batch.rst
+++ b/chef_master/source/resource_batch.rst
@@ -303,6 +303,7 @@ The following properties can be used to define a guard that is evaluated during 
 
 Examples
 =====================================================
+
 The following examples demonstrate various approaches for using resources in recipes:
 
 **Unzip a file, and then move it**

--- a/chef_master/source/resource_bff_package.rst
+++ b/chef_master/source/resource_bff_package.rst
@@ -248,9 +248,9 @@ The following properties can be used to define a guard that is evaluated during 
 
 .. end_tag
 
-
 Examples
 =====================================================
+
 The following examples demonstrate various approaches for using resources in recipes:
 
 **Install a package**

--- a/chef_master/source/resource_breakpoint.rst
+++ b/chef_master/source/resource_breakpoint.rst
@@ -564,6 +564,7 @@ To get a list of nodes using a recipe named ``postfix`` use ``search(:node,"reci
 
 Examples
 =====================================================
+
 The following examples demonstrate various approaches for using resources in recipes:
 
 **A recipe without a breakpoint**

--- a/chef_master/source/resource_build_essential.rst
+++ b/chef_master/source/resource_build_essential.rst
@@ -26,6 +26,21 @@ where:
 * ``action`` identifies which steps Chef Infra Client will take to bring the node into the desired state.
 * ``compile_time`` is the property available to this resource.
 
+Nameless
+=====================================================
+
+This resource can be **nameless**. Add the resource itself to your recipe to get the default behavior:
+
+.. code-block:: ruby
+
+   build_essential
+
+will behave the same as:
+
+.. code-block:: ruby
+
+   build_essential 'install tools'
+
 Actions
 =====================================================
 
@@ -198,3 +213,22 @@ The following properties can be used to define a guard that is evaluated during 
   Allow a resource to execute only if the condition returns ``true``.
 
 .. end_tag
+
+Examples
+=====================================================
+
+The following examples demonstrate various approaches for using resources in recipes:
+
+**Install compilation packages**
+
+.. code-block:: ruby
+
+   build_essential
+
+**Install compilation packages during the compilation phase**
+
+.. code-block:: ruby
+
+   build_essential 'Install compilation tools' do
+     compile_time true
+   end

--- a/chef_master/source/resource_chef_handler.rst
+++ b/chef_master/source/resource_chef_handler.rst
@@ -601,6 +601,7 @@ The ``run_status`` object is initialized by Chef Infra Client before the ``repor
 
 Examples
 =====================================================
+
 The following examples demonstrate various approaches for using resources in recipes:
 
 **Enable the CloudkickHandler handler**

--- a/chef_master/source/resource_chocolatey_config.rst
+++ b/chef_master/source/resource_chocolatey_config.rst
@@ -207,3 +207,25 @@ The following properties can be used to define a guard that is evaluated during 
   Allow a resource to execute only if the condition returns ``true``.
 
 .. end_tag
+
+Examples
+=====================================================
+
+The following examples demonstrate various approaches for using resources in recipes:
+
+**Set the Chocolatey cacheLocation config**
+
+.. code-block:: ruby
+
+   chocolatey_config 'Set cacheLocation config' do
+     config_key 'cacheLocation'
+     value 'C:	empoco'
+   end
+
+**Unset a Chocolatey config**
+
+.. code-block:: ruby
+
+   chocolatey_config 'BogusConfig' do
+     action :unset
+   end

--- a/chef_master/source/resource_chocolatey_feature.rst
+++ b/chef_master/source/resource_chocolatey_feature.rst
@@ -201,3 +201,24 @@ The following properties can be used to define a guard that is evaluated during 
   Allow a resource to execute only if the condition returns ``true``.
 
 .. end_tag
+
+Examples
+=====================================================
+
+The following examples demonstrate various approaches for using resources in recipes:
+
+**Enable the checksumFiles Chocolatey feature**
+
+.. code-block:: ruby
+
+   chocolatey_feature 'checksumFiles' do
+     action :enable
+   end
+
+**Disable the checksumFiles Chocolatey feature**
+
+.. code-block:: ruby
+
+   chocolatey_feature 'checksumFiles' do
+     action :disable
+   end

--- a/chef_master/source/resource_chocolatey_package.rst
+++ b/chef_master/source/resource_chocolatey_package.rst
@@ -270,6 +270,7 @@ The following properties can be used to define a guard that is evaluated during 
 
 Examples
 =====================================================
+
 The following examples demonstrate various approaches for using resources in recipes:
 
 **Install a package**

--- a/chef_master/source/resource_chocolatey_source.rst
+++ b/chef_master/source/resource_chocolatey_source.rst
@@ -245,3 +245,25 @@ The following properties can be used to define a guard that is evaluated during 
   Allow a resource to execute only if the condition returns ``true``.
 
 .. end_tag
+
+Examples
+=====================================================
+
+The following examples demonstrate various approaches for using resources in recipes:
+
+**Add a Chocolatey source**
+
+.. code-block:: ruby
+
+   chocolatey_source 'MySource' do
+     source 'http://example.com/something'
+     action :add
+   end
+
+**Remove a Chocolatey source**
+
+.. code-block:: ruby
+
+   chocolatey_source 'MySource' do
+     action :remove
+   end

--- a/chef_master/source/resource_cookbook_file.rst
+++ b/chef_master/source/resource_cookbook_file.rst
@@ -594,6 +594,7 @@ The naming of folders within cookbook directories must literally match the host 
 
 Examples
 =====================================================
+
 The following examples demonstrate various approaches for using resources in recipes:
 
 **Transfer a file**

--- a/chef_master/source/resource_cron.rst
+++ b/chef_master/source/resource_cron.rst
@@ -332,6 +332,7 @@ The following properties can be used to define a guard that is evaluated during 
 
 Examples
 =====================================================
+
 The following examples demonstrate various approaches for using resources in recipes:
 
 **Run a program at a specified interval**

--- a/chef_master/source/resource_cron_access.rst
+++ b/chef_master/source/resource_cron_access.rst
@@ -203,7 +203,7 @@ The following properties can be used to define a guard that is evaluated during 
 .. end_tag
 
 Examples
-==========================================
+=====================================================
 
 The following examples demonstrate various approaches for using resources in recipes:
 

--- a/chef_master/source/resource_cron_d.rst
+++ b/chef_master/source/resource_cron_d.rst
@@ -353,7 +353,7 @@ The following properties can be used to define a guard that is evaluated during 
 Examples
 =====================================================
 
-The following examples demonstrate various approaches for using resources in recipes
+The following examples demonstrate various approaches for using resources in recipes:
 
 **Run a program at a specified interval**
 

--- a/chef_master/source/resource_dmg_package.rst
+++ b/chef_master/source/resource_dmg_package.rst
@@ -276,3 +276,38 @@ The following properties can be used to define a guard that is evaluated during 
   Allow a resource to execute only if the condition returns ``true``.
 
 .. end_tag
+
+Examples
+=====================================================
+
+The following examples demonstrate various approaches for using resources in recipes:
+
+**Install Google Chrome via the DMG package**
+
+.. code-block:: ruby
+
+  dmg_package 'Google Chrome' do
+    dmg_name 'googlechrome'
+    source   'https://dl-ssl.google.com/chrome/mac/stable/GGRM/googlechrome.dmg'
+    checksum '7daa2dc5c46d9bfb14f1d7ff4b33884325e5e63e694810adc58f14795165c91a'
+    action   :install
+  end
+
+**Install Virtualbox from the .mpkg**
+
+.. code-block:: ruby
+
+  dmg_package 'Virtualbox' do
+    source 'http://dlc.sun.com.edgesuite.net/virtualbox/4.0.8/VirtualBox-4.0.8-71778-OSX.dmg'
+    type   'mpkg'
+  end
+
+**Install pgAdmin and automatically accept the EULA**
+
+.. code-block:: ruby
+
+  dmg_package 'pgAdmin3' do
+    source   'http://wwwmaster.postgresql.org/redir/198/h/pgadmin3/release/v1.12.3/osx/pgadmin3-1.12.3.dmg'
+    checksum '9435f79d5b52d0febeddfad392adf82db9df159196f496c1ab139a6957242ce9'
+    accept_eula true
+  end

--- a/chef_master/source/resource_dpkg_package.rst
+++ b/chef_master/source/resource_dpkg_package.rst
@@ -256,7 +256,6 @@ The following properties can be used to define a guard that is evaluated during 
 
 .. end_tag
 
-
 Examples
 =====================================================
 

--- a/chef_master/source/resource_dsc_resource.rst
+++ b/chef_master/source/resource_dsc_resource.rst
@@ -243,6 +243,7 @@ The following properties are common to every resource:
 
 Notifications
 -----------------------------------------------------
+
 ``notifies``
   **Ruby Type:** Symbol, 'Chef::Resource[String]'
 


### PR DESCRIPTION
We didn't add these when we shipped a lot of these resources. They're from the various cookbooks we shipped in the client. I also added the boilerplate text to the generator code in chef/chef so the formatting is now standardized there.

Signed-off-by: Tim Smith <tsmith@chef.io>