### PR TITLE
More resource updates from automation

### DIFF
--- a/content/resources/bff_package/_index.md
+++ b/content/resources/bff_package/_index.md
@@ -19,27 +19,9 @@ resource_description_list:
     using the installp utility. When a package is installed from a local file, it
     must be added to the node using the **remote_file** or **cookbook_file** resources.
 - note:
-    markdown: 'A Backup File Format (BFF) package may not have a `.bff` file extension.
-
-      Chef Infra Client will still identify the correct provider to use based
-
-      on the platform, regardless of the file extension.'
-syntax_description: 'A **bff_package** resource manages a package on a node, typically
-  by
-
-  installing it. The simplest use of the **bff_package** resource is:
-
-
-  ``` ruby
-
-  bff_package ''package_name''
-
-  ```
-
-
-  which will install the named package using all of the default options
-
-  and the default action (`:install`).'
+    markdown: A Backup File Format (BFF) package may not have a `.bff` file extension.
+      Chef Infra Client will still identify the correct provider to use based on the
+      platform, regardless of the file extension.
 syntax_full_code_block: |-
   bff_package 'name' do
     options           String, Array

--- a/content/resources/reboot/_index.md
+++ b/content/resources/reboot/_index.md
@@ -1,4 +1,9 @@
 ---
+resource_reference: true
+properties_shortcode: 
+resources_common_guards: true
+resources_common_notification: true
+resources_common_properties: true
 title: reboot resource
 resource: reboot
 aliases:
@@ -8,8 +13,6 @@ menu:
     title: reboot
     identifier: chef_infra/cookbook_reference/resources/reboot reboot
     parent: chef_infra/cookbook_reference/resources
-resource_reference: true
-robots: null
 resource_description_list:
 - markdown: 'Use the **reboot** resource to reboot a node, a necessary step with some
 
@@ -17,25 +20,19 @@ resource_description_list:
 
     on the Microsoft Windows, macOS, and Linux platforms.'
 resource_new_in: null
-handler_types: false
-syntax_description: "The reboot resource has the following syntax:\n\n``` ruby\nreboot\
-  \ 'name' do\n  delay_mins      Integer # default value: 0\n  reason          String\
-  \ # default value: \"Reboot by Chef Infra Client\"\n  action          Symbol # defaults\
-  \ to :nothing if not specified\nend\n```"
-syntax_code_block: null
+syntax_full_code_block: |-
+  reboot 'name' do
+    delay_mins      Integer # default value: 0
+    reason          String # default value: "Reboot by Chef Infra Client"
+    action          Symbol # defaults to :nothing if not specified
+  end
 syntax_properties_list:
-- '`reboot` is the resource.'
-- '`name` is the name given to the resource block.'
-- '`action` identifies which steps Chef Infra Client will take to bring the node into
-  the desired state.'
-- '`delay_mins` and `reason` are the properties available to this resource.'
-syntax_full_code_block: null
-syntax_full_properties_list: null
-syntax_shortcode: null
-registry_key: false
-nameless_apt_update: false
-nameless_build_essential: false
-resource_package_options: false
+syntax_full_properties_list:
+- "`reboot` is the resource."
+- "`name` is the name given to the resource block."
+- "`action` identifies which steps Chef Infra Client will take to bring the node into
+  the desired state."
+- "`delay_mins` and `reason` are the properties available to this resource."
 actions_list:
   :cancel:
     markdown: Cancel a reboot request.
@@ -51,37 +48,14 @@ properties_list:
   ruby_type: Integer
   required: false
   default_value: '0'
-  new_in: null
   description_list:
   - markdown: The amount of time (in minutes) to delay a reboot request.
 - property: reason
   ruby_type: String
   required: false
-  default_value: '"Reboot by Chef Infra Client"'
-  new_in: null
+  default_value: Reboot by Chef Infra Client
   description_list:
   - markdown: A string that describes the reboot action.
