### PR TITLE
Remove some references to Foodcritic

### DIFF
--- a/chef_master/source/about_chefdk.rst
+++ b/chef_master/source/about_chefdk.rst
@@ -11,7 +11,7 @@ ChefDK, short for Chef Development Kit, is a package that contains everything th
 
 * Chef Infra Client
 * chef and knife command line tools
-* Testing tools such as Test Kitchen, ChefSpec, Cookstyle, and Foodcritic
+* Testing tools such as Test Kitchen, ChefSpec, and Cookstyle.
 * Chef InSpec
 * Everything else needed to author cookbooks and upload them to the Chef Infra Server
 

--- a/chef_master/source/about_chefdk.rst
+++ b/chef_master/source/about_chefdk.rst
@@ -11,7 +11,7 @@ ChefDK, short for Chef Development Kit, is a package that contains everything th
 
 * Chef Infra Client
 * chef and knife command line tools
-* Testing tools such as Test Kitchen, ChefSpec, and Cookstyle.
+* Testing tools such as Test Kitchen, ChefSpec, and Cookstyle
 * Chef InSpec
 * Everything else needed to author cookbooks and upload them to the Chef Infra Server
 

--- a/chef_master/source/automate_azure.rst
+++ b/chef_master/source/automate_azure.rst
@@ -26,14 +26,14 @@ Chef provides a fully functional Chef Automate server that can be launched from 
 
    .. note:: Remember the DNS label of the Chef Automate VM. It will be required to access the Chef Automate UI and Chef Infra Server.
 
-#. While the Chef Automate VM is being provisioned, download and install `ChefDK </install_dk.html>`__.  ChefDK is a collection of tools ---Test Kitchen, ChefSpec, knife, delivery-cli, chef, chef-vault, Foodcritic, and more--- and libraries that are all packaged together to get your started with the Chef Automate workflow. You'll need this to interact with Chef Automate and Chef Infra Server from the command line.
+#. While the Chef Automate VM is being provisioned, download and install `ChefDK </install_dk.html>`__.  ChefDK is a collection of tools ---Test Kitchen, ChefSpec, knife, delivery-cli, chef, chef-vault, Cookstyle, and more--- and libraries that are all packaged together to get your started with the Chef Automate workflow. You'll need this to interact with Chef Automate and Chef Infra Server from the command line.
 
 #. After the VM has been provisioned and the Resource Manager has completed (usually 10 to 13 minutes), finish configuring Chef Automate and Chef Infra Server. Access the initial configuration page by loading the ``/biscotti/setup`` route. Build the URL by prepending ``https://`` and appending ``/biscotti/setup`` to the DNS label that you chose when the VM was launched. For example, ``https://<dns_label>.<location>.cloudapp.azure.com/biscotti/setup`` or ``https://chef-automate-01.eastus.cloudapp.azure.com/biscotti/setup``.
 
    .. note::
              In order to use TLS/SSL for the Chef Automate Web UI, the VM will automatically create and use a self-signed SSL certificate. Modern web browsers typically warn about self-signed certificates during login; however, in this case, you can ignore the warning and accept the certificate.
 
-             
+
 
 #. Fill out the setup form and submit it.
 
@@ -76,7 +76,7 @@ After verifying that your existing Chef Infra Server installation is up to date,
       $ /opt/opscode/embedded/bin/knife ec backup /tmp/chef-backup --with-user-sql --with-key-sql
       $ tar -czvf chef-backup.tgz -C /tmp/chef-backup
 
-   
+
 
 #. Using the Admin Username and FQDN that you choose when provisioning the Chef Automate Azure VM from the Azure portal, copy the resulting tarball to your Azure VM:
 
@@ -137,7 +137,7 @@ After verifying that your existing Chef Infra Server installation is up to date,
       chef_server_url          'https://<FQDN>/organizations/your_org'
       cookbook_path            ["#{current_dir}/../cookbooks"]
 
-   
+
 
 #. .. tag install_aws_chef_server_knife_ssl_fetch
 

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -125,7 +125,7 @@ Some important tools and components of Chef Workstation include:
 
        * Chef Infra Client
        * chef and knife command line tools
-       * Testing tools such as Test Kitchen, ChefSpec, Cookstyle, and Foodcritic
+       * Testing tools such as Test Kitchen, ChefSpec, and Cookstyle
        * Chef InSpec
        * Everything else needed to author cookbooks and upload them to the Chef Infra Server
 

--- a/chef_master/source/glossary.rst
+++ b/chef_master/source/glossary.rst
@@ -39,8 +39,8 @@ Glossary
 **cookbook**
    A cookbook is the fundamental unit of configuration and policy distribution.
 
