### PR TITLE
Chef Replication/Sync EOL

### DIFF
--- a/chef_master/source/versions.rst
+++ b/chef_master/source/versions.rst
@@ -210,6 +210,10 @@ End of Life (EOL) Products
      - All
      - Deprecated
      - August 31, 2019
+   * - Chef Replication/Sync
+     - All
+     - EOL
+     - August 31, 2019
    * - Reporting
      - All
      - EOL


### PR DESCRIPTION
Chef Replication/Sync has been deprecated since Chef Server 12.9.x
https://docs-archive.chef.io/release/server_12-1/server_replication.html

Let's make it official.

Signed-off-by: Sean Horn <sean_horn@chef.io>