### PR TITLE
Remove toc styling

### DIFF
--- a/themes/docs-new/assets/sass/_toc.scss
+++ b/themes/docs-new/assets/sass/_toc.scss
@@ -5,14 +5,6 @@
   height: 100%;
   font-size: rem-calc(13);
   z-index: 30;
-
-  li {
-    text-indent: 8px;
-  }
-
-  #TableOfContents > ul{
-    margin-bottom: 0;
-  }
 }
 
 .position-right.is-transition-push {


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Removes a couple TOC css styles.

I'm not sure why I thought those were important before, but they seem to be mucking things up now.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