-properties_shortcode: null
-properties_multiple_packages: false
-resource_directory_recursive_directories: false
-resources_common_atomic_update: false
-properties_resources_common_windows_security: false
-remote_file_prevent_re_downloads: false
-remote_file_unc_path: false
-ps_credential_helper: false
-ruby_style_basics_chef_log: false
-debug_recipes_chef_shell: false
-template_requirements: false
-resources_common_properties: true
-resources_common_notification: true
-resources_common_guards: true
-common_resource_functionality_multiple_packages: false
-resources_common_guard_interpreter: false
-remote_directory_recursive_directories: false
-common_resource_functionality_resources_common_windows_security: false
-handler_custom: false
-cookbook_file_specificity: false
-unit_file_verification: false
 examples: "
   Reboot a node immediately\n\n  ``` ruby\n  reboot 'now' do\n    action\
   \ :nothing\n    reason 'Cannot continue Chef run without a reboot.'\n    delay_mins\

--- a/content/resources/registry_key/_index.md
+++ b/content/resources/registry_key/_index.md
@@ -1,21 +1,19 @@
 ---
+resource_reference: true
+properties_shortcode: 
+registry_key: true
 title: registry_key resource
 resource: registry_key
-draft: false
 aliases:
-- /resource_registry_key.html
+- "/resource_registry_key.html"
 menu:
   infra:
     title: registry_key
     identifier: chef_infra/cookbook_reference/resources/registry_key registry_key
     parent: chef_infra/cookbook_reference/resources
-resource_reference: true
-robots: null
 resource_description_list:
-- markdown: 'Use the **registry_key** resource to create and delete registry keys
-    in
-
-    Microsoft Windows.'
+- markdown: Use the **registry_key** resource to create and delete registry keys in
+    Microsoft Windows.
 - note:
     markdown: '64-bit versions of Microsoft Windows have a 32-bit compatibility layer
 
@@ -51,8 +49,6 @@ resource_description_list:
       For more information, see: [Registry
 
       Reflection](https://msdn.microsoft.com/en-us/library/windows/desktop/aa384235(v=vs.85).aspx).'
-resource_new_in: null
-handler_types: false
 syntax_description: "A **registry_key** resource block creates and deletes registry\
   \ keys in\nMicrosoft Windows:\n\n``` ruby\nregistry_key 'HKEY_LOCAL_MACHINE\\\\\
   ...\\\\System' do\n  values [{\n    name: 'NewRegistryKeyValue',\n    type: :multi_string,\n\
@@ -165,8 +161,8 @@ properties_list:
 - property: architecture
   ruby_type: Symbol
   required: false
-  default_value: :machine
-  new_in: null
+  default_value: ":machine"
+  allowed_values: ":i386, :machine, :x86_64"
   description_list:
   - markdown: 'The architecture of the node for which keys are to be created or
 

--- a/content/resources/remote_directory/_index.md
+++ b/content/resources/remote_directory/_index.md
@@ -1,16 +1,21 @@
 ---
+resource_reference: true
+common_resource_functionality_resources_common_windows_security: true
+properties_shortcode: 
+remote_directory_recursive_directories: true
+resource_directory_recursive_directories: true
+resources_common_guards: true
+resources_common_notification: true
+resources_common_properties: true
 title: remote_directory resource
 resource: remote_directory
-draft: false
 aliases:
-- /resource_remote_directory.html
+- "/resource_remote_directory.html"
 menu:
   infra:
     title: remote_directory
     identifier: chef_infra/cookbook_reference/resources/remote_directory remote_directory
     parent: chef_infra/cookbook_reference/resources
-resource_reference: true
-robots: null
 resource_description_list:
 - markdown: 'Use the **remote_directory** resource to incrementally transfer a
 
@@ -21,8 +26,6 @@ resource_description_list:
     `COOKBOOK_NAME/files/default/REMOTE_DIRECTORY`. The
 
     **remote_directory** resource will obey file specificity.'
-resource_new_in: null
-handler_types: false
 syntax_description: "A **remote_directory** resource block transfers a directory from\
   \ a\ncookbook to a node, and then assigns the permissions needed on that\ndirectory.\
   \ For example:\n\n``` ruby\nremote_directory '/etc/apache2' do\n  source 'apache2'\n\
@@ -45,18 +48,13 @@ syntax_full_code_block: "remote_directory 'name' do\n  cookbook                 
   \  rights                     Hash\n  source                     String\n  action\
   \                     Symbol # defaults to :create if not specified\nend"
 syntax_full_properties_list:
-- '`remote_directory` is the resource.'
-- '`name` is the name given to the resource block.'
-- '`action` identifies which steps Chef Infra Client will take to bring the node into
-  the desired state.'
-- '`cookbook`, `files_backup`, `files_group`, `files_mode`, `files_owner`, `group`,
+- "`remote_directory` is the resource."
+- "`name` is the name given to the resource block."
+- "`action` identifies which steps Chef Infra Client will take to bring the node into
+  the desired state."
+- "`cookbook`, `files_backup`, `files_group`, `files_mode`, `files_owner`, `group`,
   `mode`, `overwrite`, `owner`, `path`, `purge`, `recursive`, and `source` are the
-  properties available to this resource.'
-syntax_shortcode: null
-registry_key: false
-nameless_apt_update: false
-nameless_build_essential: false
-resource_package_options: false
+  properties available to this resource."
 actions_list:
   :create:
     markdown: Default. Create a directory and/or the contents of that directory. If
@@ -73,24 +71,18 @@ properties_list:
 - property: cookbook
   ruby_type: String
   required: false
-  default_value: null
-  new_in: null
   description_list:
-  - markdown: 'The cookbook in which a file is located (if it is not located in the
-
-      current cookbook). The default value is the current cookbook.'
+  - markdown: The cookbook in which a file is located (if it is not located in the
+      current cookbook). The default value is the current cookbook.
 - property: files_backup
   ruby_type: Integer, false
   required: false
   default_value: '5'
-  new_in: null
   description_list:
   - markdown: The number of backup copies to keep for files in the directory.
 - property: files_group
   ruby_type: String, Integer
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: 'Configure group permissions for files. A string or ID that
 
@@ -105,7 +97,6 @@ properties_list:
   ruby_type: String, Integer
   required: false
   default_value: 0644 on *nix systems
-  new_in: null
   description_list:
   - markdown: 'The octal mode for a file.
 
@@ -149,8 +140,6 @@ properties_list:
 - property: files_owner
   ruby_type: String, Integer
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: 'Configure owner permissions for files. A string or ID that
 

--- a/content/resources/remote_file/_index.md
+++ b/content/resources/remote_file/_index.md
@@ -1,16 +1,19 @@
 ---
+resource_reference: true
+properties_resources_common_windows_security: true
+properties_shortcode: 
+remote_file_prevent_re_downloads: true
+remote_file_unc_path: true
+resources_common_atomic_update: true
 title: remote_file resource
 resource: remote_file
-draft: false
 aliases:
-- /resource_remote_file.html
+- "/resource_remote_file.html"
 menu:
   infra:
     title: remote_file
     identifier: chef_infra/cookbook_reference/resources/remote_file remote_file
     parent: chef_infra/cookbook_reference/resources
-resource_reference: true
-robots: null
 resource_description_list:
 - markdown: 'Use the **remote_file** resource to transfer a file from a remote
 
@@ -22,8 +25,6 @@ resource_description_list:
       done
 
       with the **cookbook_file** resource.'
-resource_new_in: null
-handler_types: false
 syntax_description: "A **remote_file** resource block manages files by using files\
   \ that\nexist remotely. For example, to write the home page for an Apache\nwebsite:\n\
   \n``` ruby\nremote_file '/var/www/customers/public_html/index.html' do\n  source\
@@ -56,20 +57,14 @@ syntax_full_code_block: "remote_file 'name' do\n  atomic_update              tru
   \     Array\n  action                     Symbol # defaults to :create if not specified\n\
   end"
 syntax_full_properties_list:
-- '`remote_file` is the resource.'
-- '`name` is the name given to the resource block.'
-- '`action` identifies which steps Chef Infra Client will take to bring the node into
-  the desired state.'
-- '`atomic_update`, `authentication`, `backup`, `checksum`, `content`, `diff`, `force_unlink`,
+- "`remote_file` is the resource."
+- "`name` is the name given to the resource block."
+- "`action` identifies which steps Chef Infra Client will take to bring the node into
+  the desired state."
+- "`atomic_update`, `authentication`, `backup`, `checksum`, `content`, `force_unlink`,
   `ftp_active_mode`, `group`, `headers`, `manage_symlink_source`, `mode`, `owner`,
   `path`, `remote_domain`, `remote_password`, `remote_user`, `show_progress`, `use_etag`,
-  `use_last_modified`, `sensitive`, and `verifications` are the properties available
-  to this resource.'
-syntax_shortcode: null
-registry_key: false
-nameless_apt_update: false
-nameless_build_essential: false
-resource_package_options: false
+  `use_last_modified`, and `verifications` are the properties available to this resource."
 actions_list:
   :create:
     markdown: Default. Create a file. If a file already exists (but does not match),
@@ -89,34 +84,25 @@ properties_list:
 - property: atomic_update
   ruby_type: true, false
   required: false
-  default_value: null
-  new_in: null
+  default_value: False if modifying /etc/hosts, /etc/hostname, or /etc/resolv.conf
+    within Docker containers. Otherwise default to the client.rb 'file_atomic_update'
+    config value.
   description_list:
-  - markdown: 'Perform atomic file updates on a per-resource basis. Set to `true`
-
-      for atomic file updates. Set to `false` for non-atomic file updates.
-
-      This setting overrides `file_atomic_update`, which is a global
-
-      setting found in the client.rb file.'
+  - markdown: Perform atomic file updates on a per-resource basis. Set to true for
+      atomic file updates. Set to false for non-atomic file updates. This setting
+      overrides `file_atomic_update`, which is a global setting found in the `client.rb`
+      file.
 - property: backup
   ruby_type: Integer, false
   required: false
   default_value: '5'
-  new_in: null
   description_list:
-  - markdown: 'The number of backups to be kept in `/var/chef/backup` (for UNIX-
-
-      and Linux-based platforms) or `C:/chef/backup` (for the Microsoft
-
-      Windows platform). Set to `false` to prevent backups from being
-
-      kept.'
+  - markdown: The number of backups to be kept in `/var/chef/backup` (for UNIX- and
+      Linux-based platforms) or `C:/chef/backup` (for the Microsoft Windows platform).
+      Set to `false` to prevent backups from being kept.
 - property: checksum
   ruby_type: String
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: 'Optional, see `use_conditional_get`. The SHA-256 checksum of the
 
