### PR TITLE
Add trace to available logging options

### DIFF
--- a/content/ctl_chef_client.md
+++ b/content/ctl_chef_client.md
@@ -248,7 +248,7 @@ This command has the following options:
 `-l LEVEL`, `--log_level LEVEL`
 
 :   The level of logging to be stored in a log file. Possible levels:
-    `auto` (default), `debug`, `info`, `warn`, `error`, or `fatal`.
+    `auto` (default), `debug`, `error`, `fatal`, `info`, `trace`, or `warn`.
     Default value: `warn` (when a terminal is available) or `info` (when
     a terminal is not available).
 

--- a/content/ctl_chef_solo.md
+++ b/content/ctl_chef_solo.md
@@ -102,7 +102,10 @@ This command has the following options:
 
 `-l LEVEL`, `--log_level LEVEL`
 
-:   The level of logging to be stored in a log file.
+:   The level of logging to be stored in a log file. Possible levels:
+    `auto` (default), `debug`, `error`, `fatal`, `info`, `trace`, or `warn`.
+    Default value: `warn` (when a terminal is available) or `info` (when
+    a terminal is not available).
 
 `-L LOGLOCATION`, `--logfile c`
 

--- a/content/debug.md
+++ b/content/debug.md
@@ -62,7 +62,10 @@ Use the verbose logging that is built into Chef Infra Client:
 
 `-l LEVEL`, `--log_level LEVEL`
 
-:   The level of logging to be stored in a log file.
+:   The level of logging to be stored in a log file. Possible levels:
+    `auto` (default), `debug`, `error`, `fatal`, `info`, `trace`, or `warn`.
+    Default value: `warn` (when a terminal is available) or `info` (when
+    a terminal is not available).
 
 `-L LOGLOCATION`, `--logfile c`
 


### PR DESCRIPTION
Signed-off-by: James Massardo <jmassardo@chef.io>

### Description

This change adds the `trace` option to the list of available logging options for chef-client.