### PR TITLE
Reformat yaml codeblocks

### DIFF
--- a/content/chef_deprecations_client.md
+++ b/content/chef_deprecations_client.md
@@ -31,7 +31,9 @@ To test your code for deprecations, you can put Test Kitchen in a mode
 where any deprecations cause the chef run to fail. Ensure your
 `kitchen.yml` includes:
 
-``` yaml
+<!-- yaml codeblock -->
+
+```
 provisioner:
   deprecations_as_errors: true
 ```
@@ -72,7 +74,9 @@ silence_deprecation_warnings %w{deploy_resource chef-23 recipes/install.rb:22}
 
 or in your \`kitchen.yml\`:
 
-``` yaml
+<!-- yaml codeblock -->
+
+```
 provisioner:
   name: chef_solo
     solo_rb:

--- a/content/config_yml_kitchen.md
+++ b/content/config_yml_kitchen.md
@@ -445,7 +445,9 @@ as whether to require the Chef installer or the URL from which Chef
 Infra Client is downloaded, or to override settings in the client.rb
 file:
 
-``` yaml
+
+<!-- yaml codeblock -->
+```
 provisioner:
   name: chef_zero *or* chef_solo
   require_chef_omnibus: true
@@ -490,7 +492,8 @@ Driver Settings
 Driver-specific configuration settings may be required. Use a block
 similar to:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 driver:
   name: driver_name
   optional_settings: values
@@ -532,7 +535,8 @@ Chef Workstation to converge the node.
 
 To install the latest version of Chef Workstation:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 provisioner:
   ...
   chef_omnibus_install_options: -P chef-workstation
@@ -541,7 +545,8 @@ provisioner:
 
 and to install a specific version of Chef Workstation:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 provisioner:
   ...
   chef_omnibus_install_options: -P chef-workstation
@@ -555,7 +560,8 @@ Microsoft Windows Platform
 The following example shows platform settings for the Microsoft Windows
 platform:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 ---
 
 platforms:
@@ -577,7 +583,8 @@ Chef Infra Client Cookbook
 The following kitchen.yml file is part of the `chef-client` cookbook and
 ensures Chef Infra Client is configured correctly.
 
-``` yaml
+<!-- yaml codeblock -->
+```
 driver:
   name: vagrant
 
@@ -635,7 +642,8 @@ The following kitchen.yml file is part of the `chef-splunk` cookbook and
 is used to help ensure the installation of the Splunk client and server
 is done correctly.
 
-``` yaml
+<!-- yaml codeblock -->
+```
 driver:
   name: vagrant
   customize:
@@ -677,7 +685,8 @@ yum Cookbook
 
 The following kitchen.yml file is part of the `yum` cookbook:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 driver:
   name: vagrant
 
@@ -705,7 +714,8 @@ back-end server, and two add-ons (Chef Push Jobs and Chef management
 console). The `platforms` block uses an `attributes` section to define
 Chef server-specific attributes that are used by all three test suites:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 ---
 driver:
   name: vagrant
@@ -778,7 +788,8 @@ Test-Kitchen can handle reboots (when initiated from Chef Infra Client)
 by setting `retry_on_exit_code`, `max_retries` and `wait_for_retry`
 attributes on the provisioner in `kitchen.yml` file as follows :
 
-``` yaml
+<!-- yaml codeblock -->
+```
 ---
 provisioner:
    name: chef_zero

--- a/content/cookstyle.md
+++ b/content/cookstyle.md
@@ -228,7 +228,8 @@ Syntax
 
 A .rubocop.yml file has the following syntax:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 NAME_OF_RULE:
   Description: 'a description of a rule'
   Enabled : (true or false)

--- a/content/ctl_kitchen.md
+++ b/content/ctl_kitchen.md
@@ -508,7 +508,8 @@ Examples
 
 Use the `--loader` option to include diagnostic data in the output:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 ---
 loader:
   combined_config:
@@ -523,7 +524,8 @@ loader:
 
 or:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 ---
 loader:
   global_config:
@@ -540,7 +542,8 @@ loader:
 Use the `--instances` option to track instances, which are based on the
 list of platforms and suites in the kitchen.yml file:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 ---
 instances
   default-ubuntu-1804
@@ -554,7 +557,8 @@ instances
 
 This command returns data as YAML:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 ---
 timestamp: 2014-04-15 18:59:58.460470000 Z
 kitchen-version: 1.2.2.dev
@@ -568,7 +572,8 @@ instances:
 When Test Kitchen is being used to test cookbooks, Test Kitchen will
 track state data:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 ---
 instances:
   default-ubuntu-1804
@@ -584,7 +589,8 @@ instances:
 
 and will track information that was given to a driver:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 ---
 instances:
   default-ubuntu-1804
@@ -596,7 +602,8 @@ instances:
 
 and will track information about provisioners:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 ---
 instances:
   default-ubuntu-1804

--- a/content/google.md
+++ b/content/google.md
@@ -89,7 +89,8 @@ Usage Examples
 
 The following is a basic `kitchen.yml` example:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 ---
 driver:
   name: gce

--- a/content/policyfile.md
+++ b/content/policyfile.md
@@ -260,14 +260,18 @@ Test w/Kitchen
 Kitchen may be used to test Policyfile files. Add the following to
 kitchen.yml:
 
-``` yaml
+<!-- yaml codeblock -->
+
+```
 provisioner:
   name: chef_zero
 ```
 
 A named run-list may be used on a per-suite basis:
 
-``` yaml
+<!-- yaml codeblock -->
+
+```
 suites:
   - name: client
     provisioner:
@@ -279,7 +283,9 @@ suites:
 
 or globally:
 
-``` yaml
+<!-- yaml codeblock -->
+
+```
 provisioner:
   name: chef_zero
   named_run_list: integration_test_run_list
@@ -288,7 +294,9 @@ provisioner:
 or testing with policies per-suite, once the Policyfile files are
 available in your repo:
 
-``` yaml
+<!-- yaml codeblock -->
+
+```
 suites:
    - name: defaultmega
       provisioner:

--- a/content/release_notes_chefdk.md
+++ b/content/release_notes_chefdk.md
@@ -344,7 +344,8 @@ cookstyle --except ChefStyle
 You can also disable a specific department by adding the following to
 your `.rubocop.yml` config:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 ChefStyle:
   Enabled: false
 ```

--- a/content/vmware.md
+++ b/content/vmware.md
@@ -305,7 +305,8 @@ cookbook](https://github.com/jjasghar/vsphere_testing) that attempts to
 capture everything required. The following is a basic `kitchen.yml`
 example:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 ---
 driver:
 name: vsphere
@@ -369,7 +370,8 @@ kitchen-vcenter
 
 The following is a basic `kitchen.yml` for vCenter:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 driver:
   name: vcenter
   vcenter_username: <%= ENV['VCENTER_USER'] || "administrator@vsphere.local" %>
@@ -402,7 +404,8 @@ kitchen-vra
 
 The following is a basic `kitchen.yml` example:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 driver:
   name: vra
   username: user@corp.local
@@ -433,7 +436,8 @@ kitchen-vro
 
 The following is a basic `kitchen.yml` example:
 
-``` yaml
+<!-- yaml codeblock -->
+```
 driver:
   name: vro
   vro_username: user@domain.com


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Hugo/Goldmark aren't processing yaml code blocks properly. This will strip the chroma highlighting from those code blocks but the text will display properly. This also leaves a note so they can be found again later if there's a better solution or the Hugo/Goldmark starts processing them correctly.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
