### PR TITLE
Update HTTPServerException errors to be HTTPClientException

### DIFF
--- a/chef_master/source/errors.rst
+++ b/chef_master/source/errors.rst
@@ -18,7 +18,7 @@ If you're receiving an error like the following it most likely means you'll need
    INFO: Client key /etc/chef/client.pem is not present - registering
    INFO: HTTP Request Returned 401 Unauthorized: Failed to authenticate as ORGANIZATION-validator. Ensure that your node_name and client key are correct.
    FATAL: Stacktrace dumped to c:/chef/cache/chef-stacktrace.out
-   FATAL: Net::HTTPServerException: 401 "Unauthorized"
+   FATAL: Net::HTTPClientException: 401 "Unauthorized"
 
 **Troubleshooting Steps**
 
@@ -96,13 +96,13 @@ If the system clock drifts more than 15 minutes from the actual time, the follow
    INFO: Client key /etc/chef/client.pem is not present - registering
    INFO: HTTP Request Returned 401 Unauthorized: Failed to authenticate as ORGANIZATION-validator. Synchronize the clock on your host.
    FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
-   FATAL: Net::HTTPServerException: 401 "Unauthorized"
+   FATAL: Net::HTTPClientException: 401 "Unauthorized"
 
 To resolve this error, synchronize the clock with an NTP server.
 
 All other 401 errors
 -----------------------------------------------------
-The general ``Net::HTTPServerException: 401 "Unauthorized"`` error will usually occur for one of two reasons.
+The general ``Net::HTTPClientException: 401 "Unauthorized"`` error will usually occur for one of two reasons.
 
 **Troubleshooting Steps**
 
@@ -160,7 +160,7 @@ If you're seeing output like this:
 .. code-block:: bash
 
    FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
-   FATAL: Net::HTTPServerException: 403 "Forbidden"
+   FATAL: Net::HTTPClientException: 403 "Forbidden"
 
 this is an indication that there is an issue with permissions on the Chef Infra Server.
 

--- a/chef_master/source/install_server_pre.rst
+++ b/chef_master/source/install_server_pre.rst
@@ -435,7 +435,7 @@ The Chef Infra Server server requires that every node that is under management b
    [Tue, 01 Nov 2011 16:55:24 -0700] INFO: HTTP Request Returned 401 Unauthorized:
        Failed to authenticate as ORGANIZATION-validator. Synchronize the clock on your host.
    [Tue, 01 Nov 2011 16:55:24 -0700] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
-   [Tue, 01 Nov 2011 16:55:24 -0700] FATAL: Net::HTTPServerException: 401 "Unauthorized"
+   [Tue, 01 Nov 2011 16:55:24 -0700] FATAL: Net::HTTPClientException: 401 "Unauthorized"
 
 In this situation, re-synchronize the system clocks with the Network Time Protocol (NTP) server, and then re-run Chef Infra Client.
 

--- a/chef_master/source/recipes.rst
+++ b/chef_master/source/recipes.rst
@@ -778,12 +778,12 @@ For example:
 
   begin
     dater = data_bag_item(:basket, 'flowers')
-  rescue Net::HTTPServerException
+  rescue Net::HTTPClientException
     # maybe some retry code here?
     raise 'message_to_be_raised'
   end
 
-where ``data_bag_item`` makes an HTTP request to the Chef Infra Server to get a data bag item named ``flowers``. If there is a problem, the request will return a ``Net::HTTPServerException``. The ``rescue`` block can be used to try to retry or otherwise handle the situation. If the ``rescue`` block is unable to handle the situation, then the ``raise`` keyword is used to specify the message to be raised.
+where ``data_bag_item`` makes an HTTP request to the Chef Infra Server to get a data bag item named ``flowers``. If there is a problem, the request will return a ``Net::HTTPClientException``. The ``rescue`` block can be used to try to retry or otherwise handle the situation. If the ``rescue`` block is unable to handle the situation, then the ``raise`` keyword is used to specify the message to be raised.
 
 Fatal Messages
 +++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/chef_master/source/release_notes_server.rst
+++ b/chef_master/source/release_notes_server.rst
@@ -80,7 +80,7 @@ Updates and Improvements
 
   * This fixes two CVEs: CVE-2018-9230 and CVE-2017-7529.
   * This version cannot be built on PowerPC and s390x because those platforms are not supported in mainline luajit.
-  
+
 * Updated Ruby version to 2.5.5
 * Updated Chef Infra Client to 14.11.21
 * Updated runit cookbook to 5.1.1
@@ -110,7 +110,7 @@ This release contains some minor improvements and updates to include software:
 
   * Fixed two CVEs CVE-2017-1000385 and CVE-2016-10253. SSL headers got stricter which unfortunately broke LDAP. (Issue #1642)
   * Removed ``et``, ``debugger``, ``gs``, and ``observer`` as they depend on ``wx``, which is not available on all platforms.
-  
+
 * Ruby updated to 2.5.3.
 * Chef Client updated to 14.5.
 * Erchef and Bookshelf can optionally use mTLS protocol for their internal communications.
@@ -121,7 +121,7 @@ This release contains some minor improvements and updates to include software:
   * Removed ``do_end`` function from ``chef-server-ctl`` hab plan.
   * Enhanced ``chef-server-ctl`` to function in more habitat environments.
   * ``chef-server-ctl`` commands pass relevant TLS options during bifrost API calls.
-  
+
 * Used standard ruby-cleanup definition, which shrinks install size by ~5% on disk.
 * Removed unused couchdb configurables.
 


### PR DESCRIPTION
HTTPServerException has been deprecated.

Signed-off-by: Tim Smith <tsmith@chef.io>