### PR TITLE
Cleanup some of the deprecations pages and link to Cookstyle

### DIFF
--- a/chef_master/source/deprecations_chef_gem_compile_time.rst
+++ b/chef_master/source/deprecations_chef_gem_compile_time.rst
@@ -3,13 +3,11 @@ Deprecation: Chef Gem Compile Time (CHEF-3)
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_chef_gem_compile_time.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
+.. meta::
+    :robots: noindex
+
 Originally, the `chef gem </resource_chef_gem.html>`__ resource always ran during the `compile` phase (see this section on `Chef Infra Client runs </chef_client_overview.html#the-chef-client-run>`__ for further details).
 It is now possible to control which phase the resource is run in. Calling ``chef_gem`` without specifying the phase is now deprecated.
-
-
 
 This deprecation warning was added in Chef Client 12.1.0, and using ``chef_gem`` without specifying a phase will become an error in Chef Client 13.
 

--- a/chef_master/source/deprecations_chef_platform_methods.rst
+++ b/chef_master/source/deprecations_chef_platform_methods.rst
@@ -3,13 +3,11 @@ Deprecation: Chef::Platform methods (CHEF-13)
 =============================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_chef_platform_methods.rst>`__
 
-.. meta:: 
-    :robots: noindex 
+.. meta::
+    :robots: noindex
 
 Several methods under ``Chef::Platform`` that were previously public APIs to control resolution of provider classes were replaced by the dynamic
 ``Chef::ProviderResolver`` work and the ``provides`` keyword.
-
-
 
 This deprecation warning was added in Chef Client 12.18.x, and using these APIs will become a hard error in Chef Client 13.
 

--- a/chef_master/source/deprecations_chef_rest.rst
+++ b/chef_master/source/deprecations_chef_rest.rst
@@ -3,14 +3,14 @@ Deprecation: Chef REST (CHEF-9)
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_chef_rest.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
+.. meta::
+    :robots: noindex
+
 The ``Chef::REST`` class will be removed.
 
-
-
 ``Chef::REST`` was deprecated in Chef Client 12.7.2, and will be removed in Chef Client 13.
+
+The `Cookstyle <cookstyle.html>`__ cop `ChefDeprecations/UsesChefRESTHelpers <https://github.com/chef/cookstyle/blob/master/docs/cops_chefdeprecations.md#chefdeprecationsuseschefresthelpers>`__ has been introduced to detect this deprecation.
 
 Remediation
 =============

--- a/chef_master/source/deprecations_chocolatey_uninstall.rst
+++ b/chef_master/source/deprecations_chocolatey_uninstall.rst
@@ -3,10 +3,12 @@ Deprecation: :uninstall Resource for chocolatey_package (CHEF-21)
 ==================================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_chocolatey_uninstall.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
-The Chocolatey cookbook's ``chocolatey_package`` resource originally contained an ``:uninstall`` action. When `chocolatey_package </resource_chocolatey_package.html>`__ was moved into core Chef, we made ``:uninstall`` an alias for ``:remove``. In Chef Client 14, ``:uninstall`` will no longer be a valid action. Foodcritic rule `FC103 <http://www.foodcritic.io/#FC103>`__ has been introduced to detect usage of the ``:uninstall`` action.
+.. meta::
+    :robots: noindex
+
+The Chocolatey cookbook's ``chocolatey_package`` resource originally contained an ``:uninstall`` action. When `chocolatey_package </resource_chocolatey_package.html>`__ was moved into core Chef, we made ``:uninstall`` an alias for ``:remove``. In Chef Client 14, ``:uninstall`` will no longer be a valid action.
+
+The `Cookstyle <cookstyle.html>`__ cop `ChefDeprecations/ChocolateyPackageUninstallAction <https://github.com/chef/cookstyle/blob/master/docs/cops_chefdeprecations.md#chefdeprecationschocolateypackageuninstallaction>`__ has been introduced to detect and autocorrect this deprecation.
 
 Remediation
 ================

