### PR TITLE
Document use of "chef-client -j file.json" passed attributes

### DIFF
--- a/chef_master/source/attributes.rst
+++ b/chef_master/source/attributes.rst
@@ -14,6 +14,7 @@ An attribute is a specific detail about a node. Attributes are used by Chef Infr
 Attributes are defined by:
 
 * The state of the node itself
+* Attributes passed via JSON on the CLI
 * Cookbooks (in attribute files and/or recipes)
 * Roles
 * Environments
@@ -21,6 +22,7 @@ Attributes are defined by:
 
 During every Chef Infra Client run, Chef Infra Client builds the attribute list using:
 
+* Attributes passed via JSON on the CLI
 * Data about the node collected by `[Ohai] </ohai.html>`__.
 * The node object that was saved to the Chef Infra Server at the end of the previous Chef Infra Client run.
 * The rebuilt node object from the current Chef Infra Client run, after it is updated for changes to cookbooks (attribute files and/or recipes), roles, and/or environments, and updated for any changes to the state of the node itself.
@@ -35,7 +37,7 @@ Attribute Persistence
 =====================================================
 .. tag node_attribute_persistence
 
-All attributes except for normal attributes are reset at the beginning of a Chef Infra Client run. Chef Infra Client rebuilds these attributes using automatic attributes collected by Ohai at the beginning of each Chef Infra Client run, and then uses default and override attributes that are specified in cookbooks, roles, environments, and Policyfiles. All attributes are then merged and applied to the node according to attribute precedence. The attributes that were applied to the node are saved to the Chef Infra Server as part of the node object at the conclusion of each Chef Infra Client run.
+All attributes except for normal attributes are reset at the beginning of a Chef Infra Client run. Attributes set via ``chef-client -j`` with a JSON file have normal precedence and are persisted between Chef Infra Client runs. Chef Infra Client rebuilds these attributes using automatic attributes collected by Ohai at the beginning of each Chef Infra Client run, and then uses default and override attributes that are specified in cookbooks, roles, environments, and Policyfiles. All attributes are then merged and applied to the node according to attribute precedence. The attributes that were applied to the node are saved to the Chef Infra Server as part of the node object at the conclusion of each Chef Infra Client run.
 
 .. end_tag
 
@@ -99,6 +101,7 @@ Attribute Sources
 =====================================================
 Attributes are provided to Chef Infra Client from the following locations:
 
+* JSON files passed via the ``chef-client -j``
 * Nodes (collected by Ohai at the start of each Chef Infra Client run)
 * Attribute files (in cookbooks)
 * Recipes (in cookbooks)
@@ -111,7 +114,7 @@ Notes:
 * Many attributes are maintained in the chef-repo for Policyfiles, environments, roles, and cookbooks (attribute files and recipes)
 * Many attributes are collected by Ohai on each individual node at the start of every Chef Infra Client run
 * The attributes that are maintained in the chef-repo are uploaded to the Chef Infra Server from the workstation, periodically
-* Chef Infra Client will pull down the node object from the Chef Infra Server (which contains the attribute data from the previous Chef Infra Client run), after which all attributes (except ``normal`` are reset)
+* Chef Infra Client will pull down the node object from the Chef Infra Server (which contains the attribute data from the previous Chef Infra Client run, including those set via ``-j`` with JSON files), after which all attributes (except ``normal`` are reset)
 * Chef Infra Client will update the cookbooks on the node (if required), which updates the attributes contained in attribute files and recipes
 * Chef Infra Client will update the role and environment data (if required)
 * Chef Infra Client will rebuild the attribute list and apply attribute precedence while configuring the node
@@ -321,6 +324,7 @@ Attributes are always applied by Chef Infra Client in the following order:
 #. A ``default`` attribute located in a role
 #. A ``force_default`` attribute located in a cookbook attribute file
 #. A ``force_default`` attribute located in a recipe
+#. A ``normal`` attribute located in a JSON file passed via ``chef-client -j``
 #. A ``normal`` attribute located in a cookbook attribute file
 #. A ``normal`` attribute located in a recipe
 #. An ``override`` attribute located in a cookbook attribute file

--- a/chef_master/source/attributes.rst
+++ b/chef_master/source/attributes.rst
@@ -114,7 +114,7 @@ Notes:
 * Many attributes are maintained in the chef-repo for Policyfiles, environments, roles, and cookbooks (attribute files and recipes)
 * Many attributes are collected by Ohai on each individual node at the start of every Chef Infra Client run
 * The attributes that are maintained in the chef-repo are uploaded to the Chef Infra Server from the workstation, periodically
