### PR TITLE
Clarify minor version upgrade choice

### DIFF
--- a/chef_master/source/upgrade_server_ha_v2.rst
+++ b/chef_master/source/upgrade_server_ha_v2.rst
@@ -14,7 +14,9 @@ Overview
 These instructions cover the process of upgrading a Chef Backend cluster. Please refer to the appropriate directions for the version of Chef Backend you are using, and the version you intend to upgrade to:
 
 * `Chef Backend 1.x to 2.x Upgrade`_ (downtime upgrade)
-* `Chef Backend 1.x to 1.x Upgrade`_ (rolling upgrade)
+* `Chef Backend Minor Version Upgrade`_ (rolling upgrade)
+
+.. note:: The Minor Version Upgrade is appropriate for all upgrades other than one major version to another major version, for example: 1.x to 1.x upgrades, 2.x to 2.x upgrades
 
 Chef Backend 1.x to 2.x Upgrade
 =====================================================
@@ -78,7 +80,7 @@ Chef Backend 1.x to 2.x Upgrade
 
 #. To continue the upgrades on Chef Infra Server frontends using this backend cluster, see `Upgrade Frontends Associated with a Chef Backend Cluster <https://docs.chef.io/install_server_ha.html#upgrading-chef-server-on-the-frontend-machines>`_
 
-Chef Backend 1.x to 1.x Upgrade
+Chef Backend Minor Version Upgrade
 =====================================================
 
 .. note:: The procedure assumes that the new chef-backend package has been copied to all of the nodes.

--- a/chef_master/source/upgrade_server_ha_v2.rst
+++ b/chef_master/source/upgrade_server_ha_v2.rst
@@ -11,12 +11,10 @@ This topic describes the process of upgrading a highly available Chef Infra Serv
 
 Overview
 =====================================================
-These instructions cover the process of upgrading a Chef Backend cluster. Please refer to the appropriate directions for the version of Chef Backend you are using, and the version you intend to upgrade to:
+These instructions cover the process of upgrading a Chef Backend cluster. Please refer to the appropriate directions for the version of Chef Backend that you are using and the version that you intend to upgrade to:
 
 * `Chef Backend 1.x to 2.x Upgrade`_ (downtime upgrade)
 * `Chef Backend Minor Version Upgrade`_ (rolling upgrade)
-
-.. note:: The Minor Version Upgrade is appropriate for all upgrades other than one major version to another major version, for example: 1.x to 1.x upgrades, 2.x to 2.x upgrades
 
 Chef Backend 1.x to 2.x Upgrade
 =====================================================
@@ -82,6 +80,8 @@ Chef Backend 1.x to 2.x Upgrade
 
 Chef Backend Minor Version Upgrade
 =====================================================
+
+The Minor Version Upgrade is appropriate for all upgrades of a Chef Backend cluster other than upgrades from one major version to another major version. For example, 1.x to 1.x upgrades or 2.x to 2.x upgrades.
 
 .. note:: The procedure assumes that the new chef-backend package has been copied to all of the nodes.
 


### PR DESCRIPTION
### Description

The previous instructions could be misinterpreted as specifically indicating 1.x to 1.x upgrades and not 2.x to 2.x upgrades. The Chef Backend HA code currently doesn't allow downtime upgrades for non-major version upgrades so this is an important distinction.

[Please describe what this change achieves]

### Definition of Done

### Issues Resolved

### Check List

- [ x] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
