### PR TITLE
Some Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://docs.chef.io/
 
 If you spot something in the docs that needs to be fixed, the fastest way to get in the change is to edit the file on the GitHub website using the GitHub UI.
 
-To perform edits using the GitHub UI, click on the `[edit on GitHub]` link at the top ofthe page you want to edit. The link takes you to that topic's GitHub page. In GitHub, click on the pencil icon and make your changes. You can preview how they'll look right on the page ("Preview Changes" tab).
+To perform edits using the GitHub UI, click on the `[edit on GitHub]` link at the top of the page you want to edit. The link takes you to that topic's GitHub page. In GitHub, click on the pencil icon and make your changes. You can preview how they'll look right on the page ("Preview Changes" tab).
 
 We no longer use "swaps" and include files, so you'll be able to see
 all of text in one place for each topic. If you need tips on the

--- a/chef_master/source/resource_chocolatey_config.rst
+++ b/chef_master/source/resource_chocolatey_config.rst
@@ -8,7 +8,7 @@ Use the **chocolatey_config** resource to add or remove Chocolatey configuration
 **New in Chef Client 14.3.**
 
 .. note::
-          The Chocolatey package manager is not installed on Windows by default. Install it prior to using this resource by adding the `[Chocolatey cookbook] <https://supermarket.chef.io/cookbooks/chocolatey/>`_ to your node's run list.
+          The Chocolatey package manager is not installed on Windows by default. Install it prior to using this resource by adding the `Chocolatey cookbook <https://supermarket.chef.io/cookbooks/chocolatey/>`_ to your node's run list.
 
 Syntax
 =====================================================

--- a/chef_master/source/resource_chocolatey_config.rst
+++ b/chef_master/source/resource_chocolatey_config.rst
@@ -7,6 +7,9 @@ Use the **chocolatey_config** resource to add or remove Chocolatey configuration
 
 **New in Chef Client 14.3.**
 
+.. note::
+          The Chocolatey package manager is not installed on Windows by default. Install it prior to using this resource by adding the `[Chocolatey cookbook] <https://supermarket.chef.io/cookbooks/chocolatey/>`_ to your node's run list.
+
 Syntax
 =====================================================
 

--- a/chef_master/source/resource_chocolatey_feature.rst
+++ b/chef_master/source/resource_chocolatey_feature.rst
@@ -7,6 +7,9 @@ Use the **chocolatey_feature** resource to enable and disable Chocolatey feature
 
 **New in Chef Infra Client 15.1.**
 
+.. note::
+          The Chocolatey package manager is not installed on Windows by default. Install it prior to using this resource by adding the `[Chocolatey cookbook] <https://supermarket.chef.io/cookbooks/chocolatey/>`_ to your node's run list.
+
 Syntax
 =====================================================
 

--- a/chef_master/source/resource_chocolatey_feature.rst
+++ b/chef_master/source/resource_chocolatey_feature.rst
@@ -8,7 +8,7 @@ Use the **chocolatey_feature** resource to enable and disable Chocolatey feature
 **New in Chef Infra Client 15.1.**
 
 .. note::
-          The Chocolatey package manager is not installed on Windows by default. Install it prior to using this resource by adding the `[Chocolatey cookbook] <https://supermarket.chef.io/cookbooks/chocolatey/>`_ to your node's run list.
+          The Chocolatey package manager is not installed on Windows by default. Install it prior to using this resource by adding the `Chocolatey cookbook <https://supermarket.chef.io/cookbooks/chocolatey/>`_ to your node's run list.
 
 Syntax
 =====================================================

--- a/chef_master/source/resource_chocolatey_package.rst
+++ b/chef_master/source/resource_chocolatey_package.rst
@@ -14,6 +14,9 @@ Use the **chocolatey_package** resource to manage packages using Chocolatey on t
 
 **New in Chef Client 12.7.**
 
+.. note::
+          The Chocolatey package manager is not installed on Windows by default. Install it prior to using this resource by adding the `[Chocolatey cookbook] <https://supermarket.chef.io/cookbooks/chocolatey/>`_ to your node's run list.
+
 Syntax
 =====================================================
 A **chocolatey_package** resource manages packages using Chocolatey on the Microsoft Windows platform. The simplest use of the **chocolatey_package** resource is:

--- a/chef_master/source/resource_chocolatey_package.rst
+++ b/chef_master/source/resource_chocolatey_package.rst
@@ -15,7 +15,7 @@ Use the **chocolatey_package** resource to manage packages using Chocolatey on t
 **New in Chef Client 12.7.**
 
 .. note::
-          The Chocolatey package manager is not installed on Windows by default. Install it prior to using this resource by adding the `[Chocolatey cookbook] <https://supermarket.chef.io/cookbooks/chocolatey/>`_ to your node's run list.
+          The Chocolatey package manager is not installed on Windows by default. Install it prior to using this resource by adding the `Chocolatey cookbook <https://supermarket.chef.io/cookbooks/chocolatey/>`_ to your node's run list.
 
 Syntax
 =====================================================

--- a/chef_master/source/resource_chocolatey_source.rst
+++ b/chef_master/source/resource_chocolatey_source.rst
@@ -8,7 +8,7 @@ Use the **chocolatey_source** resource to add, remove, enable, or disable Chocol
 **New in Chef Client 14.3.**
 
 .. note::
-          The Chocolatey package manager is not installed on Windows by default. Install it prior to using this resource by adding the `[Chocolatey cookbook] <https://supermarket.chef.io/cookbooks/chocolatey/>`_ to your node's run list.
+          The Chocolatey package manager is not installed on Windows by default. Install it prior to using this resource by adding the `Chocolatey cookbook <https://supermarket.chef.io/cookbooks/chocolatey/>`_ to your node's run list.
 
 Syntax
 =====================================================

--- a/chef_master/source/resource_chocolatey_source.rst
+++ b/chef_master/source/resource_chocolatey_source.rst
@@ -7,6 +7,9 @@ Use the **chocolatey_source** resource to add, remove, enable, or disable Chocol
 
 **New in Chef Client 14.3.**
 
+.. note::
+          The Chocolatey package manager is not installed on Windows by default. Install it prior to using this resource by adding the `[Chocolatey cookbook] <https://supermarket.chef.io/cookbooks/chocolatey/>`_ to your node's run list.
+
 Syntax
 =====================================================
 

--- a/chef_master/source/versions.rst
+++ b/chef_master/source/versions.rst
@@ -158,6 +158,10 @@ The following products are deprecated or end of life. Users are advised to use n
      - 2.5.x
      - Deprecated
      - TBD
+   * - Chef Infra Server
+     - 12.x
+     - Deprecated
+     - TBD
    * - Chef Workflow
      - 2.x
      - Deprecated


### PR DESCRIPTION
### Description

- Adding Chef Infra Server 12.x to deprecated list
- Adding note that Chocolatey is not installed by default
- Minor spelling fix

### Definition of Done

### Issues Resolved

### Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