--- a/chef_master/source/deprecations_deploy_resource.rst
+++ b/chef_master/source/deprecations_deploy_resource.rst
@@ -3,9 +3,9 @@ Deprecation: Deploy Resource (CHEF-20)
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_deploy_resource.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
+.. meta::
+    :robots: noindex
+
 The ``deploy`` and ``deploy_revision`` resources have been deprecated as of Chef Client 13.6, and will be removed in Chef Client 14.
 
 Remediation

--- a/chef_master/source/deprecations_dnf_package_allow_downgrade.rst
+++ b/chef_master/source/deprecations_dnf_package_allow_downgrade.rst
@@ -3,16 +3,12 @@ Deprecation: DNF Package allow_downgrade Property (CHEF-10)
 ===========================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_dnf_package_allow_downgrade.rst>`__
 
-.. meta:: 
-    :robots: noindex 
+.. meta::
+    :robots: noindex
 
-The DNF package provider in the O/S does not require ``--allow-downgrade`` like yum did, and neither does the Chef ``dnf_package`` resource.  This property has no effect on the
-``dnf_resource`` property.
-
-
+The underlying ``dnf`` command in Red Hat based operating systems does not require ``--allow-downgrade`` like the previous ``yum`` command did. This property does not affect the ``dnf_resource`` resource execution and should be removed.
 
 Remediation
 ===============
 
 Remove the ``allow_downgrade`` property on the ``dnf_package`` resource.
-

--- a/chef_master/source/deprecations_easy_install.rst
+++ b/chef_master/source/deprecations_easy_install.rst
@@ -3,16 +3,16 @@ Deprecation: Easy Install Resource (CHEF-6)
 =======================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_easy_install.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
+.. meta::
+    :robots: noindex
+
 The Python community recommends that users prefer ``pip`` rather than ``easy_install`` to install python packages.
 
-
-
 The ``easy_install`` resource was deprecated in Chef Client 12.10, and will be removed in Chef Client 13.
+
+The `Cookstyle <cookstyle.html>`__ cop `ChefDeprecations/EasyInstallResource <https://github.com/chef/cookstyle/blob/master/docs/cops_chefdeprecations.md#chefdeprecationseasyinstallresource>`__ has been introduced to detect this deprecation.
 
 Remediation
 ===============
 
-There is no built in replacement for ``easy_install`` in Chef. The `poise-python <https://supermarket.chef.io/cookbooks/poise-python>`__ cookbook provides a set of resources for managing Python installations.
+There is no built-in replacement for ``easy_install`` in Chef Infra Client at this time.

--- a/chef_master/source/deprecations_epic_fail.rst
+++ b/chef_master/source/deprecations_epic_fail.rst
@@ -3,7 +3,14 @@ Deprecation: epic_fail (CHEF-24)
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_epic_fail.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
-The original name for the ``ignore_failure`` property in resources was ``epic_fail``. Our documentation hasn't referred to ``epic_fail`` for years and out of the 3500 cookbooks on the Supermarket only one uses ``epic_fail``. In Chef Client 14 we will remove the ``epic_fail`` property entirely. Foodcritic rule `FC107 <http://www.foodcritic.io/#FC107>`__ has been introduced to detect usage of ``epic_fail``.
+.. meta::
+    :robots: noindex
+
+The original name for the ``ignore_failure`` property in resources was ``epic_fail``. Our documentation hasn't referred to ``epic_fail`` for years and out of the 3500 cookbooks on the Supermarket only one uses ``epic_fail``. In Chef Client 14 we will remove the ``epic_fail`` property entirely.
+
+The `Cookstyle <cookstyle.html>`__ cop `ChefDeprecations/EpicFail <https://github.com/chef/cookstyle/blob/master/docs/cops_chefdeprecations.md#chefdeprecationsepicfail>`__ has been introduced to detect and autocorrect this deprecation.
+
+Remediation
+===============
+
+Replace any usage of ``epic_fail`` with ``ignore_failure``.

