### PR TITLE
Update chef_license_accept.rst

### DIFF
--- a/chef_master/source/chef_license_accept.rst
+++ b/chef_master/source/chef_license_accept.rst
@@ -13,7 +13,7 @@ Accept the Chef MLSA
 -----------------------------------------------------
 There are three ways to accept the Chef MLSA:
 
-#. When running ``chef-<PRODUCT-NAME>-ctl reconfigure`` the Chef MLSA is printed. Type ``yes`` to accept it. Anything other than typing ``yes`` rejects the Chef MLSA, and the upgrade process will exit. Typing ``yes`` adds a ``.license.accepted`` file to the ``/var/opt/<PRODUCT-NAME>/`` directory. As long as this file exists in this directory, the Chef MLSA is accepted and the reconfigure process will not prompt for ``yes``.
+#. When running ``chef-<PRODUCT-NAME>-ctl reconfigure`` the Chef MLSA is printed. Type ``yes`` to accept it. Anything other than typing ``yes`` rejects the Chef MLSA, and the upgrade process will exit. Typing ``yes`` adds a ``.license.accepted`` file to the ``/etc/chef/accepted_licenses/<PRODUCT-NAME>`` file. As long as this file exists in this directory, the Chef MLSA is accepted and the reconfigure process will not prompt for ``yes``.
 
 #. Run the ``chef-<PRODUCT-NAME>-ctl reconfigure`` command using the ``--chef-license=accept`` option. This automatically types ``yes`` and skips printing the Chef MLSA.
 


### PR DESCRIPTION
updates the path where accepted licenses are kept: /etc/chef/accepted_licenses/

### Description

This page documents that accepted licenses can be created in /var/opt/chef/<PRODUCT_NAME/, but this is not true. chef-client creates /etc/chef/accepted_licenses/<PRODUCT_NAME>

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
