### PR TITLE
Remove language about default value for path.

### DIFF
--- a/content/resources/cookbook_file/_index.md
+++ b/content/resources/cookbook_file/_index.md
@@ -250,7 +250,7 @@ properties_list:
   description_list:
   - markdown: 'The path to the destination at which a file is to be created.
 
-      Default value: the `name` of the resource block For example:
+      For example:
 
       `file.txt`.
 


### PR DESCRIPTION
### Description

The `path` property no longer has the default value of the resource block's name; that belongs to `source`.

### Definition of Done

Remove text as specified.

### Issues Resolved

None.

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
