### PR TITLE
Improve pushy network port documentation

### DIFF
--- a/content/push_jobs.md
+++ b/content/push_jobs.md
@@ -594,6 +594,11 @@ This configuration file has the following settings:
     messages from each Chef Push Jobs client. (This port is the `ROUTER`
     half of the ZeroMQ DEALER / ROUTER pattern.) Default value: `10000`.
 
+`api_port`
+
+:   NGINX forwards requests to this port on the push-jobs server as part of the
+    push-jobs communication channel. Default value: `10003`.
+
 `server_name`
 
 :   The name of the Chef Push Jobs server.

--- a/layouts/shortcodes/server_firewalls_and_ports_push_jobs.md
+++ b/layouts/shortcodes/server_firewalls_and_ports_push_jobs.md
@@ -1,8 +1,12 @@
-TCP protocol ports 10000 and 10002. TCP/10000 is the default heartbeat
-port. TCP/10002 is the command port. It may be configured in the Chef
-Push Jobs configuration file . This port allows Chef Push Jobs clients
-to communicate with the Chef Push Jobs server. In a configuration with
-both front and back ends, this port only needs to be open on the back
-end servers. The Chef Push Jobs server waits for connections from the
-Chef Push Jobs client, and never initiates a connection to a Chef Push
-Jobs client.
+TCP protocol ports 10000, 10002 and 10003. 10000 is the default heartbeat
+port, 10002 is the default command port, 10003 is the default API port. These
+may be configured in the Chef Push Jobs configuration file. The command port
+allows Chef Push Jobs clients to communicate with the Chef Push Jobs server and
+also allows chef server components to communicate with the push-jobs server. In
+a configuration with both front and back ends, this port only needs to be open
+on the back end servers. The Chef Push Jobs server waits for connections from
+the Chef Push Jobs client, and never initiates a connection to a Chef Push Jobs
+client. In situations where the chef server has a non-locally-assigned public
+address (like a cloud deployment / or behind NAT ) the api port should be added
+to the network security configuration for the chef server to connect to itself
+on the public IP.

--- a/layouts/shortcodes/server_firewalls_and_ports_push_jobs.md
+++ b/layouts/shortcodes/server_firewalls_and_ports_push_jobs.md
@@ -9,4 +9,4 @@ the Chef Push Jobs client, and never initiates a connection to a Chef Push Jobs
 client. In situations where the chef server has a non-locally-assigned public
 address (like a cloud deployment / or behind NAT ) the api port should be added
 to the network security configuration for the chef server to connect to itself
-on the public IP.
+on the public IP, if that is what the chef server hostname points to.

--- a/layouts/shortcodes/server_firewalls_and_ports_push_jobs.md
+++ b/layouts/shortcodes/server_firewalls_and_ports_push_jobs.md
@@ -1,8 +1,12 @@
-TCP protocol ports 10000 and 10002. TCP/10000 is the default heartbeat
-port. TCP/10002 is the command port. It may be configured in the Chef
-Push Jobs configuration file . This port allows Chef Push Jobs clients
-to communicate with the Chef Push Jobs server. In a configuration with
-both front and back ends, this port only needs to be open on the back
-end servers. The Chef Push Jobs server waits for connections from the
-Chef Push Jobs client, and never initiates a connection to a Chef Push
-Jobs client.
+TCP protocol ports 10000, 10002 and 10003. 10000 is the default heartbeat
+port, 10002 is the default command port, 10003 is the default API port. These
+may be configured in the Chef Push Jobs configuration file. The command port
+allows Chef Push Jobs clients to communicate with the Chef Push Jobs server and
+also allows chef server components to communicate with the push-jobs server. In
+a configuration with both front and back ends, this port only needs to be open
+on the back end servers. The Chef Push Jobs server waits for connections from
+the Chef Push Jobs client, and never initiates a connection to a Chef Push Jobs
+client. In situations where the chef server has a non-locally-assigned public
+address (like a cloud deployment / or behind NAT ) the api port should be added
+to the network security configuration for the chef server to connect to itself
+on the public IP, if that is what the chef server hostname points to.


### PR DESCRIPTION
### Description

Adding to the documentation to cover some edge-case issues. Port 10003 wasn't mentioned before.

### Definition of Done

The documentation is clear and understandable and relates to reality.

### Issues Resolved

https://github.com/chef/opscode-pushy-server/issues/193

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
