### PR TITLE
Remove chef generate build-cookbook from the nav bar

### DIFF
--- a/chef_master/source/_templates/nav-docs.html
+++ b/chef_master/source/_templates/nav-docs.html
@@ -1567,11 +1567,6 @@
                 "url": "/ctl_chef.html#chef-generate-cookbook"
               },
               {
-                "title": "chef generate build-cookbook",
-                "hasSubItems": false,
-                "url": "/ctl_chef.html#chef-generate-build-cookbook"
-              },
-              {
                 "title": "chef generate file",
                 "hasSubItems": false,
                 "url": "/ctl_chef.html#chef-generate-file"


### PR DESCRIPTION
This is a command for setting up build cookbooks needed by workflow /
delivery. It should be there in search, but no one new needs to find
this.

Signed-off-by: Tim Smith <tsmith@chef.io>