### PR TITLE
Emphasize getting off definitions more

### DIFF
--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -16,7 +16,7 @@ Though a definition looked like a resource, and at first glance seems like it co
 * Are processed when resource collection is compiled, not when a node is converged
 * Did not support common resource properties, such as ``notifies``, ``subscribes``, ``only_if``, ``not_if``, and sensitive
 * Don't support input validation in passed arguments, unlike a resource can which supports validation with properties
-* Did not support why-run mode
+* Don't support ``why-run`` mode
 * Did not support reporting to Chef Automate
 * Cannot be tested with ChefSpec
 

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -96,11 +96,11 @@ which was then used in a recipe like this:
      port 4001
    end
 
-Definition vs. Resource
+Migrating to Custom Resources
 =====================================================
 We highly recommend migrating existing definitions to custom resources to unlock the full feature set of Chef Infra resources. The following example shows a definition and that same definition rewritten as a custom resources.
 
-As a Definition
+Initial Definition Code
 ----------------------------------------------------
 The following definition processes unique hostnames and ports, passed on as parameters:
 
@@ -118,9 +118,9 @@ The following definition processes unique hostnames and ports, passed on as para
      end
    end
 
-As a Resource
+Migrated to a Custom Resource
 ----------------------------------------------------
-The definition is improved by rewriting it as a custom resource:
+The definition is improved by rewriting it as a custom resource. This uses properties to accept input and has a single ``:create`` action:
 
 .. code-block:: ruby
 
@@ -139,7 +139,7 @@ The definition is improved by rewriting it as a custom resource:
 
    end
 
