### PR TITLE
fix css selector

### DIFF
--- a/themes/docs-new/assets/sass/_toc.scss
+++ b/themes/docs-new/assets/sass/_toc.scss
@@ -10,8 +10,8 @@
     text-indent: 8px;
   }
 
-  #TableOfContents ~ ul{
-    margin-top: -16px;
+  #TableOfContents > ul{
+    margin-bottom: 0;
   }
 }
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description
Fix a css selector.

It's supposed to make "manually" created TOC's that follow Hugo's generated TOC blend together so they look like one. Without this there's a 16px gap between them. I had the wrong selector in there before.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
