### PR TITLE
Fix shortcodes

### DIFF
--- a/content/chef_search.md
+++ b/content/chef_search.md
@@ -408,4 +408,4 @@ Data Bags
 
 {{% data_bag %}}
 
-{{% search_data_bag %}}
+{{< readFile_shortcode file="search_data_bag.md" >}}

--- a/content/config_rb_client.md
+++ b/content/config_rb_client.md
@@ -708,7 +708,7 @@ Ohai Settings
 
 {{% config_rb_ohai %}}
 
-{{% config_rb_ohai_settings %}}
+{{< readFile_shortcode file="config_rb_ohai_settings.md" >}}
 
 Example
 =======

--- a/content/custom_resources.md
+++ b/content/custom_resources.md
@@ -577,7 +577,7 @@ load_current_value
 new_resource.property
 ----------------------
 
-{{% dsl_custom_resource_method_new_resource %}}
+{{< readFile_shortcode file="dsl_custom_resource_method_new_resource.md" >}}
 
 property
 --------

--- a/content/debug.md
+++ b/content/debug.md
@@ -205,12 +205,12 @@ Step Through Run-list
 Debug Existing Recipe
 ---------------------
 
-{{% chef_shell_debug_existing_recipe %}}
+{{< readFile_shortcode file="chef_shell_debug_existing_recipe.md" >}}
 
 Advanced Debugging
 ------------------
 
-{{% chef_shell_advanced_debug %}}
+{{< readFile_shortcode file="chef_shell_advanced_debug.md" >}}
 
 debug_value
 ------------

--- a/content/dsl_custom_resource.md
+++ b/content/dsl_custom_resource.md
@@ -82,7 +82,7 @@ The Custom Resource DSL includes several helper methods for accessing and manipu
 
 ### new_resource.property
 
-{{% dsl_custom_resource_method_new_resource %}}
+{{< readFile_shortcode file="dsl_custom_resource_method_new_resource.md" >}}
 
 ### property_is_set?
 

--- a/content/dsl_handler.md
+++ b/content/dsl_handler.md
@@ -38,7 +38,7 @@ Send Email
 
 ### Define How Email is Sent
 
-{{% dsl_handler_slide_send_email_library %}}
+{{< readFile_shortcode file="dsl_handler_slide_send_email_library.md" >}}
 
 ### Add the Handler
 

--- a/content/dsl_recipe.md
+++ b/content/dsl_recipe.md
@@ -630,7 +630,7 @@ used in a recipe.
 
 **Use a specific binary for a specific platform**
 
-{{% resource_remote_file_use_platform_family %}}
+{{< readFile_shortcode file="resource_remote_file_use_platform_family.md" >}}
 
 reboot_pending?
 ----------------
@@ -792,7 +792,7 @@ recipe.
 
 **Use the search recipe DSL method to find users**
 
-{{% resource_execute_use_search_dsl_method %}}
+{{< readFile_shortcode file="resource_execute_use_search_dsl_method.md" >}}
 
 shell_out
 ----------

--- a/content/handlers.md
+++ b/content/handlers.md
@@ -169,7 +169,7 @@ The following examples show ways to use the Handler DSL.
 
 **Define How Email is Sent**
 
-{{% dsl_handler_slide_send_email_library %}}
+{{< readFile_shortcode file="dsl_handler_slide_send_email_library.md" >}}
 
 **Add the Handler**
 
@@ -221,12 +221,12 @@ Custom Handlers
 Syntax
 ------
 
-{{% handler_custom_syntax %}}
+{{< readFile_shortcode file="handler_custom_syntax.md" >}}
 
 report Interface
 ----------------
 
-{{% handler_custom_interface_report %}}
+{{< readFile_shortcode file="handler_custom_interface_report.md" >}}
 
 Optional Interfaces
 -------------------
@@ -262,7 +262,7 @@ Cookbook Versions
 
 ### cookbook_versions.rb
 
-{{% handler_custom_example_cookbook_versions_handler %}}
+{{< readFile_shortcode file="handler_custom_example_cookbook_versions_handler.md" >}}
 
 ### default.rb
 
@@ -326,12 +326,12 @@ end
 json_file Handler
 ------------------
 
