### PR TITLE
Change the link to more information on ssl_ciphers

### DIFF
--- a/content/config_rb_delivery.md
+++ b/content/config_rb_delivery.md
@@ -68,7 +68,7 @@ Automate server to use SSL certificates:
 :   The list of supported cipher suites that are used to establish a
     secure connection. To favor AES256 with ECDHE forward security, drop
     the `RC4-SHA:RC4-MD5:RC4:RSA` prefix. See [this
-    link](https://wiki.mozilla.org/Security/Server_Side_TLS) for more
+    link](https://www.openssl.org/docs/man1.0.2/man1/ciphers.html) for more
     information. Default value:
 
     ``` ruby
@@ -88,7 +88,7 @@ Automate server to use SSL certificates:
 
 {{< note >}}
 
-See <https://wiki.mozilla.org/Security/Server_Side_TLS> for more
+See <https://www.openssl.org/docs/man1.0.2/man1/ciphers.html> for more
 information about the values used with the `nginx['ssl_ciphers']` and
 `nginx['ssl_protocols']` settings.
 

--- a/content/config_rb_delivery_optional_settings.md
+++ b/content/config_rb_delivery_optional_settings.md
@@ -1176,7 +1176,7 @@ This configuration file has the following settings for `nginx`:
 :   The list of supported cipher suites that are used to establish a
     secure connection. To favor AES256 with ECDHE forward security, drop
     the `RC4-SHA:RC4-MD5:RC4:RSA` prefix. See [this
-    link](https://wiki.mozilla.org/Security/Server_Side_TLS) for more
+    link](https://www.openssl.org/docs/man1.0.2/man1/ciphers.html) for more
     information. Default value:
 
     ``` ruby

--- a/content/config_rb_server_optional_settings.md
+++ b/content/config_rb_server_optional_settings.md
@@ -728,7 +728,7 @@ This configuration file has the following settings for `nginx`:
 :   The list of supported cipher suites that are used to establish a
     secure connection. To favor AES256 with ECDHE forward security, drop
     the `RC4-SHA:RC4-MD5:RC4:RSA` prefix. See [this
-    link](https://wiki.mozilla.org/Security/Server_Side_TLS) for more
+    link](https://www.openssl.org/docs/man1.0.2/man1/ciphers.html) for more
     information. For example:
 
     ``` ruby

--- a/content/config_rb_supermarket.md
+++ b/content/config_rb_supermarket.md
@@ -837,7 +837,7 @@ This configuration file has the following settings for SSL:
 :   The list of supported cipher suites that are used to establish a
     secure connection. To favor AES256 with ECDHE forward security, drop
     the `RC4-SHA:RC4-MD5:RC4:RSA` prefix. See
-    <https://wiki.mozilla.org/Security/Server_Side_TLS> for more
+    <https://www.openssl.org/docs/man1.0.2/man1/ciphers.html> for more
     information. For example:
 
     ``` ruby

--- a/layouts/shortcodes/server_tuning_nginx.md
+++ b/layouts/shortcodes/server_tuning_nginx.md
@@ -47,7 +47,7 @@ Infra Server to use SSL certificates:
 
 <div class="admonition-note-text">
 
-See <https://wiki.mozilla.org/Security/Server_Side_TLS> for more
+See <https://www.openssl.org/docs/man1.0.2/man1/ciphers.html> for more
 information about the values used with the `nginx['ssl_ciphers']` and
 `nginx['ssl_protocols']` settings.
 


### PR DESCRIPTION
The mozilla page doesn't contain useful information on the format of
ssl_ciphers, which is actually an OpenSSL configuration value. The
OpenSSL documentation is much more useful.

