### PR TITLE
Remove redundant include_default_source docs.

### DIFF
--- a/content/resources/gem_package/_index.md
+++ b/content/resources/gem_package/_index.md
@@ -89,15 +89,6 @@ properties_list:
   - markdown: 'Set to `true` to download a gem from the path specified by the
 
       `source` property (and not from RubyGems).'
-- property: include_default_source
-  ruby_type: true, false
-  required: false
-  default_value: 'true'
-  new_in: '13.0'
-  description_list:
-  - markdown: 'Set to `false` to not include `Chef::Config[:rubygems_url]` in the
-
-      sources.'
 - property: gem_binary
   ruby_type: String
   required: false


### PR DESCRIPTION
### Description

The docs for the `gem_package` resource included the `include_default_source` property twice.

![gem_package_resource_-_Mozilla_Firefox](https://user-images.githubusercontent.com/22962/76133281-50b18600-5fcc-11ea-864c-3d423d2543f3.png)

From here: https://docs.chef.io/resources/gem_package/

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
