### PR TITLE
Disable Fastly management

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,7 +21,6 @@ module "docs_chef_io_site_hugo" {
   subdomain = "docs-${var.dns_suffix}"
 
   pkg_ident   = "${data.external.latest_hab_pkg.result.pkg_ident}"
-  fastly_fqdn = "${var.fastly_fqdn}"
 
   # AWS Tags
   tag_dept    = "CoreEng"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -11,9 +11,3 @@ variable "dns_suffix" {
   type        = "string"
   description = "The suffix to append to the internal cd.chef.co subdomain"
 }
-
-variable "fastly_fqdn" {
-  type        = "string"
-  default     = ""
-  description = "The Fastly service FQDN (leave empty to disable)"
-}

--- a/terraform/vars/stable.tfvars
+++ b/terraform/vars/stable.tfvars
@@ -1,3 +1,2 @@
 channel = "stable"
 dns_suffix = ""
-fastly_fqdn = "docs.chef.io"


### PR DESCRIPTION
### Description

Disable the terraform management of the Fastly configuration for docs.chef.io. This will allow
us to stage the new production docs site and then manually transition over when we are ready.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
