### PR TITLE
Update supported versions docs after infra client 16 release

### DIFF
--- a/content/versions.md
+++ b/content/versions.md
@@ -103,39 +103,45 @@ announcement](https://blog.chef.io/2019/04/02/chef-software-announces-the-enterp
 <td>Chef Infra Client</td>
 <td>15.x</td>
 <td>GA</td>
-<td>n/a</td>
+<td>April 30, 2021</td>
 </tr>
 <tr class="odd">
+<td>Chef Infra Client</td>
+<td>16.x</td>
+<td>GA</td>
+<td>April 30, 2022</td>
+</tr>
+<tr class="even">
 <td>Chef Infra Server</td>
 <td>13.x</td>
 <td>GA</td>
 <td>n/a</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>Chef Habitat</td>
 <td>0.81+</td>
 <td>GA</td>
 <td>n/a</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>Chef InSpec</td>
 <td>4.x</td>
 <td>GA</td>
 <td>n/a</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>Chef Workstation</td>
 <td>0.4+</td>
 <td>GA</td>
 <td>n/a</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>ChefDK</td>
 <td>4.x</td>
 <td>GA</td>
 <td>n/a</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>Chef Backend</td>
 <td>3.x</td>
 <td>Releasing 2020</td>
@@ -175,42 +181,36 @@ version 2.0.
 </thead>
 <tbody>
 <tr class="odd">
-<td>Chef Client</td>
-<td>14.x</td>
-<td>GA</td>
-<td>April 30, 2020</td>
-</tr>
-<tr class="even">
 <td>Chef Workstation</td>
 <td>0.3</td>
 <td>GA</td>
 <td>April 30, 2020</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>ChefDK</td>
 <td>3.x</td>
 <td>GA</td>
 <td>April 30, 2020</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>Chef InSpec</td>
 <td>3.x</td>
 <td>GA</td>
 <td>April 30, 2020</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>Chef Infra Server</td>
 <td>12.x</td>
 <td>GA</td>
 <td>TBD</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>Push Jobs</td>
 <td>2.5.x</td>
 <td>GA</td>
 <td>TBD</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>Supermarket</td>
 <td>3.x</td>
 <td>GA</td>
@@ -289,9 +289,9 @@ End of Life (EOL) Products
 </tr>
 <tr class="odd">
 <td>Chef Client</td>
-<td>13 and under</td>
+<td>14 and under</td>
 <td>EOL</td>
-<td>April 30, 2019</td>
+<td>April 30, 2020</td>
 </tr>
 <tr class="even">
 <td>Chef Compliance</td>


### PR DESCRIPTION
### Description

Chef Infra Client 16 released 2020.04.28, ending support for Chef Client 14.

This PR:

1. adds Chef Infra Client 16 to supported commercials
2. adds EOL dates for both CIC 15 and CIC 16 (April of 2021, 2022, respectively)
3. removes Chef Client 14 from supported free versions
4. adds Chef Client 14 to EOL and changes date to 2020 in that section

### Definition of Done

PR is merged and docs reflect accurate support status and dates

### Issues Resolved

With release of Chef Infra Client 16, docs are out of date

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass

Signed-off-by: Josh O'Brien jobrien@chef.io