--- a/chef_master/source/deprecations_erl_call_resource.rst
+++ b/chef_master/source/deprecations_erl_call_resource.rst
@@ -3,10 +3,12 @@ Deprecation: Deprecation of the erl_call resource (CHEF-22)
 =================================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_erl_call_resource.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
+.. meta::
+    :robots: noindex
+
 The erl_call resource was deprecated in Chef Client 13.7 and removed from Chef Client 14.0 (April 2018).
+
+The `Cookstyle <cookstyle.html>`__ cop `ChefDeprecations/ErlCallResource <https://github.com/chef/cookstyle/blob/master/docs/cops_chefdeprecations.md#chefdeprecationserlcallresource>`__ has been introduced to detect this deprecation.
 
 Remediation
 =============

--- a/chef_master/source/deprecations_exit_code.rst
+++ b/chef_master/source/deprecations_exit_code.rst
@@ -3,14 +3,12 @@ Deprecation: Old Exit Codes (CHEF-2)
 =======================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_exit_code.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
+.. meta::
+    :robots: noindex
+
 In older versions of Chef Client, it was not possible to discern why a chef run exited simply by examining the error code.
 This makes it very tricky for tools such as Test Kitchen to reason about the status of a Chef Client run.
 Starting in Chef Client 12.11, there are now well defined exit codes that the Chef Client can use to communicate the status of the run.
-
-
 
 This deprecation was added in Chef Client 12.11. In Chef Client 13, only the extended set of exit codes will be supported. For further information on the list of defined error codes,
 please see `RFC 62, which defines them <https://github.com/chef/chef-rfc/blob/master/rfc062-exit-status.md>`__.

--- a/chef_master/source/deprecations_internal_api.rst
+++ b/chef_master/source/deprecations_internal_api.rst
@@ -3,10 +3,7 @@ Deprecation: Internal API Changes (CHEF-0)
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_internal_api.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
+.. meta::
+    :robots: noindex
+
 During the lifecycle of a release, we realise that some APIs are no longer fit for purpose, or are simply unused. We try to mark those APIs for removal in the next major release.
-
-
-

--- a/chef_master/source/deprecations_launchd_hash_property.rst
+++ b/chef_master/source/deprecations_launchd_hash_property.rst
@@ -3,18 +3,18 @@ Deprecation: Launchd hash Property (CHEF-12)
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_launchd_hash_property.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
+.. meta::
+    :robots: noindex
+
 The launchd resource has a property called ``hash`` which conflicts with the already-existing Ruby ``hash`` method that exists on every object.
-
-
 
 The `CHEF-11 </deprecations_property_name_collision.html>`__ deprecation warns whenever a resource property is named the same as an existing Ruby method. Chef's core ``launchd`` resource is guilty of this behavior. The ``hash`` property accepts a Ruby Hash containing the data to be output to the launchd property list. However, ``hash`` is an already-existing Ruby method.
 
 A deprecation warning is logged when the ``hash`` property is used. In Chef Client 13, this will raise an exception and your Chef run will fail.
 
+The `Cookstyle <cookstyle.html>`__ cop `ChefDeprecations/LaunchdDeprecatedHashProperty <https://github.com/chef/cookstyle/blob/master/docs/cops_chefdeprecations.md#chefdeprecationslaunchddeprecatedhashproperty>`__ has been introduced to detect and autocorrect this deprecation.
+
 Remediation
 =============
 
-When using the ``launchd`` resource and passing a hash for the launchd property list, use the ``plist_hash`` property instead of the ``hash`` property.
+When using the ``launchd`` resource and passing a hash≈ for the launchd property list, use the ``plist_hash`` property instead of the ``hash`` property.