-{{% handler_custom_example_json_file %}}
+{{< readFile_shortcode file="handler_custom_example_json_file.md" >}}
 
 error_report Handler
 ---------------------
 
-{{% handler_custom_example_error_report %}}
+{{< readFile_shortcode file="handler_custom_example_error_report.md" >}}
 
 Community Handlers
 ------------------

--- a/content/install_chef_air_gap.md
+++ b/content/install_chef_air_gap.md
@@ -99,7 +99,7 @@ group.
     Server, and then record its location on the file system. The rest of
     these steps assume this location is in the `/tmp` directory.
 
-3.  {{% install_chef_server_install_package %}}
+3.  {{< shortcode_indent shortcode="install_chef_server_install_package">}}
 
 4.  Run the following to start all of the services:
 
@@ -111,9 +111,9 @@ group.
     that work together to create a functioning system, this step may
     take a few minutes to complete.
 
-5.  {{% ctl_chef_server_user_create_admin %}}
+5.  {{< shortcode_indent shortcode="ctl_chef_server_user_create_admin">}}
 
-6.  {{% ctl_chef_server_org_create_summary %}}
+6.  {{< shortcode_indent shortcode="ctl_chef_server_org_create_summary">}}
 
 Chef Workstation
 ================

--- a/content/install_server.md
+++ b/content/install_server.md
@@ -80,7 +80,7 @@ To install Chef Server:
     Server, and then record its location on the file system. The rest of
     these steps assume this location is in the `/tmp` directory.
 
-3.  {{% install_chef_server_install_package %}}
+3.  {{< shortcode_indent shortcode="install_chef_server_install_package" >}}
 
 4.  Run the following to start all of the services:
 
@@ -92,9 +92,9 @@ To install Chef Server:
     that work together to create a functioning system, this step may
     take a few minutes to complete.
 
-5.  {{% ctl_chef_server_user_create_admin %}}
+5.  {{< shortcode_indent shortcode="ctl_chef_server_user_create_admin" >}}
 
-6.  {{% ctl_chef_server_org_create_summary %}}
+6.  {{< shortcode_indent shortcode="ctl_chef_server_org_create_summary" >}}
 
 Update Configuration for Purchased Nodes
 ========================================
@@ -127,15 +127,13 @@ your `/etc/opscode/chef-server.rb` file by following the process below:
     ```
 
 4.  Save the file. If you're using vi, from the example above, use the
-    <span class="title-ref">esc</span> key and then :
+    <span class="title-ref">esc</span> key and then:
 
-<!-- -->
+    ``` bash
+    :wq
+    ```
 
-``` bash
-:wq
-```
-
-1.  Run `chef-server-ctl reconfigure` for the changes to be picked up by
+5.  Run `chef-server-ctl reconfigure` for the changes to be picked up by
     your Chef Infra Server.
 
     ``` bash

--- a/content/ohai.md
+++ b/content/ohai.md
@@ -368,4 +368,4 @@ Ohai Settings in client.rb
 
 {{% config_rb_ohai %}}
 
-{{% config_rb_ohai_settings %}}
+{{< readFile_shortcode file="config_rb_ohai_settings.md" >}}

--- a/content/recipes.md
+++ b/content/recipes.md
@@ -100,7 +100,7 @@ Environment Variables
 
 {{% environment_variables_summary %}}
 
-{{% environment_variables_access_resource_attributes %}}
+{{< readFile_shortcode file="environment_variables_access_resource_attributes.md" >}}
 
 Work with Recipes
 =================

--- a/content/release_notes.md
+++ b/content/release_notes.md
@@ -9301,7 +9301,7 @@ end
 ps_credential Helper
 ---------------------
 
-{{% ps_credential_helper %}}
+{{< readFile_shortcode file="ps_credential_helper.md" >}}
 
 Handler DSL
 -----------

--- a/content/resource_common.md
+++ b/content/resource_common.md
@@ -345,7 +345,7 @@ Run in Compile Phase
 run_action
 -----------
 
-{{% resources_common_compile_begin %}}
+{{< readFile_shortcode file="resources_common_compile_begin.md" >}}
 
 Windows File Security
 =====================

--- a/content/server_orgs.md
+++ b/content/server_orgs.md
@@ -644,11 +644,11 @@ Server Admins
 Scenario
 --------
 
