### PR TITLE
Cleanup some bad conditional examples

### DIFF
--- a/content/resources/cron/_index.md
+++ b/content/resources/cron/_index.md
@@ -216,7 +216,7 @@ examples_list:
   text_blocks:
   - code_block: "cron 'ganglia_tomcat_thread_max' do\n  command \"/usr/bin/gmetric\n\
       \    -n 'tomcat threads max'\n    -t uint32\n    -v '/usr/local/bin/tomcat-stat\n\
-      \    --thread-max'\"\n  only_if do File.exist?('/home/jboss') end\nend"
+      \    --thread-max'\"\n  only_if { ::File.exist?('/home/jboss') }\nend"
 - example_heading: Run every Saturday, 8:00 AM
   text_blocks:
   - markdown: 'The following example shows a schedule that will run every hour at

--- a/layouts/shortcodes/resource_template_add_file_only_if_ruby.md
+++ b/layouts/shortcodes/resource_template_add_file_only_if_ruby.md
@@ -5,6 +5,6 @@ a file based on a template, and then use Ruby to specify a condition:
 template '/tmp/somefile' do
   mode '0755'
   source 'somefile.erb'
-  only_if do ! File.exist?('/etc/passwd') end
+  only_if { ! ::File.exist?('/etc/passwd') }
 end
 ```


### PR DESCRIPTION
Use {} not do/end for ruby blocks
Make sure to ::File otherwise you're going to get a Cookstyle warning

Signed-off-by: Tim Smith <tsmith@chef.io>