### PR TITLE
Add Ubuntu 20.04 to InSpec

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -273,7 +273,7 @@ versions for Chef InSpec:
 <tr class="odd">
 <td>Ubuntu</td>
 <td><code>x86_64</code></td>
-<td><code>16.04</code>, <code>18.04</code></td>
+<td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>
 </tr>
 <tr class="even">
 <td>Microsoft Windows</td>


### PR DESCRIPTION
We support 20.04 here.

Signed-off-by: Tim Smith <tsmith@chef.io>