### PR TITLE
Remove more deprecated metadata

### DIFF
--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -149,45 +149,6 @@ This configuration file has the following settings:
 
       license 'Proprietary - All Rights Reserved'
 
-``long_description``
-   A longer description that ideally contains full instructions on the proper use of a cookbook, including resources, libraries, dependencies, and so on. There are two ways to use this field: with the contents embedded in the field itself or with the contents pulled from a file at a specified path, such as a README.rdoc located at the top of a cookbook directory.
-
-   For example, to embed the long description within the field itself:
-
-   .. code-block:: ruby
-
-      long_description <<-EOH
-      = DESCRIPTION:
-
-      Complete Debian/Ubuntu style Apache2 configuration.
-
-      = REQUIREMENTS:
-
-      Debian or Ubuntu preferred.
-
-      Red Hat/CentOS and Fedora can be used but will be converted to
-      a Debian/Ubuntu style Apache as it's far easier to manage
-      with Chef.
-
-      = ATTRIBUTES:
-
-      The file attributes/apache.rb contains the following attribute
-      types:
-
-      * platform specific locations and settings.
-      * general settings
-      * pre-fork attributes
-      * worker attributes
-
-      General settings and pre-fork/worker attributes are tunable.
-      EOH
-
-   Or to read the contents from a specified file:
-
-   .. code-block:: ruby
-
-      long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
-
 ``maintainer``
    The name of the person responsible for maintaining a cookbook, either an individual or an organization.
 
@@ -234,37 +195,6 @@ This configuration file has the following settings:
    .. code-block:: ruby
 
       privacy true
-
-``provides``
-   Add a recipe, definition, or resource that is provided by this cookbook, should the auto-populated list be insufficient.
-
-   For example, for recipes:
-
-   .. code-block:: ruby
-
-      provides 'cats::sleep'
-      provides 'cats::eat'
-
-   And for resources:
-
-   .. code-block:: ruby
-
-      provides 'service[snuggle]'
-
-``recipe``
-   A description for a recipe, mostly for cosmetic value within the Chef Infra Server user interface.
-
-   For example:
-
-   .. code-block:: ruby
-
-      recipe 'cats::sleep', 'For a crazy 20 hours a day.'
-
-   or:
-
-   .. code-block:: ruby
-
-      recipe 'cats::eat', 'When they are not sleeping.'
 
 ``source_url``
    The URL for the location in which a cookbook's source code is maintained. This setting is also used by Chef Supermarket. In Chef Supermarket, this value is used to define the destination for the "View Source" link.


### PR DESCRIPTION
We've greatly simplified the metadata.rb file by removing content we
never actually consumed anywhere.

Signed-off-by: Tim Smith <tsmith@chef.io>