### PR TITLE
Update our verbosity docs in the debug page

### DIFF
--- a/chef_master/source/debug.rst
+++ b/chef_master/source/debug.rst
@@ -37,7 +37,7 @@ Knife
 Use the verbose logging that is built into knife:
 
 ``-V``, ``--verbose``
-  et for more verbose outputs. Use ``-VV`` for much more verbose outputs. Use ``-VVV`` for maximum verbosity, which may provide more information than is actually helpful.
+  Set for more verbose outputs. Use ``-VV`` for much more verbose outputs. Use ``-VVV`` for maximum verbosity, which may provide more information than is actually helpful.
 
 .. note:: Plugins do not always support verbose logging.
 

--- a/chef_master/source/debug.rst
+++ b/chef_master/source/debug.rst
@@ -37,7 +37,7 @@ Knife
 Use the verbose logging that is built into knife:
 
 ``-V``, ``--verbose``
-  Set for more verbose outputs. Use ``-VV`` for maximum verbosity.
+  et for more verbose outputs. Use ``-VV`` for much more verbose outputs. Use ``-VVV`` for maximum verbosity, which may provide more information than is actually helpful.
 
 .. note:: Plugins do not always support verbose logging.
 


### PR DESCRIPTION
This is the same line we use in the knife CLI docs page. I've also
opened https://github.com/chef/chef-web-docs/pull/2294 to fix the CLI
help to note that you need -VVV for max now.

Signed-off-by: Tim Smith <tsmith@chef.io>