### PR TITLE
Cleanup systemd_unit resource

### DIFF
--- a/content/resources/systemd_unit/_index.md
+++ b/content/resources/systemd_unit/_index.md
@@ -18,11 +18,6 @@ resource_description_list:
     units](https://www.freedesktop.org/software/systemd/man/systemd.html#Concepts).'
 resource_new_in: '12.11'
 handler_types: false
-syntax_description: "The systemd_unit resource has the following syntax:\n\n``` ruby\n\
-  systemd_unit 'sysstat-collect.timer' do\n  content <<-EOU.gsub(/^\\s+/, '')\n  [Unit]\n\
-  \  Description=Run system activity accounting tool every 10 minutes\n\n  [Timer]\n\
-  \  OnCalendar=*:00/10\n\n  [Install]\n  WantedBy=sysstat.service\n  EOU\n\n  action\
-  \ [:create, :enable]\nend\n```"
 syntax_code_block: null
 syntax_properties_list: null
 syntax_full_code_block: "systemd_unit 'name.service' do\n  content               \
@@ -87,59 +82,35 @@ properties_list:
   default_value: null
   new_in: null
   description_list:
-  - markdown: 'A string or hash that contains a systemd [unit
-
-      file](https://www.freedesktop.org/software/systemd/man/systemd.unit.html)
-
-      definition that describes the properties of systemd-managed
-
-      entities, such as services, sockets, devices, and so on. In Chef
-
-      14.4 or later, repeatable options can be implemented with an array.'
+  - markdown: 'A string or hash that contains a systemd [unit file](https://www.freedesktop.org/software/systemd/man/systemd.unit.html) definition that describes the properties of systemd-managed entities, such as services, sockets, devices, and so on. In Chef Infra Client 14.4 or later, repeatable options can be implemented with an array.'
 - property: triggers_reload
   ruby_type: true, false
   required: false
   default_value: 'true'
   new_in: null
   description_list:
-  - markdown: 'Specifies whether to trigger a daemon reload when creating or
-
-      deleting a unit.'
+  - markdown: 'Specifies whether to trigger a daemon reload when creating or deleting a unit.'
 - property: unit_name
   ruby_type: String
   required: false
   default_value: The resource block's name
   new_in: '13.7'
   description_list:
-  - markdown: 'The name of the unit file if it differs from the resource block''s
-
-      name.'
+  - markdown: 'The name of the unit file if it differs from the resource block''s name.'
 - property: user
   ruby_type: String
   required: false
   default_value: null
   new_in: null
   description_list:
-  - markdown: 'The user account that the systemd unit process is run under. The
-
-      path to the unit for that user would be something like
-
-      `/etc/systemd/user/sshd.service`. If no user account is specified,
-
-      the systemd unit will run under a `system` account, with the path to
-
-      the unit being something like `/etc/systemd/system/sshd.service`.'
+  - markdown: 'The user account that the systemd unit process is run under. The path to the unit for that user would be something like `/etc/systemd/user/sshd.service`. If no user account is specified, the systemd unit will run under a `system` account, with the path to the unit being something like `/etc/systemd/system/sshd.service`.'
 - property: verify
   ruby_type: true, false
   required: false
   default_value: 'true'
   new_in: null
   description_list:
-  - markdown: 'Specifies if the unit will be verified before installation. Systemd
-
-      can be overly strict when verifying units, so in certain cases it is
-
-      preferable not to verify the unit.'
+  - markdown: 'Specifies if the unit will be verified before installation. Systemd can be overly strict when verifying units, so in certain cases it is preferable not to verify the unit.'
 properties_shortcode: null
 properties_multiple_packages: false
 resource_directory_recursive_directories: false
@@ -162,13 +133,19 @@ handler_custom: false
 cookbook_file_specificity: false
 unit_file_verification: true
 examples_list:
-- example_heading: Create etcd systemd service unit file
+- example_heading: Create etcd systemd service unit file from a Hash
   text_blocks:
   - code_block: "systemd_unit 'etcd.service' do\n  content({Unit: {\n            Description:\
       \ 'Etcd',\n            Documentation: ['https://coreos.com/etcd', 'man:etcd(1)'],\n\
       \            After: 'network.target',\n          },\n          Service: {\n\
       \            Type: 'notify',\n            ExecStart: '/usr/local/etcd',\n  \
       \          Restart: 'always',\n          },\n          Install: {\n        \
-      \    WantedBy: 'multi-user.target',\n          }})\n  action :create\nend"
+      \    WantedBy: 'multi-user.target',\n          }})\n  action [:create, :enable]\nend"
+- example_heading: Create etcd systemd service unit file from a String
+  text_blocks:
+  - code_block: "systemd_unit 'sysstat-collect.timer' do\n  content <<-EOU.gsub(/^\\s+/, '')\n  [Unit]\n\
+  \  Description=Run system activity accounting tool every 10 minutes\n\n  [Timer]\n\
+  \  OnCalendar=*:00/10\n\n  [Install]\n  WantedBy=sysstat.service\n  EOU\n\n  action\
+  \ [:create, :enable]\nend\n```"
 
 ---


### PR DESCRIPTION
Move the odd syntax block that was actually an example down to the examples area

Signed-off-by: Tim Smith <tsmith@chef.io>