@@ -127,7 +113,6 @@ properties_list:
   ruby_type: true, false
   required: false
   default_value: 'false'
-  new_in: null
   description_list:
   - markdown: 'How Chef Infra Client handles certain situations when the target
 
@@ -142,7 +127,6 @@ properties_list:
   ruby_type: true, false
   required: false
   default_value: 'false'
-  new_in: null
   description_list:
   - markdown: 'Whether Chef Infra Client uses active or passive FTP. Set to `true`
 

--- a/content/resources/rhsm_errata/_index.md
+++ b/content/resources/rhsm_errata/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/rhsm_errata_level/_index.md
+++ b/content/resources/rhsm_errata_level/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/rhsm_register/_index.md
+++ b/content/resources/rhsm_register/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/rhsm_repo/_index.md
+++ b/content/resources/rhsm_repo/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/rhsm_subscription/_index.md
+++ b/content/resources/rhsm_subscription/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/route/_index.md
+++ b/content/resources/route/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -22,11 +21,11 @@ syntax_description: "A **route** resource block manages the system routing table
   \  device 'eth1'\nend\n```"
 syntax_full_code_block: |-
   route 'name' do
-    comment         String, nil
-    device          String, nil
-    gateway         String, nil
-    metric          Integer, nil
-    netmask         String, nil
+    comment         String
+    device          String
+    gateway         String
+    metric          Integer
+    netmask         String
     route_type      Symbol, String # default value: :host
     target          String # default value: 'name' unless specified
     action          Symbol # defaults to :add if not specified

--- a/content/resources/rpm_package/_index.md
+++ b/content/resources/rpm_package/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -17,7 +16,6 @@ menu:
 resource_description_list:
 - markdown: Use the **rpm_package** resource to manage packages using the RPM Package
     Manager.
-resource_new_in: 
 syntax_full_code_block: |-
   rpm_package 'name' do
     allow_downgrade      true, false # default value: true

--- a/content/resources/ruby/_index.md
+++ b/content/resources/ruby/_index.md
@@ -1,17 +1,16 @@
 ---
+resource_reference: true
+properties_shortcode: 
+resources_common_guards: true
 title: ruby resource
 resource: ruby
-draft: false
 aliases:
-- /resource_ruby.html
+- "/resource_ruby.html"
 menu:
   infra:
     title: ruby
     identifier: chef_infra/cookbook_reference/resources/ruby ruby
     parent: chef_infra/cookbook_reference/resources
-
-resource_reference: true
-robots: null
 resource_description_list:
 - markdown: 'Use the **ruby** resource to execute scripts using the Ruby interpreter.
 
@@ -73,31 +72,21 @@ properties_list:
 - property: code
   ruby_type: String
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: A quoted (" ") string of code to be executed.
 - property: creates
   ruby_type: String
   required: false
-  default_value: null
-  new_in: null
   description_list:
-  - markdown: 'Prevent a command from creating a file when that file already
-
-      exists.'
+  - markdown: Prevent a command from creating a file when that file already exists.
 - property: cwd
   ruby_type: String
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: The current working directory.
 - property: environment
   ruby_type: Hash
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: 'A Hash of environment variables in the form of
 
@@ -107,8 +96,6 @@ properties_list:
 - property: flags
   ruby_type: String
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: 'One or more command line flags that are passed to the interpreter
 
@@ -116,8 +103,6 @@ properties_list:
 - property: group
   ruby_type: String, Integer
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: 'The group name or group ID that must be changed before running a
 
@@ -126,14 +111,11 @@ properties_list:
   ruby_type: true, false
   required: false
   default_value: 'false'
-  new_in: null
   description_list:
   - markdown: Continue running a recipe if a resource fails for any reason.
 - property: notifies
   ruby_type: Symbol, Chef::Resource\[String\]
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - shortcode: resources_common_notification_notifies.md
   - markdown: ''
@@ -143,8 +125,6 @@ properties_list:
 - property: path
   ruby_type: Array
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: 'An array of paths to use when searching for a command. These paths
 

--- a/content/resources/ruby_block/_index.md
+++ b/content/resources/ruby_block/_index.md
@@ -1,7 +1,8 @@
 ---
+resource_reference: true
+properties_shortcode: 
 title: ruby_block resource
 resource: ruby_block
-draft: false
 aliases:
 - /resource_ruby_block.html
 menu:
@@ -9,8 +10,6 @@ menu:
     title: ruby_block
     identifier: chef_infra/cookbook_reference/resources/ruby_block ruby_block
     parent: chef_infra/cookbook_reference/resources
-resource_reference: true
-robots: null
 resource_description_list:
 - markdown: 'Use the **ruby_block** resource to execute Ruby code during a Chef
 

--- a/content/resources/service/_index.md
+++ b/content/resources/service/_index.md
@@ -1,7 +1,11 @@
 ---
+resource_reference: true
+properties_shortcode: 
+resources_common_guards: true
+resources_common_notification: true
+resources_common_properties: true
 title: service resource
 resource: service
-draft: false
 aliases:
 - "/resource_service.html"
 menu:
@@ -9,27 +13,24 @@ menu:
     title: service
     identifier: chef_infra/cookbook_reference/resources/service service
     parent: chef_infra/cookbook_reference/resources
-resource_reference: true
-robots: null
 resource_description_list:
 - markdown: Use the **service** resource to manage a service.
-resource_new_in:
-handler_types: false
 syntax_full_code_block: |-
   service 'name' do
     init_command         String
     options              Array, String
     parameters           Hash
-    pattern              String # default value: "The value provided to 'service_name' or the resource block's name"
+    pattern              String
     priority             Integer, String, Hash
-    reload_command       String, nil, false
-    restart_command      String, nil, false
+    reload_command       String, false
+    restart_command      String, false
     run_levels           Array
     service_name         String # default value: 'name' unless specified
-    start_command        String, nil, false
-    status_command       String, nil, false
-    stop_command         String, nil, false
+    start_command        String, false
+    status_command       String, false
+    stop_command         String, false
     supports             Hash # default value: {"restart"=>nil, "reload"=>nil, "status"=>nil}
+    timeout              Integer # default value: 900
     user                 String
     action               Symbol # defaults to :nothing if not specified
   end
@@ -39,15 +40,10 @@ syntax_full_properties_list:
 - "`name` is the name given to the resource block."
 - "`action` identifies which steps Chef Infra Client will take to bring the node into
   the desired state."
-- "``init_command``, ``options``, ``parameters``, ``pattern``, ``priority``, ``reload_command``,
-  ``restart_command``, ``run_levels``, ``service_name``, ``start_command``, ``status_command``,
-  ``stop_command``, ``supports``, and ``user`` are the properties available to this
-  resource."
-syntax_shortcode: null
-registry_key: false
-nameless_apt_update: false
-nameless_build_essential: false
-resource_package_options: false
+- "`init_command`, `options`, `parameters`, `pattern`, `priority`, `reload_command`,
+  `restart_command`, `run_levels`, `service_name`, `start_command`, `status_command`,
+  `stop_command`, `supports`, `timeout`, and `user` are the properties available to
+  this resource."
 actions_list:
   :disable:
     markdown: Disable a service. This action is equivalent to a `Disabled` startup
@@ -62,7 +58,7 @@ actions_list:
       Resource Controller (SRC) does not have a standard mechanism for enabling and
       disabling services on system boot.
   :nothing:
-    markdown: Default. Do nothing with a service.
+    shortcode: resources_common_actions_nothing.md
   :reload:
     markdown: Reload the configuration for this service.
   :restart:
@@ -75,8 +71,6 @@ properties_list:
 - property: init_command
   ruby_type: String
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: 'The path to the init script that is associated with the service. Use
 
@@ -90,8 +84,6 @@ properties_list:
 - property: options
   ruby_type: Array, String
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: 'Solaris platform only. Options to pass to the service command. See
 
@@ -99,24 +91,18 @@ properties_list:
 - property: parameters
   ruby_type: Hash
   required: false
-  default_value: null
-  new_in: null
   description_list:
-  - markdown: 'Upstart only: A hash of parameters to pass to the service command
-
-      for use in the service definition.'
+  - markdown: 'Upstart only: A hash of parameters to pass to the service command for
+      use in the service definition.'
 - property: pattern
   ruby_type: String
   required: false
   default_value: The value provided to 'service_name' or the resource block's name
-  new_in: null
   description_list:
   - markdown: The pattern to look for in the process table.
 - property: priority
   ruby_type: Integer, String, Hash
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: 'Debian platform only. The relative priority of the program for start
 
@@ -134,61 +120,44 @@ properties_list:
 - property: reload_command
   ruby_type: String, false
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: The command used to tell a service to reload its configuration.
 - property: restart_command
   ruby_type: String, false
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: The command used to restart a service.
 - property: run_levels
   ruby_type: Array
   required: false
-  default_value: null
-  new_in: null
   description_list:
-  - markdown: 'RHEL platforms only: Specific run_levels the service will run
-
-      under.'
+  - markdown: 'RHEL platforms only: Specific run_levels the service will run under.'
 - property: service_name
   ruby_type: String
   required: false
   default_value: The resource block's name
-  new_in: null
   description_list:
-  - markdown: 'An optional property to set the service name if it differs from the
-
-      resource block''s name.'
+  - markdown: An optional property to set the service name if it differs from the
+      resource block's name.
 - property: start_command
-  ruby_type: String
+  ruby_type: String, false
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: The command used to start a service.
 - property: status_command
-  ruby_type: String
+  ruby_type: String, false
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: The command used to check the run status for a service.
 - property: stop_command
-  ruby_type: String
+  ruby_type: String, false
   required: false
-  default_value: null
-  new_in: null
   description_list:
   - markdown: The command used to stop a service.
 - property: supports
   ruby_type: Hash
   required: false
   default_value: '{"restart" => nil, "reload" => nil, "status" => nil}'
-  new_in: null
   description_list:
   - markdown: 'A list of properties that controls how Chef Infra Client is to
 
@@ -220,40 +189,15 @@ properties_list:
 - property: timeout
   ruby_type: Integer
   required: false
-  default_value: '60'
-  new_in: null
+  default_value: '900'
   description_list:
-  - markdown: 'Microsoft Windows platform only. The amount of time (in seconds) to
-
-      wait before timing out.'
+  - markdown: The amount of time (in seconds) to wait before timing out.
 - property: user
   ruby_type: String
   required: false
-  default_value: null
   new_in: '12.21'
   description_list:
   - markdown: 'systemd only: A username to run the service under.'
-properties_shortcode: null
-properties_multiple_packages: false
-resource_directory_recursive_directories: false
-resources_common_atomic_update: false
-properties_resources_common_windows_security: false
-remote_file_prevent_re_downloads: false
-remote_file_unc_path: false
-ps_credential_helper: false
-ruby_style_basics_chef_log: false
-debug_recipes_chef_shell: false
-template_requirements: false
-resources_common_properties: true
-resources_common_notification: true
-resources_common_guards: true
-common_resource_functionality_multiple_packages: false
-resources_common_guard_interpreter: false
-remote_directory_recursive_directories: false
-common_resource_functionality_resources_common_windows_security: false
-handler_custom: false
-cookbook_file_specificity: false
-unit_file_verification: false
 examples: "
   Start a service\n\n  ``` ruby\n  service 'example_service' do\n \
   \   action :start\n  end\n  ```\n\n  Start a service, enable it\n\n  ``` ruby\n\