--- a/chef_master/source/deprecations_legacy_hwrp_mixins.rst
+++ b/chef_master/source/deprecations_legacy_hwrp_mixins.rst
@@ -3,10 +3,12 @@ Deprecation: Legacy HWRP mixins (CHEF-23)
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_legacy_hwrp_mixins.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
-In Chef Client 14 several legacy mixins will be removed. Usage of these mixins has resulted in deprecation warnings for several years. They were traditionally used in some HWRPs, but are rarely found in code available on the Supermarket. Foodcritic rules `FC097 <http://www.foodcritic.io/#FC097>`__, `FC098 <http://www.foodcritic.io/#FC098>`__, `FC099 <http://www.foodcritic.io/#FC099>`__, `FC100 <http://www.foodcritic.io/#FC100>`__, and `FC102 <http://www.foodcritic.io/#FC102>`__ have been introduced to detect these mixins:
+.. meta::
+    :robots: noindex
+
+In Chef Client 14 several legacy mixins will be removed. Usage of these mixins has resulted in deprecation warnings for several years. They were traditionally used in some HWRPs, but are rarely found in code available on the Supermarket.
+
+The `Cookstyle <cookstyle.html>`__ cop `ChefDeprecations/UsesDeprecatedMixins <https://github.com/chef/cookstyle/blob/master/docs/cops_chefdeprecations.md#chefdeprecationsusesdeprecatedmixins>`__ has been introduced to detect these mixins:
 
 * ``Chef::Mixin::LanguageIncludeAttribute``
 * ``Chef::Mixin::RecipeDefinitionDSLCore``

--- a/chef_master/source/deprecations_local_listen.rst
+++ b/chef_master/source/deprecations_local_listen.rst
@@ -3,24 +3,12 @@ Deprecation: Local Mode Listen (CHEF-18)
 =======================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_local_listen.rst>`__
 
-.. meta:: 
+.. meta::
     :robots: noindex
 
-When using `chef-client` Local Mode, there are two ways to launch the internal
-Chef Zero server. Originally we launched it as a normal network service on
-localhost and then connected to it as per normal. Unfortunately this meant that
-any user or process on the machine could also connect to the Zero server during
-the converge and because Chef Zero has no authentication or authorization systems,
-they could potentially alter data mid-converge. We later added a "socketless"
-mode, which runs the Zero server completely internally and never exposes it on
-a real socket.
-
-This is more secure and safe in most situations, but some users of chef-provisioning,
-specifically those using the Zero tunnel mode, need the socket mode as they
-expose that out to clients via an SSH tunnel.
+When using `chef-client` Local Mode, there are two ways to launch the internal Chef Zero server. Originally we launched it as a normal network service on localhost and then connected to it as per normal. Unfortunately this meant that any user or process on the machine could also connect to the Zero server during the converge and because Chef Zero has no authentication or authorization systems, they could potentially alter data mid-converge. We later added a "socketless" mode, which runs the Zero server completely internally and never exposes it on a real socket.
 
 Remediation
 ===============
 
-If you need to re-enable socket mode for now, you can run `chef-client --local-mode --listen`
-or set `knife[:listen] = true` in your `.chef/knife.rb` or `.chef/config.rb`.
+If you need to re-enable socket mode for now, you can run `chef-client --local-mode --listen` or set `knife[:listen] = true` in your `.chef/knife.rb` or `.chef/config.rb`.

--- a/chef_master/source/deprecations_locale_lc_all.rst
+++ b/chef_master/source/deprecations_locale_lc_all.rst
@@ -3,13 +3,14 @@ Deprecation: Deprecation of lc_all from locale resource (CHEF-27)
 =======================================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_locale_lc_all.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
+.. meta::
+    :robots: noindex
+
 Setting the ``LC_ALL`` variable is NOT recommended. As a system-wide setting, ``LANG`` should provide the desired behavior. ``LC_ALL`` is intended to be used for temporarily troubleshooting issues rather than an everyday system setting.
 Changing ``LC_ALL`` can break Chef's parsing of command output in unexpected ways. Use one of the more specific ``LC_`` properties as needed.
 This deprecation warning was added in Chef Infra Client 15.0. Support for property ``lc_all`` will be removed for Chef Infra Client 16.0.
 
+The `Cookstyle <cookstyle.html>`__ cop `ChefDeprecations/LocaleDeprecatedLcAllProperty <https://github.com/chef/cookstyle/blob/master/docs/cops_chefdeprecations.md#chefdeprecationslocaledeprecatedlcallproperty>`__ has been introduced to detect and autocorrect this deprecation.
 
 
 

