### PR TITLE
Update release notes for Chef Infra Server with 13.2 notes

### DIFF
--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -22,30 +22,50 @@ describes each registered node that is managed by the Chef Infra Client.
 
 ### Improvements
 
-- Azure support for external PostgreSQL In the previous release we added support for ssl while connecting to PostgreSQL. With this release we add the ability to be able to connect to external PostgreSQL database in Azure.
-- Update HAProxy configuration We have updated the configuration for HAProxy to make it more responsive. The changes include:
-    - Set connect, client, server, and tunnel timeouts to reasonable defaults.
-    - Set client-fin and server-fin to try to mitigate connection pile-ups in the case of failing frontend services.
-    - Set on-marked-down shutdown-session to avoid stale sessions to previous leaders living longer than they need to.
-- Integration testing pipeline We have put a lot of effort into creating a test pipeline with the test infrastructure previously created. This runs multiple scenarios for Chef Infra Server with different configurations and topologies.
-- Chef Infra Server supports Elasticsearch version 6 for external Elasticsearch Chef Infra Server previously supported index creation for ElasticSearch versions 2 and 5. We now support index creation for ElasticSearch 6 as well
-- Cookstyle changes applied to the cookbooks
+- Azure support for external PostgreSQL:
+
+  In the previous release we added support for ssl while connecting to PostgreSQL.
+
+  With this release we add the ability to connect to an external PostgreSQL database in Azure.
+
+- Update HAProxy configuration:
+
+  We have updated the configuration for HAProxy to make it more responsive. The changes include:
+  - Set the connect, client, server, and tunnel timeouts to reasonable defaults.
+  - Set client-fin and server-fin to try to mitigate connection pile-ups in the case of failing frontend services.
+  - Set on-marked-down shutdown-session to avoid stale sessions to previous leaders living longer than they need to.
+
+- Integration testing pipeline:
+
+  We have put a lot of effort into creating a test pipeline with the test infrastructure previously created. This runs multiple scenarios for Chef Infra Server with different configurations and topologies.
+
+- Chef Infra Server supports Elasticsearch version 6 for external Elasticsearch:
+
+  Chef Infra Server previously supported index creation for ElasticSearch versions 2 and 5. We now support index creation for ElasticSearch 6 as well.
+
+- Cookstyle changes applied to the cookbooks.
 - Disable actions rabbitmq queue by default.
 - Log all errors triggered due to Elasticsearch reindex.
 
 ### Bug Fixes
 
 - Fix a regression that broke FIPS 140-2 support in Chef Infra Server 13.1.13.
-- Fix habitat db config for external database
+- Fix habitat db config for external database.
 - Elasticsearch recipes should not create indexes at compile time.
 
 ### Updates
 
 - Chef Infra Client: 15.5.17 -> 15.8.23
 - rack(oc-chef-pedant): 2.0.7 -> 2.0.8
-- rack(oc-id): 1.6.11 to 1.6.12)
+- rack(oc-id): 1.6.11 -> 1.6.12
 - Ruby(oc-id): 1.6.11 -> 1.6.12