--- a/content/resources/smartos_package/_index.md
+++ b/content/resources/smartos_package/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -18,7 +17,6 @@ menu:
 resource_description_list:
 - markdown: Use the **smartos_package** resource to manage packages for the SmartOS
     platform.
-resource_new_in: 
 syntax_full_code_block: |-
   smartos_package 'name' do
     options           String, Array

--- a/content/resources/snap_package/_index.md
+++ b/content/resources/snap_package/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -90,5 +89,4 @@ properties_list:
   description_list:
   - markdown: The version of a package to be installed or upgraded.
 examples: 
-
 ---

--- a/content/resources/solaris_package/_index.md
+++ b/content/resources/solaris_package/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -18,7 +17,6 @@ menu:
 resource_description_list:
 - markdown: Use the **solaris_package** resource to manage packages on the Solaris
     platform.
-resource_new_in: 
 syntax_full_code_block: |-
   solaris_package 'name' do
     options           String, Array

--- a/content/resources/ssh_known_hosts_entry/_index.md
+++ b/content/resources/ssh_known_hosts_entry/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/subversion/_index.md
+++ b/content/resources/subversion/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -30,13 +29,13 @@ resource_new_in:
 syntax_full_code_block: |-
   subversion 'name' do
     destination        String # default value: 'name' unless specified
