### PR TITLE
Add dtags for docs conversion to Hugo

### DIFF
--- a/chef_master/source/handlers.rst
+++ b/chef_master/source/handlers.rst
@@ -676,7 +676,11 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
 
 Optional Interfaces
 -----------------------------------------------------
+.. tag handler_custom_optional_interfaces
+
 The following interfaces may be used in a handler in the same way as the ``report`` interface to override the default handler behavior in Chef Infra Client. That said, the following interfaces are not typically used in a handler and, for the most part, are completely unnecessary for a handler to work properly and/or as desired.
+
+.. end_tag
 
 data
 +++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/chef_master/source/release_notes.rst
+++ b/chef_master/source/release_notes.rst
@@ -5808,6 +5808,7 @@ Unlike definitions, custom resources are able to use `common resource properties
 
 ps_credential Helper
 -----------------------------------------------------
+.. tag ps_credential_helper
 
 Use the ``ps_credential`` helper to embed a ``PSCredential`` object--- `a set of security credentials, such as a user name or password <https://technet.microsoft.com/en-us/magazine/ff714574.aspx>`__ ---within a script, which allows that script to be run using security credentials.
 
@@ -5834,6 +5835,8 @@ For example, assuming the ``CertificateID`` is configured in the local configura
       }
     EOH
   end
+
+.. end_tag
 
 Handler DSL
 -----------------------------------------------------

--- a/chef_master/source/resource_apt_update.rst
+++ b/chef_master/source/resource_apt_update.rst
@@ -30,6 +30,7 @@ where:
 
 Nameless
 =====================================================
+.. tag nameless_apt_update
 
 This resource can be **nameless**. Add the resource itself to your recipe to get the default behavior:
 
@@ -42,6 +43,8 @@ will behave the same as:
 .. code-block:: ruby
 
    apt_update 'update'
+
+.. end_tag
 
 Actions
 =====================================================

--- a/chef_master/source/resource_build_essential.rst
+++ b/chef_master/source/resource_build_essential.rst
@@ -28,6 +28,7 @@ where:
 
 Nameless
 =====================================================
+.. tag nameless_build_essential
 
 This resource can be **nameless**. Add the resource itself to your recipe to get the default behavior:
 
@@ -40,6 +41,8 @@ will behave the same as:
 .. code-block:: ruby
 
    build_essential 'install tools'
+
+.. end_tag
 
 Actions
 =====================================================

--- a/chef_master/source/resource_chef_handler.rst
+++ b/chef_master/source/resource_chef_handler.rst
@@ -510,7 +510,11 @@ The `json_file <https://github.com/chef/chef/blob/master/lib/chef/handler/json_f
 
 Optional Interfaces
 -----------------------------------------------------
+.. tag handler_custom_optional_interfaces
+
 The following interfaces may be used in a handler in the same way as the ``report`` interface to override the default handler behavior in Chef Infra Client. That said, the following interfaces are not typically used in a handler and, for the most part, are completely unnecessary for a handler to work properly and/or as desired.
+
+.. end_tag
 
 data
 +++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/chef_master/source/resource_cookbook_file.rst
+++ b/chef_master/source/resource_cookbook_file.rst
@@ -522,6 +522,8 @@ The following properties can be used to define a guard that is evaluated during 
 
 File Specificity
 =====================================================
+.. tag cookbook_file_specificity
+
 A cookbook is frequently designed to work across many platforms and is often required to distribute a specific file to a specific platform. A cookbook can be designed to support the distribution of files across platforms, while ensuring that the correct file ends up on each system.
 
 The pattern for file specificity depends on two things: the lookup path and the source attribute. The first pattern that matches is used:
@@ -591,6 +593,8 @@ If the ``apache2_module_conf_generate.pl`` file was located in the cookbook dire
 **Host Notation**
 
 The naming of folders within cookbook directories must literally match the host notation used for file specificity matching. For example, if a host is named ``foo.example.com``, the folder must be named ``host-foo.example.com``.
+
+.. end_tag
 
 Examples
 =====================================================

--- a/chef_master/source/resource_dsc_script.rst
+++ b/chef_master/source/resource_dsc_script.rst
@@ -176,19 +176,21 @@ The dsc_script resource has the following properties:
 
 ps_credential Helper
 ----------------------------------------------------
+.. tag ps_credential_helper
+
 Use the ``ps_credential`` helper to embed a ``PSCredential`` object--- `a set of security credentials, such as a user name or password <https://technet.microsoft.com/en-us/magazine/ff714574.aspx>`__ ---within a script, which allows that script to be run using security credentials.
 
 For example, assuming the ``CertificateID`` is configured in the local configuration manager, the ``SeaPower1@3`` object is created and embedded within the ``seapower-user`` script:
 
 .. code-block:: ruby
 
