### PR TITLE
fix desktop resources menu weight

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -857,7 +857,7 @@ weight = 10
 title = "Resources"
 identifier = "desktop/resources"
 parent = "desktop"
-weight = 40
+weight = 999
 
 ####
 # End Chef Desktop Menu


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This bumps the desktop resources down to the bottom of the desktop menu.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