-    environment        Hash, nil
+    environment        Hash
     group              String, Integer
     repository         String
     revision           String # default value: "HEAD"
-    svn_arguments      String, nil, false # default value: "--no-auth-cache"
+    svn_arguments      String, false # default value: "--no-auth-cache"
     svn_binary         String
-    svn_info_args      String, nil, false # default value: "--no-auth-cache"
+    svn_info_args      String, false # default value: "--no-auth-cache"
     svn_password       String
     svn_username       String
     timeout            Integer
@@ -77,7 +76,7 @@ properties_list:
   - markdown: 'The location path to which the source is to be cloned, checked out,
       or exported. Default value: the name of the resource block.'
 - property: environment
-  ruby_type: Hash, nil
+  ruby_type: Hash
   required: false
   description_list:
   - markdown: A Hash of environment variables in the form of ({'ENV_VARIABLE' => 'VALUE'}).
@@ -113,7 +112,7 @@ properties_list:
   description_list:
   - markdown: The location of the svn binary.
 - property: svn_info_args
-  ruby_type: String, nil, false
+  ruby_type: String, false
   required: false
   default_value: "--no-auth-cache"
   description_list:

--- a/content/resources/sudo/_index.md
+++ b/content/resources/sudo/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -44,7 +43,7 @@ syntax_full_code_block: |-
     setenv                 true, false # default value: false
     template               String
     users                  String, Array
