### PR TITLE
Remove podcasts that are no longer active (all of them)

### DIFF
--- a/chef_master/source/community.rst
+++ b/chef_master/source/community.rst
@@ -19,17 +19,6 @@ Learn
 * `Chef training <https://training.chef.io/>`_
 * `Self-guided learning <https://learn.chef.io/>`_
 
-Listen
-=====================================================
-* `Food Fight Show <http://foodfightshow.org>`_
-* `The Ship Show <http://theshipshow.com/>`_
-* `Ops All The Things <http://opsallthethings.com>`_
-* `DevOps Cafe <http://devopscafe.com>`_
-* `The Goat Farm <https://itunes.apple.com/us/podcast/the-goat-farm/id963113606?mt=2>`_
-* `Software Defined Talk <http://cote.io/sdt/>`_
-
-.. * `Arrested DevOps <https://www.arresteddevops.com/>`_
-
 Interact
 =====================================================
 * `Community Guidelines </community_guidelines.html>`__


### PR DESCRIPTION
Food Fight just ended and the others haven't had new content in over a
year.

Signed-off-by: Tim Smith <tsmith@chef.io>