### PR TITLE
Remove berks test command that is no longer in berks

### DIFF
--- a/chef_master/source/berkshelf.rst
+++ b/chef_master/source/berkshelf.rst
@@ -456,26 +456,6 @@ This command has the following options:
 ``--source URL``
    The URL at which remote cookbooks are located. Default value: ``https://supermarket.chef.io``.
 
-berks test
------------------------------------------------------
-Use ``berks test`` to run Test Kitchen from within Berkshelf.
-
-.. warning:: This command is deprecated. Please use ``kitchen test`` instead.
-
-Options
-+++++++++++++++++++++++++++++++++++++++++++++++++++++
-This command may run any Kitchen CLI command, such as:
-
-* `kitchen create </ctl_kitchen.html#kitchen-create>`__
-* `kitchen converge </ctl_kitchen.html#kitchen-converge>`__
-* `kitchen destroy </ctl_kitchen.html#kitchen-destroy>`__
-* `kitchen exec </ctl_kitchen.html#kitchen-exec>`__
-* `kitchen list </ctl_kitchen.html#kitchen-list>`__
-* `kitchen test </ctl_kitchen.html#kitchen-test>`__
-* `kitchen verify </ctl_kitchen.html#kitchen-verify>`__
-
-See `kitchen (executable) </ctl_kitchen.html>`__ for descriptions of every Test Kitchen subcommand.
-
 berks show
 -----------------------------------------------------
 Use ``berks show`` to show the path to the named cookbook.


### PR DESCRIPTION
This just results in an error

Signed-off-by: Tim Smith <tsmith@chef.io>