-    variables              Hash, nil
+    variables              Hash
     visudo_binary          String # default value: "/usr/sbin/visudo"
     action                 Symbol # defaults to :create if not specified
   end

--- a/content/resources/swap_file/_index.md
+++ b/content/resources/swap_file/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/sysctl/_index.md
+++ b/content/resources/sysctl/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -48,10 +47,10 @@ syntax_full_properties_list:
 actions_list:
   :apply:
     markdown: Default. Set the kernel parameter and update the `sysctl` settings.
-  :remove:
-    markdown: Remove the kernel parameter and update the `sysctl` settings.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :remove:
+    markdown: Remove the kernel parameter and update the `sysctl` settings.
 properties_list:
 - property: comment
   ruby_type: Array, String
@@ -85,20 +84,62 @@ properties_list:
   required: true
   description_list:
   - markdown: The value to set.
-examples: "
-  Set vm.swappiness\n\n  ``` ruby\n  sysctl 'vm.swappiness' do\n  \
-  \  value 19\n  end\n  ```\n\n  Remove kernel.msgmax\n\n  Note: This only removes\
-  \ the sysctl.d config for kernel.msgmax. The value\n  will be set back to the kernel\
-  \ default value.\n\n  ``` ruby\n  sysctl 'kernel.msgmax' do\n    action :remove\n\
-  \  end\n  ```\n\n  Adding Comments to sysctl configuration files\n\n  ``` ruby\n\
-  \  sysctl 'vm.swappiness' do\n    value 19\n    comment \"define how aggressively\
-  \ the kernel will swap memory pages.\"\n  end\n  ```\n\n  This produces /etc/sysctl.d/99-chef-vm.swappiness.conf\
-  \ as follows:\n\n  ``` none\n  # define how aggressively the kernel will swap memory\
-  \ pages.\n  vm.swappiness = 1\n  ```\n\n  Converting sysctl settings from shell\
-  \ scripts\n\n  Example of existing settings:\n\n  `fs.aio-max-nr = 1048576` `net.ipv4.ip_local_port_range\
-  \ = 9000 65500`\n  `kernel.sem = 250 32000 100 128`\n\n  Converted to sysctl resources:\n\
-  \n  ``` ruby\n  sysctl 'fs.aio-max-nr' do\n    value '1048576'\n  end\n\n  sysctl\
-  \ 'net.ipv4.ip_local_port_range' do\n    value '9000 65500'\n  end\n\n  sysctl 'kernel.sem'\
-  \ do\n    value '250 32000 100 128'\n  end\n  ```\n"
+examples: |
+  **Set vm.swappiness**:
 
