### PR TITLE
Allow custom TOC partials

### DIFF
--- a/themes/docs-new/layouts/_default/baseof.html
+++ b/themes/docs-new/layouts/_default/baseof.html
@@ -27,7 +27,12 @@
         {{ $headers := findRE "<h[12].*?>(.|\n])+?</h[12]>" .Content }}
         {{ if and (ge (len $headers) 1) (ne .Params.toc false )}}
           <div class="cell off-canvas position-right toc off-canvas-absolute reveal-for-large" id="onCanvasRightTOC" data-off-canvas >
-            {{ partial "table-of-contents" . }}
+            {{ if .Params.toc_layout }}
+              {{ partial .Params.toc_layout . }}
+            {{ else }}
+              {{ partial "table-of-contents" . }}
+            {{ end }}
+
           </div>
         {{ end }}
 
@@ -40,7 +45,11 @@
 
     <div class="off-canvas position-right toc off-canvas-absolute hide-for-large" id="offCanvasRightTOC" data-off-canvas
       data-transition="overlap">
-      {{ partial "table-of-contents" . }}
+      {{ if .Params.toc_layout }}
+        {{ partial .Params.toc_layout . }}
+      {{ else }}
+        {{ partial "table-of-contents" . }}
+      {{ end }}
     </div>
 
   {{ end }}


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This allows a custom TOC partial to be added based on a `toc_layout` parameter in the page frontmatter.
For Automate docs of course.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
