### PR TITLE
Fix appearance of shortcode

### DIFF
--- a/content/chef_shell.md
+++ b/content/chef_shell.md
@@ -69,7 +69,13 @@ This command has the following options:
 
     {{< warning >}}
 
-    {{% node_ctl_attribute %}}
+{{% node_ctl_attribute_text %}}
+
+{{% node_ctl_attribute_code_block_1 %}}
+
+will result in a node object similar to:
+
+{{% node_ctl_attribute_code_block_2 %}}
 
     {{< /warning >}}
 

--- a/content/ctl_chef_solo.md
+++ b/content/ctl_chef_solo.md
@@ -97,7 +97,13 @@ This command has the following options:
 
     {{< warning >}}
 
-    {{% node_ctl_attribute %}}
+{{% node_ctl_attribute_text %}}
+
+{{% node_ctl_attribute_code_block_1 %}}
+
+will result in a node object similar to:
+
+{{% node_ctl_attribute_code_block_2 %}}
 
     {{< /warning >}}
 

--- a/layouts/shortcodes/node_ctl_attribute.md
+++ b/layouts/shortcodes/node_ctl_attribute.md
@@ -3,33 +3,33 @@ treated as a `normal` attribute. Setting attributes at other precedence
 levels is not possible. For example, attempting to update `override`
 attributes using the `-j` option:
 
-``` javascript
-{
-  "name": "dev-99",
-  "description": "Install some stuff",
-  "override_attributes": {
-    "apptastic": {
-      "enable_apptastic": "false",
-      "apptastic_tier_name": "dev-99.bomb.com"
-    }
-  }
-}
-```
-
-will result in a node object similar to:
-
-``` javascript
-{
-  "name": "maybe-dev-99",
-  "normal": {
-    "name": "dev-99",
-    "description": "Install some stuff",
-    "override_attributes": {
-      "apptastic": {
-        "enable_apptastic": "false",
-        "apptastic_tier_name": "dev-99.bomb.com"
+    ``` javascript
+    {
+      "name": "dev-99",
+      "description": "Install some stuff",
+      "override_attributes": {
+        "apptastic": {
+          "enable_apptastic": "false",
+          "apptastic_tier_name": "dev-99.bomb.com"
+        }
       }
     }
-  }
-}
-```
+    ```
+
+    will result in a node object similar to:
+
+    ``` javascript
+    {
+      "name": "maybe-dev-99",
+      "normal": {
+        "name": "dev-99",
+        "description": "Install some stuff",
+        "override_attributes": {
+          "apptastic": {
+            "enable_apptastic": "false",
+            "apptastic_tier_name": "dev-99.bomb.com"
+          }
+        }
+      }
+    }
+    ```

--- a/layouts/shortcodes/node_ctl_attribute_code_block_1.md
+++ b/layouts/shortcodes/node_ctl_attribute_code_block_1.md
@@ -1,0 +1,12 @@
+``` javascript
+{
+  "name": "dev-99",
+  "description": "Install some stuff",
+  "override_attributes": {
+    "apptastic": {
+      "enable_apptastic": "false",
+      "apptastic_tier_name": "dev-99.bomb.com"
+    }
+  }
+}
+```

--- a/layouts/shortcodes/node_ctl_attribute_code_block_2.md
+++ b/layouts/shortcodes/node_ctl_attribute_code_block_2.md
@@ -1,0 +1,15 @@
+``` javascript
+{
+  "name": "maybe-dev-99",
+  "normal": {
+    "name": "dev-99",
+    "description": "Install some stuff",
+    "override_attributes": {
+      "apptastic": {
+        "enable_apptastic": "false",
+        "apptastic_tier_name": "dev-99.bomb.com"
+      }
+    }
+  }
+}
+```

--- a/layouts/shortcodes/node_ctl_attribute_text.md
+++ b/layouts/shortcodes/node_ctl_attribute_text.md
@@ -1,0 +1,4 @@
+Any other attribute type that is contained in this JSON file will be
+treated as a `normal` attribute. Setting attributes at other precedence
+levels is not possible. For example, attempting to update `override`
+attributes using the `-j` option:

--- a/layouts/shortcodes/node_ctl_run_list.md
+++ b/layouts/shortcodes/node_ctl_run_list.md
@@ -1,16 +1,16 @@
 Use this option to define a `run_list` object. For example, a JSON file
 similar to:
 
-``` javascript
-"run_list": [
-  "recipe[base]",
-  "recipe[foo]",
-  "recipe[bar]",
-  "role[webserver]"
-],
-```
+    ``` javascript
+    "run_list": [
+      "recipe[base]",
+      "recipe[foo]",
+      "recipe[bar]",
+      "role[webserver]"
+    ],
+    ```
 
-may be used by running `chef-client -j path/to/file.json`.
+    may be used by running `chef-client -j path/to/file.json`.
 
-In certain situations this option may be used to update `normal`
-attributes.
+    In certain situations this option may be used to update `normal`
+    attributes.


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Due to the idiosyncrasies of Hugo and Goldmark and how they process shortcodes, this text looks awful after its rendered. This will fix the appearance of the text on all three pages, but also creates four shortcodes on three pages where there used to be just one shortcode. I'll try to come up with a more permanent solution at some point.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