-* Chef Infra Client will pull down the node object from the Chef Infra Server (which contains the attribute data from the previous Chef Infra Client run, including those set via ``-j`` with JSON files), after which all attributes (except ``normal`` are reset)
+* Chef Infra Client will pull down the node object from the Chef Infra Server and then reset all the attributes except ``normal``. The node object will contain the attribute data from the previous Chef Infra Client run including attributes set with JSON files via ``-j``.
 * Chef Infra Client will update the cookbooks on the node (if required), which updates the attributes contained in attribute files and recipes
 * Chef Infra Client will update the role and environment data (if required)
 * Chef Infra Client will rebuild the attribute list and apply attribute precedence while configuring the node

--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -111,7 +111,7 @@ This command has the following options:
    The frequency (in seconds) at which Chef Infra Client runs. When running Chef Infra Client at intervals, apply ``--splay`` and ``--interval`` values before a Chef Infra Client run. Default value: ``1800``.
 
 ``-j PATH``, ``--json-attributes PATH``
-   The path to a file that contains JSON data. Used to setup the first client run. For all the future runs with option -i the attributes are expected to be persisted in the chef-server.
+   The path to a file that contains JSON data. Used to setup the first client run. **For all the future runs with option -j the attributes are expected to be persisted in the chef-server.**
 
    **Run-lists**
 

--- a/chef_master/source/ctl_chef_client.rst
+++ b/chef_master/source/ctl_chef_client.rst
@@ -111,7 +111,7 @@ This command has the following options:
    The frequency (in seconds) at which Chef Infra Client runs. When running Chef Infra Client at intervals, apply ``--splay`` and ``--interval`` values before a Chef Infra Client run. Default value: ``1800``.
 
 ``-j PATH``, ``--json-attributes PATH``
-   The path to a file that contains JSON data. Used to setup the first client run. **For all the future runs with option -j the attributes are expected to be persisted in the chef-server.**
+   The path to a file that contains JSON data. Used to setup the first client run. The attributes will persist on the Chef Infra Server for all future runs with option ``-j``.
 
    **Run-lists**
 

--- a/chef_master/source/environments.rst
+++ b/chef_master/source/environments.rst
@@ -69,6 +69,7 @@ Attributes are always applied by Chef Infra Client in the following order:
 #. A ``default`` attribute located in a role
 #. A ``force_default`` attribute located in a cookbook attribute file
 #. A ``force_default`` attribute located in a recipe
+#. A ``normal`` attribute located in a JSON file passed via ``chef-client -j``
 #. A ``normal`` attribute located in a cookbook attribute file
 #. A ``normal`` attribute located in a recipe
 #. An ``override`` attribute located in a cookbook attribute file

--- a/chef_master/source/nodes.rst
+++ b/chef_master/source/nodes.rst
@@ -192,6 +192,7 @@ An attribute is a specific detail about a node. Attributes are used by Chef Infr
 Attributes are defined by:
 
 * The state of the node itself
+* Attributes passed via JSON on the CLI
 * Cookbooks (in attribute files and/or recipes)
 * Roles
 * Environments
@@ -199,6 +200,7 @@ Attributes are defined by:
 
 During every Chef Infra Client run, Chef Infra Client builds the attribute list using:
 
+* Attributes passed via JSON on the CLI
 * Data about the node collected by `[Ohai] </ohai.html>`__.
 * The node object that was saved to the Chef Infra Server at the end of the previous Chef Infra Client run.
 * The rebuilt node object from the current Chef Infra Client run, after it is updated for changes to cookbooks (attribute files and/or recipes), roles, and/or environments, and updated for any changes to the state of the node itself.
@@ -304,7 +306,7 @@ Attribute Persistence
 -----------------------------------------------------
 .. tag node_attribute_persistence
 
-All attributes except for normal attributes are reset at the beginning of a Chef Infra Client run. Chef Infra Client rebuilds these attributes using automatic attributes collected by Ohai at the beginning of each Chef Infra Client run, and then uses default and override attributes that are specified in cookbooks, roles, environments, and Policyfiles. All attributes are then merged and applied to the node according to attribute precedence. The attributes that were applied to the node are saved to the Chef Infra Server as part of the node object at the conclusion of each Chef Infra Client run.
+All attributes except for normal attributes are reset at the beginning of a Chef Infra Client run. Attributes set via ``chef-client -j`` with a JSON file have normal precedence and are persisted between Chef Infra Client runs. Chef Infra Client rebuilds these attributes using automatic attributes collected by Ohai at the beginning of each Chef Infra Client run, and then uses default and override attributes that are specified in cookbooks, roles, environments, and Policyfiles. All attributes are then merged and applied to the node according to attribute precedence. The attributes that were applied to the node are saved to the Chef Infra Server as part of the node object at the conclusion of each Chef Infra Client run.
 
 .. end_tag
 
@@ -320,6 +322,7 @@ Attributes are always applied by Chef Infra Client in the following order:
 #. A ``default`` attribute located in a role
 #. A ``force_default`` attribute located in a cookbook attribute file
 #. A ``force_default`` attribute located in a recipe
+#. A ``normal`` attribute located in a JSON file passed via ``chef-client -j``
 #. A ``normal`` attribute located in a cookbook attribute file
 #. A ``normal`` attribute located in a recipe
 #. An ``override`` attribute located in a cookbook attribute file

