### PR TITLE
Fix bug that prevented git lastmod date/time from being added to page…

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@ baseURL = "/"
 languageCode = "en-us"
 title = "Chef Web Docs"
 theme = "docs-new"
+enableGitInfo = true
 
 
 [markup]
@@ -54,8 +55,6 @@ theme = "docs-new"
     ordered = false
     startLevel = 1
 
-
-enableGitInfo = true
 
 [params]
   enable_search = true

--- a/themes/docs-new/layouts/partials/footer.html
+++ b/themes/docs-new/layouts/partials/footer.html
@@ -12,7 +12,9 @@
           <li><a href="https://www.chef.io/privacy-policy/" target="_blank">Privacy Policy</a></li>
           <li><a href="https://www.chef.io/cookie-policy/" target="_blank">Cookie Policy</a></li>
         </ul>
-        <p class="modified">Page Last Modified: {{ .Lastmod }}</p>
+        {{ if and (ne .Kind "taxonomy") (ne .Kind "taxonomyTerm") (ne .Kind "404")}}
+          <p class="modified">Page Last Modified: {{ .Lastmod }}</p>
+        {{ end }}
         <p class="legal">&copy; 2008-{{ now.Format "2006" }} Chef Software, Inc. All Rights Reserved.</p>
       </div>
     </div>


### PR DESCRIPTION
… footer

Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

For some reason placing enableGitInfo below the markup section of the config prevents it from working. This fixes it.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
