### PR TITLE
Update example for multi string registry_key 

### DIFF
--- a/chef_master/source/resource_registry_key.rst
+++ b/chef_master/source/resource_registry_key.rst
@@ -28,11 +28,11 @@ A **registry_key** resource block creates and deletes registry keys in Microsoft
 
 .. code-block:: ruby
 
-   registry_key "HKEY_LOCAL_MACHINE\\...\\System" do
+   registry_key 'HKEY_LOCAL_MACHINE\\...\\System' do
      values [{
-       name: "NewRegistryKeyValue",
+       name: 'NewRegistryKeyValue',
        type: :multi_string,
-       data: ['foo\0bar\0\0']
+       data: %w(foo bar baz),
      }]
      action :create
    end


### PR DESCRIPTION
### Description

The :multi_string registry key type accepts a string array and is idempotent when used this way (unlike the previous example which uses nul terminated strings and is not idempotent). This small update corrects the example.

### Definition of Done

Updated example, including corrected style

### Issues Resolved

N/A - updating after observing internal discussion in Slack.

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
