### PR TITLE
Replace superscript 1

### DIFF
--- a/content/versions.md
+++ b/content/versions.md
@@ -136,7 +136,7 @@ announcement](https://blog.chef.io/2019/04/02/chef-software-announces-the-enterp
 <td>n/a</td>
 </tr>
 <tr class="even">
-<td>Chef Backend¹</td>
+<td>Chef Backend</td>
 <td>3.x</td>
 <td>Releasing 2020</td>
 <td>n/a</td>
@@ -144,9 +144,13 @@ announcement](https://blog.chef.io/2019/04/02/chef-software-announces-the-enterp
 </tbody>
 </table>
 
-1.  These distributions do not directly require acceptance of the Chef
-    EULA, but have functionality that requires its acceptance in other
-    products.
+{{< note >}}
+
+**Chef Backend** does not directly require acceptance of the Chef
+EULA, but it does have functionality that requires its acceptance in other
+products.
+
+{{< /note >}}
 
 Supported Free Distributions
 ============================


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This will replace a superscript 1 that gets snagged by the hugo_lint.sh script with a note at the bottom of the table. 

Another alternative would be to leave the superscript 1 but wrap it with superscript tags like, ``<sup>1</sup>``. The note option is a bit simpler and more markdown-y.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