-Once built, the custom resource may be used in a recipe just like the any of the resources that are built into Chef. The resource gets its name from the cookbook and from the file name in the ``/resources`` directory, with an underscore (``_``) separating them. For example, a cookbook named ``host`` with a custom resource in the ``/resources`` directory named ``porter.rb``. Use it in a recipe like this:
+Once written, the custom resource may be used in a recipe just like the any of the resources that are built into Chef Infra. The resource gets its name from the cookbook and from the file name in the ``/resources`` directory, with an underscore (``_``) separating them. For example, a cookbook named ``host`` with a custom resource in the ``/resources`` directory named ``porter.rb``. Use it in a recipe like this:
 
 .. code-block:: ruby
 

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -4,7 +4,7 @@ Converting Definitions to Custom Resources
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/definitions.rst>`__
 
 
-This topic covers migrating existing definitions to custom resources. Custom resources are integral to the modern Chef Infra workflow. While definitions are not yet deprecated, we *strongly* advise migrating to custom resources immediately, in order to benefit from the many features of Chef Infra such as notifications, reporting, why-run mode, and ChefSpec unit testing.
+This topic covers migrating existing definitions to custom resources. Custom resources are integral to the modern Chef Infra workflow. While definitions are not yet deprecated, we *strongly* advise migrating to custom resources immediately in order to benefit from the many features of Chef Infra such as notifications, reporting, why-run mode, and ChefSpec unit testing.
 
 Definitions
 =====================================================

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -13,7 +13,7 @@ A definition behaved like a compile-time macro that was reusable across recipes.
 Though a definition looked like a resource, and at first glance seems like it could have been used interchangeably, some important differences exist. A definition:
 
 * Was not a true resource
-* Was processed while the resource collection is compiled (whereas resources are processed while a node is converged)
+* Are processed when resource collection is compiled, not when a node is converged
 * Did not support common resource properties, such as ``notifies``, ``subscribes``, ``only_if``, ``not_if``, and sensitive
 * Did not support input validation in passed arguments like a resource does with properties
 * Did not support why-run mode

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -10,7 +10,7 @@ Definitions
 =====================================================
 A definition behaved like a compile-time macro that was reusable across recipes. A definition was typically created by wrapping arbitrary code around Chef Infra resources that were declared as if they were in a recipe. A definition was then used in one (or more) actual recipes as if the definition were a resource.
 
-Though a definition looked like a resource, and at first glance seems like it could have been used interchangeably, some important differences exist. Definitions:
+Though a definition looks like a resource, and at first glance seems like it could be used interchangeably, some important differences exist. Definitions:
 
 * Are not true resources
 * Are processed when resource collection is compiled, not when a node is converged

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -14,7 +14,7 @@ Though a definition looked like a resource, and at first glance seems like it co
 
 * Are not true resources
 * Are processed when resource collection is compiled, not when a node is converged
-* Did not support common resource properties, such as ``notifies``, ``subscribes``, ``only_if``, ``not_if``, and sensitive
+* Don't support common resource properties, such as ``notifies``, ``subscribes``, ``only_if``, ``not_if``, and ``sensitive``
 * Don't support input validation in passed arguments, unlike a resource can which supports validation with properties
 * Don't support ``why-run`` mode
 * Can't report to Chef Automate

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -15,7 +15,7 @@ Though a definition looks like a resource, and at first glance seems like it cou
 * Are not true resources
 * Are processed when resource collection is compiled, not when a node is converged
 * Don't support common resource properties, such as ``notifies``, ``subscribes``, ``only_if``, ``not_if``, and ``sensitive``
-* Don't support input validation in passed arguments, unlike a resource can which supports validation with properties
+* Don't support input validation in passed arguments, unlike a resource which supports validation with properties
 * Don't support ``why-run`` mode
 * Can't report to Chef Automate
 * Cannot be tested with ChefSpec

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -98,11 +98,7 @@ which was then used in a recipe like this:
 
 Definition vs. Resource
 =====================================================
-The following examples show:
-
-#. A definition
-#. The same definition rewritten as a custom resource
-#. The same definition, rewritten again to use a `common resource property </resource_common.html>`__
+We highly recommend migrating existing definitions to custom resources to unlock the full feature set of Chef Infra resources. The following example shows a definition and that same definition rewritten as a custom resources.
 
 As a Definition
 ----------------------------------------------------
@@ -157,15 +153,4 @@ or:
 
    host_porter 'www1' do
      port 4001
-   end
-
-Use Common Properties
-----------------------------------------------------
-Unlike definitions, custom resources are able to use `common resource properties </resource_common.html>`__. For example, ``only_if``:
-
-.. code-block:: ruby
-
-   host_porter 'www1' do
-     port 4001
-     only_if { node['hostname'] == 'foo.bar.com' }
    end

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -4,7 +4,7 @@ Converting Definitions to Custom Resources
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/definitions.rst>`__
 
 
-In 2016 with Chef Client 12.5 `custom resources </custom_resources.html>`__ were introduced to allow users to easily create their own resources within cookbooks. Custom resources are intended to replace both LWRPs and definitions in cookbook code. While not formally deprecated we *highly* suggest that existing definitions be migrated to custom resources as many features such as notifications, reporting, why-run mode, and ChefSpec unit testinng are not possible with definitions. This topic covers what a definition is and shows how to convert an existing definition to a custom resource.
+This topic covers migrating existing definitions to custom resources. Custom resources are integral to the modern Chef Infra workflow. While definitions are not yet deprecated, we *strongly* advise migrating to custom resources immediately, in order to benefit from the many features of Chef Infra such as notifications, reporting, why-run mode, and ChefSpec unit testing.
 
 Definitions
 =====================================================

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -15,7 +15,7 @@ Though a definition looked like a resource, and at first glance seems like it co
 * Are not true resources
 * Are processed when resource collection is compiled, not when a node is converged
 * Did not support common resource properties, such as ``notifies``, ``subscribes``, ``only_if``, ``not_if``, and sensitive
