### PR TITLE
reword EOL_manage warning

### DIFF
--- a/chef_master/source/config_rb_manage.rst
+++ b/chef_master/source/config_rb_manage.rst
@@ -15,7 +15,7 @@ manage.rb
 
 .. tag EOL_manage
 
-.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__. The `Chef Enterprise Automation Stack <https://www.chef.io/products/enterprise-automation-stack>`_ allows you to define infrastructure, security policies, and application dependencies as code, deliver the stack via an automated pipeline to any platform, and deploy, observe, and manage the stack over its lifecycle. Chef Automate is included as part of the Chef license agreement and is `available via subscription <https://www.chef.io/pricing/>`_.
+.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__ and does not work with Chef Automate 2.0. See our `documentation <https://automate.chef.io/docs/quickstart/>`_ to learn more about Chef Automate 2. This document is no longer maintained.
 
 .. end_tag
 

--- a/chef_master/source/ctl_manage.rst
+++ b/chef_master/source/ctl_manage.rst
@@ -15,7 +15,7 @@ chef-manage-ctl (executable)
 
 .. tag EOL_manage
 
-.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__. The `Chef Enterprise Automation Stack <https://www.chef.io/products/enterprise-automation-stack>`_ allows you to define infrastructure, security policies, and application dependencies as code, deliver the stack via an automated pipeline to any platform, and deploy, observe, and manage the stack over its lifecycle. Chef Automate is included as part of the Chef license agreement and is `available via subscription <https://www.chef.io/pricing/>`_.
+.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__ and does not work with Chef Automate 2.0. See our `documentation <https://automate.chef.io/docs/quickstart/>`_ to learn more about Chef Automate 2. This document is no longer maintained.
 
 .. end_tag
 

--- a/chef_master/source/manage.rst
+++ b/chef_master/source/manage.rst
@@ -5,7 +5,7 @@ Chef Manage
 
 .. tag EOL_manage
 
-.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__. The `Chef Enterprise Automation Stack <https://www.chef.io/products/enterprise-automation-stack>`_ allows you to define infrastructure, security policies, and application dependencies as code, deliver the stack via an automated pipeline to any platform, and deploy, observe, and manage the stack over its lifecycle. Chef Automate is included as part of the Chef license agreement and is `available via subscription <https://www.chef.io/pricing/>`_.
+.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__ and does not work with Chef Automate 2.0. See our `documentation <https://automate.chef.io/docs/quickstart/>`_ to learn more about Chef Automate 2. This document is no longer maintained.
 
 .. end_tag
 

--- a/chef_master/source/server_configure_saml.rst
+++ b/chef_master/source/server_configure_saml.rst
@@ -8,7 +8,7 @@ Configuring for SAML Authentication
 
 .. tag EOL_manage
 
-.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__. The `Chef Enterprise Automation Stack <https://www.chef.io/products/enterprise-automation-stack>`_ allows you to define infrastructure, security policies, and application dependencies as code, deliver the stack via an automated pipeline to any platform, and deploy, observe, and manage the stack over its lifecycle. Chef Automate is included as part of the Chef license agreement and is `available via subscription <https://www.chef.io/pricing/>`_.
+.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__ and does not work with Chef Automate 2.0. See our `documentation <https://automate.chef.io/docs/quickstart/>`_ to learn more about Chef Automate 2. This document is no longer maintained.
 
 .. end_tag
 

--- a/chef_master/source/server_manage_clients.rst
+++ b/chef_master/source/server_manage_clients.rst
@@ -8,7 +8,7 @@ Manage Client Keys
 
 .. tag EOL_manage
 
-.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__. The `Chef Enterprise Automation Stack <https://www.chef.io/products/enterprise-automation-stack>`_ allows you to define infrastructure, security policies, and application dependencies as code, deliver the stack via an automated pipeline to any platform, and deploy, observe, and manage the stack over its lifecycle. Chef Automate is included as part of the Chef license agreement and is `available via subscription <https://www.chef.io/pricing/>`_.
+.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__ and does not work with Chef Automate 2.0. See our `documentation <https://automate.chef.io/docs/quickstart/>`_ to learn more about Chef Automate 2. This document is no longer maintained.
 
 .. end_tag
 

--- a/chef_master/source/server_manage_cookbooks.rst
+++ b/chef_master/source/server_manage_cookbooks.rst
@@ -8,7 +8,7 @@ Manage Cookbooks
 
 .. tag EOL_manage
 
-.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__. The `Chef Enterprise Automation Stack <https://www.chef.io/products/enterprise-automation-stack>`_ allows you to define infrastructure, security policies, and application dependencies as code, deliver the stack via an automated pipeline to any platform, and deploy, observe, and manage the stack over its lifecycle. Chef Automate is included as part of the Chef license agreement and is `available via subscription <https://www.chef.io/pricing/>`_.
+.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__ and does not work with Chef Automate 2.0. See our `documentation <https://automate.chef.io/docs/quickstart/>`_ to learn more about Chef Automate 2. This document is no longer maintained.
 
 .. end_tag
 

