### PR TITLE
Remove mention of old cookbooks in libraries

### DIFF
--- a/chef_master/source/libraries.rst
+++ b/chef_master/source/libraries.rst
@@ -12,13 +12,13 @@ A library allows arbitrary Ruby code to be included in a cookbook. The most comm
 Use a library to:
 
 * Connect to a database
+* Fetch secrets from a cloud provider
 * Talk to an LDAP provider
 * Do anything that can be done with Ruby
 
 Syntax
 =====================================================
-The syntax for a library varies because library files are created using Ruby and are designed to handle custom situations. See the Examples section below for some ideas. Also, the https://github.com/chef-cookbooks/database and https://github.com/chef-cookbooks/chef-splunk cookbooks contain more detailed and complex examples.
-
+The syntax for a library varies because library files are created using Ruby and are designed to handle custom situations. See the Examples section below for samples.
 
 Template Helper Modules
 =====================================================


### PR DESCRIPTION
Database is in the boneyard. Don't link folks to that anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>