### PR TITLE
Ohai plugin install

### DIFF
--- a/content/ohai_custom.md
+++ b/content/ohai_custom.md
@@ -692,7 +692,7 @@ Installing
 Via a Cookbook
 --------------
 
-The following cookbook code will install a custom OHai plugin and make it accessible to any subsequent OHai execution or Chef run. To allow this plugin to be used by the rest of the run, this cookbook should be near the top of the runlist. 
+The following cookbook code will install a custom Ohai plugin and make it accessible to any subsequent Ohai execution or Chef run. To allow this plugin to be used by the rest of the run, this cookbook should be near the top of the runlist. 
 
 ``` ruby
 # Step 1: Make sure the /etc/chef/ohai/plugins directory exists

--- a/content/ohai_custom.md
+++ b/content/ohai_custom.md
@@ -692,7 +692,7 @@ Installing
 Via a Cookbook
 --------------
 
-The following cookbook code will install a custom Ohai plugin and make it accessible to any subsequent Ohai execution or Chef run. To allow this plugin to be used by the rest of the run, this cookbook should be near the top of the runlist. 
+The following cookbook code will install a custom Ohai plugin and make it accessible to any subsequent Ohai execution or Chef run. To allow this plugin to be used by the rest of the run, this cookbook should be near the top of the run-list. 
 
 ``` ruby
 # Step 1: Make sure the /etc/chef/ohai/plugins directory exists

--- a/content/ohai_custom.md
+++ b/content/ohai_custom.md
@@ -685,3 +685,34 @@ Ohai.plugin(:Kernel) do
 
   ...
 ```
+
+Installing
+==========
+
+Via a Cookbook
+--------------
+
+The following cookbook code will install a custom OHai plugin and make it accessible to any subsequent OHai execution or Chef run. To allow this plugin to be used by the rest of the run, this cookbook should be near the top of the runlist. 
+
+``` ruby
+# Step 1: Make sure the /etc/chef/ohai/plugins directory exists
+directory '/etc/chef/ohai/plugins' do
+ recursive true
+end
+ 
+# Step 2: Put the plugin into that directory
+cookbook_file '/etc/chef/ohai/plugins/my_plugin.rb' do
+ source 'ohai/my_plugin.rb'
+ owner 'root'
+ group 'root'
+ mode '0755'
+ # Reload when this block is ran, immediately
+ notifies :reload, 'ohai[reload_my_plugin]', :immediately
+end
+ 
+# Step 3: Reload the tomcat plugin
+ohai 'reload_my_plugin' do
+ plugin 'my_plugin'
+ action :nothing
+end
+```

--- a/content/ohai_custom.md
+++ b/content/ohai_custom.md
@@ -710,7 +710,7 @@ cookbook_file '/etc/chef/ohai/plugins/my_plugin.rb' do
  notifies :reload, 'ohai[reload_my_plugin]', :immediately
 end
  
-# Step 3: Reload the tomcat plugin
+# Step 3: Reload the my_plugin plugin
 ohai 'reload_my_plugin' do
  plugin 'my_plugin'
  action :nothing


### PR DESCRIPTION
Signed-off-by: Scott Vidmar <svidmar@chef.io>

### Description

This change provides an example cookbook to install an OHai plugin on a node, and make it available without a chef-client run (ad-hoc OHai run).

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [X] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
