### PR TITLE
Fix quoting to allow string interpolation

### DIFF
--- a/chef_master/source/resource_bash.rst
+++ b/chef_master/source/resource_bash.rst
@@ -377,7 +377,7 @@ The following example shows how Bash can be used to install a plug-in for rbenv 
    end
 
    bash 'install_ruby_build' do
-     cwd '#{Chef::Config[:file_cache_path]}/ruby-build'
+     cwd "#{Chef::Config[:file_cache_path]}/ruby-build"
      user 'rbenv'
      group 'rbenv'
      code <<-EOH


### PR DESCRIPTION
### Description

It's possible there's some chef specific thing going on here, but if not then we'll need double quotes in this example in order for the string interpolation to work.

### Definition of Done

String interpolation in the bash `install_ruby_build` example works.

### Issues Resolved

N/A

### Check List

- [X] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