-{{% server_rbac_server_admins_scenario %}}
+{{< readFile_shortcode file="server_rbac_server_admins_scenario.md" >}}
 
 ### Superuser Accounts
 
-{{% server_rbac_server_admins_superusers %}}
+{{< readFile_shortcode file="server_rbac_server_admins_superusers.md" >}}
 
 Manage server-admins Group
 --------------------------

--- a/content/templates.md
+++ b/content/templates.md
@@ -25,12 +25,12 @@ aliases = ["/templates.html"]
 Requirements
 ============
 
-{{% template_requirements %}}
+{{< readFile_shortcode file="template_requirements.md" >}}
 
 Variables
 =========
 
-{{% template_variables %}}
+{{< readFile_shortcode file="template_variables.md" >}}
 
 File Specificity
 ================
@@ -59,9 +59,9 @@ Partial Templates
 variables Attribute
 -------------------
 
-{{% template_partials_variables_attribute %}}
+{{< readFile_shortcode file="template_partials_variables_attribute.md" >}}
 
 render Method
 -------------
 
-{{% template_partials_render_method %}}
+{{< readFile_shortcode file = "template_partials_render_method.md" >}}

--- a/content/workstation/chef_shell.md
+++ b/content/workstation/chef_shell.md
@@ -126,12 +126,12 @@ Step Through Run-list
 Debug Existing Recipe
 ---------------------
 
-{{% ws_chef_shell_debug_existing_recipe %}}
+{{< readFile_shortcode file="ws_chef_shell_debug_existing_recipe.md" >}}
 
 Advanced Debugging
 ------------------
 
-{{% ws_chef_shell_advanced_debug %}}
+{{< readFile_shortcode file="ws_chef_shell_advanced_debug.md" >}}
 
 Manipulating Chef Infra Server Data
 ===================================
@@ -146,7 +146,7 @@ The following examples show how to use chef-shell.
 "Hello World"
 -------------
 
-{{% ws_chef_shell_example_hello_world %}}
+{{< readFile_shortcode file="ws_chef_shell_example_hello_world.md" >}}
 
 Get Specific Nodes
 ------------------

--- a/content/workstation/config_yml_kitchen.md
+++ b/content/workstation/config_yml_kitchen.md
@@ -435,7 +435,7 @@ kitchen.yml file when the transport is WinRM:
 Work with Proxies
 -----------------
 
-{{% ws_test_kitchen_yml_syntax_proxy %}}
+{{< readFile_shortcode file="ws_test_kitchen_yml_syntax_proxy.md" >}}
 
 Chef Infra Client Settings
 ==========================

--- a/content/workstation/kitchen.md
+++ b/content/workstation/kitchen.md
@@ -86,7 +86,7 @@ Syntax
 Work with Proxies
 -----------------
 
-{{% ws_test_kitchen_yml_syntax_proxy %}}
+{{< readFile_shortcode file="ws_test_kitchen_yml_syntax_proxy.md" >}}
 
 For more information ...
 ========================

--- a/themes/docs-new/layouts/shortcodes/readFile_shortcode.html
+++ b/themes/docs-new/layouts/shortcodes/readFile_shortcode.html
@@ -1,0 +1,6 @@
+
+{{ readFile (delimit (slice "layouts/shortcodes/" (.Get "file")) "") | markdownify }}
+
+{{/* This shortcode is used only for processing other shortcodes that have a code block
+  that contains the less than character "<". For some reason Hugo converts that
+  to its html equivalent &lt; in the html output.*/}}


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Fixes two things:

#### **Less than character**
For some reason the less than symbol "<" is converted to its html equivalent if it is in code blocks that are also in a shortcode. This is an issue in inline and block code. So `if x <= 100:` is turned into `if x &lt;= 100:`.

This isn't a problem if readFile and markdownify are used to read the shortcode in as opposed to the normal method of just adding the shortcode text.

So this adds a new shortcode called readFile_shortcode and then uses it to read the markdown content and convert it into html.

#### **Shortcodes in list items**
Shortcodes don't render properly if they're in a list. The text content takes up the full width of the page instead of indenting. The **install_server** and **install_chef_airgap** pages have several shortcodes in list items. The **shortcode_indent** shortcode handles them properly.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
