### PR TITLE
Remove Chef books that are 5+ years old

### DIFF
--- a/chef_master/source/community.rst
+++ b/chef_master/source/community.rst
@@ -39,27 +39,18 @@ Interact
 * `Facebook <https://www.facebook.com/getchefdotcom>`_
 * `Chef Community Slack <https://community-slack.chef.io/>`_
 * Join the "Chef Software Users Group" on LinkedIn
-* `Chef Software Mailing List <https://discourse.chef.io>`_ (for discussion among users, developers, and other interested parties)
+* `Chef Software Mailing List <https://discourse.chef.io/>`_ (for discussion among users, developers, and other interested parties)
 
 Read
 =====================================================
-Recommended reading:
 
 * `Effective DevOps (Building a Culture of Collaboration, Affinity, and Tooling at Scale) <http://shop.oreilly.com/product/0636920039846.do>`_
-* `Learning Chef (A Guide to Configuration Management and Automation) <http://shop.oreilly.com/product/0636920032397.do>`_
 * `Customizing Chef (Getting the Most Out of Your Infrastructure Automation) <http://shop.oreilly.com/product/0636920032984.do>`_
-
-More books about Chef:
-
-* `Chef Essentials <https://www.packtpub.com/networking-and-servers/chef-essentials>`_
-* `Instant Chef Starter <https://www.packtpub.com/application-development/instant-chef-starter-instant>`_
+* `Chef: Powerful Infrastructure Automation [Packt Publishing] <https://www.packtpub.com/virtualization-and-cloud/chef-powerful-infrastructure-automation>`_
+* `Chef Cookbook - Third Edition [Packt Publishing] <https://www.packtpub.com/networking-and-servers/chef-cookbook-third-edition>`_
 * `Learning Chef [Packt Publishing] <https://www.packtpub.com/networking-and-servers/learning-chef>`_
 * `Chef Infrastructure Automation Cookbook - Second Edition [Packt Publishing] <https://www.packtpub.com/networking-and-servers/chef-infrastructure-automation-cookbook-second-edition/>`_
 * `Mastering Chef [Packt Publishing] <https://www.packtpub.com/networking-and-servers/mastering-chef/>`_
-* `Managing Windows Servers with Chef <https://www.packtpub.com/networking-and-servers/managing-windows-servers-chef>`_
-* `Test-Driven Infrastructure with Chef, 2nd Edition <http://shop.oreilly.com/product/0636920030973.do>`_
-* `Chef Cookbook - Third Edition [Packt Publishing] <https://www.packtpub.com/networking-and-servers/chef-cookbook-third-edition>`_
-* `Chef: Powerful Infrastructure Automation [Packt Publishing] <https://www.packtpub.com/virtualization-and-cloud/chef-powerful-infrastructure-automation>`_
 
 Contribute
 =====================================================


### PR DESCRIPTION
We want to make sure we're directing folks to books that are going to describe current best practices. A lot of these books were great when written, but are very dated at this point. This removes everything that's about 5+ years old and collapses the list into a single set of books w/o recommendations. We haven't reviewed everything that's out there so we can't say what's best.

Signed-off-by: Tim Smith <tsmith@chef.io>