### PR TITLE
Remove reference to Chef 12 in uninstall docs

### DIFF
--- a/chef_master/source/uninstall.rst
+++ b/chef_master/source/uninstall.rst
@@ -107,8 +107,6 @@ To remove the system installation entry:
 
 To remove symlinks:
 
-* For Chef Client 12.x, under ``/usr/local/bin``:
-
   .. code-block:: bash
 
      $ sudo find /usr/local/bin -lname '`/opt/chef-workstation/*' -delete


### PR DESCRIPTION
Workstation never shipped with 12. This is just weird

Signed-off-by: Tim Smith <tsmith@chef.io>