### PR TITLE
remove dtag duplicate in script resource page

### DIFF
--- a/chef_master/source/resource_script.rst
+++ b/chef_master/source/resource_script.rst
@@ -239,21 +239,6 @@ Notifications
 
   .. end_tag
 
-.. tag resources_common_notification_timers
-
-A timer specifies the point during a Chef Infra Client run at which a notification is run. The following timers are available:
-
-``:before``
-   Specifies that the action on a notified resource should be run before processing the resource block in which the notification is located.
-
-``:delayed``
-   Default. Specifies that a notification should be queued up, and then executed at the end of a Chef Infra Client run.
-
-``:immediate``, ``:immediately``
-   Specifies that a notification should be run immediately, per resource notified.
-
-.. end_tag
-
 .. tag resources_common_notification_notifies_syntax
 
 The syntax for ``notifies`` is:


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

The dtag resources_common_notification_timers appears twice in resource_script.rst. This deletes the first instance.

### Check List

- [ ] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