-* Did not support input validation in passed arguments like a resource does with properties
+* Don't support input validation in passed arguments, unlike a resource can which supports validation with properties
 * Did not support why-run mode
 * Did not support reporting to Chef Automate
 * Cannot be tested with ChefSpec

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -4,7 +4,7 @@ Converting Definitions to Custom Resources
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/definitions.rst>`__
 
 
-In 2016 with Chef Client 12.5 `custom resources </custom_resources.html>`__ were introduced to allow users to easily create their own resources within cookbooks. Custom resources are intended to replace both LWRPs and definitions in cookbook code. While not formally deprecated we *highly* suggest that existing definitions be migrated to custom resources as many features such as notifications, reporting, and why-run mode are not possible with definitions. This topic covers what a definition is and shows how to convert an existing definition to a custom resource.
+In 2016 with Chef Client 12.5 `custom resources </custom_resources.html>`__ were introduced to allow users to easily create their own resources within cookbooks. Custom resources are intended to replace both LWRPs and definitions in cookbook code. While not formally deprecated we *highly* suggest that existing definitions be migrated to custom resources as many features such as notifications, reporting, why-run mode, and ChefSpec unit testinng are not possible with definitions. This topic covers what a definition is and shows how to convert an existing definition to a custom resource.
 
 Definitions
 =====================================================
@@ -14,9 +14,11 @@ Though a definition looked like a resource, and at first glance seems like it co
 
 * Was not a true resource
 * Was processed while the resource collection is compiled (whereas resources are processed while a node is converged)
-* Does not support common resource properties, such as ``notifies``, ``subscribes``, ``only_if``, and ``not_if``
+* Did not support common resource properties, such as ``notifies``, ``subscribes``, ``only_if``, ``not_if``, and sensitive
+* Did not support input validation in passed arguments like a resource does with properties
 * Did not support why-run mode
 * Did not support reporting to Chef Automate
+* Cannot be tested with ChefSpec
 
 Syntax
 =====================================================

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -10,7 +10,7 @@ Definitions
 =====================================================
 A definition behaved like a compile-time macro that was reusable across recipes. A definition was typically created by wrapping arbitrary code around Chef Infra resources that were declared as if they were in a recipe. A definition was then used in one (or more) actual recipes as if the definition were a resource.
 
-Though a definition looked like a resource, and at first glance seems like it could have been used interchangeably, some important differences exist. A definition:
+Though a definition looked like a resource, and at first glance seems like it could have been used interchangeably, some important differences exist. Definitions:
 
 * Are not true resources
 * Are processed when resource collection is compiled, not when a node is converged

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -139,7 +139,7 @@ The definition is improved by rewriting it as a custom resource. This uses prope
 
    end
 
-Once written, the custom resource may be used in a recipe just like the any of the resources that are built into Chef Infra. The resource gets its name from the cookbook and from the file name in the ``/resources`` directory, with an underscore (``_``) separating them. For example, a cookbook named ``host`` with a custom resource in the ``/resources`` directory named ``porter.rb``. Use it in a recipe like this:
+Once written, a custom resource may be used in a recipe just like any resource that is built into Chef Infra. A custom resource gets its name from the cookbook and the name of its file in the ``/resources`` directory with an underscore (``_``) separating them. For example, a cookbook named ``host`` with a custom resource file named ``porter.rb`` in the ``/resources`` directory would be called ``host_porter``. Use it in a recipe like this:
 
 .. code-block:: ruby
 

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -17,7 +17,7 @@ Though a definition looked like a resource, and at first glance seems like it co
 * Did not support common resource properties, such as ``notifies``, ``subscribes``, ``only_if``, ``not_if``, and sensitive
 * Don't support input validation in passed arguments, unlike a resource can which supports validation with properties
 * Don't support ``why-run`` mode
-* Did not support reporting to Chef Automate
+* Can't report to Chef Automate
 * Cannot be tested with ChefSpec
 
 Syntax

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -12,7 +12,7 @@ A definition behaved like a compile-time macro that was reusable across recipes.
 
 Though a definition looked like a resource, and at first glance seems like it could have been used interchangeably, some important differences exist. A definition:
 
-* Was not a true resource
+* Are not true resources
 * Are processed when resource collection is compiled, not when a node is converged
 * Did not support common resource properties, such as ``notifies``, ``subscribes``, ``only_if``, ``not_if``, and sensitive
 * Did not support input validation in passed arguments like a resource does with properties

--- a/chef_master/source/definitions.rst
+++ b/chef_master/source/definitions.rst
@@ -98,7 +98,7 @@ which was then used in a recipe like this:
 
 Migrating to Custom Resources
 =====================================================
-We highly recommend migrating existing definitions to custom resources to unlock the full feature set of Chef Infra resources. The following example shows a definition and that same definition rewritten as a custom resources.
+We highly recommend migrating existing definitions to custom resources to unlock the full feature set of Chef Infra resources. The following example shows a definition and that same definition rewritten as a custom resource.
 
 Initial Definition Code
 ----------------------------------------------------


### PR DESCRIPTION
Add more reasons not to write definitions. Tweak wording to focus more on the migration.