--- a/chef_master/source/deprecations_map_collision.rst
+++ b/chef_master/source/deprecations_map_collision.rst
@@ -3,10 +3,10 @@ Deprecation: Map Collision (CHEF-25)
 =======================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_map_collision.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
-The resource(s) referenced in the error message has been loaded from a cookbook. This resource is now included in Chef and will take precedence over the existing cookbook resource in the next major release of Chef (15.0, April 2019). Alternatively, there may be a newer version of this cookbook without this resource.
+.. meta::
+    :robots: noindex
+
+The resource(s) referenced in the error message has been loaded from a cookbook. This resource is now included in Chef Infra Client and will take precedence over the existing cookbook resource in the next major release of Chef Infra Client (15.0, April 2019). Alternatively, there may be a newer version of this cookbook without this resource.
 
 Remediation
 =============

--- a/chef_master/source/deprecations_namespace_collisions.rst
+++ b/chef_master/source/deprecations_namespace_collisions.rst
@@ -3,14 +3,12 @@ Deprecation: Use of property_name inside of actions (CHEF-19)
 ==================================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_namespace_collisions.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
+.. meta::
+    :robots: noindex
+
 In Chef Client 12.5.1, the custom resources API allowed specifying property names as the short form of ``property_name`` inside of actions, instead of the long form of
 ``new_resource.property_name`` (as was previously required in provider code in LWRPs/HWRPs/etc).  That change caused unsolvable namespace clashes and will be
 removed in Chef Client 14.0, and it will become mandatory to refer to properties as ``new_resource.property_name`` in actions.
-
-
 
 Example
 ==========

