### PR TITLE
Update Chef Infra Server Release Notes for 13.1.13

### DIFF
--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -26,7 +26,7 @@ Improvements/Bug Fixes
 Deprecation Notice
 -----------------------------------------------------
 
-* SLES 11 is no longer supported per our [platform policy](https://docs.chef.io/platforms.html#platform-end-of-life-policy), as upstream support ended in March of this year.
+* SLES 11 is no longer supported per our `platform policy </platforms.html#platform-end-of-life-policy>`_, as upstream support ended in March of this year.
 
 Updates and Improvements
 -----------------------------------------------------

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -15,7 +15,7 @@ Improvements/Bug Fixes
 * Data collector proxy-header X-Forwarded is set as expected.
 * ``chef-server-ctl`` is no longer installed in the user path. Now only the appbundled version is installed in the user path.
 * Fixed an issue with Chef Support Zendesk sign-ins when a first name is not set in Hosted Chef.
-* Added support for running the Chef Infra Server on Red Hat Enterprise Linux 8
+* Added support for running the Chef Infra Server on Red Hat Enterprise Linux 8.
 * Improvements to ``chef-server-ctl gather-logs``
 
  * Add AWS to known platforms

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -11,7 +11,7 @@ What's New in 13.1.13
 Improvements/Bug Fixes
 -----------------------------------------------------
 
-* ``_status`` endpoint reports healthy even if ``data_collector`` is down not causing unnecessary failovers 
+* The ``_status`` endpoint now reports healthy even if the ``data_collector`` is down which will no longer cause unnecessary failovers.
 * Data collector proxy-header X-Forwarded for is set as expected
 * ``chef-server-ctl`` is no longer installed in the user path only the appbundled version is installed in the user path
 * Fixes issue with Chef Support Zendesk sign-ins when a first name is not set in Hosted Chef

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -14,7 +14,7 @@ Improvements/Bug Fixes
 * The ``_status`` endpoint now reports healthy even if the ``data_collector`` is down which will no longer cause unnecessary failovers.
 * Data collector proxy-header X-Forwarded is set as expected.
 * ``chef-server-ctl`` is no longer installed in the user path. Now only the appbundled version is installed in the user path.
-* Fixes issue with Chef Support Zendesk sign-ins when a first name is not set in Hosted Chef
+* Fixed an issue with Chef Support Zendesk sign-ins when a first name is not set in Hosted Chef.
 * Added support for running the Chef Infra Server on Red Hat Enterprise Linux 8
 * Improvements to ``chef-server-ctl gather-logs``
 

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -5,6 +5,44 @@ Release Notes: Chef Infra Server 12.0 - 13.0.11
 
 Chef Server acts as a hub for configuration data by storing cookbooks, the policies that are applied to nodes, and metadata that describes each registered node that is managed by the chef-client.
 
+What's New in 13.1.13
+=====================================================
+
+Improvements/Bug Fixes
+-----------------------------------------------------
+
+* ``_status`` endpoint reports healthy even if ``data_collector`` is down not causing unnecessary failovers 
+* Data collector proxy-header X-Forwarded for is set as expected
+* ``chef-server-ctl`` is no longer installed in the user path only the appbundled version is installed in the user path
+* Fixes issue with Chef Support Zendesk sign-ins when a first name is not set in Hosted Chef
+* Added support for running the Chef Infra Server on Red Hat Enterprise Linux 8
+* Improvements to ``chef-server-ctl gather-logs``
+ * Add AWS to known platforms
+ * Add AWS Native Chef Server info
+ * Add elasticsearch info
+ * Switched compression from bzip2 to gzip
+
+Deprecation Notice
+-----------------------------------------------------
+
+* SLES 11 is no longer supported per our [platform policy](https://docs.chef.io/platforms.html#platform-end-of-life-policy), as upstream support ended in March of this year.
+
+Updates and Improvements
+-----------------------------------------------------
+
+* Yard 0.9.19 -> 0.9.20
+* Bundler 1.17.2 -> 1.17.2
+* Postgres 9.6.10 -> 9.6.15
+* Chef v15.3.14 -> v15.4.45
+* OpenResty 1.13.6.2 -> 1.15.8.1
+* Nokogiri 1.8.5 -> 1.10.4
+* Rebar3 -> 3.12.0
+* Updated erlang deps to be the latest
+* Loofah 2.2.3 -> 2.3.1
+* Erlang R18 -> 20.3.8.9
+* Updated for cookstyle
+* Ruby 2.5.5 -> 2.6.3
+
 What's New in 13.0.11
 =====================================================
 

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -13,7 +13,7 @@ Improvements/Bug Fixes
 
 * The ``_status`` endpoint now reports healthy even if the ``data_collector`` is down which will no longer cause unnecessary failovers.
 * Data collector proxy-header X-Forwarded for is set as expected
-* ``chef-server-ctl`` is no longer installed in the user path only the appbundled version is installed in the user path
+* ``chef-server-ctl`` is no longer installed in the user path. Now only the appbundled version is installed in the user path.
 * Fixes issue with Chef Support Zendesk sign-ins when a first name is not set in Hosted Chef
 * Added support for running the Chef Infra Server on Red Hat Enterprise Linux 8
 * Improvements to ``chef-server-ctl gather-logs``

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -12,7 +12,7 @@ Improvements/Bug Fixes
 -----------------------------------------------------
 
 * The ``_status`` endpoint now reports healthy even if the ``data_collector`` is down which will no longer cause unnecessary failovers.
-* Data collector proxy-header X-Forwarded for is set as expected
+* Data collector proxy-header X-Forwarded is set as expected.
 * ``chef-server-ctl`` is no longer installed in the user path. Now only the appbundled version is installed in the user path.
 * Fixes issue with Chef Support Zendesk sign-ins when a first name is not set in Hosted Chef
 * Added support for running the Chef Infra Server on Red Hat Enterprise Linux 8

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -16,7 +16,7 @@ Improvements/Bug Fixes
 * ``chef-server-ctl`` is no longer installed in the user path. Now only the appbundled version is installed in the user path.
 * Fixed an issue with Chef Support Zendesk sign-ins when a first name is not set in Hosted Chef.
 * Added support for running the Chef Infra Server on Red Hat Enterprise Linux 8.
-* Improvements to ``chef-server-ctl gather-logs``
+* ``chef-server-ctl gather-logs`` was updated with the following improvements:
 
  * Add AWS to known platforms
  * Add AWS Native Chef Server info

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -17,6 +17,7 @@ Improvements/Bug Fixes
 * Fixes issue with Chef Support Zendesk sign-ins when a first name is not set in Hosted Chef
 * Added support for running the Chef Infra Server on Red Hat Enterprise Linux 8
 * Improvements to ``chef-server-ctl gather-logs``
+
  * Add AWS to known platforms
  * Add AWS Native Chef Server info
  * Add elasticsearch info


### PR DESCRIPTION
### Description

This updates release notes documentation for Chef Infra Server version 13.1.13

### Definition of Done

Documentation accurately portrays information from [release announcement in discourse](https://discourse.chef.io/t/chef-infra-server-13-1-13-released/16282).

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass

Signed-off by: Josh O'Brien jobrien@chef.io