### PR TITLE
Note about `start_day` property for `windows_task`

### DIFF
--- a/chef_master/source/resource_windows_task.rst
+++ b/chef_master/source/resource_windows_task.rst
@@ -35,7 +35,7 @@ The windows_task resource has the following syntax:
     priority                            Integer # default value: 7
     random_delay                        String, Integer
     run_level                           Symbol # default value: :limited
-    start_day                           String
+    start_day                           String # defaults to current date if not specified
     start_time                          String
     start_when_available                true, false # default value: false
     stop_if_going_on_batteries          true, false # default value: false


### PR DESCRIPTION
The documentation should specify that `start_day` has a default value that it will set a scheduled task to run at. This should be noted as it can cause a run of Chef-client to not be idempotent if unset.

### Description

[Please describe what this change achieves]

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
