### PR TITLE
Fix expeditor command

### DIFF
--- a/.expeditor/update_hugo_modules.sh
+++ b/.expeditor/update_hugo_modules.sh
@@ -41,7 +41,7 @@ git add .
 # audit of our codebase that no DCO sign-off is needed for this sort of PR since
 #it contains no intellectual property
 
-dco_safe_commit "Bump Hugo module $EXPEDITOR_PRODUCT_KEY to $EXPEDITOR_VERSION.
+dco_safe_git_commit "Bump Hugo module $EXPEDITOR_PRODUCT_KEY to $EXPEDITOR_VERSION.
 
 The new commit for $EXPEDITOR_PRODUCT_KEY is $EXPEDITOR_BUILD_COMMIT"
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

The correct command is `dco_safe_git_commit` not `dco_safe_commit`. 

### Definition of Done

### Issues Resolved

The expeditor shell script isn't updating hugo modules when workstation is promoted to stable.

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
