### PR TITLE
More changes to environments

### DIFF
--- a/chef_master/source/api_chef_server.rst
+++ b/chef_master/source/api_chef_server.rst
@@ -2827,7 +2827,7 @@ The response is similar to:
 -----------------------------------------------------
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments. Generally, an environment is also associated with one (or more) cookbook versions.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
 
 .. end_tag
 

--- a/chef_master/source/api_chef_server.rst
+++ b/chef_master/source/api_chef_server.rst
@@ -2827,7 +2827,7 @@ The response is similar to:
 -----------------------------------------------------
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, you can change cookbook configurations depending on the system's designation. For example, by designating different staging and production environments, you can then define the correct URL of a database server for each environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/api_chef_server.rst
+++ b/chef_master/source/api_chef_server.rst
@@ -2827,7 +2827,7 @@ The response is similar to:
 -----------------------------------------------------
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/attributes.rst
+++ b/chef_master/source/attributes.rst
@@ -294,15 +294,15 @@ Environments
 -----------------------------------------------------
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments. Generally, an environment is also associated with one (or more) cookbook versions.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
 
 .. end_tag
 
 .. tag environment_attribute
 
-An attribute can be defined in an environment and then used to override the default settings on a node. When an environment is applied during a Chef Infra Client run, these attributes are compared to the attributes that are already present on the node. When the environment attributes take precedence over the default attributes, Chef Infra Client applies those new settings and values during a Chef Infra Client run.
+Attributes can be defined in an environment and then used to override the default attributes in a cookbook. When an environment is applied during a Chef Infra Client run, environment attributes are compared to the attributes that are already present on the node. When the environment attributes take precedence over the default attributes, Chef Infra Client applies those new settings and values during a Chef Infra Client run.
 
-An environment attribute can only be set to be a default attribute or an override attribute. An environment attribute cannot be set to be a ``normal`` attribute. Use the ``default_attribute`` and ``override_attribute`` methods in the Ruby DSL file or the ``default_attributes`` and ``override_attributes`` hashes in a JSON data file.
+Environment attributes can be set to either ``default`` attribute level or an ``override`` attribute level.
 
 .. end_tag
 

--- a/chef_master/source/attributes.rst
+++ b/chef_master/source/attributes.rst
@@ -294,7 +294,7 @@ Environments
 -----------------------------------------------------
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, you can change cookbook configurations depending on the system's designation. For example, by designating different staging and production environments, you can then define the correct URL of a database server for each environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/attributes.rst
+++ b/chef_master/source/attributes.rst
@@ -294,7 +294,7 @@ Environments
 -----------------------------------------------------
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -527,7 +527,7 @@ Some important aspects of policy include:
 
      - .. tag environment
 
-       An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments. Generally, an environment is also associated with one (or more) cookbook versions.
+       An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
 
        .. end_tag
 

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -527,7 +527,7 @@ Some important aspects of policy include:
 
      - .. tag environment
 
-       An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
+       An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, you can change cookbook configurations depending on the system's designation. For example, by designating different staging and production environments, you can then define the correct URL of a database server for each environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
        .. end_tag
 

--- a/chef_master/source/chef_overview.rst
+++ b/chef_master/source/chef_overview.rst
@@ -527,7 +527,7 @@ Some important aspects of policy include:
 
      - .. tag environment
 
-       An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
+       An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
        .. end_tag
 

--- a/chef_master/source/chef_search.rst
+++ b/chef_master/source/chef_search.rst
@@ -987,7 +987,7 @@ Environments
 -----------------------------------------------------
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments. Generally, an environment is also associated with one (or more) cookbook versions.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
 
 .. end_tag
 

--- a/chef_master/source/chef_search.rst
+++ b/chef_master/source/chef_search.rst
@@ -987,7 +987,7 @@ Environments
 -----------------------------------------------------
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, you can change cookbook configurations depending on the system's designation. For example, by designating different staging and production environments, you can then define the correct URL of a database server for each environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/chef_search.rst
+++ b/chef_master/source/chef_search.rst
@@ -987,7 +987,7 @@ Environments
 -----------------------------------------------------
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/chef_solo.rst
+++ b/chef_master/source/chef_solo.rst
@@ -176,8 +176,8 @@ and like the following in the Ruby DSL:
    name 'environment_name'
    description 'environment_description'
    cookbook OR cookbook_versions  'cookbook' OR 'cookbook' => 'cookbook_version'
