### PR TITLE
Chef generate requires the -b option to generate a Berksfile

### DIFF
--- a/chef_master/source/berkshelf.rst
+++ b/chef_master/source/berkshelf.rst
@@ -12,7 +12,7 @@ Berkshelf is a dependency manager for Chef cookbooks. With it, you can easily de
 Quick Start
 ===============
 
-Running ``chef generate cookbook`` will, by default, create a ``Berksfile`` in the root of the cookbook, alongside the cookbook's ``metadata.rb``. As usual, add your cookbook's dependencies to the metadata:
+Run ``chef generate cookbook -b`` or ``--berks`` to create a Berksfile in the root of the cookbook. The Berksfile will be placed alongside the cookbook's metadata.rb file. As usual, add your cookbook's dependencies to the metadata.rb file:
 
 .. code-block:: ruby
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

The `chef generate cookbook` command doesn't automatically generate a new Berksfile. The user has to use `-b` or `--berks` to generate one.

### Check List

- [ ] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