--- a/chef_master/source/server_manage_data_bags.rst
+++ b/chef_master/source/server_manage_data_bags.rst
@@ -8,7 +8,7 @@ Manage Data Bags
 
 .. tag EOL_manage
 
-.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__. The `Chef Enterprise Automation Stack <https://www.chef.io/products/enterprise-automation-stack>`_ allows you to define infrastructure, security policies, and application dependencies as code, deliver the stack via an automated pipeline to any platform, and deploy, observe, and manage the stack over its lifecycle. Chef Automate is included as part of the Chef license agreement and is `available via subscription <https://www.chef.io/pricing/>`_.
+.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__ and does not work with Chef Automate 2.0. See our `documentation <https://automate.chef.io/docs/quickstart/>`_ to learn more about Chef Automate 2. This document is no longer maintained.
 
 .. end_tag
 

--- a/chef_master/source/server_manage_environments.rst
+++ b/chef_master/source/server_manage_environments.rst
@@ -10,7 +10,7 @@ Manage Environments
 
 .. tag EOL_manage
 
-.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__. The `Chef Enterprise Automation Stack <https://www.chef.io/products/enterprise-automation-stack>`_ allows you to define infrastructure, security policies, and application dependencies as code, deliver the stack via an automated pipeline to any platform, and deploy, observe, and manage the stack over its lifecycle. Chef Automate is included as part of the Chef license agreement and is `available via subscription <https://www.chef.io/pricing/>`_.
+.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__ and does not work with Chef Automate 2.0. See our `documentation <https://automate.chef.io/docs/quickstart/>`_ to learn more about Chef Automate 2. This document is no longer maintained.
 
 .. end_tag
 

--- a/chef_master/source/server_manage_nodes.rst
+++ b/chef_master/source/server_manage_nodes.rst
@@ -8,7 +8,7 @@ Manage Nodes
 
 .. tag EOL_manage
 
-.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__. The `Chef Enterprise Automation Stack <https://www.chef.io/products/enterprise-automation-stack>`_ allows you to define infrastructure, security policies, and application dependencies as code, deliver the stack via an automated pipeline to any platform, and deploy, observe, and manage the stack over its lifecycle. Chef Automate is included as part of the Chef license agreement and is `available via subscription <https://www.chef.io/pricing/>`_.
+.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__ and does not work with Chef Automate 2.0. See our `documentation <https://automate.chef.io/docs/quickstart/>`_ to learn more about Chef Automate 2. This document is no longer maintained.
 
 .. end_tag
 

--- a/chef_master/source/server_manage_roles.rst
+++ b/chef_master/source/server_manage_roles.rst
@@ -8,7 +8,7 @@ Manage Roles
 
 .. tag EOL_manage
 
-.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__. The `Chef Enterprise Automation Stack <https://www.chef.io/products/enterprise-automation-stack>`_ allows you to define infrastructure, security policies, and application dependencies as code, deliver the stack via an automated pipeline to any platform, and deploy, observe, and manage the stack over its lifecycle. Chef Automate is included as part of the Chef license agreement and is `available via subscription <https://www.chef.io/pricing/>`_.
+.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__ and does not work with Chef Automate 2.0. See our `documentation <https://automate.chef.io/docs/quickstart/>`_ to learn more about Chef Automate 2. This document is no longer maintained.
 
 .. end_tag
 

--- a/chef_master/source/server_orgs.rst
+++ b/chef_master/source/server_orgs.rst
@@ -166,7 +166,7 @@ The knife plugin `knife-acl <https://github.com/chef/knife-acl>`_ provides a fin
 
 .. tag EOL_manage
 
-.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__. The `Chef Enterprise Automation Stack <https://www.chef.io/products/enterprise-automation-stack>`_ allows you to define infrastructure, security policies, and application dependencies as code, deliver the stack via an automated pipeline to any platform, and deploy, observe, and manage the stack over its lifecycle. Chef Automate is included as part of the Chef license agreement and is `available via subscription <https://www.chef.io/pricing/>`_.
+.. warning:: Chef Manage is `deprecated </versions.html#deprecated-products-and-versions>`__ and does not work with Chef Automate 2.0. See our `documentation <https://automate.chef.io/docs/quickstart/>`_ to learn more about Chef Automate 2. This document is no longer maintained.
 
 .. end_tag
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Rewords the warning that Chef Manage is deprecated and doesn't work with A2.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [X] Local build
- [ ] Examine the local build
- [ ] All tests pass