-   default_attributes 'node' => { 'attribute' => [ 'value', 'value', 'etc.' ] }
-   override_attributes 'node' => { 'attribute' => [ 'value', 'value', 'etc.' ] }
+   default_attributes 'node' => { 'attribute' => %w(value value etc.) }
+   override_attributes 'node' => { 'attribute' => %w(value value etc.) }
 
 .. end_tag
 

--- a/chef_master/source/environments.rst
+++ b/chef_master/source/environments.rst
@@ -140,17 +140,17 @@ Each environment is defined as a Ruby file (i.e. a file that ends with ``.rb``).
 
        .. code-block:: ruby
 
-          cookbook_versions({
-            'couchdb'=>'= 11.0.0',
-            'my_rails_app'=>'~> 1.2.0'
-          })
+          cookbook_versions(
+            'couchdb' => '= 11.0.0',
+            'my_rails_app' => '~> 1.2.0'
+          )
 
    * - ``default_attributes``
      - Optional. A set of attributes to be applied to all nodes, assuming the node does not already have a value for the attribute. This is useful for setting global defaults that can then be overridden for specific nodes. If more than one role attempts to set a default value for the same attribute, the last role applied is the role to set the attribute value. When nested attributes are present, they are preserved. For example, to specify that a node that has the attribute ``apache2`` should listen on ports 80 and 443 (unless ports are already specified):
 
        .. code-block:: ruby
 
-          default_attributes 'apache2' => { 'listen_ports' => [ '80', '443' ] }
+          default_attributes 'apache2' => { 'listen_ports' => %w(80 443) }
 
    * - ``description``
      - A description of the functionality that is covered. For example:
