### PR TITLE
Simplify what you do from the Chef Workstation

### DIFF
--- a/content/chef_overview.md
+++ b/content/chef_overview.md
@@ -99,13 +99,10 @@ interact with nodes.
 
 The workstation is where users do most of their work, including:
 
--   Developing and testing cookbooks and recipes
--   Testing Chef code
--   Keeping the Chef repository synchronized with version source control
--   Configuring organizational policy, including defining roles and
-    environments, and ensuring that critical data is stored in data bags
--   Interacting with nodes, as (or when) required, such as performing a
-    bootstrap operation
+- Developing and testing cookbooks
+- Keeping the Chef Infra repository synchronized with version source control
+- Configuring organizational by including defining and applying Policyfiles or Policy Groups
+- Interacting with nodes, as (or when) required, such as performing a bootstrap operation
 
 ### Chef Workstation Components and Tools
 


### PR DESCRIPTION
Talk about Policyfiles and not the legacy stuff. Call them cookbooks and avoid the what is a cookbook and what is a recipe mess.

Signed-off-by: Tim Smith <tsmith@chef.io>