### PR TITLE
Rework the files page to focus on cookbook files

### DIFF
--- a/chef_master/source/files.rst
+++ b/chef_master/source/files.rst
@@ -1,11 +1,6 @@
 =====================================================
-About Files
+Cookbook Files
 =====================================================
 `[edit on GitHub] <https://github.com/chef/chef-web-docs/blob/master/chef_master/source/files.rst>`__
 
-Files are managed using the following resources:
-
-* Use the `cookbook_file </resource_cookbook_file.html>`__ resource to manage files that are added to nodes based on files that are located in the ``/files`` directory in a cookbook.
-* Use the `file </resource_file.html>`__ resource to manage files directly on a node.
-* Use the `remote_file </resource_remote_file.html>`__ resource to transfer files to nodes from remote locations.
-* Use the `template </resource_template.html>`__ resource to manage files that are added to nodes based on files that are located in the ``/templates`` directory in a cookbook.
+The ``files`` directory in Chef Infra cookbooks stores files that are used in your cookbook with the `cookbook_file </resource_cookbook_file.html>`__ resource.


### PR DESCRIPTION
We link here from the cookbook page and then we talk about all this
other stuff that doesn't have anything to do with the files directory.
It's really strange.

Signed-off-by: Tim Smith <tsmith@chef.io>