-**cookstyle**
-  A linter to enforce Ruby code quality and style based on the popular Rubocop linter.
+**Cookstyle**
+   A linting tool that helps you write better Chef Infra cookbooks by detecting and automatically correcting style, syntax, and logic mistakes in your code.
 
 **data bag**
    A data_bag is a global variable that is stored as JSON data and is accessible from a Chef Infra Server.

--- a/chef_master/source/install_dk.rst
+++ b/chef_master/source/install_dk.rst
@@ -3,7 +3,7 @@ Install ChefDK
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/install_dk.rst>`__
 
-Use the ChefDK installer to set up ChefDK on a workstation. ChefDK includes Chef Infra Client, an embedded version of Ruby, RubyGems, and OpenSSL, as well as our tools: Test Kitchen, Cookstyle, Foodcritic and ChefSpec. The Chef installer puts everything into a unique directory (``/opt/chefdk/`` on macOS / Linux and ``C:\opscode\chefdk\`` on Windows) so that these components will not interfere with other applications that may be running on the target machine.
+Use the ChefDK installer to set up ChefDK on a workstation. ChefDK includes Chef Infra Client, an embedded version of Ruby, RubyGems, and OpenSSL, as well as our tools: Test Kitchen, Cookstyle, and ChefSpec. The Chef installer puts everything into a unique directory (``/opt/chefdk/`` on macOS / Linux and ``C:\opscode\chefdk\`` on Windows) so that these components will not interfere with other applications that may be running on the target machine.
 
 .. note:: The Chef installer must run as a privileged user.
 

--- a/chef_master/source/platform_overview.rst
+++ b/chef_master/source/platform_overview.rst
@@ -30,7 +30,7 @@ Using the workstation
 -----------------------------------------------------
 You create and test your code on your workstation before you deploy it to other environments. Your workstation is the computer where you author your cookbooks and administer your infrastructure. It's typically the machine you use everyday. It can be any OS you choose, whether it's Linux, macOS, or Windows.
 
-You'll need to install a text editor (whichever you like) to write code and ChefDK to get the tools to test your code. The primary testing tools you'll use are Cookstyle, Foodcritic, ChefSpec, Chef InSpec, and Test Kitchen. With them, you can make sure your Chef code does what you intended before you deploy it to environments used by others, such as staging or production.
+You'll need to install a text editor (whichever you like) to write code and ChefDK to get the tools to test your code. The primary testing tools you'll use are Cookstyle, ChefSpec, Chef InSpec, and Test Kitchen. With them, you can make sure your Chef code does what you intended before you deploy it to environments used by others, such as staging or production.
 
 When you write your code, you use resources to describe your infrastructure. A resource corresponds to some piece of infrastructure, such as a file, a template, or a package. Each resource declares what state a part of the system should be in, but not how to get there. Chef handles these complexities for you. Chef provides many resources that are ready for you to use. You can also utilize resources shipped in community cookbooks, or write your own resources specific to your infrastructure.
 

--- a/chef_master/source/ruby.rst
+++ b/chef_master/source/ruby.rst
@@ -22,7 +22,7 @@ To learn more about Ruby, see:
 
 .. end_tag
 
-As of Chef Client 14.0, Chef ships with Ruby 2.5.
+As of Chef Infra Client 15.x, Chef Infra Client ships with Ruby 2.6.
 
 Ruby Basics
 =====================================================

--- a/chef_master/source/ruby.rst
+++ b/chef_master/source/ruby.rst
@@ -772,28 +772,12 @@ Default and override attributes are cleared at the start of a Chef Infra Client 
 
 ``node.set`` (and ``node.normal``) should only be used to do something like generate a password for a database on the first Chef Infra Client run, after which it's remembered (instead of persisted). Even this case should be avoided, as using a data bag is the recommended way to store this type of data.
 
-Cookbook Linting with Chef Workstation Tools
-=====================================================
-Chef Workstation includes Foodcritic for linting the Chef specific portion of your cookbook code, and Cookstyle for linting the Ruby specific portion of your code.
-
-Foodcritic Linting
------------------------------------------------------
-All cookbooks should pass Foodcritic rules before being uploaded.
-
-.. code-block:: bash
-
-   $ foodcritic -P -f all your-cookbook
-
-should return nothing.
-
 Cookstyle Linting
------------------------------------------------------
-All cookbooks should pass Cookstyle rules before being uploaded.
+=====================================================
+Chef Workstation includes Cookstyle for linting the Ruby-specific and Chef-specific portions of your cookbook code. All cookbooks should pass Cookstyle rules before being uploaded.
 
 .. code-block:: bash
 
    $ cookstyle your-cookbook
 
 should return ``no offenses detected``
-
-


### PR DESCRIPTION
Foodcritic is in the process of being deprecated. We shouldn't be recommending it to anyone new to Chef.

Signed-off-by: Tim Smith <tsmith@chef.io>