### PR TITLE
fix links to headers

### DIFF
--- a/layouts/partials/resource_list_toc.html
+++ b/layouts/partials/resource_list_toc.html
@@ -61,7 +61,7 @@
       <ul>
         <li><a href="#resource_package_options_hash">Specify with Hash</a></li>
         <li><a href="#resource_package_options_string">Specify with String</a></li>
-        <li><a href="resource_package_options_gemrc">Specify with .gemrc File</a></li>
+        <li><a href="#resource_package_options_gemrc">Specify with .gemrc File</a></li>
       </ul>
     </li>
     {{ end }}
@@ -198,7 +198,7 @@
 		
 		{{ if .Params.unit_file_verification }}
 			<li>
-				<a href="unit_file_verification">Unit file verification</a>
+				<a href="#unit_file_verification">Unit file verification</a>
 			</li>
 		{{ end }}
 		
@@ -260,7 +260,7 @@
     <li>
       <a href="#handler_custom">Custom Handlers</a>
       <ul>
-        <li><a href="handler_custom_syntax">Syntax</a></li>
+        <li><a href="#handler_custom_syntax">Syntax</a></li>
         <li><a href="#handler_custom_interface_report">report Interface</a></li>
         <li>
           <a href="#handler_custom_optional_interfaces">Optional Interfaces</a>

--- a/layouts/partials/resource_terms_toc.html
+++ b/layouts/partials/resource_terms_toc.html
@@ -205,7 +205,7 @@
 		          <ul>
 		            <li><a href="#resource_package_options_hash">Specify with Hash</a></li>
 		            <li><a href="#resource_package_options_string">Specify with String</a></li>
-		            <li><a href="resource_package_options_gemrc">Specify with .gemrc File</a></li>
+		            <li><a href="#resource_package_options_gemrc">Specify with .gemrc File</a></li>
 		          </ul>
 		        </li>
 		        {{ end }}
@@ -346,7 +346,7 @@
 		        {{ end }}
 						{{ if .Params.unit_file_verification }}
 							<li>
-								<a href="unit_file_verification">Unit file verification</a>
+								<a href="#unit_file_verification">Unit file verification</a>
 							</li>
 						{{ end }}
 						
@@ -426,7 +426,7 @@
 		        <li>
 		          <a href="#handler_custom">Custom Handlers</a>
 		          <ul>
-		            <li><a href="handler_custom_syntax">Syntax</a></li>
+		            <li><a href="#handler_custom_syntax">Syntax</a></li>
 		            <li><a href="#handler_custom_interface_report">report Interface</a></li>
 		            <li>
 		              <a href="#handler_custom_optional_interfaces">Optional Interfaces</a>


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Several links to headings in the toc do not have the `#` so they actually link to pages that don't exist.

This links them to the proper headings. 

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
