### PR TITLE
Update the list of platforms we support

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -70,7 +70,7 @@ versions for Chef Infra Client:
 </tr>
 <tr class="even">
 <td>Amazon Linux</td>
-<td></td>
+<td><code>x86_64</code></td>
 <td>2013+ and 2.0</td>
 </tr>
 <tr class="odd">
@@ -100,7 +100,7 @@ versions for Chef Infra Client:
 </tr>
 <tr class="even">
 <td>Red Hat Enterprise Linux</td>
-<td><code>x86_64</code>, <code>ppc64le</code> (7.x only), <code>ppc64</code> (7.x only), <code>aarch64</code> (7.x only)</td>
+<td><code>x86_64</code> <code>s390x</code> (7.x only), <code>ppc64le</code> (7.x only), <code>ppc64</code> (7.x only), <code>aarch64</code> (7.x only)</td>
 <td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
 </tr>
 <tr class="odd">
@@ -110,13 +110,13 @@ versions for Chef Infra Client:
 </tr>
 <tr class="even">
 <td>SUSE Enterprise Linux Server</td>
-<td><code>x86_64</code>, <code>ppc64le</code>, <code>ppc64</code></td>
+<td><code>x86_64</code>, <code>s390x</code> (12.x only)</td>
 <td><code>12 SP1+</code>, <code>15</code></td>
 </tr>
 <tr class="odd">
 <td>Ubuntu (LTS releases)</td>
-<td><code>x86_64</code></td>
-<td><code>16.04</code>, <code>18.04</code></td>
+<td><code>x86_64</code>,<code>aarch64</code> (18.04 only)</td>
+<td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>
 </tr>
 <tr class="even">
 <td>Microsoft Windows</td>
@@ -166,7 +166,7 @@ The following platforms are supported only via the community:
 </tr>
 <tr class="odd">
 <td>openSUSE</td>
-<td></td>
+<td><code>x86_64</code></td>
 <td><code>15.x</code></td>
 </tr>
 <tr class="even">
@@ -176,7 +176,7 @@ The following platforms are supported only via the community:
 </tr>
 <tr class="odd">
 <td>Ubuntu</td>
-<td><code>i386</code>, <code>x86_64</code></td>
+<td><code>x86_64</code></td>
 <td>Current non-LTS releases</td>
 </tr>
 <tr class="even">
@@ -255,26 +255,31 @@ versions for Chef InSpec:
 </thead>
 <tbody>
 <tr class="odd">
+<td>Debian</td>
+<td><code>x86_64</code></td>
+<td><code>8.x</code>, <code>9.x</code>, <code>10.x</code></td>
+</tr>
+<tr class="even">
 <td>macOS</td>
 <td><code>x86_64</code></td>
 <td><code>10.13</code>, <code>10.14</code>, <code>10.15</code></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>Red Hat Enterprise Linux</td>
 <td><code>x86_64</code></td>
 <td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>SUSE Enterprise Linux Server</td>
 <td><code>x86_64</code></td>
 <td><code>12 SP4+</code>, <code>15</code></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>Ubuntu</td>
 <td><code>x86_64</code></td>
 <td><code>16.04</code>, <code>18.04</code></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>Microsoft Windows</td>
 <td><code>x86_64</code></td>
 <td><code>2012</code>, <code>2012 R2</code>, <code>2016</code>, <code>10 (all channels except "insider" builds)</code>, <code>2019</code></td>


### PR DESCRIPTION
We shipped a few new platforms this last week and some of this data was horribly out of date:

- Add x86_64 as the arch for Amazon Linux (for now)
- Remove PPC from Redhat since we don't ship that anymore
- Add s390x and aarch64 to RHEL 7
- Remove PPC from SLES since we don't ship that anymore
- Add s390x to SLES
- Add Ubuntu 20.04
- Add aarch64 on Ubuntu 18.04
- Add x86_64 to opensuse in community
- Remove i386 from Ubuntu in community
- Add Debian to InSpec

Signed-off-by: Tim Smith <tsmith@chef.io>