### PR TITLE
RFC2606 - example.com

### DIFF
--- a/chef_master/source/config_rb.rst
+++ b/chef_master/source/config_rb.rst
@@ -201,7 +201,7 @@ If the Chef Infra Server is configured to use HTTP, add the following settings:
 
    .. code-block:: ruby
 
-      http_proxy 'http://proxy.vmware.com:3128'
+      http_proxy 'http://proxy.example.com:3128'
 
 ``http_proxy_user``
    The user name for the proxy server when the proxy server is using an HTTP connection. Default value: ``nil``.


### PR DESCRIPTION
### Description

I also think it's less confusing when using the example domains in documentation rather than specific domain names. This way people can see to fill in their own values rather than a specific hostname that may or may not exist, or that may or may not have permission to use.

### Definition of Done

Minor change.

### Issues Resolved

N/A

### Check List

- [x] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
