### PR TITLE
WIP: Introduce the concept of a "Chef Language"

### DIFF
--- a/archetypes/resource_index.md
+++ b/archetypes/resource_index.md
@@ -20,7 +20,7 @@ menu:
 
 resource_description:
 resource_note:
-resource_new_in:      
+resource_new_in:
 
 
 ######## Handler Types ########
@@ -34,15 +34,15 @@ package_resource: false
 ######## Syntax ########
 
 ## Resource Block: For example, under Syntax in batch_resource
-resource_block_description: 
+resource_block_description:
 resource_block_codeblock: |
 resource_block_list:
 
 syntax_codeblock: |
-syntax_property_list: 
+syntax_property_list:
 
 
-##Activates the Registry Key Path Separators and Recipe DSL Methods in registry_key resource
+##Activates the Registry Key Path Separators and Chef Infra Language Methods in registry_key resource
 registry_key: false
 
 
@@ -70,7 +70,7 @@ properties_list:
   - property:
     ruby_type:
     default_value:
-    description: 
+    description:
     new_in:
 
 ## Multiple Packages in Properties section from, for example, dnf_package resource
@@ -80,16 +80,16 @@ properties_multiple_packages: false
 resource_directory_recursive_directory: false
 
 ## Atomic File Updates in the Properties Section of, for example, cookbook_file resource
-resources_common_atomic_update: false 
+resources_common_atomic_update: false
 
 ## Windows File Security in the Properties section of, for example, cookbook_file resource
-properties_resources_common_windows_security: false 
+properties_resources_common_windows_security: false
 
 ## Prevent Re-downloads from remote_file resource
-remote_file_prevent_re_downloads: false 
+remote_file_prevent_re_downloads: false
 
 ## Access a remote UNC path on Windows from remote_file resource
-remote_file_unc_path: false 
+remote_file_unc_path: false
 
 ## ps_credential Helper from dsc_script resource
 ps_credential_helper: false
@@ -103,7 +103,7 @@ ruby_style_basics_chef_log: false
 
 ######## Debug Recipes with chef-shell ########
 
-## Debug Recipes with chef-shell from breakpoint resource 
+## Debug Recipes with chef-shell from breakpoint resource
 debug_recipes_chef_shell: false
 
 
@@ -115,16 +115,16 @@ template_requirements: false
 
 ########Common Resource Functionality ########
 
-## Common Properties in, for example, apt_package resource 
+## Common Properties in, for example, apt_package resource
 resources_common_properties: false
 
-## Notifications in, for example, apt_package resource 
+## Notifications in, for example, apt_package resource
 resources_common_notification: false
 
-## Guards in, for example, apt_package resource  
+## Guards in, for example, apt_package resource
 resources_common_guards: false
 
-## Multiple Packages in, for example, apt_package resource   
+## Multiple Packages in, for example, apt_package resource
 common_resource_functionality_multiple_packages: false
 
 ## Guard Interpreters in, for example, common resource
@@ -134,26 +134,26 @@ resources_common_guard_interpreter: false
 remote_directory_recursive_directories: false
 
 ## Windows File Security under Common Resource Functionality in, for example, remote_directory resource
-common_resource_functionality_resources_common_windows_security: false 
+common_resource_functionality_resources_common_windows_security: false
 
 
 ########Custom Handlers ########
 
 ## Custom Handlers in chef_handler resource
-handler_custom: false 
+handler_custom: false
 
 
 ########File Specificity ########
 
 ## File Specificity in cookbook_file resource
-cookbook_file_specificity: false 
+cookbook_file_specificity: false
 
 
 ########Examples ########
 examples_list:
   - example1:
-      heading: 
-      description: 
+      heading:
+      description:
       codeblock:
 
 

--- a/config.toml
+++ b/config.toml
@@ -388,259 +388,42 @@ weight = 30
     weight = 80
 
   [[menu.infra]]
-  title = "Cookbook Reference"
-  identifier = "chef_infra/cookbook_reference"
+  title = "Chef Infra Language"
+  identifier = "chef_infra/language"
   parent = "chef_infra"
-  weight = 60
-
-    [[menu.infra]]
-    title = "Recipes"
-    identifier = "chef_infra/cookbook_reference/recipes"
-    parent = "chef_infra/cookbook_reference"
-    weight = 50
-
-    [[menu.infra]]
-    title = "Recipe DSL"
-    identifier = "chef_infra/cookbook_reference/recipe_dsl"
-    parent = "chef_infra/cookbook_reference"
-    weight = 60
-
-      [[menu.infra]]
-      title = "attribute?"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#attribute attribute?"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#attribute"
-      weight = 20
-
-      [[menu.infra]]
-      title = "cookbook_name"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#cookbook-name cookbook_name"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#cookbook-name"
-      weight = 30
-
-      [[menu.infra]]
-      title = "data_bag"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#data-bag data_bag"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#data-bag"
-      weight = 40
-
-      [[menu.infra]]
-      title = "data_bag_item"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#data-bag-item data_bag_item"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#data-bag-item"
-      weight = 50
-
-      [[menu.infra]]
-      title = "declare_resource"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#declare-resource declare_resource"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#declare-resource"
-      weight = 60
-
-      [[menu.infra]]
-      title = "delete_resource"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#delete-resource delete_resource"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#delete-resource"
-      weight = 70
-
-      [[menu.infra]]
-      title = "delete_resource!"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#id1 delete_resource!"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#delete-resource-1"
-      weight = 80
-
-      [[menu.infra]]
-      title = "edit_resource"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#edit-resource edit_resource"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#edit-resource"
-      weight = 90
-
-      [[menu.infra]]
-      title = "edit_resource!"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#id2 edit_resource!"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#edit-resource-1"
-      weight = 100
-
-      [[menu.infra]]
-      title = "find_resource"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#find-resource find_resource"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#find-resource"
-      weight = 110
-
-      [[menu.infra]]
-      title = "find_resource!"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#id3 find_resource!"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#find-resource-1"
-      weight = 120
-
-      [[menu.infra]]
-      title = "platform?"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#platform platform?"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#platform"
-      weight = 130
-
-      [[menu.infra]]
-      title = "platform_family?"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#platform-family platform_family?"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#platform-family"
-      weight = 140
-
-      [[menu.infra]]
-      title = "reboot_pending?"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#reboot-pending reboot_pending?"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#reboot-pending"
-      weight = 150
-
-      [[menu.infra]]
-      title = "recipe_name"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#recipe-name recipe_name"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#recipe-name"
-      weight = 160
-
-      [[menu.infra]]
-      title = "resources"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#resources resources"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#resources"
-      weight = 170
-
-      [[menu.infra]]
-      title = "search"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#search search"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#search"
-      weight = 180
-
-      [[menu.infra]]
-      title = "shell_out"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#shell-out shell_out"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#shell-out"
-      weight = 190
-
-      [[menu.infra]]
-      title = "shell_out!"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#id6 shell_out!"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#shell-out-1"
-      weight = 200
-
-      [[menu.infra]]
-      title = "tag, tagged?, untag"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#tag-tagged-untag tag, tagged?, untag"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#tag-tagged-untag"
-      weight = 210
-
-      [[menu.infra]]
-      title = "value_for_platform"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#value-for-platform value_for_platform"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#value-for-platform"
-      weight = 220
-
-      [[menu.infra]]
-      title = "value_for_platform_family"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#value-for-platform-family value_for_platform_family"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#value-for-platform-family"
-      weight = 230
-
-      [[menu.infra]]
-      title = "with_run_context"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#with-run-context with_run_context"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#with-run-context"
-      weight = 240
-
-      [[menu.infra]]
-      title = "Windows Platform"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#windows-platform Windows Platform"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#windows-platform"
-      weight = 250
-
-      [[menu.infra]]
-      title = "registry_data_exists?"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#registry-data-exists registry_data_exists?"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#registry-data-exists"
-      weight = 260
-
-      [[menu.infra]]
-      title = "registry_get_subkeys"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#registry-get-subkeys registry_get_subkeys"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#registry-get-subkeys"
-      weight = 270
-
-      [[menu.infra]]
-      title = "registry_get_values"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#registry-get-values registry_get_values"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#registry-get-values"
-      weight = 280
-
-      [[menu.infra]]
-      title = "registry_has_subkeys?"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#registry-has-subkeys registry_has_subkeys?"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#registry-has-subkeys"
-      weight = 290
-
-      [[menu.infra]]
-      title = "registry_key_exists?"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#registry-key-exists registry_key_exists?"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#registry-key-exists"
-      weight = 300
-
-      [[menu.infra]]
-      title = "registry_value_exists?"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#registry-value-exists registry_value_exists?"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#registry-value-exists"
-      weight = 310
-
-      [[menu.infra]]
-      title = "Log Entries"
-      identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md#log-entries Log Entries"
-      parent = "chef_infra/cookbook_reference/recipe_dsl"
-      url = "/dsl_recipe/#log-entries"
-      weight = 320
+  weight = 55
 
     [[menu.infra]]
     title = "Resources"
-    identifier = "chef_infra/cookbook_reference/resources"
-    parent = "chef_infra/cookbook_reference"
+    identifier = "chef_infra/cookbooks/resources"
+    parent = "chef_infra/language"
     weight = 80
 
       [[menu.infra]]
       title = "All Resources (Single Page)"
-      identifier = "chef_infra/cookbook_reference/resources/resources All Resources (Single Page)"
-      parent = "chef_infra/cookbook_reference/resources"
+      identifier = "chef_infra/cookbooks/resources/resources All Resources (Single Page)"
+      parent = "chef_infra/language/resources"
       url = "/resources/"
       weight = 60
 
       [[menu.infra]]
       title = "reference"
-      identifier = "chef_infra/cookbook_reference/resources/resources reference"
-      parent = "chef_infra/cookbook_reference/resources"
+      identifier = "chef_infra/cookbooks/resources/resources reference"
+      parent = "chef_infra/language/resources"
       url = "/resources/"
       weight = 940
+
+  [[menu.infra]]
+  title = "Cookbooks"
+  identifier = "chef_infra/cookbooks"
+  parent = "chef_infra"
+  weight = 60
+
+    [[menu.infra]]
+    title = "Recipes"
+    identifier = "chef_infra/cookbooks/recipes"
+    parent = "chef_infra/cookbooks"
+    weight = 50
 
   [[menu.infra]]
   title = "Managing Chef Infra Server"

--- a/content/attributes.md
+++ b/content/attributes.md
@@ -7,8 +7,8 @@ aliases = ["/attributes.html"]
 [menu]
   [menu.infra]
     title = "Attributes"
-    identifier = "chef_infra/cookbook_reference/attributes.md Attributes"
-    parent = "chef_infra/cookbook_reference"
+    identifier = "chef_infra/cookbooks/attributes.md Attributes"
+    parent = "chef_infra/cookbooks"
     weight = 20
 +++
 

--- a/content/config_rb_metadata.md
+++ b/content/config_rb_metadata.md
@@ -7,8 +7,8 @@ aliases = ["/config_rb_metadata.html"]
 [menu]
   [menu.infra]
     title = "metadata.rb"
-    identifier = "chef_infra/cookbook_reference/config_rb_metadata.md metadata.rb"
-    parent = "chef_infra/cookbook_reference"
+    identifier = "chef_infra/cookbooks/config_rb_metadata.md metadata.rb"
+    parent = "chef_infra/cookbooks"
     weight = 110
 +++
 

