### PR TITLE
Update the versions of opensuse we support

### DIFF
--- a/chef_master/source/platforms.rst
+++ b/chef_master/source/platforms.rst
@@ -97,7 +97,7 @@ The following platforms are supported only via the community:
      - stable and LTS releases
    * - openSUSE
      -
-     - ``42.x``
+     - ``15.x``
    * - Scientific Linux
      - ``x86_64``
      - ``6.x``, ``7.x``
@@ -216,7 +216,7 @@ The following platforms are supported only via the community:
      - Version
    * - openSUSE
      -
-     - ``42.x``
+     - ``15.x``
    * - Scientific Linux
      - ``x86_64``
      - ``6.x``, ``7.x``


### PR DESCRIPTION
42 is EOL so no one is supporting that anymore

Signed-off-by: Tim Smith <tsmith@chef.io>