### PR TITLE
Im/redundant resource link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -380,13 +380,6 @@ weight = 30
       url = "/knife_supermarket/"
       weight = 80
 
-    [[menu.infra]]
-    title = "Management Console"
-    identifier = "chef_infra/setup/ctl_chef_server.md Management Console"
-    parent = "chef_infra/setup"
-    url = "/ctl_chef_server/"
-    weight = 80
-
   [[menu.infra]]
   title = "Cookbook Reference"
   identifier = "chef_infra/cookbook_reference"

--- a/config.toml
+++ b/config.toml
@@ -635,13 +635,6 @@ weight = 30
       url = "/resources/"
       weight = 60
 
-      [[menu.infra]]
-      title = "reference"
-      identifier = "chef_infra/cookbook_reference/resources/resources reference"
-      parent = "chef_infra/cookbook_reference/resources"
-      url = "/resources/"
-      weight = 940
-
   [[menu.infra]]
   title = "Managing Chef Infra Server"
   identifier = "chef_infra/managing_chef_infra_server"


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Remove redundant nav links. 

The Resource Reference link is in the nav twice, this removes the second one.

The Management Console link goes to ctl_chef_server but the title suggests it should go to Manage. Both ctl_chef_server and manage have links elsewhere in the nav. 

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