+  ```ruby
+  sysctl 'vm.swappiness' do
+    value 19
+  end
+  ```
+
+  **Remove kernel.msgmax**:
+
+  **Note**: This only removes the sysctl.d config for kernel.msgmax. The value will be set back to the kernel default value.
+
+  ```ruby
+  sysctl 'kernel.msgmax' do
+    action :remove
+  end
+  ```
+
+  **Adding Comments to sysctl configuration files**:
+
+  ```ruby
+  sysctl 'vm.swappiness' do
+    value 19
+    comment "define how aggressively the kernel will swap memory pages."
+  end
+  ```
+
+  This produces /etc/sysctl.d/99-chef-vm.swappiness.conf as follows:
+
+  ```
+  # define how aggressively the kernel will swap memory pages.
+  vm.swappiness = 1
+  ```
+
+  **Converting sysctl settings from shell scripts**:
+
+  Example of existing settings:
+
+  ```bash
+  fs.aio-max-nr = 1048576 net.ipv4.ip_local_port_range = 9000 65500 kernel.sem = 250 32000 100 128
+  ```
+
+  Converted to sysctl resources:
+
+  ```ruby
+  sysctl 'fs.aio-max-nr' do
+    value '1048576'
+  end
+
+  sysctl 'net.ipv4.ip_local_port_range' do
+    value '9000 65500'
+  end
+
+  sysctl 'kernel.sem' do
+    value '250 32000 100 128'
+  end
+  ```
 ---

--- a/content/resources/systemd_unit/_index.md
+++ b/content/resources/systemd_unit/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/template/_index.md
+++ b/content/resources/template/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_resources_common_windows_security: true
 properties_shortcode: 
 resources_common_atomic_update: true

--- a/content/resources/timezone/_index.md
+++ b/content/resources/timezone/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -38,10 +37,10 @@ syntax_full_properties_list:
   the desired state."
 - "`timezone` is the property available to this resource."
 actions_list:
-  :set:
-    markdown: Set the system timezone.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :set:
+    markdown: Set the system timezone.
 properties_list:
 - property: timezone
   ruby_type: String

--- a/content/resources/user_ulimit/_index.md
+++ b/content/resources/user_ulimit/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_ad_join/_index.md
+++ b/content/resources/windows_ad_join/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_auto_run/_index.md
+++ b/content/resources/windows_auto_run/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -36,10 +35,10 @@ syntax_full_properties_list:
 actions_list:
   :create:
     markdown: Create an item to be run at login.
-  :remove:
-    markdown: Remover an item that was previously configured to run at login.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :remove:
+    markdown: Remover an item that was previously configured to run at login.
 properties_list:
 - property: args
   ruby_type: String

--- a/content/resources/windows_certificate/_index.md
+++ b/content/resources/windows_certificate/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_dfs_folder/_index.md
+++ b/content/resources/windows_dfs_folder/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -35,10 +34,10 @@ syntax_full_properties_list:
 - "`description`, `folder_path`, `namespace_name`, and `target_path` are the properties
   available to this resource."
 actions_list:
-  :delete:
-    markdown: Deletes the folder in the dfs namespace.
   :create:
     markdown: Creates the folder in dfs namespace. Default.
+  :delete:
+    markdown: Deletes the folder in the dfs namespace.
   :nothing:
     shortcode: resources_common_actions_nothing.md
 properties_list:

--- a/content/resources/windows_dfs_namespace/_index.md
+++ b/content/resources/windows_dfs_namespace/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -81,5 +80,4 @@ properties_list:
   description_list:
   - markdown: The root from which to create the DFS tree. Defaults to C:\DFSRoots.
 examples: 
-
 ---

--- a/content/resources/windows_dfs_server/_index.md
+++ b/content/resources/windows_dfs_server/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -65,12 +64,8 @@ properties_list:
   required: false
   default_value: 'false'
   description_list:
-  - markdown: 'Indicates whether a DFS namespace server uses FQDNs in referrals. If
-
-      this parameter has a value of true, the server uses FQDNs in
-
-      referrals. If this parameter has a value of false, the server uses
-
-      NetBIOS names.'
-
+  - markdown: Indicates whether a DFS namespace server uses FQDNs in referrals. If
+      this property is set to true, the server uses FQDNs in referrals. If this property
+      is set to false then the server uses NetBIOS names.
+examples: 
 ---

--- a/content/resources/windows_dns_record/_index.md
+++ b/content/resources/windows_dns_record/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -66,5 +65,4 @@ properties_list:
   description_list:
   - markdown: The zone to create the record in.
 examples: 
-
 ---

--- a/content/resources/windows_dns_zone/_index.md
+++ b/content/resources/windows_dns_zone/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -59,30 +58,7 @@ properties_list:
   required: false
   default_value: The resource block's name
   description_list:
-  - markdown: 'An optional property to set the dns zone name if it differs from the
-
-      resource block''s name.'
-properties_shortcode: null
-properties_multiple_packages: false
-resource_directory_recursive_directories: false
-resources_common_atomic_update: false
-properties_resources_common_windows_security: false
-remote_file_prevent_re_downloads: false
-remote_file_unc_path: false
-ps_credential_helper: false
-ruby_style_basics_chef_log: false
-debug_recipes_chef_shell: false
-template_requirements: false
-resources_common_properties: true
-resources_common_notification: true
-resources_common_guards: true
-common_resource_functionality_multiple_packages: false
-resources_common_guard_interpreter: false
-remote_directory_recursive_directories: false
-common_resource_functionality_resources_common_windows_security: false
-handler_custom: false
-cookbook_file_specificity: false
-unit_file_verification: false
-examples_list: null
-
+  - markdown: An optional property to set the dns zone name if it differs from the
+      resource block's name.
+examples: 
 ---