@@ -178,8 +178,8 @@ Each environment is defined as a Ruby file (i.e. a file that ends with ``.rb``).
        .. code-block:: ruby
 
           override_attributes(
-            :apache2 => {
-              :prefork => { :min_spareservers => '5' }
+            apache2: {
+              prefork: { min_spareservers: '5' },
             }
           )
 
@@ -188,11 +188,11 @@ Each environment is defined as a Ruby file (i.e. a file that ends with ``.rb``).
        .. code-block:: ruby
 
           override_attributes(
-            :apache2 => {
-              :prefork => { :min_spareservers => '5' }
+            apache2: {
+              prefork: { min_spareservers: '5' },
             },
-            :tomcat => {
-              :worker_threads => '100'
+            tomcat: {
+              worker_threads: '100',
             }
           )
 
@@ -213,7 +213,7 @@ where both default and override attributes are optional and either a cookbook or
    name 'dev'
    description 'The development environment'
    cookbook_versions  'couchdb' => '= 11.0.0'
-   default_attributes 'apache2' => { 'listen_ports' => [ '80', '443' ] }
+   default_attributes 'apache2' => { 'listen_ports' => %w(80 443) }
 
 Or (using the same scenario) to specify a version constraint for only one cookbook:
 
@@ -226,21 +226,21 @@ More than one cookbook version can be specified:
 .. code-block:: ruby
 
    cookbook_versions({
-     'couchdb'=>'= 11.0.0',
-     'my_rails_app'=>'~> 1.2.0'
+     'couchdb' => '= 11.0.0',
+     'my_rails_app' => '~> 1.2.0'
    })
 
 Attributes are optional and can be set at the default and override levels. These will be processed according to attribute precedence. An environment attribute will be applied to all nodes within the environment, except in places where it is overridden by an attribute with higher precedence. For example:
 
 .. code-block:: ruby
 
-   default_attributes 'apache2' => { 'listen_ports' => [ '80', '443' ] }
+   default_attributes 'apache2' => { 'listen_ports' => %w(80 443) }
 
 will have all nodes in the environment (``node[:apache2][:listen_ports]``) set to ``'80'`` and ``'443'`` unless they were overridden by an attribute with higher precedence. For example:
 
 .. code-block:: ruby
 
-   override_attributes 'apache2' => { 'listen_ports' => [ '99', '999' ] }
+   override_attributes 'apache2' => { 'listen_ports' => %w(80 443) }
 
 JSON
 -----------------------------------------------------
@@ -432,7 +432,7 @@ and like the following in the Ruby DSL:
    name 'environment_name'
    description 'environment_description'
    cookbook OR cookbook_versions  'cookbook' OR 'cookbook' => 'cookbook_version'
-   default_attributes 'node' => { 'attribute' => [ 'value', 'value', 'etc.' ] }
-   override_attributes 'node' => { 'attribute' => [ 'value', 'value', 'etc.' ] }
+   default_attributes 'node' => { 'attribute' => %w(value value etc.) }
+   override_attributes 'node' => { 'attribute' => %w(value value etc.) }
 
 .. end_tag

--- a/chef_master/source/environments.rst
+++ b/chef_master/source/environments.rst
@@ -95,7 +95,7 @@ Attribute precedence, when viewed as a table:
 Cookbook Pinning
 =====================================================
 
-Cookbook versions can be pinned per evironment. This allows for the controlled rollout of new cookbook releases through environments for testing before new versions reach production environments. See the environment format examples below for the cookbook pinning syntax.
+Cookbook versions can be pinned in each environment, which allows you to control the rollout of new cookbook releases through successive testing environments before releasing new cookbook versions into production environments. See the environment format examples below for the cookbook pinning syntax.
 
 Environment Formats
 =====================================================

--- a/chef_master/source/environments.rst
+++ b/chef_master/source/environments.rst
@@ -127,13 +127,13 @@ Each environment is defined as a Ruby file (i.e. a file that ends with ``.rb``).
 
        .. code-block:: ruby
 
-          cookbook 'my_rails_app', '< 1.2.0'
+          cookbook 'my_rails_app', '= 1.2.0'
 
        or:
 
        .. code-block:: ruby
 
-          cookbook 'gems', '< 1.4.0'
+          cookbook 'gems', '~> 1.4'
 
    * - ``cookbook_versions``
      - A version constraint for a group of cookbooks. For example:

--- a/chef_master/source/environments.rst
+++ b/chef_master/source/environments.rst
@@ -366,7 +366,7 @@ A node is considered to be associated with an environment when the ``chef_enviro
 
 Move Nodes
 -----------------------------------------------------
-Nodes can be moved between environments, such as from a "dev" to a "production" environment by using the ``knife exec`` subcommand. For example:
+Use the ``knife exec`` subcommand to move nodes between environments, such as from a "dev" to a "production" environment. For example:
 
 .. code-block:: bash
 

--- a/chef_master/source/environments.rst
+++ b/chef_master/source/environments.rst
@@ -11,7 +11,7 @@ An environment is a way to map an organization's real-life workflow to what can 
 
 The _default Environment
 =====================================================
-Every Chef Infra Server organization must have at least one environment. Each organization starts out with a single environment that is named ``_default``. The ``_default`` environment cannot be modified in any way. Nodes, roles, run-lists, cookbooks (and cookbook versions), and attributes specific to an organization can only be associated with a custom environment.
+Every Chef Infra Server organization must have at least one environment. Each organization starts out with a single ``_default`` environment. The ``_default`` environment cannot be modified in any way. Nodes, roles, run-lists, cookbooks (and cookbook versions), and attributes specific to an organization can only be associated with a custom environment.
 
 Environment Attributes
 =====================================================

--- a/chef_master/source/environments.rst
+++ b/chef_master/source/environments.rst
@@ -5,7 +5,7 @@ About Environments
 
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, you can change cookbook configurations depending on the system's designation. For example, by designating different staging and production environments, you can then define the correct URL of a database server for each environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/environments.rst
+++ b/chef_master/source/environments.rst
@@ -5,13 +5,14 @@ About Environments
 
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 
 The _default Environment
 =====================================================
-Every Chef Infra Server organization must have at least one environment. Each organization starts out with a single ``_default`` environment. The ``_default`` environment cannot be modified in any way. Nodes, roles, run-lists, cookbooks (and cookbook versions), and attributes specific to an organization can only be associated with a custom environment.
+
+Every Chef Infra Server organization must have at least one environment. Each organization starts out with a single ``_default`` environment. The ``_default`` environment cannot be modified in any way. Nodes, roles, run-lists, cookbooks (and cookbook versions), and attributes specific to an organization can only be associated with a custom environment. Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
 
 Environment Attributes
 =====================================================

--- a/chef_master/source/knife_environment.rst
+++ b/chef_master/source/knife_environment.rst
@@ -5,7 +5,7 @@ knife environment
 
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments. Generally, an environment is also associated with one (or more) cookbook versions.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
 
 .. end_tag
 

--- a/chef_master/source/knife_environment.rst
+++ b/chef_master/source/knife_environment.rst
@@ -5,7 +5,7 @@ knife environment
 
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/knife_environment.rst
+++ b/chef_master/source/knife_environment.rst
@@ -5,7 +5,7 @@ knife environment
 
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, you can change cookbook configurations depending on the system's designation. For example, by designating different staging and production environments, you can then define the correct URL of a database server for each environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/policy.rst
+++ b/chef_master/source/policy.rst
@@ -40,7 +40,7 @@ Environments
 =====================================================
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments. Generally, an environment is also associated with one (or more) cookbook versions.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
 
 .. end_tag
 

--- a/chef_master/source/policy.rst
+++ b/chef_master/source/policy.rst
@@ -40,7 +40,7 @@ Environments
 =====================================================
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, you can change cookbook configurations depending on the system's designation. For example, by designating different staging and production environments, you can then define the correct URL of a database server for each environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/policy.rst
+++ b/chef_master/source/policy.rst
@@ -40,7 +40,7 @@ Environments
 =====================================================
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/resource_chef_environment.rst
+++ b/chef_master/source/resource_chef_environment.rst
@@ -16,7 +16,7 @@ chef_environment
 
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments. Generally, an environment is also associated with one (or more) cookbook versions.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
 
 .. end_tag
 

--- a/chef_master/source/resource_chef_environment.rst
+++ b/chef_master/source/resource_chef_environment.rst
@@ -3,8 +3,8 @@ chef_environment
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_chef_environment.rst>`__
 
-.. meta:: 
-    :robots: noindex 
+.. meta::
+    :robots: noindex
 
 .. warning:: .. tag EOL_provisioning
 
@@ -16,7 +16,7 @@ chef_environment
 
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/resource_chef_environment.rst
+++ b/chef_master/source/resource_chef_environment.rst
@@ -16,7 +16,7 @@ chef_environment
 
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, you can change cookbook configurations depending on the system's designation. For example, by designating different staging and production environments, you can then define the correct URL of a database server for each environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/server_manage_environments.rst
+++ b/chef_master/source/server_manage_environments.rst
@@ -24,7 +24,7 @@ Manage Environments
 
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments. Generally, an environment is also associated with one (or more) cookbook versions.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
 
 .. end_tag
 

--- a/chef_master/source/server_manage_environments.rst
+++ b/chef_master/source/server_manage_environments.rst
@@ -3,8 +3,8 @@ Manage Environments
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/server_manage_environments.rst>`__
 
-.. meta:: 
-    :robots: noindex 
+.. meta::
+    :robots: noindex
 
 .. note:: This topic is about using the Chef management console to manage environments.
 
@@ -24,7 +24,7 @@ Manage Environments
 
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. Every organization begins with a single environment called the ``_default`` environment, which cannot be modified (or deleted). Additional environments can be created to reflect each organization's patterns and workflow. For example, creating ``production``, ``staging``, ``testing``, and ``development`` environments.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 

--- a/chef_master/source/server_manage_environments.rst
+++ b/chef_master/source/server_manage_environments.rst
@@ -24,7 +24,7 @@ Manage Environments
 
 .. tag environment
 
-An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, cookbook configurations can be changed depending on the system's designation. For example you may want to change the URL to a database server depending on if a system is in a staging or a production environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
+An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra. This mapping is accomplished by setting attributes and pinning cookbooks at the environment level. With environments, you can change cookbook configurations depending on the system's designation. For example, by designating different staging and production environments, you can then define the correct URL of a database server for each environment. Environments also allow organizations to move new cookbook releases from staging to production with confidence by stepping releases through testing environments before entering production.
 
 .. end_tag
 


### PR DESCRIPTION
Explain cookbook version pinning

Remove Attribute Persistence which should only be in the attributes doc

Remove the () from node.environment. This isn't javascript

Move the chef solo instructions to their own category

Make an initial mention of cookbook pinning. This is a super important feature that all our large customers do and we don't even call it out here. Kinda weird

Remove the odd section explaining what Ruby is. We have that earlier on and we don't have a similar section for what JSON is. Eventually we need to get hover overs or aggressive links for this kinda thing. Right now though this just bloats the doc and detracts from the real content.

Signed-off-by: Tim Smith <tsmith@chef.io>