### PR TITLE
Preparing Supported Versions page for Chef Workstation GA

### DIFF
--- a/content/versions.md
+++ b/content/versions.md
@@ -125,7 +125,7 @@ announcement](https://blog.chef.io/2019/04/02/chef-software-announces-the-enterp
 </tr>
 <tr class="odd">
 <td>Chef Workstation</td>
-<td>20.5+ (May 2020)</td>
+<td>20.6+ (May 2020)</td>
 <td>GA</td>
 <td>n/a</td>
 </tr>

--- a/content/versions.md
+++ b/content/versions.md
@@ -125,13 +125,7 @@ announcement](https://blog.chef.io/2019/04/02/chef-software-announces-the-enterp
 </tr>
 <tr class="odd">
 <td>Chef Workstation</td>
-<td>0.4+</td>
-<td>GA</td>
-<td>n/a</td>
-</tr>
-<tr class="even">
-<td>ChefDK</td>
-<td>4.x</td>
+<td>20.5+ (May 2020)</td>
 <td>GA</td>
 <td>n/a</td>
 </tr>
@@ -173,18 +167,6 @@ version 2.0.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
-<td>Chef Workstation</td>
-<td>0.3</td>
-<td>GA</td>
-<td>April 30, 2020</td>
-</tr>
-<tr class="even">
-<td>ChefDK</td>
-<td>3.x</td>
-<td>GA</td>
-<td>April 30, 2020</td>
-</tr>
 <tr class="odd">
 <td>Chef InSpec</td>
 <td>3.x</td>
@@ -234,12 +216,18 @@ newer versions or products.
 </thead>
 <tbody>
 <tr class="odd">
+<td>ChefDK</td>
+<td>4.x</td>
+<td>Deprecated</td>
+<td>December 31, 2020</td>
+</tr>
+<tr class="even">
 <td>Chef Manage</td>
 <td>2.5.x</td>
 <td>Deprecated</td>
 <td>TBD</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td>Chef Workflow</td>
 <td>2.x</td>
 <td>Deprecated</td>
@@ -292,9 +280,9 @@ newer versions or products.
 </tr>
 <tr class="odd">
 <td>ChefDK</td>
-<td>2 and under</td>
+<td>3 and under</td>
 <td>EOL</td>
-<td>April 30, 2019</td>
+<td>April 30, 2020</td>
 </tr>
 <tr class="even">
 <td>Enterprise Chef</td>


### PR DESCRIPTION
### Description

Also updating to show that ChefDK 3 is EOL and ChefDK 4 is deprecated

### Definition of Done

Approval from Docs team that Workstation versioning note with date is okay, and verify that page renders correctly in netlify (already verified locally)

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
