### PR TITLE
Fix relative link in redirects.json

### DIFF
--- a/config/redirects.json
+++ b/config/redirects.json
@@ -477,7 +477,7 @@
   "release/automate/api_delivery.html": "https://automate.chef.io/release-notes/",
   "release/automate/chef_automate.html": "https://automate.chef.io/release-notes/",
   "release/automate/compliance.html": "https://automate.chef.io/release-notes/",
-  "release/automate/config_json_delivery.html": "config_json_delivery.html",
+  "release/automate/config_json_delivery.html": "/config_json_delivery.html",
   "release/automate/config_rb_compliance.html": "https://automate.chef.io/release-notes/",
   "release/automate/config_rb_delivery.html": "/config_rb_delivery.html",
   "release/automate/config_rb_delivery_optional_settings.html": "/config_rb_delivery_optional_settings.html",


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

A missing forward slash in redirects.json is giving buildkite problems. This fixes it.

### Definition of Done

### Issues Resolved


### Check List

- [ ] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