--- a/chef_master/source/deprecations_ohai_cloud_v2.rst
+++ b/chef_master/source/deprecations_ohai_cloud_v2.rst
@@ -3,9 +3,9 @@ Deprecation: Cloud_v2 attribute removal (OHAI-11)
 ==================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/deprecations_ohai_cloud_v2.rst>`__
 
-.. meta:: 
-    :robots: noindex 
-    
+.. meta::
+    :robots: noindex
+
 In Ohai/Chef Client 13 we replaced the existing Cloud plugin with the Cloud V2 plugin. That was done by having Ohai populate both ``node['cloud']`` and ``node['cloud_v2']`` with the data previously found at ``node['cloud_v2']``. In Chef Client 14 we will no longer populate ``node['cloud_v2']``.
 
 Remediation

--- a/chef_master/source/deprecations_property_name_collision.rst
+++ b/chef_master/source/deprecations_property_name_collision.rst
@@ -5,10 +5,8 @@ Deprecation: Resource Property Name Collision (CHEF-11)
 
 .. meta::
     :robots: noindex
-    
+
 A resource property, defined with the ``property`` method, conflicts with an already-existing property or method. This could indicate an error that could lead to unintended behavior.
-
-
 
 All Ruby objects have a number of methods that are expected to always be available. When a resource property is created, Ruby methods for setting and getting the property value are created for you. If a resource creates a property which is named the same as an existing method, the original method will be overwritten.
 

--- a/chef_master/source/deprecations_resource_cloning.rst
+++ b/chef_master/source/deprecations_resource_cloning.rst
@@ -5,13 +5,11 @@ Deprecation: Resource Cloning (CHEF-3694)
 
 .. meta::
     :robots: noindex
-    
+
 Chef allows resources to be created with duplicate names, rather than treating that as an error. This means that several cookbooks can request the same package be installed, without needing to carefully create unique names.
 This is problematic because having multiple resources with the same name makes it impossible to safely deliver notifications to the right resource.
 
 In Chef Client 13, resources with the same name will be treated as entirely separate, without any cloning of properties.
-
-
 
 The behavior in Chef Client 12 and earlier, which is now deprecated, is that we will try to clone the existing resource, and then apply any properties from the new resource. For example:
 

--- a/chef_master/source/deprecations_run_command.rst
+++ b/chef_master/source/deprecations_run_command.rst
@@ -8,8 +8,6 @@ Deprecation: Deprecation of run_command (CHEF-14)
 
 The old run_command API has been replaced by shell_out (a wrapper around Mixlib::ShellOut).
 
-
-
 This deprecation warning was added in Chef Client 12.18.31, and run_command will be removed permanently in Chef Client 13.
 
 Example

--- a/chef_master/source/deprecations_shell_out.rst
+++ b/chef_master/source/deprecations_shell_out.rst
@@ -5,11 +5,9 @@ Deprecation: Deprecation of old shell_out APIs (CHEF-26)
 
 .. meta::
     :robots: noindex
-    
+
 The functionality of mutiple old `shell_out` APIs has been collapsed into the `shell_out` API itself, and the old methods
 have been deprecated.
-
-
 
 The `shell_out_compact` API has been migrated into `shell_out`, so those methods can be renamed.  The functionality of
 `shell_out_compact_timeout` and `shell_out_with_timeout` have been migrated into `shell_out` for internal resources, and will
@@ -18,7 +16,6 @@ be migrated into custom resources and LWRPs in Chef-15, in the meantime consumer
 `default_env: false` flag.
 
 The "banged" versions of those APIs (e.g. `shell_out_compact!`) changes identically to use `shell_out!`.
-
 
 Example
 =====================================================

--- a/chef_master/source/deprecations_supports_property.rst
+++ b/chef_master/source/deprecations_supports_property.rst
@@ -5,10 +5,8 @@ Deprecation: "Supports" metaproperty (CHEF-8)
 
 .. meta::
     :robots: noindex
-    
+
 The ``user`` resource previously allowed a cookbook author to set policy for the resource in two ways. The ``supports`` metaproperty, which is now deprecated, enabled the ``manage_home`` and ``non_unique`` properties to be set.
-
-
 
 The ``supports`` metaproperty was deprecated in Chef Client 12.14 and will be removed in Chef Client 13.
 

--- a/chef_master/source/deprecations_verify_file.rst
+++ b/chef_master/source/deprecations_verify_file.rst
@@ -5,10 +5,8 @@ Deprecation: Verify File Expansion (CHEF-7)
 
 .. meta::
     :robots: noindex
-    
+
 The ``verify`` metaproperty allows the user to specify a ``{path}`` variable that is expanded to the path of the file to be verified. Previously, it was possible to use ``{file}`` as the variable, but that is now deprecated.
-
-
 
 The ``{file}`` expansion was deprecated in Chef Client 12.5, and will be removed in Chef Client 13.
 

--- a/chef_master/source/depreciations_ohai_system_profile.rst
+++ b/chef_master/source/depreciations_ohai_system_profile.rst
@@ -5,10 +5,8 @@ Deprecation: System Profile plugin (OHAI-14)
 
 .. meta::
     :robots: noindex
-    
+
 The system_profile plugin will be removed from Chef/Ohai 15 in April 2019. This plugin does not correctly return data on modern Mac systems. Additionally the same data is provided by the hardware plugin, which has a format that is simpler to consume. Removing this plugin will reduce Ohai return by ~3 seconds and greatly reduce the size of the node object on the Chef Infra Server.
-
-
 
 Remediation
 ==============


### PR DESCRIPTION
Remove references to Foodcritic and let folks know that we have Cookstyle rules for a lot of these.

Signed-off-by: Tim Smith <tsmith@chef.io>