--- a/content/cookbook_repo.md
+++ b/content/cookbook_repo.md
@@ -7,8 +7,8 @@ aliases = ["/cookbook_repo.html"]
 [menu]
   [menu.infra]
     title = "Cookbook Repo"
-    identifier = "chef_infra/cookbook_reference/cookbook_repo.md Cookbook Repo"
-    parent = "chef_infra/cookbook_reference"
+    identifier = "chef_infra/cookbooks/cookbook_repo.md Cookbook Repo"
+    parent = "chef_infra/cookbooks"
     weight = 100
 +++
 

--- a/content/cookbook_versioning.md
+++ b/content/cookbook_versioning.md
@@ -7,8 +7,8 @@ aliases = ["/cookbook_versioning.html", "/cookbook_versions.html"]
 [menu]
   [menu.infra]
     title = "Cookbook Versioning"
-    identifier = "chef_infra/cookbook_reference/cookbook_versioning.md Cookbook Versioning"
-    parent = "chef_infra/cookbook_reference"
+    identifier = "chef_infra/cookbooks/cookbook_versioning.md Cookbook Versioning"
+    parent = "chef_infra/cookbooks"
     weight = 120
 +++
 

--- a/content/cookbooks.md
+++ b/content/cookbooks.md
@@ -7,8 +7,8 @@ aliases = ["/cookbooks.html"]
 [menu]
   [menu.infra]
     title = "About Cookbooks"
-    identifier = "chef_infra/cookbook_reference/cookbooks.md About Cookbooks"
-    parent = "chef_infra/cookbook_reference"
+    identifier = "chef_infra/cookbooks/cookbooks.md About Cookbooks"
+    parent = "chef_infra/cookbooks"
     weight = 10
 +++
 

--- a/content/custom_resources.md
+++ b/content/custom_resources.md
@@ -7,8 +7,8 @@ aliases = ["/custom_resources.html"]
 [menu]
   [menu.infra]
     title = "Custom Resources"
-    identifier = "chef_infra/cookbook_reference/resources/custom_resources.md Custom Resources"
-    parent = "chef_infra/cookbook_reference/resources"
+    identifier = "chef_infra/cookbooks/resources/custom_resources.md Custom Resources"
+    parent = "chef_infra/cookbooks/resources"
     weight = 40
 +++
 

--- a/content/custom_resources_notes.md
+++ b/content/custom_resources_notes.md
@@ -7,8 +7,8 @@ aliases = ["/custom_resources_notes.html"]
 [menu]
   [menu.infra]
     title = "Custom Resource Guide"
-    identifier = "chef_infra/cookbook_reference/resources/custom_resources_notes.md Custom Resource Guide"
-    parent = "chef_infra/cookbook_reference/resources"
+    identifier = "chef_infra/cookbooks/resources/custom_resources_notes.md Custom Resource Guide"
+    parent = "chef_infra/cookbooks/resources"
     weight = 50
 +++
 

--- a/content/data_bags.md
+++ b/content/data_bags.md
@@ -118,7 +118,7 @@ Recipes
 
 {{% data_bag_recipes %}}
 
-### Load with Recipe DSL
+### Load with Chef Infra Language
 
 {{% data_bag_recipes_load_using_recipe_dsl %}}
 

--- a/content/debug.md
+++ b/content/debug.md
@@ -7,8 +7,8 @@ aliases = ["/debug.html"]
 [menu]
   [menu.infra]
     title = "Debug Recipes, Client Runs"
-    identifier = "chef_infra/cookbook_reference/recipes/debug.md Debug Recipes, Client Runs"
-    parent = "chef_infra/cookbook_reference/recipes"
+    identifier = "chef_infra/cookbooks/recipes/debug.md Debug Recipes, Client Runs"
+    parent = "chef_infra/cookbooks/recipes"
     weight = 20
 +++
 

--- a/content/definitions.md
+++ b/content/definitions.md
@@ -7,8 +7,8 @@ aliases = ["/definitions.html"]
 [menu]
   [menu.infra]
     title = "Migrating from Definitions"
-    identifier = "chef_infra/cookbook_reference/resources/definitions.md Migrating from Definitions"
-    parent = "chef_infra/cookbook_reference/resources"
+    identifier = "chef_infra/cookbooks/resources/definitions.md Migrating from Definitions"
+    parent = "chef_infra/cookbooks/resources"
     weight = 30
 +++
 

--- a/content/dsl_custom_resource.md
+++ b/content/dsl_custom_resource.md
@@ -1,20 +1,20 @@
 +++
-title = "Custom Resource DSL"
+title = "Custom Resource Language"
 draft = false
 
 aliases = ["/dsl_custom_resource.html"]
 
 [menu]
   [menu.infra]
-    title = "Custom Resources DSL"
-    identifier = "chef_infra/cookbook_reference/dsl_custom_resource.md Custom Resources DSL"
-    parent = "chef_infra/cookbook_reference"
+    title = "Custom Resources Language"
+    identifier = "chef_infra/cookbooks/dsl_custom_resource.md Custom Resources DSL"
+    parent = "chef_infra/cookbooks"
     weight = 70
 +++
 
 [\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/dsl_custom_resource.md)
 
-Use the Custom Resource DSL to define behaviors within custom resources, such as:
+Use the Custom Resource Language to define behaviors within custom resources, such as:
 
 -   Loading the value of a specific property
 -   Comparing the current property value against a desired property value

--- a/content/files.md
+++ b/content/files.md
@@ -7,8 +7,8 @@ aliases = ["/files.html"]
 [menu]
   [menu.infra]
     title = "Files"
-    identifier = "chef_infra/cookbook_reference/files.md Files"
-    parent = "chef_infra/cookbook_reference"
+    identifier = "chef_infra/cookbooks/files.md Files"
+    parent = "chef_infra/cookbooks"
     weight = 30
 +++
 

--- a/content/infra_language.md
+++ b/content/infra_language.md
@@ -1,14 +1,14 @@
 +++
-title = "About the Recipe DSL"
+title = "About the Chef Infra Language"
 draft = false
 
-aliases = ["/dsl_recipe.html"]
+aliases = ["/dsl_recipe.html", "dsl_recipe"]
 
 [menu]
   [menu.infra]
-    title = "DSL Overview"
-    identifier = "chef_infra/cookbook_reference/recipe_dsl/dsl_recipe.md DSL Overview"
-    parent = "chef_infra/cookbook_reference/recipe_dsl"
+    title = "Chef Language Overview"
+    identifier = "chef_infra/language/infra_language.md DSL Overview"
+    parent = "chef_infra/language"
     weight = 10
 +++
 
@@ -16,36 +16,30 @@ aliases = ["/dsl_recipe.html"]
 
 {{% dsl_recipe_summary %}}
 
-Because the Recipe DSL is a Ruby DSL, anything that can be done using
-Ruby can also be done in a recipe or custom resource, including `if` and
-`case` statements, using the `include?` Ruby method, including recipes
-in recipes, and checking for dependencies. See the [Ruby
-Guide](/ruby/) for further information on built-in Ruby
-functionality.
+The Chef Infra Language is based on Ruby, allowing you to utilize the power of Ruby when the built-in language doesn't meet your needs out of the box. If you'd like to learn more about extending your Chef Infra code by using Ruby see our [Ruby Guide](/ruby/) for further information on Ruby functionality.
+
+Resources
+==================
+
+Chef Infra Client ships with over 150 resources for configuring components such as packages, file, directories, or firewalls. For more information on resources in Chef Infra Client including a complete list of those included out of the box see [Resources](/resources).
+
+Language Helpers
+==================
+
+The Chef Infra Language provides support for using attributes, data bags (and
+encrypted data), and search results in a recipe, as well as four helper
+methods that can be used to check for a node's platform from the recipe
+to ensure that specific actions are taken for specific platforms.
 
 Include Recipes
-===============
+-----------------
 
 {{% cookbooks_recipe_include_in_recipe %}}
 
-Reload Attributes
+Reload Node Attributes
 -----------------
 
 {{% cookbooks_attribute_file_reload_from_recipe %}}
-
-Recipe DSL Methods
-==================
-
-The Recipe DSL provides support for using attributes, data bags (and
-encrypted data), and search results in a recipe, as well as four helper
-methods that can be used to check for a node's platform from the recipe
-to ensure that specific actions are taken for specific platforms. The
-helper methods are:
-
--   `platform?`
--   `platform_family?`
--   `value_for_platform`
--   `value_for_platform_family`
 
 attribute?
 ----------

--- a/content/libraries.md
+++ b/content/libraries.md
@@ -7,8 +7,8 @@ aliases = ["/libraries.html"]
 [menu]
   [menu.infra]
     title = "Libraries"
-    identifier = "chef_infra/cookbook_reference/libraries.md Libraries"
-    parent = "chef_infra/cookbook_reference"
+    identifier = "chef_infra/cookbooks/libraries.md Libraries"
+    parent = "chef_infra/cookbooks"
     weight = 40
 +++
 

--- a/content/recipes.md
+++ b/content/recipes.md
@@ -7,8 +7,8 @@ aliases = ["/recipes.html"]
 [menu]
   [menu.infra]
     title = "About Recipes"
-    identifier = "chef_infra/cookbook_reference/recipes/recipes.md About Recipes"
-    parent = "chef_infra/cookbook_reference/recipes"
+    identifier = "chef_infra/cookbooks/recipes/recipes.md About Recipes"
+    parent = "chef_infra/cookbooks/recipes"
     weight = 10
 +++
 

--- a/content/resource.md
+++ b/content/resource.md
@@ -7,8 +7,8 @@ aliases = ["/resource.html"]
 [menu]
   [menu.infra]
     title = "About Resources"
-    identifier = "chef_infra/cookbook_reference/resources/resource.md About Resources"
-    parent = "chef_infra/cookbook_reference/resources"
+    identifier = "chef_infra/cookbooks/resources/resource.md About Resources"
+    parent = "chef_infra/cookbooks/resources"
     weight = 10
 +++
 

--- a/content/resource_common.md
+++ b/content/resource_common.md
@@ -7,8 +7,8 @@ aliases = ["/resource_common.html"]
 [menu]
   [menu.infra]
     title = "Common Resource Functionality"
-    identifier = "chef_infra/cookbook_reference/resources/resource_common.md Common Resource Functionality"
-    parent = "chef_infra/cookbook_reference/resources"
+    identifier = "chef_infra/cookbooks/resources/resource_common.md Common Resource Functionality"
+    parent = "chef_infra/cookbooks/resources"
     weight = 20
 +++
 

--- a/content/resources/README.md
+++ b/content/resources/README.md
@@ -3,20 +3,20 @@
 The resource pages and [resource reference page](/resources/)
 are generated using yaml data located in `chef-web-docs/content/resources`.
 The yaml data is generated directly from the Chef Infra code.
-Each resource page has its own subdirectory and the yaml data is stored in 
-an `_index.md` page. For example, the apt package resource data is stored in 
+Each resource page has its own subdirectory and the yaml data is stored in
+an `_index.md` page. For example, the apt package resource data is stored in
 `chef-web-docs/content/resources/apt_package/_index.md`.
 
