### PR TITLE
Internal Link Fix for Release Notes

### DIFF
--- a/content/release_notes.md
+++ b/content/release_notes.md
@@ -95,7 +95,7 @@ In Chef Infra Client 14 we introduced a modernized filesystem layout of Ohai dat
 
 The behavior of `required: true` has been changed to better align with the expected behavior. Previously, if you set a property `required: true` on a custom resource property and did not explicitly reference the property in an action, then Chef Infra Client would not raise an exception. This meant many users would add their own validation to raise for resources they wanted to ensure they were always set. `required: true` will now properly raise if a property has not been set.
 
-We have also expanded the `required` field for added flexibility in defining exactly which actions a property is required for. See [Improved property require behavior](#Improved-property-require-behavior) below for more details.
+We have also expanded the `required` field for added flexibility in defining exactly which actions a property is required for. See [Improved property require behavior](#improved-property-require-behavior) below for more details.
 
 #### Removal of Legacy metadata.rb depends Version Constraints
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/chef/chef-web-docs
 
 go 1.14
 
-require (
-	github.com/chef/chef-workstation/www v0.0.0-20200428223350-8a826c337c81 // indirect
-)
+require github.com/chef/chef-workstation/www v0.0.0-20200428223350-8a826c337c81 // indirect
 
 //replace github.com/chef/chef-workstation/www => ../chef-workstation/www


### PR DESCRIPTION
Signed-off-by: Mary Jinglewski <mjinglewski@chef.io>

### Description

An internal link referring to a header further down in the release notes was not working as expected. This PR fixes that issue.

### Definition of Done
🟢 = good!

### Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [ ] All tests pass