-- Ruby: 2.6.3 -> 2.6.5 (fixes the following CVEs CVE-2019-16255: A code injection vulnerability of Shell#[] and Shell#test CVE-2019-16254: HTTP response splitting in WEBrick (Additional fix) CVE-2019-15845: A NUL injection vulnerability of File.fnmatch and File.fnmatch? CVE-2019-16201: Regular Expression Denial of Service vulnerability of WEBrick's Digest access authentication CVE-2012-6708 CVE-2015-9251)
+- Ruby: 2.6.3 -> 2.6.5 fixes the following CVEs:
+  - CVE-2019-16255: A code injection vulnerability of Shell#[] and Shell#test
+  - CVE-2019-16254: HTTP response splitting in WEBrick (Additional fix)
+  - CVE-2019-15845: A NUL injection vulnerability of File.fnmatch and File.fnmatch?
+  - CVE-2019-16201: Regular Expression Denial of Service vulnerability of WEBrick's Digest access authentication
+  - CVE-2012-6708
+  - CVE-2015-9251
 - rubyzip(oc-id): 1.2.3 -> 1.3.0 (fixes CVE-2019-16892)
 - Erlang(habitat): 18 -> 20
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -1,5 +1,5 @@
 +++
-title = "Release Notes: Chef Infra Server 12.0 - 13.1.13"
+title = "Release Notes: Chef Infra Server 12.0 - 13.2"
 draft = false
 
 aliases = ["/release_notes_server.html"]
@@ -17,6 +17,37 @@ aliases = ["/release_notes_server.html"]
 Chef Infra Server acts as a hub for configuration data by storing
 cookbooks, the policies that are applied to nodes, and metadata that
 describes each registered node that is managed by the Chef Infra Client.
+
+## What's New in 13.2
+
+### Improvements
+
+- Azure support for external PostgreSQL In the previous release we added support for ssl while connecting to PostgreSQL. With this release we add the ability to be able to connect to external PostgreSQL database in Azure.
+- Update HAProxy configuration We have updated the configuration for HAProxy to make it more responsive. The changes include:
+    - Set connect, client, server, and tunnel timeouts to reasonable defaults.
+    - Set client-fin and server-fin to try to mitigate connection pile-ups in the case of failing frontend services.
+    - Set on-marked-down shutdown-session to avoid stale sessions to previous leaders living longer than they need to.
+- Integration testing pipeline We have put a lot of effort into creating a test pipeline with the test infrastructure previously created. This runs multiple scenarios for Chef Infra Server with different configurations and topologies.
+- Chef Infra Server supports Elasticsearch version 6 for external Elasticsearch Chef Infra Server previously supported index creation for ElasticSearch versions 2 and 5. We now support index creation for ElasticSearch 6 as well
+- Cookstyle changes applied to the cookbooks
+- Disable actions rabbitmq queue by default.
+- Log all errors triggered due to Elasticsearch reindex.
+
+### Bug Fixes
+
+- Fix a regression that broke FIPS 140-2 support in Chef Infra Server 13.1.13.
+- Fix habitat db config for external database
+- Elasticsearch recipes should not create indexes at compile time.
+
+### Updates
+
+- Chef Infra Client: 15.5.17 -> 15.8.23
+- rack(oc-chef-pedant): 2.0.7 -> 2.0.8
+- rack(oc-id): 1.6.11 to 1.6.12)
+- Ruby(oc-id): 1.6.11 -> 1.6.12
+- Ruby: 2.6.3 -> 2.6.5 (fixes the following CVEs CVE-2019-16255: A code injection vulnerability of Shell#[] and Shell#test CVE-2019-16254: HTTP response splitting in WEBrick (Additional fix) CVE-2019-15845: A NUL injection vulnerability of File.fnmatch and File.fnmatch? CVE-2019-16201: Regular Expression Denial of Service vulnerability of WEBrick’s Digest access authentication CVE-2012-6708 CVE-2015-9251)
+- rubyzip(oc-id): 1.2.3 -> 1.3.0 (fixes CVE-2019-16892)
+- Erlang(habitat): 18 -> 20
 
 ## What's New in 13.1.13
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -1,5 +1,5 @@
 +++
-title = "Release Notes: Chef Infra Server 12.0 - 13.1.13"
+title = "Release Notes: Chef Infra Server 12.0 - 13.2"
 draft = false
 
 aliases = ["/release_notes_server.html"]
@@ -17,6 +17,37 @@ aliases = ["/release_notes_server.html"]
 Chef Infra Server acts as a hub for configuration data by storing
 cookbooks, the policies that are applied to nodes, and metadata that
 describes each registered node that is managed by the Chef Infra Client.
+
+## What's New in 13.2
+
+### Improvements
+
+- Azure support for external PostgreSQL In the previous release we added support for ssl while connecting to PostgreSQL. With this release we add the ability to be able to connect to external PostgreSQL database in Azure.
+- Update HAProxy configuration We have updated the configuration for HAProxy to make it more responsive. The changes include:
+    - Set connect, client, server, and tunnel timeouts to reasonable defaults.
+    - Set client-fin and server-fin to try to mitigate connection pile-ups in the case of failing frontend services.
+    - Set on-marked-down shutdown-session to avoid stale sessions to previous leaders living longer than they need to.
+- Integration testing pipeline We have put a lot of effort into creating a test pipeline with the test infrastructure previously created. This runs multiple scenarios for Chef Infra Server with different configurations and topologies.
+- Chef Infra Server supports Elasticsearch version 6 for external Elasticsearch Chef Infra Server previously supported index creation for ElasticSearch versions 2 and 5. We now support index creation for ElasticSearch 6 as well
+- Cookstyle changes applied to the cookbooks
+- Disable actions rabbitmq queue by default.
+- Log all errors triggered due to Elasticsearch reindex.
+
+### Bug Fixes
+
+- Fix a regression that broke FIPS 140-2 support in Chef Infra Server 13.1.13.
+- Fix habitat db config for external database
+- Elasticsearch recipes should not create indexes at compile time.
+
+### Updates
+
+- Chef Infra Client: 15.5.17 -> 15.8.23
+- rack(oc-chef-pedant): 2.0.7 -> 2.0.8
+- rack(oc-id): 1.6.11 to 1.6.12)
+- Ruby(oc-id): 1.6.11 -> 1.6.12
+- Ruby: 2.6.3 -> 2.6.5 (fixes the following CVEs CVE-2019-16255: A code injection vulnerability of Shell#[] and Shell#test CVE-2019-16254: HTTP response splitting in WEBrick (Additional fix) CVE-2019-15845: A NUL injection vulnerability of File.fnmatch and File.fnmatch? CVE-2019-16201: Regular Expression Denial of Service vulnerability of WEBrick's Digest access authentication CVE-2012-6708 CVE-2015-9251)
+- rubyzip(oc-id): 1.2.3 -> 1.3.0 (fixes CVE-2019-16892)
+- Erlang(habitat): 18 -> 20
 
 ## What's New in 13.1.13
 


### PR DESCRIPTION
### Description

Update Chef Infra Server release notes to include 13.2

### Definition of Done

Accurately reflects GitHub release notes.

### Issues Resolved

Fixes https://github.com/chef/chef-web-docs/issues/2413

### Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass

Signed-off-by: Josh O'Brien <jobrien@chef.io>