### PR TITLE
Fix github links to .html files which should be .rst

### DIFF
--- a/chef_master/source/automate_compliance_credentials.rst
+++ b/chef_master/source/automate_compliance_credentials.rst
@@ -1,7 +1,7 @@
 ==============================
 Credentials
 ==============================
-`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/automate_compliance_credentials.html>`__
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/automate_compliance_credentials.rst>`__
 
 .. meta::
     :robots: noindex

--- a/chef_master/source/automate_compliance_reporting.rst
+++ b/chef_master/source/automate_compliance_reporting.rst
@@ -1,7 +1,7 @@
 =======================================
 Reporting
 =======================================
-`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/automate_compliance_reporting.html>`__
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/automate_compliance_reporting.rst>`__
 
 .. meta::
     :robots: noindex

--- a/chef_master/source/automate_compliance_scanner.rst
+++ b/chef_master/source/automate_compliance_scanner.rst
@@ -1,7 +1,7 @@
 =====================================================
 Scanner
 =====================================================
-`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/automate_compliance_scanner.html>`__
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/automate_compliance_scanner.rst>`__
 
 .. meta:: 
     :robots: noindex 

--- a/chef_master/source/chef_automate_compliance.rst
+++ b/chef_master/source/chef_automate_compliance.rst
@@ -1,7 +1,7 @@
 =====================================================
 An Overview of Compliance in Chef Automate
 =====================================================
-`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/chef_automate_compliance.html>`__
+`[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/chef_automate_compliance.rst>`__
 
 .. meta:: 
     :robots: noindex 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

These files link to nonexistent .html pages on github which should be .rst.

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
