### PR TITLE
Replace chef-server with infra-server

### DIFF
--- a/content/install_bootstrap.md
+++ b/content/install_bootstrap.md
@@ -473,7 +473,7 @@ C:\opscode\chef\bin\chef-client.bat -j C:\chef\first-boot.json
 # Setup hosts file correctly
 cat >> "/etc/hosts" << EOF
 10.0.0.5    compliance-server compliance-server.automate.com
-10.0.0.6    infra-server chef-server.automate.com
+10.0.0.6    infra-server infra-server.automate.com
 10.0.0.7    automate-server automate-server.automate.com
 EOF
 

--- a/content/install_bootstrap.md
+++ b/content/install_bootstrap.md
@@ -473,7 +473,7 @@ C:\opscode\chef\bin\chef-client.bat -j C:\chef\first-boot.json
 # Setup hosts file correctly
 cat >> "/etc/hosts" << EOF
 10.0.0.5    compliance-server compliance-server.automate.com
-10.0.0.6    chef-server chef-server.automate.com
+10.0.0.6    infra-server chef-server.automate.com
 10.0.0.7    automate-server automate-server.automate.com
 EOF
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Replace `chef-server` with `infra-server`.

See also chef/automate#3181

### Definition of Done

### Issues Resolved

chef/automate#3176

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