--- a/content/resources/windows_env/_index.md
+++ b/content/resources/windows_env/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -41,7 +40,7 @@ resource_description_list:
       the same permanent effect as using the **windows_env** resource.'
 syntax_full_code_block: |-
   windows_env 'name' do
-    delim         String, nil, false
+    delim         String, false
     key_name      String # default value: 'name' unless specified
     user          String # default value: "<System>"
     value         String

--- a/content/resources/windows_feature/_index.md
+++ b/content/resources/windows_feature/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_feature_dism/_index.md
+++ b/content/resources/windows_feature_dism/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -39,10 +38,10 @@ actions_list:
     markdown: Delete a Windows role / feature from the image using DISM.
   :install:
     markdown: Default. Install a Windows role / feature using DISM.
-  :remove:
-    markdown: Remove a Windows role / feature using DISM.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :remove:
+    markdown: Remove a Windows role / feature using DISM.
 properties_list:
 - property: all
   ruby_type: true, false

--- a/content/resources/windows_feature_powershell/_index.md
+++ b/content/resources/windows_feature_powershell/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_firewall_rule/_index.md
+++ b/content/resources/windows_firewall_rule/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_font/_index.md
+++ b/content/resources/windows_font/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_package/_index.md
+++ b/content/resources/windows_package/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -45,7 +44,7 @@ syntax_full_code_block: |-
     options                     String
     package_name                String
     remote_file_attributes      Hash
-    returns                     String, Integer, Array # default value: "0 (success) and 3010 (success where a reboot is necessary)"
+    returns                     String, Integer, Array
     source                      String # default value: "The resource block's name"
     timeout                     String, Integer # default value: "600 (seconds)"
     version                     String

--- a/content/resources/windows_path/_index.md
+++ b/content/resources/windows_path/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_printer/_index.md
+++ b/content/resources/windows_printer/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_printer_port/_index.md
+++ b/content/resources/windows_printer_port/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_security_policy/_index.md
+++ b/content/resources/windows_security_policy/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -41,6 +40,10 @@ properties_list:
   ruby_type: String
   required: true
   default_value: The resource block's name
+  allowed_values: '"ClearTextPassword", "EnableAdminAccount", "EnableGuestAccount",
+    "ForceLogoffWhenHourExpire", "LSAAnonymousNameLookup", "LockoutBadCount", "MaximumPasswordAge",
+    "MinimumPasswordAge", "MinimumPasswordLength", "NewAdministratorName", "NewGuestName",
+    "PasswordComplexity", "PasswordHistorySize", "RequireLogonToChangePassword"'
   description_list:
   - markdown: The name of the policy to be set on windows platform to maintain its
       security.

--- a/content/resources/windows_service/_index.md
+++ b/content/resources/windows_service/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_share/_index.md
+++ b/content/resources/windows_share/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_shortcut/_index.md
+++ b/content/resources/windows_shortcut/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_task/_index.md
+++ b/content/resources/windows_task/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_uac/_index.md
+++ b/content/resources/windows_uac/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_user_privilege/_index.md
+++ b/content/resources/windows_user_privilege/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/windows_workgroup/_index.md
+++ b/content/resources/windows_workgroup/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true

--- a/content/resources/yum_package/_index.md
+++ b/content/resources/yum_package/_index.md
@@ -28,8 +28,6 @@ resource_description_list:
       `yum_package "/bin/sh"`) is not available because the volume of data
 
       required to parse for this is excessive.'
-- notes_resource_based_on_package: true
-resource_new_in:
 syntax_full_code_block: |-
   yum_package 'name' do
     allow_downgrade      true, false # default value: true
@@ -75,7 +73,7 @@ properties_list:
   required: false
   default_value: 'true'
   description_list:
-  - markdown: Downgrade a package to satisfy requested version requirements.
+  - markdown: Allow downgrading a package to satisfy requested version requirements.
 - property: arch
   ruby_type: String, Array
   required: false

--- a/content/resources/yum_repository/_index.md
+++ b/content/resources/yum_repository/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true
@@ -137,6 +136,7 @@ properties_list:
 - property: failovermethod
   ruby_type: String
   required: false
+  allowed_values: '"priority", "roundrobin"'
   description_list:
   - markdown: Method to determine how to switch to a new server if the current one
       fails, which can either be `roundrobin` or `priority`. `roundrobin` randomly

--- a/content/resources/zypper_package/_index.md
+++ b/content/resources/zypper_package/_index.md
@@ -19,7 +19,6 @@ menu:
 resource_description_list:
 - markdown: Use the **zypper_package** resource to install, upgrade, and remove packages
     with Zypper for the SUSE Enterprise and openSUSE platforms.
-resource_new_in:
 syntax_full_code_block: |-
   zypper_package 'name' do
     allow_downgrade      true, false # default value: true

--- a/content/resources/zypper_repository/_index.md
+++ b/content/resources/zypper_repository/_index.md
@@ -1,6 +1,5 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: false
 properties_shortcode: 
 resources_common_guards: true
 resources_common_notification: true


### PR DESCRIPTION
Update sysctl examples to work with Chef Infra Client 16
Adds some equal_to values
Removes nil types
Adds a missing property
Fixes the timeout description and value in service
Cleans up markdown formatting
Removes a bunch of default yaml hugo config
Remove a very long default value in the block example
Shuffle things for easier diffs