### PR TITLE
Set Provisioning to EOL

### DIFF
--- a/chef_master/source/versions.rst
+++ b/chef_master/source/versions.rst
@@ -208,7 +208,7 @@ End of Life (EOL) Products
      - December 31, 2018
    * - Chef Provisioning
      - All
-     - Deprecated
+     - EOL
      - August 31, 2019
    * - Chef Replication/Sync
      - All


### PR DESCRIPTION
Provisioning is under the EOL section, but marked as Deprecated. This marks as EOL.

Signed-off-by: Josh O'Brien jobrien@chef.io