### PR TITLE
Disclose Chef Infra Client 16 Solaris support blocker

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -44,6 +44,14 @@ SLA-based assistance from our support desk.
 
 #### Commercial Support
 
+{{< important >}}
+
+**Chef Infra Client 16 currently cannot build for Solaris**
+
+Due to the impact of COVID-19, Chef's employees cannot access our physical data center, which is a requirement for Solaris support. Until we can physically access the data center, Solaris builds on Chef Infra Client 16 will not be supported. They are available on Chef Infra Client 15, and we will begin building for Chef Infra Client 16 as soon as we responsibly can.
+
+{{< /important >}}
+
 The following table lists the commercially-supported platforms and
 versions for Chef Infra Client:
 


### PR DESCRIPTION
In order to support Solaris builds for Chef Infra Client 16, we must access
our physical data center, which is not currently possible due to COVID-19.

Signed-off-by: Josh O'Brien <jobrien@chef.io>

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
