### PR TITLE
Put resource pages back in left nav

### DIFF
--- a/content/resources/README.md
+++ b/content/resources/README.md
@@ -82,7 +82,7 @@ Example menu section:
 
 ```
 menu:
-  docs:
+  infra:
     title: resource_name
     identifier: chef_infra/cookbook_reference/resources/resource_name
       resource_name

--- a/content/resources/apt_package/_index.md
+++ b/content/resources/apt_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_apt_package.html
 menu:
-  docs:
+  infra:
     title: apt_package
     identifier: chef_infra/cookbook_reference/resources/apt_package apt_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/apt_preference/_index.md
+++ b/content/resources/apt_preference/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_apt_preference.html
 menu:
-  docs:
+  infra:
     title: apt_preference
     identifier: chef_infra/cookbook_reference/resources/apt_preference apt_preference
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/apt_repository/_index.md
+++ b/content/resources/apt_repository/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_apt_repository.html
 menu:
-  docs:
+  infra:
     title: apt_repository
     identifier: chef_infra/cookbook_reference/resources/apt_repository apt_repository
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/apt_update/_index.md
+++ b/content/resources/apt_update/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_apt_update.html
 menu:
-  docs:
+  infra:
     title: apt_update
     identifier: chef_infra/cookbook_reference/resources/apt_update apt_update
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/archive_file/_index.md
+++ b/content/resources/archive_file/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_archive_file.html
 menu:
-  docs:
+  infra:
     title: archive_file
     identifier: chef_infra/cookbook_reference/resources/archive_file archive_file
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/bash/_index.md
+++ b/content/resources/bash/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_bash.html
 menu:
-  docs:
+  infra:
     title: bash
     identifier: chef_infra/cookbook_reference/resources/bash bash
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/batch/_index.md
+++ b/content/resources/batch/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_batch.html
 menu:
-  docs:
+  infra:
     title: batch
     identifier: chef_infra/cookbook_reference/resources/batch batch
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/bff_package/_index.md
+++ b/content/resources/bff_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_bff_package.html
 menu:
-  docs:
+  infra:
     title: bff_package
     identifier: chef_infra/cookbook_reference/resources/bff_package bff_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/breakpoint/_index.md
+++ b/content/resources/breakpoint/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_breakpoint.html
 menu:
-  docs:
+  infra:
     title: breakpoint
     identifier: chef_infra/cookbook_reference/resources/breakpoint breakpoint
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/build_essential/_index.md
+++ b/content/resources/build_essential/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_build_essential.html
 menu:
-  docs:
+  infra:
     title: build_essential
     identifier: chef_infra/cookbook_reference/resources/build_essential build_essential
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/cab_package/_index.md
+++ b/content/resources/cab_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_cab_package.html
 menu:
-  docs:
+  infra:
     title: cab_package
     identifier: chef_infra/cookbook_reference/resources/cab_package cab_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_acl/_index.md
+++ b/content/resources/chef_acl/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_acl.html
 menu:
-  docs:
+  infra:
     title: chef_acl
     identifier: chef_infra/cookbook_reference/resources/chef_acl chef_acl
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_client/_index.md
+++ b/content/resources/chef_client/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_client.html
 menu:
-  docs:
+  infra:
     title: chef_client
     identifier: chef_infra/cookbook_reference/resources/chef_client chef_client
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_container/_index.md
+++ b/content/resources/chef_container/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_container.html
 menu:
-  docs:
+  infra:
     title: chef_container
     identifier: chef_infra/cookbook_reference/resources/chef_container chef_container
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_data_bag/_index.md
+++ b/content/resources/chef_data_bag/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_data_bag.html
 menu:
-  docs:
+  infra:
     title: chef_data_bag
     identifier: chef_infra/cookbook_reference/resources/chef_data_bag chef_data_bag
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_data_bag_item/_index.md
+++ b/content/resources/chef_data_bag_item/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_data_bag_item.html
 menu:
-  docs:
+  infra:
     title: chef_data_bag_item
     identifier: chef_infra/cookbook_reference/resources/chef_data_bag_item chef_data_bag_item
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_environment/_index.md
+++ b/content/resources/chef_environment/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_environment.html
 menu:
-  docs:
+  infra:
     title: chef_environment
     identifier: chef_infra/cookbook_reference/resources/chef_environment chef_environment
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_gem/_index.md
+++ b/content/resources/chef_gem/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_gem.html
 menu:
-  docs:
+  infra:
     title: chef_gem
     identifier: chef_infra/cookbook_reference/resources/chef_gem chef_gem
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_group/_index.md
+++ b/content/resources/chef_group/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_group.html
 menu:
-  docs:
+  infra:
     title: chef_group
     identifier: chef_infra/cookbook_reference/resources/chef_group chef_group
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_handler/_index.md
+++ b/content/resources/chef_handler/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_handler.html
 menu:
-  docs:
+  infra:
     title: chef_handler
     identifier: chef_infra/cookbook_reference/resources/chef_handler chef_handler
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_mirror/_index.md
+++ b/content/resources/chef_mirror/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_mirror.html
 menu:
-  docs:
+  infra:
     title: chef_mirror
     identifier: chef_infra/cookbook_reference/resources/chef_mirror chef_mirror
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_node/_index.md
+++ b/content/resources/chef_node/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_node.html
 menu:
-  docs:
+  infra:
     title: chef_node
     identifier: chef_infra/cookbook_reference/resources/chef_node chef_node
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_organization/_index.md
+++ b/content/resources/chef_organization/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_organization.html
 menu:
-  docs:
+  infra:
     title: chef_organization
     identifier: chef_infra/cookbook_reference/resources/chef_organization chef_organization
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_role/_index.md
+++ b/content/resources/chef_role/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_role.html
 menu:
-  docs:
+  infra:
     title: chef_role
     identifier: chef_infra/cookbook_reference/resources/chef_role chef_role
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_sleep/_index.md
+++ b/content/resources/chef_sleep/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_sleep.html
 menu:
-  docs:
+  infra:
     title: chef_sleep
     identifier: chef_infra/cookbook_reference/resources/chef_sleep chef_sleep
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chef_user/_index.md
+++ b/content/resources/chef_user/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chef_user.html
 menu:
-  docs:
+  infra:
     title: chef_user
     identifier: chef_infra/cookbook_reference/resources/chef_user chef_user
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chocolatey_config/_index.md
+++ b/content/resources/chocolatey_config/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chocolatey_config.html
 menu:
-  docs:
+  infra:
     title: chocolatey_config
     identifier: chef_infra/cookbook_reference/resources/chocolatey_config chocolatey_config
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chocolatey_feature/_index.md
+++ b/content/resources/chocolatey_feature/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chocolatey_feature.html
 menu:
-  docs:
+  infra:
     title: chocolatey_feature
     identifier: chef_infra/cookbook_reference/resources/chocolatey_feature chocolatey_feature
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chocolatey_package/_index.md
+++ b/content/resources/chocolatey_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chocolatey_package.html
 menu:
-  docs:
+  infra:
     title: chocolatey_package
     identifier: chef_infra/cookbook_reference/resources/chocolatey_package chocolatey_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/chocolatey_source/_index.md
+++ b/content/resources/chocolatey_source/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_chocolatey_source.html
 menu:
-  docs:
+  infra:
     title: chocolatey_source
     identifier: chef_infra/cookbook_reference/resources/chocolatey_source chocolatey_source
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/cookbook_file/_index.md
+++ b/content/resources/cookbook_file/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_cookbook_file.html
 menu:
-  docs:
+  infra:
     title: cookbook_file
     identifier: chef_infra/cookbook_reference/resources/cookbook_file cookbook_file
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/cron/_index.md
+++ b/content/resources/cron/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_cron.html
 menu:
-  docs:
+  infra:
     title: cron
     identifier: chef_infra/cookbook_reference/resources/cron cron
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/cron_access/_index.md
+++ b/content/resources/cron_access/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_cron_access.html
 menu:
-  docs:
+  infra:
     title: cron_access
     identifier: chef_infra/cookbook_reference/resources/cron_access cron_access
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/cron_d/_index.md
+++ b/content/resources/cron_d/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_cron_d.html
 menu:
-  docs:
+  infra:
     title: cron_d
     identifier: chef_infra/cookbook_reference/resources/cron_d cron_d
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/csh/_index.md
+++ b/content/resources/csh/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_csh.html
 menu:
-  docs:
+  infra:
     title: csh
     identifier: chef_infra/cookbook_reference/resources/csh csh
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/directory/_index.md
+++ b/content/resources/directory/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_directory.html
 menu:
-  docs:
+  infra:
     title: directory
     identifier: chef_infra/cookbook_reference/resources/directory directory
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/dmg_package/_index.md
+++ b/content/resources/dmg_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_dmg_package.html
 menu:
-  docs:
+  infra:
     title: dmg_package
     identifier: chef_infra/cookbook_reference/resources/dmg_package dmg_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/dnf_package/_index.md
+++ b/content/resources/dnf_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_dnf_package.html
 menu:
-  docs:
+  infra:
     title: dnf_package
     identifier: chef_infra/cookbook_reference/resources/dnf_package dnf_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/dpkg_package/_index.md
+++ b/content/resources/dpkg_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_dpkg_package.html
 menu:
-  docs:
+  infra:
     title: dpkg_package
     identifier: chef_infra/cookbook_reference/resources/dpkg_package dpkg_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/dsc_resource/_index.md
+++ b/content/resources/dsc_resource/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_dsc_resource.html
 menu:
-  docs:
+  infra:
     title: dsc_resource
     identifier: chef_infra/cookbook_reference/resources/dsc_resource dsc_resource
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/dsc_script/_index.md
+++ b/content/resources/dsc_script/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_dsc_script.html
 menu:
-  docs:
+  infra:
     title: dsc_script
     identifier: chef_infra/cookbook_reference/resources/dsc_script dsc_script
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/execute/_index.md
+++ b/content/resources/execute/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_execute.html
 menu:
-  docs:
+  infra:
     title: execute
     identifier: chef_infra/cookbook_reference/resources/execute execute
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/file/_index.md
+++ b/content/resources/file/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_file.html
 menu:
-  docs:
+  infra:
     title: file
     identifier: chef_infra/cookbook_reference/resources/file file
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/freebsd_package/_index.md
+++ b/content/resources/freebsd_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_freebsd_package.html
 menu:
-  docs:
+  infra:
     title: freebsd_package
     identifier: chef_infra/cookbook_reference/resources/freebsd_package freebsd_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/gem_package/_index.md
+++ b/content/resources/gem_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_gem_package.html
 menu:
-  docs:
+  infra:
     title: gem_package
     identifier: chef_infra/cookbook_reference/resources/gem_package gem_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/git/_index.md
+++ b/content/resources/git/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_git.html
 menu:
-  docs:
+  infra:
     title: git
     identifier: chef_infra/cookbook_reference/resources/git git
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/group/_index.md
+++ b/content/resources/group/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_group.html
 menu:
-  docs:
+  infra:
     title: group
     identifier: chef_infra/cookbook_reference/resources/group group
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/homebrew_cask/_index.md
+++ b/content/resources/homebrew_cask/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_homebrew_cask.html
 menu:
-  docs:
+  infra:
     title: homebrew_cask
     identifier: chef_infra/cookbook_reference/resources/homebrew_cask homebrew_cask
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/homebrew_package/_index.md
+++ b/content/resources/homebrew_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_homebrew_package.html
 menu:
-  docs:
+  infra:
     title: homebrew_package
     identifier: chef_infra/cookbook_reference/resources/homebrew_package homebrew_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/homebrew_tap/_index.md
+++ b/content/resources/homebrew_tap/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_homebrew_tap.html
 menu:
-  docs:
+  infra:
     title: homebrew_tap
     identifier: chef_infra/cookbook_reference/resources/homebrew_tap homebrew_tap
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/hostname/_index.md
+++ b/content/resources/hostname/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_hostname.html
 menu:
-  docs:
+  infra:
     title: hostname
     identifier: chef_infra/cookbook_reference/resources/hostname hostname
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/http_request/_index.md
+++ b/content/resources/http_request/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_http_request.html
 menu:
-  docs:
+  infra:
     title: http_request
     identifier: chef_infra/cookbook_reference/resources/http_request http_request
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/ifconfig/_index.md
+++ b/content/resources/ifconfig/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_ifconfig.html
 menu:
-  docs:
+  infra:
     title: ifconfig
     identifier: chef_infra/cookbook_reference/resources/ifconfig ifconfig
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/ips_package/_index.md
+++ b/content/resources/ips_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_ips_package.html
 menu:
-  docs:
+  infra:
     title: ips_package
     identifier: chef_infra/cookbook_reference/resources/ips_package ips_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/kernel_module/_index.md
+++ b/content/resources/kernel_module/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_kernel_module.html
 menu:
-  docs:
+  infra:
     title: kernel_module
     identifier: chef_infra/cookbook_reference/resources/kernel_module kernel_module
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/ksh/_index.md
+++ b/content/resources/ksh/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_ksh.html
 menu:
-  docs:
+  infra:
     title: ksh
     identifier: chef_infra/cookbook_reference/resources/ksh ksh
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/launchd/_index.md
+++ b/content/resources/launchd/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_launchd.html
 menu:
-  docs:
+  infra:
     title: launchd
     identifier: chef_infra/cookbook_reference/resources/launchd launchd
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/link/_index.md
+++ b/content/resources/link/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_link.html
 menu:
-  docs:
+  infra:
     title: link
     identifier: chef_infra/cookbook_reference/resources/link link
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/locale/_index.md
+++ b/content/resources/locale/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_locale.html
 menu:
-  docs:
+  infra:
     title: locale
     identifier: chef_infra/cookbook_reference/resources/locale locale
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/log/_index.md
+++ b/content/resources/log/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_log.html
 menu:
-  docs:
+  infra:
     title: log
     identifier: chef_infra/cookbook_reference/resources/log log
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/macos_userdefaults/_index.md
+++ b/content/resources/macos_userdefaults/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_macos_userdefaults.html
 menu:
-  docs:
+  infra:
     title: macos_userdefaults
     identifier: chef_infra/cookbook_reference/resources/macos_userdefaults macos_userdefaults
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/macports_package/_index.md
+++ b/content/resources/macports_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_macports_package.html
 menu:
-  docs:
+  infra:
     title: macports_package
     identifier: chef_infra/cookbook_reference/resources/macports_package macports_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/mdadm/_index.md
+++ b/content/resources/mdadm/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_mdadm.html
 menu:
-  docs:
+  infra:
     title: mdadm
     identifier: chef_infra/cookbook_reference/resources/mdadm mdadm
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/mount/_index.md
+++ b/content/resources/mount/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_mount.html
 menu:
-  docs:
+  infra:
     title: mount
     identifier: chef_infra/cookbook_reference/resources/mount mount
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/msu_package/_index.md
+++ b/content/resources/msu_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_msu_package.html
 menu:
-  docs:
+  infra:
     title: msu_package
     identifier: chef_infra/cookbook_reference/resources/msu_package msu_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/ohai/_index.md
+++ b/content/resources/ohai/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_ohai.html
 menu:
-  docs:
+  infra:
     title: ohai
     identifier: chef_infra/cookbook_reference/resources/ohai ohai
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/ohai_hint/_index.md
+++ b/content/resources/ohai_hint/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_ohai_hint.html
 menu:
-  docs:
+  infra:
     title: ohai_hint
     identifier: chef_infra/cookbook_reference/resources/ohai_hint ohai_hint
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/openbsd_package/_index.md
+++ b/content/resources/openbsd_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_openbsd_package.html
 menu:
-  docs:
+  infra:
     title: openbsd_package
     identifier: chef_infra/cookbook_reference/resources/openbsd_package openbsd_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/openssl_dhparam/_index.md
+++ b/content/resources/openssl_dhparam/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_openssl_dhparam.html
 menu:
-  docs:
+  infra:
     title: openssl_dhparam
     identifier: chef_infra/cookbook_reference/resources/openssl_dhparam openssl_dhparam
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/openssl_ec_private_key/_index.md
+++ b/content/resources/openssl_ec_private_key/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_openssl_ec_private_key.html
 menu:
-  docs:
+  infra:
     title: openssl_ec_private_key
     identifier: chef_infra/cookbook_reference/resources/openssl_ec_private_key openssl_ec_private_key
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/openssl_ec_public_key/_index.md
+++ b/content/resources/openssl_ec_public_key/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_openssl_ec_public_key.html
 menu:
-  docs:
+  infra:
     title: openssl_ec_public_key
     identifier: chef_infra/cookbook_reference/resources/openssl_ec_public_key openssl_ec_public_key
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/openssl_rsa_private_key/_index.md
+++ b/content/resources/openssl_rsa_private_key/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_openssl_rsa_private_key.html
 menu:
-  docs:
+  infra:
     title: openssl_rsa_private_key
     identifier: chef_infra/cookbook_reference/resources/openssl_rsa_private_key openssl_rsa_private_key
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/openssl_rsa_public_key/_index.md
+++ b/content/resources/openssl_rsa_public_key/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_openssl_rsa_public_key.html
 menu:
-  docs:
+  infra:
     title: openssl_rsa_public_key
     identifier: chef_infra/cookbook_reference/resources/openssl_rsa_public_key openssl_rsa_public_key
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/openssl_x509_certificate/_index.md
+++ b/content/resources/openssl_x509_certificate/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_openssl_x509_certificate.html
 menu:
-  docs:
+  infra:
     title: openssl_x509_certificate
     identifier: chef_infra/cookbook_reference/resources/openssl_x509_certificate openssl_x509_certificate
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/openssl_x509_crl/_index.md
+++ b/content/resources/openssl_x509_crl/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_openssl_x509_crl.html
 menu:
-  docs:
+  infra:
     title: openssl_x509_crl
     identifier: chef_infra/cookbook_reference/resources/openssl_x509_crl openssl_x509_crl
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/openssl_x509_request/_index.md
+++ b/content/resources/openssl_x509_request/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_openssl_x509_request.html
 menu:
-  docs:
+  infra:
     title: openssl_x509_request
     identifier: chef_infra/cookbook_reference/resources/openssl_x509_request openssl_x509_request
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/osx_profile/_index.md
+++ b/content/resources/osx_profile/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_osx_profile.html
 menu:
-  docs:
+  infra:
     title: osx_profile
     identifier: chef_infra/cookbook_reference/resources/osx_profile osx_profile
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/package/_index.md
+++ b/content/resources/package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_package.html
 menu:
-  docs:
+  infra:
     title: package
     identifier: chef_infra/cookbook_reference/resources/package package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/pacman_package/_index.md
+++ b/content/resources/pacman_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_pacman_package.html
 menu:
-  docs:
+  infra:
     title: pacman_package
     identifier: chef_infra/cookbook_reference/resources/pacman_package pacman_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/paludis_package/_index.md
+++ b/content/resources/paludis_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_paludis_package.html
 menu:
-  docs:
+  infra:
     title: paludis_package
     identifier: chef_infra/cookbook_reference/resources/paludis_package paludis_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/perl/_index.md
+++ b/content/resources/perl/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_perl.html
 menu:
-  docs:
+  infra:
     title: perl
     identifier: chef_infra/cookbook_reference/resources/perl perl
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/portage_package/_index.md
+++ b/content/resources/portage_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_portage_package.html
 menu:
-  docs:
+  infra:
     title: portage_package
     identifier: chef_infra/cookbook_reference/resources/portage_package portage_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/powershell_package/_index.md
+++ b/content/resources/powershell_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_powershell_package.html
 menu:
-  docs:
+  infra:
     title: powershell_package
     identifier: chef_infra/cookbook_reference/resources/powershell_package powershell_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/powershell_package_source/_index.md
+++ b/content/resources/powershell_package_source/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_powershell_package_source.html
 menu:
-  docs:
+  infra:
     title: powershell_package_source
     identifier: chef_infra/cookbook_reference/resources/powershell_package_source
       powershell_package_source

--- a/content/resources/powershell_script/_index.md
+++ b/content/resources/powershell_script/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_powershell_script.html
 menu:
-  docs:
+  infra:
     title: powershell_script
     identifier: chef_infra/cookbook_reference/resources/powershell_script powershell_script
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/python/_index.md
+++ b/content/resources/python/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_python.html
 menu:
-  docs:
+  infra:
     title: python
     identifier: chef_infra/cookbook_reference/resources/python python
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/reboot/_index.md
+++ b/content/resources/reboot/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_reboot.html
 menu:
-  docs:
+  infra:
     title: reboot
     identifier: chef_infra/cookbook_reference/resources/reboot reboot
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/registry_key/_index.md
+++ b/content/resources/registry_key/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_registry_key.html
 menu:
-  docs:
+  infra:
     title: registry_key
     identifier: chef_infra/cookbook_reference/resources/registry_key registry_key
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/remote_directory/_index.md
+++ b/content/resources/remote_directory/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_remote_directory.html
 menu:
-  docs:
+  infra:
     title: remote_directory
     identifier: chef_infra/cookbook_reference/resources/remote_directory remote_directory
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/remote_file/_index.md
+++ b/content/resources/remote_file/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_remote_file.html
 menu:
-  docs:
+  infra:
     title: remote_file
     identifier: chef_infra/cookbook_reference/resources/remote_file remote_file
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/rhsm_errata/_index.md
+++ b/content/resources/rhsm_errata/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_rhsm_errata.html
 menu:
-  docs:
+  infra:
     title: rhsm_errata
     identifier: chef_infra/cookbook_reference/resources/rhsm_errata rhsm_errata
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/rhsm_errata_level/_index.md
+++ b/content/resources/rhsm_errata_level/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_rhsm_errata_level.html
 menu:
-  docs:
+  infra:
     title: rhsm_errata_level
     identifier: chef_infra/cookbook_reference/resources/rhsm_errata_level rhsm_errata_level
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/rhsm_register/_index.md
+++ b/content/resources/rhsm_register/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_rhsm_register.html
 menu:
-  docs:
+  infra:
     title: rhsm_register
     identifier: chef_infra/cookbook_reference/resources/rhsm_register rhsm_register
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/rhsm_repo/_index.md
+++ b/content/resources/rhsm_repo/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_rhsm_repo.html
 menu:
-  docs:
+  infra:
     title: rhsm_repo
     identifier: chef_infra/cookbook_reference/resources/rhsm_repo rhsm_repo
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/rhsm_subscription/_index.md
+++ b/content/resources/rhsm_subscription/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_rhsm_subscription.html
 menu:
-  docs:
+  infra:
     title: rhsm_subscription
     identifier: chef_infra/cookbook_reference/resources/rhsm_subscription rhsm_subscription
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/route/_index.md
+++ b/content/resources/route/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_route.html
 menu:
-  docs:
+  infra:
     title: route
     identifier: chef_infra/cookbook_reference/resources/route route
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/rpm_package/_index.md
+++ b/content/resources/rpm_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_rpm_package.html
 menu:
-  docs:
+  infra:
     title: rpm_package
     identifier: chef_infra/cookbook_reference/resources/rpm_package rpm_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/ruby/_index.md
+++ b/content/resources/ruby/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_ruby.html
 menu:
-  docs:
+  infra:
     title: ruby
     identifier: chef_infra/cookbook_reference/resources/ruby ruby
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/ruby_block/_index.md
+++ b/content/resources/ruby_block/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_ruby_block.html
 menu:
-  docs:
+  infra:
     title: ruby_block
     identifier: chef_infra/cookbook_reference/resources/ruby_block ruby_block
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/script/_index.md
+++ b/content/resources/script/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_script.html
 menu:
-  docs:
+  infra:
     title: script
     identifier: chef_infra/cookbook_reference/resources/script script
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/service/_index.md
+++ b/content/resources/service/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_service.html
 menu:
-  docs:
+  infra:
     title: service
     identifier: chef_infra/cookbook_reference/resources/service service
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/smartos_package/_index.md
+++ b/content/resources/smartos_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_smartos_package.html
 menu:
-  docs:
+  infra:
     title: smartos_package
     identifier: chef_infra/cookbook_reference/resources/smartos_package smartos_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/snap_package/_index.md
+++ b/content/resources/snap_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_snap_package.html
 menu:
-  docs:
+  infra:
     title: snap_package
     identifier: chef_infra/cookbook_reference/resources/snap_package snap_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/solaris_package/_index.md
+++ b/content/resources/solaris_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_solaris_package.html
 menu:
-  docs:
+  infra:
     title: solaris_package
     identifier: chef_infra/cookbook_reference/resources/solaris_package solaris_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/ssh_known_hosts_entry/_index.md
+++ b/content/resources/ssh_known_hosts_entry/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_ssh_known_hosts_entry.html
 menu:
-  docs:
+  infra:
     title: ssh_known_hosts_entry
     identifier: chef_infra/cookbook_reference/resources/ssh_known_hosts_entry ssh_known_hosts_entry
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/subversion/_index.md
+++ b/content/resources/subversion/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_subversion.html
 menu:
-  docs:
+  infra:
     title: subversion
     identifier: chef_infra/cookbook_reference/resources/subversion subversion
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/sudo/_index.md
+++ b/content/resources/sudo/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_sudo.html
 menu:
-  docs:
+  infra:
     title: sudo
     identifier: chef_infra/cookbook_reference/resources/sudo sudo
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/swap_file/_index.md
+++ b/content/resources/swap_file/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_swap_file.html
 menu:
-  docs:
+  infra:
     title: swap_file
     identifier: chef_infra/cookbook_reference/resources/swap_file swap_file
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/sysctl/_index.md
+++ b/content/resources/sysctl/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_sysctl.html
 menu:
-  docs:
+  infra:
     title: sysctl
     identifier: chef_infra/cookbook_reference/resources/sysctl sysctl
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/systemd_unit/_index.md
+++ b/content/resources/systemd_unit/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_systemd_unit.html
 menu:
-  docs:
+  infra:
     title: systemd_unit
     identifier: chef_infra/cookbook_reference/resources/systemd_unit systemd_unit
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/template/_index.md
+++ b/content/resources/template/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_template.html
 menu:
-  docs:
+  infra:
     title: template
     identifier: chef_infra/cookbook_reference/resources/template template
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/timezone/_index.md
+++ b/content/resources/timezone/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_timezone.html
 menu:
-  docs:
+  infra:
     title: timezone
     identifier: chef_infra/cookbook_reference/resources/timezone timezone
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/user/_index.md
+++ b/content/resources/user/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_user.html
 menu:
-  docs:
+  infra:
     title: user
     identifier: chef_infra/cookbook_reference/resources/user user
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_ad_join/_index.md
+++ b/content/resources/windows_ad_join/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_ad_join.html
 menu:
-  docs:
+  infra:
     title: windows_ad_join
     identifier: chef_infra/cookbook_reference/resources/windows_ad_join windows_ad_join
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_auto_run/_index.md
+++ b/content/resources/windows_auto_run/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_auto_run.html
 menu:
-  docs:
+  infra:
     title: windows_auto_run
     identifier: chef_infra/cookbook_reference/resources/windows_auto_run windows_auto_run
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_certificate/_index.md
+++ b/content/resources/windows_certificate/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_certificate.html
 menu:
-  docs:
+  infra:
     title: windows_certificate
     identifier: chef_infra/cookbook_reference/resources/windows_certificate windows_certificate
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_dfs_folder/_index.md
+++ b/content/resources/windows_dfs_folder/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_dfs_folder.html
 menu:
-  docs:
+  infra:
     title: windows_dfs_folder
     identifier: chef_infra/cookbook_reference/resources/windows_dfs_folder windows_dfs_folder
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_dfs_namespace/_index.md
+++ b/content/resources/windows_dfs_namespace/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_dfs_namespace.html
 menu:
-  docs:
+  infra:
     title: windows_dfs_namespace
     identifier: chef_infra/cookbook_reference/resources/windows_dfs_namespace windows_dfs_namespace
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_dfs_server/_index.md
+++ b/content/resources/windows_dfs_server/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_dfs_server.html
 menu:
-  docs:
+  infra:
     title: windows_dfs_server
     identifier: chef_infra/cookbook_reference/resources/windows_dfs_server windows_dfs_server
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_dns_record/_index.md
+++ b/content/resources/windows_dns_record/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_dns_record.html
 menu:
-  docs:
+  infra:
     title: windows_dns_record
     identifier: chef_infra/cookbook_reference/resources/windows_dns_record windows_dns_record
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_dns_zone/_index.md
+++ b/content/resources/windows_dns_zone/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_dns_zone.html
 menu:
-  docs:
+  infra:
     title: windows_dns_zone
     identifier: chef_infra/cookbook_reference/resources/windows_dns_zone windows_dns_zone
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_env/_index.md
+++ b/content/resources/windows_env/_index.md
@@ -6,7 +6,7 @@ aliases:
 - /resource_windows_env.html
 - /resource_env.html
 menu:
-  docs:
+  infra:
     title: windows_env
     identifier: chef_infra/cookbook_reference/resources/windows_env windows_env
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_feature/_index.md
+++ b/content/resources/windows_feature/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_feature.html
 menu:
-  docs:
+  infra:
     title: windows_feature
     identifier: chef_infra/cookbook_reference/resources/windows_feature windows_feature
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_feature_dism/_index.md
+++ b/content/resources/windows_feature_dism/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_feature_dism.html
 menu:
-  docs:
+  infra:
     title: windows_feature_dism
     identifier: chef_infra/cookbook_reference/resources/windows_feature_dism windows_feature_dism
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_feature_powershell/_index.md
+++ b/content/resources/windows_feature_powershell/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_feature_powershell.html
 menu:
-  docs:
+  infra:
     title: windows_feature_powershell
     identifier: chef_infra/cookbook_reference/resources/windows_feature_powershell
       windows_feature_powershell

--- a/content/resources/windows_firewall_rule/_index.md
+++ b/content/resources/windows_firewall_rule/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_firewall_rule.html
 menu:
-  docs:
+  infra:
     title: windows_firewall_rule
     identifier: chef_infra/cookbook_reference/resources/windows_firewall_rule windows_firewall_rule
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_font/_index.md
+++ b/content/resources/windows_font/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_font.html
 menu:
-  docs:
+  infra:
     title: windows_font
     identifier: chef_infra/cookbook_reference/resources/windows_font windows_font
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_package/_index.md
+++ b/content/resources/windows_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_package.html
 menu:
-  docs:
+  infra:
     title: windows_package
     identifier: chef_infra/cookbook_reference/resources/windows_package windows_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_pagefile/_index.md
+++ b/content/resources/windows_pagefile/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_pagefile.html
 menu:
-  docs:
+  infra:
     title: windows_pagefile
     identifier: chef_infra/cookbook_reference/resources/windows_pagefile windows_pagefile
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_path/_index.md
+++ b/content/resources/windows_path/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_path.html
 menu:
-  docs:
+  infra:
     title: windows_path
     identifier: chef_infra/cookbook_reference/resources/windows_path windows_path
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_printer/_index.md
+++ b/content/resources/windows_printer/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_printer.html
 menu:
-  docs:
+  infra:
     title: windows_printer
     identifier: chef_infra/cookbook_reference/resources/windows_printer windows_printer
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_printer_port/_index.md
+++ b/content/resources/windows_printer_port/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_printer_port.html
 menu:
-  docs:
+  infra:
     title: windows_printer_port
     identifier: chef_infra/cookbook_reference/resources/windows_printer_port windows_printer_port
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_service/_index.md
+++ b/content/resources/windows_service/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_service.html
 menu:
-  docs:
+  infra:
     title: windows_service
     identifier: chef_infra/cookbook_reference/resources/windows_service windows_service
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_share/_index.md
+++ b/content/resources/windows_share/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_share.html
 menu:
-  docs:
+  infra:
     title: windows_share
     identifier: chef_infra/cookbook_reference/resources/windows_share windows_share
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_shortcut/_index.md
+++ b/content/resources/windows_shortcut/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_shortcut.html
 menu:
-  docs:
+  infra:
     title: windows_shortcut
     identifier: chef_infra/cookbook_reference/resources/windows_shortcut windows_shortcut
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_task/_index.md
+++ b/content/resources/windows_task/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_task.html
 menu:
-  docs:
+  infra:
     title: windows_task
     identifier: chef_infra/cookbook_reference/resources/windows_task windows_task
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_uac/_index.md
+++ b/content/resources/windows_uac/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_uac.html
 menu:
-  docs:
+  infra:
     title: windows_uac
     identifier: chef_infra/cookbook_reference/resources/windows_uac windows_uac
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/windows_workgroup/_index.md
+++ b/content/resources/windows_workgroup/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_windows_workgroup.html
 menu:
-  docs:
+  infra:
     title: windows_workgroup
     identifier: chef_infra/cookbook_reference/resources/windows_workgroup windows_workgroup
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/yum_package/_index.md
+++ b/content/resources/yum_package/_index.md
@@ -6,7 +6,7 @@ aliases:
 - /resource_yum_package.html
 - /resource_yum.html
 menu:
-  docs:
+  infra:
     title: yum_package
     identifier: chef_infra/cookbook_reference/resources/yum_package yum_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/yum_repository/_index.md
+++ b/content/resources/yum_repository/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_yum_repository.html
 menu:
-  docs:
+  infra:
     title: yum_repository
     identifier: chef_infra/cookbook_reference/resources/yum_repository yum_repository
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/zypper_package/_index.md
+++ b/content/resources/zypper_package/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_zypper_package.html
 menu:
-  docs:
+  infra:
     title: zypper_package
     identifier: chef_infra/cookbook_reference/resources/zypper_package zypper_package
     parent: chef_infra/cookbook_reference/resources

--- a/content/resources/zypper_repository/_index.md
+++ b/content/resources/zypper_repository/_index.md
@@ -5,7 +5,7 @@ draft: false
 aliases:
 - /resource_zypper_repository.html
 menu:
-  docs:
+  infra:
     title: zypper_repository
     identifier: chef_infra/cookbook_reference/resources/zypper_repository zypper_repository
     parent: chef_infra/cookbook_reference/resources

--- a/content/runbook/server_tuning.md
+++ b/content/runbook/server_tuning.md
@@ -12,7 +12,7 @@ runbook_weight = 60
     identifier = "chef_infra/managing_chef_infra_server/server_tuning.md Tuning"
     parent = "chef_infra/managing_chef_infra_server"
     weight = 110
-+++    
++++
 
 [\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/runbook/server_tuning.md)
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Resource pages got removed when I updated the left nav menu. This puts them back in the "infra" menu.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
