### PR TITLE
Add note to distinguish Chef Compliance Server from Chef Compliance

### DIFF
--- a/content/versions.md
+++ b/content/versions.md
@@ -238,6 +238,14 @@ newer versions or products.
 
 ## End of Life (EOL) Products
 
+{{< note >}}
+
+Chef Compliance Server, which reached EOL status in 2018, should not be
+confused with the modern Chef Compliance offering that can be explored in
+detail [here](https://docs.chef.io/compliance/).
+
+{{< /note >}}
+
 <table>
 <colgroup>
 <col style="width: 25%" />

--- a/content/versions.md
+++ b/content/versions.md
@@ -241,8 +241,7 @@ newer versions or products.
 {{< note >}}
 
 Chef Compliance Server, which reached EOL status in 2018, should not be
-confused with the modern Chef Compliance offering that can be explored in
-detail [here](https://docs.chef.io/compliance/).
+confused with the modern [Chef Compliance offering](https://docs.chef.io/compliance/).
 
 {{< /note >}}
 

--- a/content/versions.md
+++ b/content/versions.md
@@ -241,7 +241,7 @@ newer versions or products.
 {{< note >}}
 
 Chef Compliance Server, which reached EOL status in 2018, should not be
-confused with the modern [Chef Compliance offering](https://docs.chef.io/compliance/).
+confused with the modern [Chef Compliance offering](/compliance/).
 
 {{< /note >}}
 


### PR DESCRIPTION
Chef Compliance Server went EOL in 2018, and we just released Chef
Compliance. This could cause confusion for users, so making a note
to clarify any confusion under the EOL section of the supported
versions page.

Signed-off-by: Josh O'Brien <jobrien@chef.io>

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