-The templates that generate those resource pages are found in 
-`chef-web-docs/layouts/resources`. The templates that generate the tables of 
-contents for the resource are stored in `chef-web-docs/layouts/partials`. 
+The templates that generate those resource pages are found in
+`chef-web-docs/layouts/resources`. The templates that generate the tables of
+contents for the resource are stored in `chef-web-docs/layouts/partials`.
 
 There are two template types, terms and list. The terms template is used to generate
 the [resources reference page](/resources/) and the list
 template generates the individual resource pages, for example
 https://docs.chef.io/resources/apt_package/.
 
-For more general information about lists and terms templates see Hugo's 
+For more general information about lists and terms templates see Hugo's
 [taxonomy template documentation](https://gohugo.io/templates/taxonomy-templates/).
 
 For general information about yaml see the official [yaml website](https://yaml.org/).
@@ -24,9 +24,9 @@ For general information about yaml see the official [yaml website](https://yaml.
 ## yaml data
 
 The yaml data is contained in a markdown page and surrounded by opening and closing
-dashes `---`. 
+dashes `---`.
 
-The data in those files can be split into three categories: page metadata, 
+The data in those files can be split into three categories: page metadata,
 resource data, and shortcodes.
 
 ### Page metadata
@@ -36,7 +36,7 @@ resource data, and shortcodes.
 This is the title of the page as it appears at the top of its page or at the top of
 its section in the resource reference page. For example, `apt_package resource`.
 
-**resource** 
+**resource**
 
 This is the name of the resource. For example, `apt_package`.
 
@@ -46,13 +46,13 @@ Hugo will not render the page if set to `true`.
 
 **aliases**
 
-Pages that you want to redirect to the page that you are editing. See Hugo's 
+Pages that you want to redirect to the page that you are editing. See Hugo's
 [aliases documentation](https://gohugo.io/content-management/urls/#aliases).
 
 **menu/docs**
 
 This section provides information that will add the page to the left navigation
-menu. Delete this entire section if you want to remove a page from the left 
+menu. Delete this entire section if you want to remove a page from the left
 navigation menu.
 
 See the example at the bottom of this section.
@@ -60,18 +60,18 @@ See the example at the bottom of this section.
 - title
 
 	The name of the page as it appears in the left navigation menu.
-	
+
 - identifier
 
-	The unique identifier for the page. No two pages in the left navigation menu 
-	can have the same identifier. For this reason we've adopted the convention of 
-	creating identifiers that start with the path of the page in the left navigation 
+	The unique identifier for the page. No two pages in the left navigation menu
+	can have the same identifier. For this reason we've adopted the convention of
+	creating identifiers that start with the path of the page in the left navigation
 	menu followed by a space and then the name of the page itself.
 
 - parent
 
 	The location of the resource page in the left navigation menu. For resource pages
-	this is always `chef_infra/cookbook_reference/resources`.
+	this is always `chef_infra/cookbooks/resources`.
 
 - weight
 
@@ -84,9 +84,9 @@ Example menu section:
 menu:
   infra:
     title: resource_name
-    identifier: chef_infra/cookbook_reference/resources/resource_name
+    identifier: chef_infra/cookbooks/resources/resource_name
       resource_name
-    parent: chef_infra/cookbook_reference/resources
+    parent: chef_infra/cookbooks/resources
     weight: 730
 ```
 
@@ -98,10 +98,10 @@ appear in https://docs.chef.io/resources/page_name/. Values are `true` or `false
 
 **robots**
 
-This adds meta robots directions to a page that instruct search engines crawlers 
-how to crawl a page. Valid values are `noindex` and `nofollow`, separated by a comma. This is 
-useful for removing a page from [Swiftype](https://swiftype.com/documentation/site-search/crawler-configuration/meta-tags#robots_meta) 
-and Google search results. See the [robotstxt.org](https://www.robotstxt.org/meta.html) 
+This adds meta robots directions to a page that instruct search engines crawlers
+how to crawl a page. Valid values are `noindex` and `nofollow`, separated by a comma. This is
+useful for removing a page from [Swiftype](https://swiftype.com/documentation/site-search/crawler-configuration/meta-tags#robots_meta)
+and Google search results. See the [robotstxt.org](https://www.robotstxt.org/meta.html)
 site for more information about meta robots tags.
 
 If this is deleted or left blank Hugo will use the site robots parameter in the
@@ -111,13 +111,13 @@ If this is deleted or left blank Hugo will use the site robots parameter in the
 
 **resource_description_list**
 
-This is a list of content that will build the introductory description section of each 
-resource page. Markdown, notes, warnings, and shortcodes can be added to the list. 
-Notes and warnings can include Markdown or shortcode content. 
+This is a list of content that will build the introductory description section of each
+resource page. Markdown, notes, warnings, and shortcodes can be added to the list.
+Notes and warnings can include Markdown or shortcode content.
 
 This content will display on the page in the same order that it appears in the list.
 
-Example: 
+Example:
 
 ```
 resource_description_list:
@@ -129,7 +129,7 @@ resource_description_list:
 
 **resource_new_in**
 
-This will add **New in Chef Infra Client X.Y** to the description of the 
+This will add **New in Chef Infra Client X.Y** to the description of the
 resource page. The text won't appear if value is blank.
 
 Example:
@@ -140,7 +140,7 @@ resource_new_in: 14.0
 
 **syntax_description**
 
-A short introductory description in Markdown that explains the syntax of the resource and includes 
+A short introductory description in Markdown that explains the syntax of the resource and includes
 an example code block.
 
 For example:
@@ -208,7 +208,7 @@ actions_list:
 
 **properties_shortcode**
 
-The properties section of some resource pages is a shortcode. This will display 
+The properties section of some resource pages is a shortcode. This will display
 the shortcode specified in lieu of describing the properties using ``properties_list``.
 
 **properties_list**
@@ -225,23 +225,23 @@ This is a list of each property in a resource.
 
 - required
 
-  `True` or `False`. Indicates if the property is required by the resource and 
+  `True` or `False`. Indicates if the property is required by the resource and
   adds ``REQUIRED`` to the description of the property.
 
 - default_value
 
 	The default value of the property.
-	
+
 - new_in
 
 	The version of Chef Infra Client that this property was introduced in.
 
 - description_list
 
-	A list of content used to describe the property. Valid keys are `markdown`, 
-	`note`, `warning`, and `shortcode`. Notes and warnings can have markdown or 
+	A list of content used to describe the property. Valid keys are `markdown`,
+	`note`, `warning`, and `shortcode`. Notes and warnings can have markdown or
 	shortcode content.
-	
+
 	This content will display on the page in the same order that it appears in the list.
 
 For example:
@@ -255,16 +255,16 @@ properties_list:
   new_in: 14.0
   description_list:
   - markdown: Some text describing the property.
-	- note: 
+	- note:
 		- shortcode: shortcode_file.md
-	- warning: 
+	- warning:
 		- markdown: Markdown text warning the user about the propery.
 ```
 
 **examples_list**
 
-Each example starts with a heading, which is bolded on its resource page, followed by 
-blocks of text that describe and demonstrate how the resource works. 
+Each example starts with a heading, which is bolded on its resource page, followed by
+blocks of text that describe and demonstrate how the resource works.
 
 - example_heading
 
@@ -272,11 +272,11 @@ blocks of text that describe and demonstrate how the resource works.
 
 - text_blocks
 
-	A list of text blocks that describe and demonstrate each example. Valid keys for 
+	A list of text blocks that describe and demonstrate each example. Valid keys for
 	the text blocks are `shortcode`, `note`, `code_block`, and `markdown`. Notes only
 	accept markdown text.
 
-	This content will display on the page in the same order that it appears in 
+	This content will display on the page in the same order that it appears in
 	the `text_blocks` list.
 
 For example:
@@ -291,27 +291,27 @@ examples_list:
 
 ### Shortcodes
 
-These values, if set to `true`, will display sections of text that include headings 
+These values, if set to `true`, will display sections of text that include headings
 followed by text from various shortcodes.
 
 **handler_types**
 
-Only used in the chef handler resource. This adds the **Handler Types** section 
+Only used in the chef handler resource. This adds the **Handler Types** section
 to this resource page.
 
 **registry_key**
 
-Only used in the registry key resource. This adds the **Registry Key Path Separators** 
+Only used in the registry key resource. This adds the **Registry Key Path Separators**
 and **Recipe DSL Methods** sections to resource page.
 
 **nameless_apt_update**
 
-Only used in the apt update resource. Adds the **Nameless** section to the 
+Only used in the apt update resource. Adds the **Nameless** section to the
 apt update resource page.
 
 **nameless_build_essential**
 
-Only used in the build essential resource. Adds the **Nameless** section to the 
+Only used in the build essential resource. Adds the **Nameless** section to the
 build essential resource page.
 
 **resource_package_options**
@@ -320,7 +320,7 @@ Only used in the package resource page. Adds the **Gem Package Options** section
 
 **properties_multiple_packages**
 
-Used in the dnf package, package, and zypper package resource pages. Adds 
+Used in the dnf package, package, and zypper package resource pages. Adds
 the **Multiple Packages** section to the Properties section of the resource page.
 
 
@@ -331,109 +331,109 @@ section to the Properties section of the resource page.
 
 **resources_common_atomic_update**
 
-Used in the cookbook file, file, remote file, and template resource pages. Adds 
+Used in the cookbook file, file, remote file, and template resource pages. Adds
 the **Atomic File Updates** section to the Properties section of the resource page.
 
 **properties_resources_common_windows_security**
 
-Used in the cookbook file, directory, file, remote file, and template resource 
+Used in the cookbook file, directory, file, remote file, and template resource
 pages. Adds the **Windows File Security** section to the Properties section of the
 resource page.
 
 **remote_file_prevent_re_downloads**
 
-Used in the remote file resource page. Adds the **Prevent Re-downloads** section 
+Used in the remote file resource page. Adds the **Prevent Re-downloads** section
 to the Properties section of the resource page.
 
 **remote_file_unc_path**
 
-Used in the remote file resource page. Adds the **Access a remote UNC path on Windows** section 
+Used in the remote file resource page. Adds the **Access a remote UNC path on Windows** section
 to the Properties section of the resource page.
 
 **ps_credential_helper**
 
-Used in the dsc script resource page. Adds the **ps_credential Helper** section 
+Used in the dsc script resource page. Adds the **ps_credential Helper** section
 to the Properties section of the resource page.
 
 **ruby_style_basics_chef_log**
 
-Used in the log resource page. Adds the **Log Entries** section 
+Used in the log resource page. Adds the **Log Entries** section
 to the resource page.
 
 **debug_recipes_chef_shell**
 
-Used in the breakpoint resource page. Adds the **Debug Recipes with chef-shell** 
+Used in the breakpoint resource page. Adds the **Debug Recipes with chef-shell**
 section to the resource page.
 
 **template_requirements**
 
-Used in the template resource page. Adds the **Debug Recipes with chef-shell** 
+Used in the template resource page. Adds the **Debug Recipes with chef-shell**
 section to the Properties section of the resource page.
 
 **resources_common_properties**
 
-Used in several resource pages. Adds the **Common Properties** section to the 
+Used in several resource pages. Adds the **Common Properties** section to the
 Common Resource Functionality section of the resource page.
 
 **resources_common_notification**
 
-Used in several resource pages. Adds the **Notifications** section to the 
+Used in several resource pages. Adds the **Notifications** section to the
 Common Resource Functionality section of the resource page.
 
 **resources_common_guards**
 
-Used in several resource pages. Adds the **Guards** section to the 
+Used in several resource pages. Adds the **Guards** section to the
 Common Resource Functionality section of the resource page.
 
 **common_resource_functionality_multiple_packages**
 
-Used in the apt package and yum package resource pages. Adds the 
-**Multiple Packages** section to the Common Resource Functionality section of 
+Used in the apt package and yum package resource pages. Adds the
+**Multiple Packages** section to the Common Resource Functionality section of
 the resource page.
 
 **resources_common_guard_interpreter**
 
-Used in the script resource page. Adds the **Guard Interpreter** section to the 
+Used in the script resource page. Adds the **Guard Interpreter** section to the
 Common Resource Functionality section of the resource page.
 
 **remote_directory_recursive_directories**
 
-Used in the remote directory resource page. Adds the **Recursive Directories** 
+Used in the remote directory resource page. Adds the **Recursive Directories**
 section to the Common Resource Functionality section of the resource page.
 
 **common_resource_functionality_resources_common_windows_security**
 
-Used in the remote directory resource page. Adds the **Windows File Security** 
+Used in the remote directory resource page. Adds the **Windows File Security**
 section to the Common Resource Functionality section of the resource page.
 
 **handler_custom**
 
-Used in the chef handler resource page. Adds the **Custom Handlers** 
+Used in the chef handler resource page. Adds the **Custom Handlers**
 section to the resource page.
 
 **cookbook_file_specificity**
 
-Used in the cookbook file resource page. Adds the **File Specificity** 
+Used in the cookbook file resource page. Adds the **File Specificity**
 section to the resource page.
 
 **unit_file_verification**
 
-Used in the systemd_unit resource page. Adds the **Unit File Verification** 
+Used in the systemd_unit resource page. Adds the **Unit File Verification**
 section to the resource page.
 
 ## Resource page tables of contents
 
-The tables of contents templates for the resource pages are located in 
+The tables of contents templates for the resource pages are located in
 `chef-web-docs/layouts/partials`.
 
-The tables of contents for the resource reference page and the individual resource 
-pages are generated in the same way that the resource reference 
-page and the individual resources pages are created. Hugo crawls through the resource 
-yaml files and builds an unordered list listing each H1 through H3 heading. This 
-means that if a section of content is added or removed from the resource page 
-templates, then those headings also have to be added or removed to the respective 
+The tables of contents for the resource reference page and the individual resource
+pages are generated in the same way that the resource reference
+page and the individual resources pages are created. Hugo crawls through the resource
+yaml files and builds an unordered list listing each H1 through H3 heading. This
+means that if a section of content is added or removed from the resource page
+templates, then those headings also have to be added or removed to the respective
 tables of contents templates.
 
 Failure to update the resource page table of contents templates
-may lead to links that don't link to the proper content, links that don't work properly, 
+may lead to links that don't link to the proper content, links that don't work properly,
 or content that isn't linked to in the table of contents.

--- a/content/resources/apt_package/_index.md
+++ b/content/resources/apt_package/_index.md
@@ -6,8 +6,8 @@ aliases: [/resource_apt_package.html]
 menu:
   infra:
     title: apt_package
-    identifier: chef_infra/cookbook_reference/resources/apt_package apt_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/apt_package apt_package
+    parent: chef_infra/cookbooks/resources
     weight: 70
 resource_reference: true
 robots: null

--- a/content/resources/apt_preference/_index.md
+++ b/content/resources/apt_preference/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: apt_preference
-    identifier: chef_infra/cookbook_reference/resources/apt_preference apt_preference
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/apt_preference apt_preference
+    parent: chef_infra/cookbooks/resources
     weight: 80
 resource_reference: true
 robots: null

--- a/content/resources/apt_repository/_index.md
+++ b/content/resources/apt_repository/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: apt_repository
-    identifier: chef_infra/cookbook_reference/resources/apt_repository apt_repository
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/apt_repository apt_repository
+    parent: chef_infra/cookbooks/resources
     weight: 90
 resource_reference: true
 robots: null

--- a/content/resources/apt_update/_index.md
+++ b/content/resources/apt_update/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: apt_update
-    identifier: chef_infra/cookbook_reference/resources/apt_update apt_update
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/apt_update apt_update
+    parent: chef_infra/cookbooks/resources
     weight: 100
 resource_reference: true
 robots: null

--- a/content/resources/archive_file/_index.md
+++ b/content/resources/archive_file/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: archive_file
-    identifier: chef_infra/cookbook_reference/resources/archive_file archive_file
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/archive_file archive_file
+    parent: chef_infra/cookbooks/resources
     weight: 110
 resource_reference: true
 robots: null

--- a/content/resources/bash/_index.md
+++ b/content/resources/bash/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: bash
-    identifier: chef_infra/cookbook_reference/resources/bash bash
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/bash bash
+    parent: chef_infra/cookbooks/resources
     weight: 120
 resource_reference: true
 robots: null

--- a/content/resources/batch/_index.md
+++ b/content/resources/batch/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: batch
-    identifier: chef_infra/cookbook_reference/resources/batch batch
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/batch batch
+    parent: chef_infra/cookbooks/resources
     weight: 130
 resource_reference: true
 robots: null

--- a/content/resources/bff_package/_index.md
+++ b/content/resources/bff_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: bff_package
-    identifier: chef_infra/cookbook_reference/resources/bff_package bff_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/bff_package bff_package
+    parent: chef_infra/cookbooks/resources
     weight: 140
 resource_reference: true
 robots: null

--- a/content/resources/breakpoint/_index.md
+++ b/content/resources/breakpoint/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: breakpoint
-    identifier: chef_infra/cookbook_reference/resources/breakpoint breakpoint
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/breakpoint breakpoint
+    parent: chef_infra/cookbooks/resources
     weight: 150
 resource_reference: true
 robots: null

--- a/content/resources/build_essential/_index.md
+++ b/content/resources/build_essential/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: build_essential
-    identifier: chef_infra/cookbook_reference/resources/build_essential build_essential
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/build_essential build_essential
+    parent: chef_infra/cookbooks/resources
     weight: 160
 resource_reference: true
 robots: null

--- a/content/resources/cab_package/_index.md
+++ b/content/resources/cab_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: cab_package
-    identifier: chef_infra/cookbook_reference/resources/cab_package cab_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/cab_package cab_package
+    parent: chef_infra/cookbooks/resources
     weight: 170
 resource_reference: true
 robots: null

--- a/content/resources/chef_acl/_index.md
+++ b/content/resources/chef_acl/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_acl
-    identifier: chef_infra/cookbook_reference/resources/chef_acl chef_acl
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_acl chef_acl
+    parent: chef_infra/cookbooks/resources
     weight: 180
 resource_reference: true
 robots: null

--- a/content/resources/chef_client/_index.md
+++ b/content/resources/chef_client/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_client
-    identifier: chef_infra/cookbook_reference/resources/chef_client chef_client
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_client chef_client
+    parent: chef_infra/cookbooks/resources
     weight: 190
 resource_reference: true
 robots: null

--- a/content/resources/chef_container/_index.md
+++ b/content/resources/chef_container/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_container
-    identifier: chef_infra/cookbook_reference/resources/chef_container chef_container
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_container chef_container
+    parent: chef_infra/cookbooks/resources
     weight: 200
 resource_reference: true
 robots: null

--- a/content/resources/chef_data_bag/_index.md
+++ b/content/resources/chef_data_bag/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_data_bag
-    identifier: chef_infra/cookbook_reference/resources/chef_data_bag chef_data_bag
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_data_bag chef_data_bag
+    parent: chef_infra/cookbooks/resources
     weight: 210
 resource_reference: true
 robots: null

--- a/content/resources/chef_data_bag_item/_index.md
+++ b/content/resources/chef_data_bag_item/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_data_bag_item
-    identifier: chef_infra/cookbook_reference/resources/chef_data_bag_item chef_data_bag_item
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_data_bag_item chef_data_bag_item
+    parent: chef_infra/cookbooks/resources
     weight: 220
 resource_reference: true
 robots: null

--- a/content/resources/chef_environment/_index.md
+++ b/content/resources/chef_environment/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_environment
-    identifier: chef_infra/cookbook_reference/resources/chef_environment chef_environment
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_environment chef_environment
+    parent: chef_infra/cookbooks/resources
     weight: 230
 resource_reference: true
 robots: null

--- a/content/resources/chef_gem/_index.md
+++ b/content/resources/chef_gem/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_gem
-    identifier: chef_infra/cookbook_reference/resources/chef_gem chef_gem
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_gem chef_gem
+    parent: chef_infra/cookbooks/resources
     weight: 240
 resource_reference: true
 robots: null

--- a/content/resources/chef_group/_index.md
+++ b/content/resources/chef_group/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_group
-    identifier: chef_infra/cookbook_reference/resources/chef_group chef_group
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_group chef_group
+    parent: chef_infra/cookbooks/resources
     weight: 250
 resource_reference: true
 robots: null

--- a/content/resources/chef_handler/_index.md
+++ b/content/resources/chef_handler/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_handler
-    identifier: chef_infra/cookbook_reference/resources/chef_handler chef_handler
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_handler chef_handler
+    parent: chef_infra/cookbooks/resources
     weight: 260
 resource_reference: true
 robots: null

--- a/content/resources/chef_mirror/_index.md
+++ b/content/resources/chef_mirror/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_mirror
-    identifier: chef_infra/cookbook_reference/resources/chef_mirror chef_mirror
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_mirror chef_mirror
+    parent: chef_infra/cookbooks/resources
     weight: 270
 resource_reference: true
 robots: null

--- a/content/resources/chef_node/_index.md
+++ b/content/resources/chef_node/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_node
-    identifier: chef_infra/cookbook_reference/resources/chef_node chef_node
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_node chef_node
+    parent: chef_infra/cookbooks/resources
     weight: 280
 resource_reference: true
 robots: null

--- a/content/resources/chef_organization/_index.md
+++ b/content/resources/chef_organization/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_organization
-    identifier: chef_infra/cookbook_reference/resources/chef_organization chef_organization
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_organization chef_organization
+    parent: chef_infra/cookbooks/resources
     weight: 290
 resource_reference: true
 robots: null

--- a/content/resources/chef_role/_index.md
+++ b/content/resources/chef_role/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_role
-    identifier: chef_infra/cookbook_reference/resources/chef_role chef_role
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_role chef_role
+    parent: chef_infra/cookbooks/resources
     weight: 300
 resource_reference: true
 robots: null

--- a/content/resources/chef_sleep/_index.md
+++ b/content/resources/chef_sleep/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_sleep
-    identifier: chef_infra/cookbook_reference/resources/chef_sleep chef_sleep
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_sleep chef_sleep
+    parent: chef_infra/cookbooks/resources
     weight: 310
 resource_reference: true
 robots: null

--- a/content/resources/chef_user/_index.md
+++ b/content/resources/chef_user/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chef_user
-    identifier: chef_infra/cookbook_reference/resources/chef_user chef_user
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chef_user chef_user
+    parent: chef_infra/cookbooks/resources
     weight: 320
 resource_reference: true
 robots: null

--- a/content/resources/chocolatey_config/_index.md
+++ b/content/resources/chocolatey_config/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chocolatey_config
-    identifier: chef_infra/cookbook_reference/resources/chocolatey_config chocolatey_config
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chocolatey_config chocolatey_config
+    parent: chef_infra/cookbooks/resources
     weight: 330
 resource_reference: true
 robots: null

--- a/content/resources/chocolatey_feature/_index.md
+++ b/content/resources/chocolatey_feature/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chocolatey_feature
-    identifier: chef_infra/cookbook_reference/resources/chocolatey_feature chocolatey_feature
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chocolatey_feature chocolatey_feature
+    parent: chef_infra/cookbooks/resources
     weight: 340
 resource_reference: true
 robots: null

--- a/content/resources/chocolatey_package/_index.md
+++ b/content/resources/chocolatey_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chocolatey_package
-    identifier: chef_infra/cookbook_reference/resources/chocolatey_package chocolatey_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chocolatey_package chocolatey_package
+    parent: chef_infra/cookbooks/resources
     weight: 350
 resource_reference: true
 robots: null

--- a/content/resources/chocolatey_source/_index.md
+++ b/content/resources/chocolatey_source/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: chocolatey_source
-    identifier: chef_infra/cookbook_reference/resources/chocolatey_source chocolatey_source
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/chocolatey_source chocolatey_source
+    parent: chef_infra/cookbooks/resources
     weight: 360
 resource_reference: true
 robots: null

--- a/content/resources/cookbook_file/_index.md
+++ b/content/resources/cookbook_file/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: cookbook_file
-    identifier: chef_infra/cookbook_reference/resources/cookbook_file cookbook_file
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/cookbook_file cookbook_file
+    parent: chef_infra/cookbooks/resources
     weight: 370
 resource_reference: true
 robots: null

--- a/content/resources/cron/_index.md
+++ b/content/resources/cron/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: cron
-    identifier: chef_infra/cookbook_reference/resources/cron cron
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/cron cron
+    parent: chef_infra/cookbooks/resources
     weight: 380
 resource_reference: true
 robots: null

--- a/content/resources/cron_access/_index.md
+++ b/content/resources/cron_access/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: cron_access
-    identifier: chef_infra/cookbook_reference/resources/cron_access cron_access
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/cron_access cron_access
+    parent: chef_infra/cookbooks/resources
     weight: 400
 resource_reference: true
 robots: null

--- a/content/resources/cron_d/_index.md
+++ b/content/resources/cron_d/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: cron_d
-    identifier: chef_infra/cookbook_reference/resources/cron_d cron_d
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/cron_d cron_d
+    parent: chef_infra/cookbooks/resources
     weight: 390
 resource_reference: true
 robots: null

--- a/content/resources/csh/_index.md
+++ b/content/resources/csh/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: csh
-    identifier: chef_infra/cookbook_reference/resources/csh csh
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/csh csh
+    parent: chef_infra/cookbooks/resources
     weight: 410
 resource_reference: true
 robots: null

--- a/content/resources/directory/_index.md
+++ b/content/resources/directory/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: directory
-    identifier: chef_infra/cookbook_reference/resources/directory directory
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/directory directory
+    parent: chef_infra/cookbooks/resources
     weight: 420
 resource_reference: true
 robots: null

--- a/content/resources/dmg_package/_index.md
+++ b/content/resources/dmg_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: dmg_package
-    identifier: chef_infra/cookbook_reference/resources/dmg_package dmg_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/dmg_package dmg_package
+    parent: chef_infra/cookbooks/resources
     weight: 430
 resource_reference: true
 robots: null

--- a/content/resources/dnf_package/_index.md
+++ b/content/resources/dnf_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: dnf_package
-    identifier: chef_infra/cookbook_reference/resources/dnf_package dnf_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/dnf_package dnf_package
+    parent: chef_infra/cookbooks/resources
     weight: 440
 resource_reference: true
 robots: null

--- a/content/resources/dpkg_package/_index.md
+++ b/content/resources/dpkg_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: dpkg_package
-    identifier: chef_infra/cookbook_reference/resources/dpkg_package dpkg_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/dpkg_package dpkg_package
+    parent: chef_infra/cookbooks/resources
     weight: 450
 resource_reference: true
 robots: null

--- a/content/resources/dsc_resource/_index.md
+++ b/content/resources/dsc_resource/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: dsc_resource
-    identifier: chef_infra/cookbook_reference/resources/dsc_resource dsc_resource
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/dsc_resource dsc_resource
+    parent: chef_infra/cookbooks/resources
     weight: 460
 resource_reference: true
 robots: null

--- a/content/resources/dsc_script/_index.md
+++ b/content/resources/dsc_script/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: dsc_script
-    identifier: chef_infra/cookbook_reference/resources/dsc_script dsc_script
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/dsc_script dsc_script
+    parent: chef_infra/cookbooks/resources
     weight: 470
 resource_reference: true
 robots: null

--- a/content/resources/execute/_index.md
+++ b/content/resources/execute/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: execute
-    identifier: chef_infra/cookbook_reference/resources/execute execute
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/execute execute
+    parent: chef_infra/cookbooks/resources
     weight: 480
 resource_reference: true
 robots: null

--- a/content/resources/file/_index.md
+++ b/content/resources/file/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: file
-    identifier: chef_infra/cookbook_reference/resources/file file
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/file file
+    parent: chef_infra/cookbooks/resources
     weight: 490
 resource_reference: true
 robots: null

--- a/content/resources/freebsd_package/_index.md
+++ b/content/resources/freebsd_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: freebsd_package
-    identifier: chef_infra/cookbook_reference/resources/freebsd_package freebsd_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/freebsd_package freebsd_package
+    parent: chef_infra/cookbooks/resources
     weight: 500
 resource_reference: true
 robots: null

--- a/content/resources/gem_package/_index.md
+++ b/content/resources/gem_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: gem_package
-    identifier: chef_infra/cookbook_reference/resources/gem_package gem_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/gem_package gem_package
+    parent: chef_infra/cookbooks/resources
     weight: 510
 resource_reference: true
 robots: null

--- a/content/resources/git/_index.md
+++ b/content/resources/git/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: git
-    identifier: chef_infra/cookbook_reference/resources/git git
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/git git
+    parent: chef_infra/cookbooks/resources
     weight: 520
 resource_reference: true
 robots: null

--- a/content/resources/group/_index.md
+++ b/content/resources/group/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: group
-    identifier: chef_infra/cookbook_reference/resources/group group
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/group group
+    parent: chef_infra/cookbooks/resources
     weight: 530
 resource_reference: true
 robots: null

--- a/content/resources/homebrew_cask/_index.md
+++ b/content/resources/homebrew_cask/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: homebrew_cask
-    identifier: chef_infra/cookbook_reference/resources/homebrew_cask homebrew_cask
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/homebrew_cask homebrew_cask
+    parent: chef_infra/cookbooks/resources
     weight: 540
 resource_reference: true
 robots: null

--- a/content/resources/homebrew_package/_index.md
+++ b/content/resources/homebrew_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: homebrew_package
-    identifier: chef_infra/cookbook_reference/resources/homebrew_package homebrew_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/homebrew_package homebrew_package
+    parent: chef_infra/cookbooks/resources
     weight: 550
 resource_reference: true
 robots: null

--- a/content/resources/homebrew_tap/_index.md
+++ b/content/resources/homebrew_tap/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: homebrew_tap
-    identifier: chef_infra/cookbook_reference/resources/homebrew_tap homebrew_tap
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/homebrew_tap homebrew_tap
+    parent: chef_infra/cookbooks/resources
     weight: 560
 resource_reference: true
 robots: null

--- a/content/resources/hostname/_index.md
+++ b/content/resources/hostname/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: hostname
-    identifier: chef_infra/cookbook_reference/resources/hostname hostname
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/hostname hostname
+    parent: chef_infra/cookbooks/resources
     weight: 570
 resource_reference: true
 robots: null

--- a/content/resources/http_request/_index.md
+++ b/content/resources/http_request/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: http_request
-    identifier: chef_infra/cookbook_reference/resources/http_request http_request
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/http_request http_request
+    parent: chef_infra/cookbooks/resources
     weight: 580
 resource_reference: true
 robots: null

--- a/content/resources/ifconfig/_index.md
+++ b/content/resources/ifconfig/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: ifconfig
-    identifier: chef_infra/cookbook_reference/resources/ifconfig ifconfig
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/ifconfig ifconfig
+    parent: chef_infra/cookbooks/resources
     weight: 590
 resource_reference: true
 robots: null

--- a/content/resources/ips_package/_index.md
+++ b/content/resources/ips_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: ips_package
-    identifier: chef_infra/cookbook_reference/resources/ips_package ips_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/ips_package ips_package
+    parent: chef_infra/cookbooks/resources
     weight: 600
 resource_reference: true
 robots: null

--- a/content/resources/kernel_module/_index.md
+++ b/content/resources/kernel_module/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: kernel_module
-    identifier: chef_infra/cookbook_reference/resources/kernel_module kernel_module
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/kernel_module kernel_module
+    parent: chef_infra/cookbooks/resources
     weight: 610
 resource_reference: true
 robots: null

--- a/content/resources/ksh/_index.md
+++ b/content/resources/ksh/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: ksh
-    identifier: chef_infra/cookbook_reference/resources/ksh ksh
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/ksh ksh
+    parent: chef_infra/cookbooks/resources
     weight: 620
 resource_reference: true
 robots: null

--- a/content/resources/launchd/_index.md
+++ b/content/resources/launchd/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: launchd
-    identifier: chef_infra/cookbook_reference/resources/launchd launchd
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/launchd launchd
+    parent: chef_infra/cookbooks/resources
     weight: 630
 resource_reference: true
 robots: null

--- a/content/resources/link/_index.md
+++ b/content/resources/link/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: link
-    identifier: chef_infra/cookbook_reference/resources/link link
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/link link
+    parent: chef_infra/cookbooks/resources
     weight: 640
 resource_reference: true
 robots: null

--- a/content/resources/locale/_index.md
+++ b/content/resources/locale/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: locale
-    identifier: chef_infra/cookbook_reference/resources/locale locale
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/locale locale
+    parent: chef_infra/cookbooks/resources
     weight: 650
 resource_reference: true
 robots: null

--- a/content/resources/log/_index.md
+++ b/content/resources/log/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: log
-    identifier: chef_infra/cookbook_reference/resources/log log
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/log log
+    parent: chef_infra/cookbooks/resources
     weight: 660
 resource_reference: true
 robots: null

--- a/content/resources/macos_userdefaults/_index.md
+++ b/content/resources/macos_userdefaults/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: macos_userdefaults
-    identifier: chef_infra/cookbook_reference/resources/macos_userdefaults macos_userdefaults
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/macos_userdefaults macos_userdefaults
+    parent: chef_infra/cookbooks/resources
     weight: 670
 resource_reference: true
 robots: null

--- a/content/resources/macports_package/_index.md
+++ b/content/resources/macports_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: macports_package
-    identifier: chef_infra/cookbook_reference/resources/macports_package macports_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/macports_package macports_package
+    parent: chef_infra/cookbooks/resources
     weight: 680
 resource_reference: true
 robots: null

--- a/content/resources/mdadm/_index.md
+++ b/content/resources/mdadm/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: mdadm
-    identifier: chef_infra/cookbook_reference/resources/mdadm mdadm
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/mdadm mdadm
+    parent: chef_infra/cookbooks/resources
     weight: 690
 resource_reference: true
 robots: null

--- a/content/resources/mount/_index.md
+++ b/content/resources/mount/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: mount
-    identifier: chef_infra/cookbook_reference/resources/mount mount
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/mount mount
+    parent: chef_infra/cookbooks/resources
     weight: 700
 resource_reference: true
 robots: null

--- a/content/resources/msu_package/_index.md
+++ b/content/resources/msu_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: msu_package
-    identifier: chef_infra/cookbook_reference/resources/msu_package msu_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/msu_package msu_package
+    parent: chef_infra/cookbooks/resources
     weight: 710
 resource_reference: true
 robots: null

--- a/content/resources/ohai/_index.md
+++ b/content/resources/ohai/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: ohai
-    identifier: chef_infra/cookbook_reference/resources/ohai ohai
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/ohai ohai
+    parent: chef_infra/cookbooks/resources
     weight: 730
 resource_reference: true
 robots: null

--- a/content/resources/ohai_hint/_index.md
+++ b/content/resources/ohai_hint/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: ohai_hint
-    identifier: chef_infra/cookbook_reference/resources/ohai_hint ohai_hint
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/ohai_hint ohai_hint
+    parent: chef_infra/cookbooks/resources
     weight: 720
 resource_reference: true
 robots: null

--- a/content/resources/openbsd_package/_index.md
+++ b/content/resources/openbsd_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: openbsd_package
-    identifier: chef_infra/cookbook_reference/resources/openbsd_package openbsd_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/openbsd_package openbsd_package
+    parent: chef_infra/cookbooks/resources
     weight: 740
 resource_reference: true
 robots: null

--- a/content/resources/openssl_dhparam/_index.md
+++ b/content/resources/openssl_dhparam/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: openssl_dhparam
-    identifier: chef_infra/cookbook_reference/resources/openssl_dhparam openssl_dhparam
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/openssl_dhparam openssl_dhparam
+    parent: chef_infra/cookbooks/resources
     weight: 750
 resource_reference: true
 robots: null

--- a/content/resources/openssl_ec_private_key/_index.md
+++ b/content/resources/openssl_ec_private_key/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: openssl_ec_private_key
-    identifier: chef_infra/cookbook_reference/resources/openssl_ec_private_key openssl_ec_private_key
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/openssl_ec_private_key openssl_ec_private_key
+    parent: chef_infra/cookbooks/resources
     weight: 760
 resource_reference: true
 robots: null

--- a/content/resources/openssl_ec_public_key/_index.md
+++ b/content/resources/openssl_ec_public_key/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: openssl_ec_public_key
-    identifier: chef_infra/cookbook_reference/resources/openssl_ec_public_key openssl_ec_public_key
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/openssl_ec_public_key openssl_ec_public_key
+    parent: chef_infra/cookbooks/resources
     weight: 770
 resource_reference: true
 robots: null

--- a/content/resources/openssl_rsa_private_key/_index.md
+++ b/content/resources/openssl_rsa_private_key/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: openssl_rsa_private_key
-    identifier: chef_infra/cookbook_reference/resources/openssl_rsa_private_key openssl_rsa_private_key
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/openssl_rsa_private_key openssl_rsa_private_key
+    parent: chef_infra/cookbooks/resources
     weight: 780
 resource_reference: true
 robots: null

--- a/content/resources/openssl_rsa_public_key/_index.md
+++ b/content/resources/openssl_rsa_public_key/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: openssl_rsa_public_key
-    identifier: chef_infra/cookbook_reference/resources/openssl_rsa_public_key openssl_rsa_public_key
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/openssl_rsa_public_key openssl_rsa_public_key
+    parent: chef_infra/cookbooks/resources
     weight: 790
 resource_reference: true
 robots: null

--- a/content/resources/openssl_x509_certificate/_index.md
+++ b/content/resources/openssl_x509_certificate/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: openssl_x509_certificate
-    identifier: chef_infra/cookbook_reference/resources/openssl_x509_certificate openssl_x509_certificate
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/openssl_x509_certificate openssl_x509_certificate
+    parent: chef_infra/cookbooks/resources
     weight: 800
 resource_reference: true
 robots: null

--- a/content/resources/openssl_x509_crl/_index.md
+++ b/content/resources/openssl_x509_crl/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: openssl_x509_crl
-    identifier: chef_infra/cookbook_reference/resources/openssl_x509_crl openssl_x509_crl
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/openssl_x509_crl openssl_x509_crl
+    parent: chef_infra/cookbooks/resources
     weight: 810
 resource_reference: true
 robots: null

--- a/content/resources/openssl_x509_request/_index.md
+++ b/content/resources/openssl_x509_request/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: openssl_x509_request
-    identifier: chef_infra/cookbook_reference/resources/openssl_x509_request openssl_x509_request
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/openssl_x509_request openssl_x509_request
+    parent: chef_infra/cookbooks/resources
     weight: 820
 resource_reference: true
 robots: null

--- a/content/resources/osx_profile/_index.md
+++ b/content/resources/osx_profile/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: osx_profile
-    identifier: chef_infra/cookbook_reference/resources/osx_profile osx_profile
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/osx_profile osx_profile
+    parent: chef_infra/cookbooks/resources
     weight: 830
 resource_reference: true
 robots: null

--- a/content/resources/package/_index.md
+++ b/content/resources/package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: package
-    identifier: chef_infra/cookbook_reference/resources/package package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/package package
+    parent: chef_infra/cookbooks/resources
     weight: 840
 resource_reference: true
 robots: null

--- a/content/resources/pacman_package/_index.md
+++ b/content/resources/pacman_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: pacman_package
-    identifier: chef_infra/cookbook_reference/resources/pacman_package pacman_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/pacman_package pacman_package
+    parent: chef_infra/cookbooks/resources
     weight: 850
 resource_reference: true
 robots: null

--- a/content/resources/paludis_package/_index.md
+++ b/content/resources/paludis_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: paludis_package
-    identifier: chef_infra/cookbook_reference/resources/paludis_package paludis_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/paludis_package paludis_package
+    parent: chef_infra/cookbooks/resources
     weight: 860
 resource_reference: true
 robots: null

--- a/content/resources/perl/_index.md
+++ b/content/resources/perl/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: perl
-    identifier: chef_infra/cookbook_reference/resources/perl perl
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/perl perl
+    parent: chef_infra/cookbooks/resources
     weight: 870
 resource_reference: true
 robots: null

--- a/content/resources/portage_package/_index.md
+++ b/content/resources/portage_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: portage_package
-    identifier: chef_infra/cookbook_reference/resources/portage_package portage_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/portage_package portage_package
+    parent: chef_infra/cookbooks/resources
     weight: 880
 resource_reference: true
 robots: null

--- a/content/resources/powershell_package/_index.md
+++ b/content/resources/powershell_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: powershell_package
-    identifier: chef_infra/cookbook_reference/resources/powershell_package powershell_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/powershell_package powershell_package
+    parent: chef_infra/cookbooks/resources
     weight: 890
 resource_reference: true
 robots: null

--- a/content/resources/powershell_package_source/_index.md
+++ b/content/resources/powershell_package_source/_index.md
@@ -7,9 +7,9 @@ aliases:
 menu:
   infra:
     title: powershell_package_source
-    identifier: chef_infra/cookbook_reference/resources/powershell_package_source
+    identifier: chef_infra/cookbooks/resources/powershell_package_source
       powershell_package_source
-    parent: chef_infra/cookbook_reference/resources
+    parent: chef_infra/cookbooks/resources
     weight: 900
 resource_reference: true
 robots: null

--- a/content/resources/powershell_script/_index.md
+++ b/content/resources/powershell_script/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: powershell_script
-    identifier: chef_infra/cookbook_reference/resources/powershell_script powershell_script
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/powershell_script powershell_script
+    parent: chef_infra/cookbooks/resources
     weight: 910
 resource_reference: true
 robots: null

--- a/content/resources/python/_index.md
+++ b/content/resources/python/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: python
-    identifier: chef_infra/cookbook_reference/resources/python python
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/python python
+    parent: chef_infra/cookbooks/resources
     weight: 920
 resource_reference: true
 robots: null

--- a/content/resources/reboot/_index.md
+++ b/content/resources/reboot/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: reboot
-    identifier: chef_infra/cookbook_reference/resources/reboot reboot
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/reboot reboot
+    parent: chef_infra/cookbooks/resources
     weight: 930
 resource_reference: true
 robots: null

--- a/content/resources/registry_key/_index.md
+++ b/content/resources/registry_key/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: registry_key
-    identifier: chef_infra/cookbook_reference/resources/registry_key registry_key
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/registry_key registry_key
+    parent: chef_infra/cookbooks/resources
     weight: 950
 resource_reference: true
 robots: null

--- a/content/resources/remote_directory/_index.md
+++ b/content/resources/remote_directory/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: remote_directory
-    identifier: chef_infra/cookbook_reference/resources/remote_directory remote_directory
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/remote_directory remote_directory
+    parent: chef_infra/cookbooks/resources
     weight: 960
 resource_reference: true
 robots: null

--- a/content/resources/remote_file/_index.md
+++ b/content/resources/remote_file/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: remote_file
-    identifier: chef_infra/cookbook_reference/resources/remote_file remote_file
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/remote_file remote_file
+    parent: chef_infra/cookbooks/resources
     weight: 970
 resource_reference: true
 robots: null

--- a/content/resources/rhsm_errata/_index.md
+++ b/content/resources/rhsm_errata/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: rhsm_errata
-    identifier: chef_infra/cookbook_reference/resources/rhsm_errata rhsm_errata
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/rhsm_errata rhsm_errata
+    parent: chef_infra/cookbooks/resources
     weight: 990
 resource_reference: true
 robots: null

--- a/content/resources/rhsm_errata_level/_index.md
+++ b/content/resources/rhsm_errata_level/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: rhsm_errata_level
-    identifier: chef_infra/cookbook_reference/resources/rhsm_errata_level rhsm_errata_level
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/rhsm_errata_level rhsm_errata_level
+    parent: chef_infra/cookbooks/resources
     weight: 980
 resource_reference: true
 robots: null

--- a/content/resources/rhsm_register/_index.md
+++ b/content/resources/rhsm_register/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: rhsm_register
-    identifier: chef_infra/cookbook_reference/resources/rhsm_register rhsm_register
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/rhsm_register rhsm_register
+    parent: chef_infra/cookbooks/resources
     weight: 1000
 resource_reference: true
 robots: null

--- a/content/resources/rhsm_repo/_index.md
+++ b/content/resources/rhsm_repo/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: rhsm_repo
-    identifier: chef_infra/cookbook_reference/resources/rhsm_repo rhsm_repo
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/rhsm_repo rhsm_repo
+    parent: chef_infra/cookbooks/resources
     weight: 1010
 resource_reference: true
 robots: null

--- a/content/resources/rhsm_subscription/_index.md
+++ b/content/resources/rhsm_subscription/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: rhsm_subscription
-    identifier: chef_infra/cookbook_reference/resources/rhsm_subscription rhsm_subscription
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/rhsm_subscription rhsm_subscription
+    parent: chef_infra/cookbooks/resources
     weight: 1020
 resource_reference: true
 robots: null

--- a/content/resources/route/_index.md
+++ b/content/resources/route/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: route
-    identifier: chef_infra/cookbook_reference/resources/route route
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/route route
+    parent: chef_infra/cookbooks/resources
     weight: 1030
 resource_reference: true
 robots: null

--- a/content/resources/rpm_package/_index.md
+++ b/content/resources/rpm_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: rpm_package
-    identifier: chef_infra/cookbook_reference/resources/rpm_package rpm_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/rpm_package rpm_package
+    parent: chef_infra/cookbooks/resources
     weight: 1040
 resource_reference: true
 robots: null

--- a/content/resources/ruby/_index.md
+++ b/content/resources/ruby/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: ruby
-    identifier: chef_infra/cookbook_reference/resources/ruby ruby
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/ruby ruby
+    parent: chef_infra/cookbooks/resources
     weight: 1050
 resource_reference: true
 robots: null

--- a/content/resources/ruby_block/_index.md
+++ b/content/resources/ruby_block/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: ruby_block
-    identifier: chef_infra/cookbook_reference/resources/ruby_block ruby_block
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/ruby_block ruby_block
+    parent: chef_infra/cookbooks/resources
     weight: 1060
 resource_reference: true
 robots: null

--- a/content/resources/script/_index.md
+++ b/content/resources/script/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: script
-    identifier: chef_infra/cookbook_reference/resources/script script
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/script script
+    parent: chef_infra/cookbooks/resources
     weight: 1070
 resource_reference: true
 robots: null

--- a/content/resources/service/_index.md
+++ b/content/resources/service/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: service
-    identifier: chef_infra/cookbook_reference/resources/service service
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/service service
+    parent: chef_infra/cookbooks/resources
     weight: 1080
 resource_reference: true
 robots: null

--- a/content/resources/smartos_package/_index.md
+++ b/content/resources/smartos_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: smartos_package
-    identifier: chef_infra/cookbook_reference/resources/smartos_package smartos_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/smartos_package smartos_package
+    parent: chef_infra/cookbooks/resources
     weight: 1090
 resource_reference: true
 robots: null

--- a/content/resources/snap_package/_index.md
+++ b/content/resources/snap_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: snap_package
-    identifier: chef_infra/cookbook_reference/resources/snap_package snap_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/snap_package snap_package
+    parent: chef_infra/cookbooks/resources
     weight: 1100
 resource_reference: true
 robots: null

--- a/content/resources/solaris_package/_index.md
+++ b/content/resources/solaris_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: solaris_package
-    identifier: chef_infra/cookbook_reference/resources/solaris_package solaris_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/solaris_package solaris_package
+    parent: chef_infra/cookbooks/resources
     weight: 1110
 resource_reference: true
 robots: null

--- a/content/resources/ssh_known_hosts_entry/_index.md
+++ b/content/resources/ssh_known_hosts_entry/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: ssh_known_hosts_entry
-    identifier: chef_infra/cookbook_reference/resources/ssh_known_hosts_entry ssh_known_hosts_entry
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/ssh_known_hosts_entry ssh_known_hosts_entry
+    parent: chef_infra/cookbooks/resources
     weight: 1120
 resource_reference: true
 robots: null

--- a/content/resources/subversion/_index.md
+++ b/content/resources/subversion/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: subversion
-    identifier: chef_infra/cookbook_reference/resources/subversion subversion
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/subversion subversion
+    parent: chef_infra/cookbooks/resources
     weight: 1130
 resource_reference: true
 robots: null

--- a/content/resources/sudo/_index.md
+++ b/content/resources/sudo/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: sudo
-    identifier: chef_infra/cookbook_reference/resources/sudo sudo
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/sudo sudo
+    parent: chef_infra/cookbooks/resources
     weight: 1140
 resource_reference: true
 robots: null

--- a/content/resources/swap_file/_index.md
+++ b/content/resources/swap_file/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: swap_file
-    identifier: chef_infra/cookbook_reference/resources/swap_file swap_file
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/swap_file swap_file
+    parent: chef_infra/cookbooks/resources
     weight: 1150
 resource_reference: true
 robots: null

--- a/content/resources/sysctl/_index.md
+++ b/content/resources/sysctl/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: sysctl
-    identifier: chef_infra/cookbook_reference/resources/sysctl sysctl
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/sysctl sysctl
+    parent: chef_infra/cookbooks/resources
     weight: 1160
 resource_reference: true
 robots: null

--- a/content/resources/systemd_unit/_index.md
+++ b/content/resources/systemd_unit/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: systemd_unit
-    identifier: chef_infra/cookbook_reference/resources/systemd_unit systemd_unit
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/systemd_unit systemd_unit
+    parent: chef_infra/cookbooks/resources
     weight: 1170
 resource_reference: true
 robots: null

--- a/content/resources/template/_index.md
+++ b/content/resources/template/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: template
-    identifier: chef_infra/cookbook_reference/resources/template template
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/template template
+    parent: chef_infra/cookbooks/resources
     weight: 1180
 resource_reference: true
 robots: null

--- a/content/resources/timezone/_index.md
+++ b/content/resources/timezone/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: timezone
-    identifier: chef_infra/cookbook_reference/resources/timezone timezone
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/timezone timezone
+    parent: chef_infra/cookbooks/resources
     weight: 1190
 resource_reference: true
 robots: null

--- a/content/resources/user/_index.md
+++ b/content/resources/user/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: user
-    identifier: chef_infra/cookbook_reference/resources/user user
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/user user
+    parent: chef_infra/cookbooks/resources
     weight: 1200
 resource_reference: true
 robots: null

--- a/content/resources/windows_ad_join/_index.md
+++ b/content/resources/windows_ad_join/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_ad_join
-    identifier: chef_infra/cookbook_reference/resources/windows_ad_join windows_ad_join
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_ad_join windows_ad_join
+    parent: chef_infra/cookbooks/resources
     weight: 1210
 resource_reference: true
 robots: null

--- a/content/resources/windows_auto_run/_index.md
+++ b/content/resources/windows_auto_run/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_auto_run
-    identifier: chef_infra/cookbook_reference/resources/windows_auto_run windows_auto_run
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_auto_run windows_auto_run
+    parent: chef_infra/cookbooks/resources
     weight: 1220
 resource_reference: true
 robots: null

--- a/content/resources/windows_certificate/_index.md
+++ b/content/resources/windows_certificate/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_certificate
-    identifier: chef_infra/cookbook_reference/resources/windows_certificate windows_certificate
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_certificate windows_certificate
+    parent: chef_infra/cookbooks/resources
     weight: 1230
 resource_reference: true
 robots: null

--- a/content/resources/windows_dfs_folder/_index.md
+++ b/content/resources/windows_dfs_folder/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_dfs_folder
-    identifier: chef_infra/cookbook_reference/resources/windows_dfs_folder windows_dfs_folder
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_dfs_folder windows_dfs_folder
+    parent: chef_infra/cookbooks/resources
     weight: 1240
 resource_reference: true
 robots: null

--- a/content/resources/windows_dfs_namespace/_index.md
+++ b/content/resources/windows_dfs_namespace/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_dfs_namespace
-    identifier: chef_infra/cookbook_reference/resources/windows_dfs_namespace windows_dfs_namespace
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_dfs_namespace windows_dfs_namespace
+    parent: chef_infra/cookbooks/resources
     weight: 1250
 resource_reference: true
 robots: null

--- a/content/resources/windows_dfs_server/_index.md
+++ b/content/resources/windows_dfs_server/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_dfs_server
-    identifier: chef_infra/cookbook_reference/resources/windows_dfs_server windows_dfs_server
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_dfs_server windows_dfs_server
+    parent: chef_infra/cookbooks/resources
     weight: 1260
 resource_reference: true
 robots: null

--- a/content/resources/windows_dns_record/_index.md
+++ b/content/resources/windows_dns_record/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_dns_record
-    identifier: chef_infra/cookbook_reference/resources/windows_dns_record windows_dns_record
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_dns_record windows_dns_record
+    parent: chef_infra/cookbooks/resources
     weight: 1270
 resource_reference: true
 robots: null

--- a/content/resources/windows_dns_zone/_index.md
+++ b/content/resources/windows_dns_zone/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_dns_zone
-    identifier: chef_infra/cookbook_reference/resources/windows_dns_zone windows_dns_zone
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_dns_zone windows_dns_zone
+    parent: chef_infra/cookbooks/resources
     weight: 1280
 resource_reference: true
 robots: null

--- a/content/resources/windows_env/_index.md
+++ b/content/resources/windows_env/_index.md
@@ -8,8 +8,8 @@ aliases:
 menu:
   infra:
     title: windows_env
-    identifier: chef_infra/cookbook_reference/resources/windows_env windows_env
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_env windows_env
+    parent: chef_infra/cookbooks/resources
     weight: 1290
 resource_reference: true
 robots: null

--- a/content/resources/windows_feature/_index.md
+++ b/content/resources/windows_feature/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_feature
-    identifier: chef_infra/cookbook_reference/resources/windows_feature windows_feature
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_feature windows_feature
+    parent: chef_infra/cookbooks/resources
     weight: 1300
 resource_reference: true
 robots: null

--- a/content/resources/windows_feature_dism/_index.md
+++ b/content/resources/windows_feature_dism/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_feature_dism
-    identifier: chef_infra/cookbook_reference/resources/windows_feature_dism windows_feature_dism
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_feature_dism windows_feature_dism
+    parent: chef_infra/cookbooks/resources
     weight: 1310
 resource_reference: true
 robots: null

--- a/content/resources/windows_feature_powershell/_index.md
+++ b/content/resources/windows_feature_powershell/_index.md
@@ -7,9 +7,9 @@ aliases:
 menu:
   infra:
     title: windows_feature_powershell
-    identifier: chef_infra/cookbook_reference/resources/windows_feature_powershell
+    identifier: chef_infra/cookbooks/resources/windows_feature_powershell
       windows_feature_powershell
-    parent: chef_infra/cookbook_reference/resources
+    parent: chef_infra/cookbooks/resources
     weight: 1320
 resource_reference: true
 robots: null

--- a/content/resources/windows_firewall_rule/_index.md
+++ b/content/resources/windows_firewall_rule/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_firewall_rule
-    identifier: chef_infra/cookbook_reference/resources/windows_firewall_rule windows_firewall_rule
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_firewall_rule windows_firewall_rule
+    parent: chef_infra/cookbooks/resources
     weight: 1330
 resource_reference: true
 robots: null

--- a/content/resources/windows_font/_index.md
+++ b/content/resources/windows_font/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_font
-    identifier: chef_infra/cookbook_reference/resources/windows_font windows_font
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_font windows_font
+    parent: chef_infra/cookbooks/resources
     weight: 1340
 resource_reference: true
 robots: null

--- a/content/resources/windows_package/_index.md
+++ b/content/resources/windows_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_package
-    identifier: chef_infra/cookbook_reference/resources/windows_package windows_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_package windows_package
+    parent: chef_infra/cookbooks/resources
     weight: 1350
 resource_reference: true
 robots: null

--- a/content/resources/windows_pagefile/_index.md
+++ b/content/resources/windows_pagefile/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_pagefile
-    identifier: chef_infra/cookbook_reference/resources/windows_pagefile windows_pagefile
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_pagefile windows_pagefile
+    parent: chef_infra/cookbooks/resources
     weight: 1360
 resource_reference: true
 robots: null

--- a/content/resources/windows_path/_index.md
+++ b/content/resources/windows_path/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_path
-    identifier: chef_infra/cookbook_reference/resources/windows_path windows_path
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_path windows_path
+    parent: chef_infra/cookbooks/resources
     weight: 1370
 resource_reference: true
 robots: null

--- a/content/resources/windows_printer/_index.md
+++ b/content/resources/windows_printer/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_printer
-    identifier: chef_infra/cookbook_reference/resources/windows_printer windows_printer
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_printer windows_printer
+    parent: chef_infra/cookbooks/resources
     weight: 1380
 resource_reference: true
 robots: null

--- a/content/resources/windows_printer_port/_index.md
+++ b/content/resources/windows_printer_port/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_printer_port
-    identifier: chef_infra/cookbook_reference/resources/windows_printer_port windows_printer_port
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_printer_port windows_printer_port
+    parent: chef_infra/cookbooks/resources
     weight: 1390
 resource_reference: true
 robots: null

--- a/content/resources/windows_service/_index.md
+++ b/content/resources/windows_service/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_service
-    identifier: chef_infra/cookbook_reference/resources/windows_service windows_service
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_service windows_service
+    parent: chef_infra/cookbooks/resources
     weight: 1400
 resource_reference: true
 robots: null

--- a/content/resources/windows_share/_index.md
+++ b/content/resources/windows_share/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_share
-    identifier: chef_infra/cookbook_reference/resources/windows_share windows_share
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_share windows_share
+    parent: chef_infra/cookbooks/resources
     weight: 1410
 resource_reference: true
 robots: null

--- a/content/resources/windows_shortcut/_index.md
+++ b/content/resources/windows_shortcut/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_shortcut
-    identifier: chef_infra/cookbook_reference/resources/windows_shortcut windows_shortcut
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_shortcut windows_shortcut
+    parent: chef_infra/cookbooks/resources
     weight: 1420
 resource_reference: true
 robots: null

--- a/content/resources/windows_task/_index.md
+++ b/content/resources/windows_task/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_task
-    identifier: chef_infra/cookbook_reference/resources/windows_task windows_task
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_task windows_task
+    parent: chef_infra/cookbooks/resources
     weight: 1430
 resource_reference: true
 robots: null

--- a/content/resources/windows_uac/_index.md
+++ b/content/resources/windows_uac/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_uac
-    identifier: chef_infra/cookbook_reference/resources/windows_uac windows_uac
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_uac windows_uac
+    parent: chef_infra/cookbooks/resources
     weight: 1440
 resource_reference: true
 robots: null

--- a/content/resources/windows_workgroup/_index.md
+++ b/content/resources/windows_workgroup/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: windows_workgroup
-    identifier: chef_infra/cookbook_reference/resources/windows_workgroup windows_workgroup
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/windows_workgroup windows_workgroup
+    parent: chef_infra/cookbooks/resources
     weight: 1450
 resource_reference: true
 robots: null

--- a/content/resources/yum_package/_index.md
+++ b/content/resources/yum_package/_index.md
@@ -8,8 +8,8 @@ aliases:
 menu:
   infra:
     title: yum_package
-    identifier: chef_infra/cookbook_reference/resources/yum_package yum_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/yum_package yum_package
+    parent: chef_infra/cookbooks/resources
     weight: 1460
 resource_reference: true
 robots: null

--- a/content/resources/yum_repository/_index.md
+++ b/content/resources/yum_repository/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: yum_repository
-    identifier: chef_infra/cookbook_reference/resources/yum_repository yum_repository
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/yum_repository yum_repository
+    parent: chef_infra/cookbooks/resources
     weight: 1470
 resource_reference: true
 robots: null

--- a/content/resources/zypper_package/_index.md
+++ b/content/resources/zypper_package/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: zypper_package
-    identifier: chef_infra/cookbook_reference/resources/zypper_package zypper_package
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/zypper_package zypper_package
+    parent: chef_infra/cookbooks/resources
     weight: 1480
 resource_reference: true
 robots: null

--- a/content/resources/zypper_repository/_index.md
+++ b/content/resources/zypper_repository/_index.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   infra:
     title: zypper_repository
-    identifier: chef_infra/cookbook_reference/resources/zypper_repository zypper_repository
-    parent: chef_infra/cookbook_reference/resources
+    identifier: chef_infra/cookbooks/resources/zypper_repository zypper_repository
+    parent: chef_infra/cookbooks/resources
     weight: 1490
 resource_reference: true
 robots: null

--- a/content/ruby.md
+++ b/content/ruby.md
@@ -7,8 +7,8 @@ aliases = ["/ruby.html"]
 [menu]
   [menu.infra]
     title = "Ruby Guide"
-    identifier = "chef_infra/cookbook_reference/ruby.md Ruby Guide"
-    parent = "chef_infra/cookbook_reference"
+    identifier = "chef_infra/cookbooks/ruby.md Ruby Guide"
+    parent = "chef_infra/language"
     weight = 130
 +++
 
@@ -461,16 +461,6 @@ Cookbook Versioning
 -   Always update CHANGELOG.md with any changes, with the JIRA ticket
     and a brief description.
 
-Cookbook Patterns
------------------
-
-Good cookbook examples:
-
--   <https://github.com/chef-cookbooks/tomcat>
--   <https://github.com/chef-cookbooks/apparmor>
--   <https://github.com/chef-cookbooks/mysql>
--   <https://github.com/chef-cookbooks/httpd>
-
 Naming
 ------
 
@@ -513,26 +503,6 @@ template '/tmp/foobar.txt' do
 end
 ```
 
-File Modes
-----------
-
-Always specify the file mode with a quoted 3-5 character string that
-defines the octal mode:
-
-``` ruby
-mode '755'
-```
-
-``` ruby
-mode '0755'
-```
-
-Wrong:
-
-``` ruby
-mode 755
-```
-
 Specify Resource Action?
 ------------------------
 
@@ -557,25 +527,6 @@ obvious to the reader, specifying the default action is recommended:
 ohai 'apache_modules' do
   action :reload
 end
-```
-
-Symbols or Strings?
--------------------
-
-Prefer strings over symbols, because they're easier to read and you
-don't need to explain to non-Rubyists what a symbol is. Please retrofit
-old cookbooks as you come across them.
-
-Right:
-
-``` ruby
-default['foo']['bar'] = 'baz'
-```
-
-Wrong:
-
-``` ruby
-default[:foo][:bar] = 'baz'
 ```
 
 String Quoting

--- a/content/ruby.md
+++ b/content/ruby.md
@@ -4,19 +4,13 @@ draft = false
 
 aliases = ["/ruby.html"]
 
-[menu]
-  [menu.infra]
-    title = "Ruby Guide"
-    identifier = "chef_infra/cookbooks/ruby.md Ruby Guide"
-    parent = "chef_infra/language"
-    weight = 130
 +++
 
 [\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/ruby.md)
 
 {{% ruby_summary %}}
 
-As of Chef Infra Client 15.x, Chef Infra Client ships with Ruby 2.6.
+Chef Infra Client 15 ships with Ruby 2.6 and Chef Infra Client 16 ships with Ruby 2.7.
 
 Ruby Basics
 ===========

--- a/content/secrets.md
+++ b/content/secrets.md
@@ -108,7 +108,7 @@ Data bags can be accessed in the following ways:
 
 {{% data_bag_recipes %}}
 
-#### Load with Recipe DSL
+#### Load with Chef Infra Language
 
 {{% data_bag_recipes_load_using_recipe_dsl %}}
 

--- a/content/sitemap.md
+++ b/content/sitemap.md
@@ -548,7 +548,8 @@ Extension APIs
 Resources
 ---------
 
-**Recipe DSL**: [attribute?](/dsl_recipe/#attribute) |
+**Chef Infra Language**:
+[attribute?](/dsl_recipe/#attribute) |
 [control](/dsl_recipe/#control) |
 [control_group](/dsl_recipe/#control-group) |
 [cookbook_name](/dsl_recipe/#cookbook-name) |
@@ -572,10 +573,9 @@ Resources
 [tagged?](/dsl_recipe/#tag-tagged-untag) |
 [untag](/dsl_recipe/#tag-tagged-untag) |
 [value_for_platform](/dsl_recipe/#value-for-platform) |
-[value_for_platform_family](/dsl_recipe/#value-for-platform-family)
-| [Custom
-Resource DSL](/dsl_custom_resource/) | [Community
-Resources](https://supermarket.chef.io)
+[value_for_platform_family](/dsl_recipe/#value-for-platform-family)|
+[Custom Resource DSL](/dsl_custom_resource/) |
+[Community Resources](https://supermarket.chef.io)
 
 Handlers
 --------

--- a/content/templates.md
+++ b/content/templates.md
@@ -7,8 +7,8 @@ aliases = ["/templates.html"]
 [menu]
   [menu.infra]
     title = "Templates"
-    identifier = "chef_infra/cookbook_reference/templates.md Templates"
-    parent = "chef_infra/cookbook_reference"
+    identifier = "chef_infra/cookbooks/templates.md Templates"
+    parent = "chef_infra/cookbooks"
     weight = 90
 +++
 

--- a/layouts/shortcodes/dsl_recipe_summary.md
+++ b/layouts/shortcodes/dsl_recipe_summary.md
@@ -1,6 +1,1 @@
-The Recipe DSL is a Ruby DSL that is primarily used to declare resources
-from within a recipe. The Recipe DSL also helps ensure that recipes
-interact with nodes (and node properties) in the desired manner. Most of
-the methods in the Recipe DSL are used to find a specific parameter and
-then tell Chef Infra Client what action(s) to take, based on whether
-that parameter is present on a node.
+The Chef Infra Language is a comprehensive systems configuration language with resources and helpers for configuring various operating systems. The language is primarily used in Chef Infra recipes and custom resources to tell the Chef Infra Client what action(s) to take to properly configure a system. The Chef Infra Language provides resources for system-level components such as packages, users, or firewalls, and also includes helpers to allow you to make configuration decisions based on operating systems, clouds, virtualization hypervisors, and more.


### PR DESCRIPTION
I've always struggled with the way our docs were structured and I realized that a lot of it comes down to how we describe the cookbooks language in Chef. We use a lot of different names for it because we don't have an actual name. This PR gives it one true name: The Chef Infra Language which includes all our helpers and the out of the box resources. If you're writing a cookbook you're not writing Ruby or recipe code or Chef code, or Chef DSL, or Recipe DSL. You're writing Chef Infra Language code. Once we have this concept we can better split up how we describe part of our language from the structure of the cookbook. It's all intermixed right now in a way that's SUPER confusing. We do need to describe the parts of a cookbook, but that's not actually the language. That's more folder structure and high level concepts of how Chef Infra works.

I think this is going to give us room to expand to include the 50+ helpers that aren't documented yet, but are included in Chef Infra Client 15.4 and later. I didn't want to just shove those into the existing structure since it was just wrong.

Signed-off-by: Tim Smith <tsmith@chef.io>