### PR TITLE
Remove mentions of the opensuse platform

### DIFF
--- a/chef_master/source/config_rb_metadata.rst
+++ b/chef_master/source/config_rb_metadata.rst
@@ -230,7 +230,7 @@ This configuration file has the following settings:
 
    .. code-block:: ruby
 
-      %w( aix amazon centos fedora freebsd debian oracle mac_os_x redhat suse opensuse opensuseleap ubuntu windows zlinux ).each do |os|
+      %w( aix amazon centos fedora freebsd debian oracle mac_os_x redhat suse opensuseleap ubuntu windows zlinux ).each do |os|
         supports os
       end
 

--- a/chef_master/source/dsl_recipe.rst
+++ b/chef_master/source/dsl_recipe.rst
@@ -475,8 +475,6 @@ The following parameters can be used with this method:
      - NetBSD. All platform variants of NetBSD return ``netbsd``.
    * - ``openbsd``
      - OpenBSD. All platform variants of OpenBSD return ``openbsd``.
-   * - ``opensuse``
-     - openSUSE
    * - ``opensuseleap``
      - openSUSE leap
    * - ``slackware``

--- a/chef_master/source/knife_supermarket.rst
+++ b/chef_master/source/knife_supermarket.rst
@@ -384,7 +384,6 @@ where ``mysql`` is the cookbook and ``8.5.1`` is the cookbook version. This will
       centos:       >= 6.0
       debian:       >= 7.0
       fedora:       >= 0.0.0
-      opensuse:     >= 13.0
       opensuseleap: >= 0.0.0
       oracle:       >= 6.0
       redhat:       >= 6.0


### PR DESCRIPTION
This is a WAY EOL platform that we shouldn't mention anymore

Signed-off-by: Tim Smith <tsmith@chef.io>