### PR TITLE
The response for /users GET verbose=true is a hash

### DIFF
--- a/chef_master/source/api_chef_server.rst
+++ b/chef_master/source/api_chef_server.rst
@@ -615,7 +615,7 @@ This method has the following parameters:
    * - ``external_authentication_uid=jane@chef.com``
      - Filter the users returned based on their external login id.
    * - ``verbose=true``
-     - Returns a user list with "email", "first_name", "last_name" fields.  If this flag is set the email and external_authentication_uid parameters are ignored and the response format is an array instead of a hash.
+     - Returns a user list with "email", "first_name", "last_name" fields.  If this flag is set the email and external_authentication_uid parameters are ignored.
 
 **Request**
 


### PR DESCRIPTION
The example return value is accurate. The description was wrong.

Signed-off-by: markgibbons <mark.gibbons@nordstrom.com>

### Description

Fix the description of the values returned by /users GET verbose=true

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
