### PR TITLE
Replace hugo-specific swiftype search with search already used on Sphinx

### DIFF
--- a/themes/docs-new/layouts/partials/javascript.html
+++ b/themes/docs-new/layouts/partials/javascript.html
@@ -19,5 +19,5 @@
   e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
   })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
   
-  _st('install','ZXHpCfPLzPHWHG5upsR7','2.0.0');
+  _st('install','s1Pemn_yrUKJw9_K5zRT','2.0.0');
 </script>


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This will replace the Swiftype search that was set up specifically for Hugo with the one already used by the Sphinx site.

### Definition of Done

### Issues Resolved

chef/release-engineering#788

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