--- a/chef_master/source/recipes.rst
+++ b/chef_master/source/recipes.rst
@@ -93,7 +93,7 @@ Attribute Persistence
 -----------------------------------------------------
 .. tag node_attribute_persistence
 
-All attributes except for normal attributes are reset at the beginning of a Chef Infra Client run. Chef Infra Client rebuilds these attributes using automatic attributes collected by Ohai at the beginning of each Chef Infra Client run, and then uses default and override attributes that are specified in cookbooks, roles, environments, and Policyfiles. All attributes are then merged and applied to the node according to attribute precedence. The attributes that were applied to the node are saved to the Chef Infra Server as part of the node object at the conclusion of each Chef Infra Client run.
+All attributes except for normal attributes are reset at the beginning of a Chef Infra Client run. Attributes set via ``chef-client -j`` with a JSON file have normal precedence and are persisted between Chef Infra Client runs. Chef Infra Client rebuilds these attributes using automatic attributes collected by Ohai at the beginning of each Chef Infra Client run, and then uses default and override attributes that are specified in cookbooks, roles, environments, and Policyfiles. All attributes are then merged and applied to the node according to attribute precedence. The attributes that were applied to the node are saved to the Chef Infra Server as part of the node object at the conclusion of each Chef Infra Client run.
 
 .. end_tag
 
@@ -109,6 +109,7 @@ Attributes are always applied by Chef Infra Client in the following order:
 #. A ``default`` attribute located in a role
 #. A ``force_default`` attribute located in a cookbook attribute file
 #. A ``force_default`` attribute located in a recipe
+#. A ``normal`` attribute located in a JSON file passed via ``chef-client -j``
 #. A ``normal`` attribute located in a cookbook attribute file
 #. A ``normal`` attribute located in a recipe
 #. An ``override`` attribute located in a cookbook attribute file

--- a/chef_master/source/roles.rst
+++ b/chef_master/source/roles.rst
@@ -53,7 +53,7 @@ Attribute Persistence
 -----------------------------------------------------
 .. tag node_attribute_persistence
 
-All attributes except for normal attributes are reset at the beginning of a Chef Infra Client run. Chef Infra Client rebuilds these attributes using automatic attributes collected by Ohai at the beginning of each Chef Infra Client run, and then uses default and override attributes that are specified in cookbooks, roles, environments, and Policyfiles. All attributes are then merged and applied to the node according to attribute precedence. The attributes that were applied to the node are saved to the Chef Infra Server as part of the node object at the conclusion of each Chef Infra Client run.
+All attributes except for normal attributes are reset at the beginning of a Chef Infra Client run. Attributes set via ``chef-client -j`` with a JSON file have normal precedence and are persisted between Chef Infra Client runs. Chef Infra Client rebuilds these attributes using automatic attributes collected by Ohai at the beginning of each Chef Infra Client run, and then uses default and override attributes that are specified in cookbooks, roles, environments, and Policyfiles. All attributes are then merged and applied to the node according to attribute precedence. The attributes that were applied to the node are saved to the Chef Infra Server as part of the node object at the conclusion of each Chef Infra Client run.
 
 .. end_tag
 
@@ -69,6 +69,7 @@ Attributes are always applied by Chef Infra Client in the following order:
 #. A ``default`` attribute located in a role
 #. A ``force_default`` attribute located in a cookbook attribute file
 #. A ``force_default`` attribute located in a recipe
+#. A ``normal`` attribute located in a JSON file passed via ``chef-client -j``
 #. A ``normal`` attribute located in a cookbook attribute file
 #. A ``normal`` attribute located in a recipe
 #. An ``override`` attribute located in a cookbook attribute file

--- a/chef_master/source/server_manage_nodes.rst
+++ b/chef_master/source/server_manage_nodes.rst
@@ -85,6 +85,7 @@ An attribute is a specific detail about a node. Attributes are used by Chef Infr
 Attributes are defined by:
 
 * The state of the node itself
+* Attributes passed via JSON on the CLI
 * Cookbooks (in attribute files and/or recipes)
 * Roles
 * Environments
@@ -92,6 +93,7 @@ Attributes are defined by:
 
 During every Chef Infra Client run, Chef Infra Client builds the attribute list using:
 
+* Attributes passed via JSON on the CLI
 * Data about the node collected by `[Ohai] </ohai.html>`__.
 * The node object that was saved to the Chef Infra Server at the end of the previous Chef Infra Client run.
 * The rebuilt node object from the current Chef Infra Client run, after it is updated for changes to cookbooks (attribute files and/or recipes), roles, and/or environments, and updated for any changes to the state of the node itself.


### PR DESCRIPTION
Attributes passed via "chef-client -j file.json" were poorly documented, this attempts to fill in the gaps for how they are applied, their precedence and their persistence.
