### PR TITLE
Fix typo on resource_cron_access.rst

### DIFF
--- a/chef_master/source/resource_cron_access.rst
+++ b/chef_master/source/resource_cron_access.rst
@@ -3,7 +3,7 @@ cron_access resource
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_cron_access.rst>`__
 
-Use the **cron_access** resource to manage the /etc/cron.allow and /etc/cron.deny files. Note: This resource previously shipped in the ``cron`` cookbook as ``cron_manage``, which it can still be used as for backwards compatibility with existing Chef Infra Clien releases.
+Use the **cron_access** resource to manage the /etc/cron.allow and /etc/cron.deny files. Note: This resource previously shipped in the ``cron`` cookbook as ``cron_manage``, which it can still be used as for backwards compatibility with existing Chef Infra Client releases.
 
 **New in Chef Client 14.4.**
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

Fixes a typo in resource_cron_access.rst

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
