### PR TITLE
Update the wording around cookbook authoring best practices

### DIFF
--- a/chef_master/source/debug.rst
+++ b/chef_master/source/debug.rst
@@ -7,8 +7,7 @@ Elements of good approaches to building cookbooks and recipes that are reliable 
 
 * A consistent syntax pattern when constructing recipes
 * Using the same patterns in Ruby
-* Using platform resources before creating custom ones
-* Using community-authored resources before creating custom ones
+* Using resources included in Chef Infra Client or community cookbooks before creating custom ones
 
 Ideally, the best way to debug a recipe is to not have to debug it in the first place. That said, the following sections discuss various approaches to debugging recipes and failed Chef Infra Client runs.
 


### PR DESCRIPTION
"platform resources" is not a thing. I know what we're trying to say
here, but that's just not a thing.

Signed-off-by: Tim Smith <tsmith@chef.io>