-   dsc_script 'seapower-user' do
-     code <<-EOH
-       User AlbertAtom
-       {
-         UserName = 'AlbertAtom'
-         Password = #{ps_credential('SeaPower1@3')}
-       }
+  dsc_script 'seapower-user' do
+    code <<-EOH
+      User AlbertAtom
+      {
+        UserName = 'AlbertAtom'
+        Password = #{ps_credential('SeaPower1@3')}
+      }
     EOH
     configuration_data <<-EOH
       @{
@@ -202,7 +204,7 @@ For example, assuming the ``CertificateID`` is configured in the local configura
     EOH
   end
 
-
+.. end_tag
 
 Common Resource Functionality
 =====================================================

--- a/chef_master/source/resource_package.rst
+++ b/chef_master/source/resource_package.rst
@@ -9,6 +9,8 @@ Use the **package** resource to manage packages. When the package is installed f
 
 .. end_tag
 
+.. tag package_resource
+
 This resource is the base resource for several other resources used for package management on specific platforms. While it is possible to use each of these specific resources, it is recommended to use the **package** resource as often as possible.
 
 For more information about specific resources for specific platforms, see the following topics:
@@ -35,6 +37,8 @@ For more information about specific resources for specific platforms, see the fo
 * `windows_package </resource_windows_package.html>`__
 * `yum_package </resource_yum_package.html>`__
 * `zypper_package </resource_zypper_package.html>`__
+
+.. end_tag
 
 Syntax
 =====================================================

--- a/chef_master/source/resource_remote_directory.rst
+++ b/chef_master/source/resource_remote_directory.rst
@@ -321,6 +321,8 @@ The following properties can be used to define a guard that is evaluated during 
 
 Recursive Directories
 -----------------------------------------------------
+.. tag remote_directory_recursive_directories
+
 The **remote_directory** resource can be used to recursively create the path outside of remote directory structures, but the permissions of those outside paths are not managed. This is because the ``recursive`` attribute only applies ``group``, ``mode``, and ``owner`` attribute values to the remote directory itself and any inner directories the resource copies.
 
 A directory structure::
@@ -354,8 +356,12 @@ But with this example, the ``group``, ``mode``, and ``owner`` attribute values w
 
 This approach will create the correct hierarchy---``/foo``, then ``/bar`` in ``/foo``, and then ``/baz`` in ``/bar``---and also with the correct attribute values for ``group``, ``mode``, and ``owner``.
 
+.. end_tag
+
 Example
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. tag remote_directory_recursive_directories_example
+
 This section contains a more detailed example of how Chef Infra Client manages recursive directory structures:
 
 * A cookbook named ``cumbria`` that is used to build a website
@@ -446,6 +452,8 @@ Chef Infra Client will manage the permissions of the entire directory structure 
    drwxrwx--- 2 hamilton root 4096 /var/www/html/places
    dr--r----- 1 yan      root 4096 /var/www/html/places/furness_abbey.html
    dr--r----- 1 yan      root 4096 /var/www/html/places/hadrians_wall.html
+
+.. end_tag
 
 Windows File Security
 -----------------------------------------------------

--- a/chef_master/source/resource_remote_file.rst
+++ b/chef_master/source/resource_remote_file.rst
@@ -608,6 +608,8 @@ Because the ``inherits`` property is not specified, Chef Infra Client will defau
 
 Prevent Re-downloads
 -----------------------------------------------------
+.. tag remote_file_prevent_re_downloads
+
 To prevent Chef Infra Client from re-downloading files that are already present on a node, use one of the following attributes in a recipe: ``use_conditional_get`` (default) or ``checksum``.
 
 * The ``use_conditional_get`` attribute is the default behavior of Chef Infra Client. If the remote file is located on a server that supports ETag and/or If-Modified-Since headers, Chef Infra Client will use a conditional ``GET`` to determine if the file has been updated. If the file has been updated, Chef Infra Client will re-download the file.
@@ -616,8 +618,12 @@ To prevent Chef Infra Client from re-downloading files that are already present 
 
 The desired approach just depends on the desired workflow. For example, if a node requires a new file every day, using the checksum approach would require that the local checksum be updated and/or verified every day as well, in order to ensure that the local checksum was the correct one. Using a conditional ``GET`` in this scenario will greatly simplify the management required to ensure files are being updated accurately.
 
+.. end_tag
+
 Access a remote UNC path on Windows
 -----------------------------------------------------
+.. tag remote_file_unc_path
+
 The ``remote_file`` resource on Windows supports accessing files from a remote SMB/CIFS share. The file name should be specified in the source property as a UNC path e.g. ``\\myserver\myshare\mydirectory\myfile.txt``. This
 allows access to the file at that path location even if the Chef Infra Client process identity does not have permission to access the file. Credentials for authenticating to the remote system can be specified using the ``remote_user``, ``remote_domain``, and ``remote_password`` properties when the user that Chef Infra Client is running does not have access to the remote file. See the "Properties" section for more details on these options.
 
@@ -667,6 +673,8 @@ OR
      remote_user ".\\username"
      remote_password "password"
    end
+
+.. end_tag
 
 Examples
 =====================================================

--- a/chef_master/source/resource_template.rst
+++ b/chef_master/source/resource_template.rst
@@ -570,6 +570,8 @@ This resource would be matched in the same order as the ``/templates`` directory
 
 Helpers
 -----------------------------------------------------
+.. tag template_helpers
+
 A helper is a method or a module that can be used to extend a template. There are three approaches:
 
 * An inline helper method
@@ -578,8 +580,12 @@ A helper is a method or a module that can be used to extend a template. There ar
 
 Use the ``helper`` attribute in a recipe to define an inline helper method. Use the ``helpers`` attribute to define an inline helper module or a cookbook library module.
 
+.. end_tag
+
 Inline Methods
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. tag resource_template_inline_method
+
 A template helper method is always defined inline on a per-resource basis. A simple example:
 
 .. code-block:: ruby
@@ -622,8 +628,12 @@ or:
 
    node['app']['log_location'] is: <%= app_conf('log_location') %>
 
+.. end_tag
+
 Inline Modules
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. tag resource_template_inline_module
+
 A template helper module can be defined inline on a per-resource basis. This approach can be useful when a template requires more complex information. For example:
 
 .. code-block:: ruby
@@ -647,6 +657,8 @@ A template helper module can be defined inline on a per-resource basis. This app
    end
 
 where the ``hello_world``, ``app``, and ``app_conf(setting)`` methods comprise the module that extends a template.
+
+.. end_tag
 
 Library Modules
 +++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This adds dtags to sections of text so they can be converted to shortcodes in Hugo. Those shortcodes will be easier to add or remove in resource pages in Hugo. 

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
