### PR TITLE
add css selector

### DIFF
--- a/themes/docs-new/assets/sass/_toc.scss
+++ b/themes/docs-new/assets/sass/_toc.scss
@@ -9,6 +9,10 @@
   li {
     text-indent: 8px;
   }
+
+  #TableOfContents ~ ul{
+    margin-top: -16px;
+  }
 }
 
 .position-right.is-transition-push {


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This adds a css selector that styles a Hugo generated TOC followed by a template generated TOC so they look like one unified TOC.

Without this there's a 16px gap between them.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
