### PR TITLE
remove resource_name references from custom resources page

### DIFF
--- a/content/custom_resources.md
+++ b/content/custom_resources.md
@@ -122,18 +122,6 @@ exampleco_site 'httpd' do
 end
 ```
 
-### resource_name
-
-{{< note >}}
-
-{{% ruby_style_patterns_hyphens %}}
-
-{{< /note >}}
-
-{{% dsl_custom_resource_method_resource_name %}}
-
-{{% dsl_custom_resource_method_resource_name_example %}}
-
 ## Scenario: website Resource
 
 Create a resource that configures Apache httpd for Red Hat Enterprise

--- a/layouts/shortcodes/dsl_custom_resource_method_new_resource.md
+++ b/layouts/shortcodes/dsl_custom_resource_method_new_resource.md
@@ -5,8 +5,6 @@ the purpose of overriding that property when used with the custom
 resource. For example:
 
 ``` ruby
-resource_name :node_execute
-
 property :command, String, name_property: true
 property :version, String
 
@@ -54,8 +52,6 @@ to process the properties from the core resource instead of the
 properties in the custom resource. For example:
 
 ``` ruby
-resource_name :node_execute
-
 property :command, String, name_property: true
 property :version, String
 

--- a/layouts/shortcodes/dsl_custom_resource_method_provides.md
+++ b/layouts/shortcodes/dsl_custom_resource_method_provides.md
@@ -3,11 +3,11 @@ DSL on different operating systems. When multiple custom resources use
 the same DSL, specificity rules are applied to determine the priority,
 from highest to lowest:
 
-1.  provides :resource_name, platform_version: '0.1.2'
-2.  provides :resource_name, platform: 'platform_name'
-3.  provides :resource_name, platform_family: 'platform_family'
-4.  provides :resource_name, os: 'operating_system'
-5.  provides :resource_name
+1.  provides :my_custom_resource, platform_version: '0.1.2'
+2.  provides :my_custom_resource, platform: 'platform_name'
+3.  provides :my_custom_resource, platform_family: 'platform_family'
+4.  provides :my_custom_resource, os: 'operating_system'
+5.  provides :my_custom_resource
 
 For example:
 


### PR DESCRIPTION
In Chef-16 the resource_name DSL method has been demoted to being nearly
useless so we don't want this put in front of people on a learning-chef
style page.

Most of the references were already deleted, but this gets rid of some
remaining stragglers

