### PR TITLE
Resource pages fixes

### DIFF
--- a/chef_master/source/resource_kernel_module.rst
+++ b/chef_master/source/resource_kernel_module.rst
@@ -241,14 +241,15 @@ Examples
 
 The following examples demonstrate various approaches for using resources in recipes:
 
-Install and load a kernel module and ensure it loads on reboot.
+**Install and load a kernel module and ensure it loads on reboot.**
 
 .. code-block:: ruby
 
   kernel_module 'loop'
 
-Install and load a kernel with a specific set of options and ensure it loads on reboot. Consult kernel module
-documentation for specific options that are supported.
+**Install and load a kernel with a specific set of options and ensure it loads on reboot.**
+
+Consult kernel module documentation for specific options that are supported.
 
 .. code-block:: ruby
 
@@ -256,7 +257,7 @@ documentation for specific options that are supported.
     options [ 'max_loop=4', 'max_part=8' ]
   end
 
-Load a kernel module.
+**Load a kernel module.**
 
 .. code-block:: ruby
 
@@ -264,7 +265,7 @@ Load a kernel module.
     action :load
   end
 
-Unload a kernel module and remove module config so it doesn’t load on reboot.
+**Unload a kernel module and remove module config so it doesn’t load on reboot.**
 
 .. code-block:: ruby
 
@@ -272,7 +273,7 @@ Unload a kernel module and remove module config so it doesn’t load on reboot.
     action :uninstall
   end
 
-Unload kernel module.
+**Unload kernel module.**
 
 .. code-block:: ruby
 
@@ -280,7 +281,7 @@ Unload kernel module.
     action :unload
   end
 
-Blacklist a module from loading.
+**Blacklist a module from loading.**
 
 .. code-block:: ruby
 
@@ -288,7 +289,7 @@ Blacklist a module from loading.
     action :blacklist
   end
 
-Disable a kernel module.
+**Disable a kernel module.**
 
 .. code-block:: ruby
 

--- a/chef_master/source/resource_systemd_unit.rst
+++ b/chef_master/source/resource_systemd_unit.rst
@@ -145,10 +145,13 @@ The systemd_unit resource has the following properties:
 Unit file verification
 =====================================================
 
+.. tag unit_file_verification
+
 The unit file is verified via a ``systemd-analyze verify`` call before being written to disk.
 
 Be aware that the referenced commands and files need to already exist before verification.
 
+.. end_tag
 
 Common Resource Functionality
 =====================================================

--- a/chef_master/source/resource_windows_task.rst
+++ b/chef_master/source/resource_windows_task.rst
@@ -190,7 +190,7 @@ The windows_task resource has the following properties:
 ``run_level``
    **Ruby Type:** Symbol | **Default Value:** ``:limited``
 
-  Run with ``:limited`` or ``:highest`` privileges.
+   Run with ``:limited`` or ``:highest`` privileges.
 
 ``start_day``
    **Ruby Type:** String


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Corrects a few things.

- adds a dtag to resource_systemd_unit page to make my life easier in Hugo.
- one property wasn't indented far enough
- the example headings in a page aren't bolded.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
