### PR TITLE
Make examples work again on resource reference page

### DIFF
--- a/layouts/resources/terms.html
+++ b/layouts/resources/terms.html
@@ -1133,9 +1133,9 @@
                     {{ $ExamplesID.Add "Value" 1 }}
                     <h2 id = "examples-{{ $ExamplesID.Get "Value" }}">Examples</h2>
                     <hr>
-                    {{ if .Params.examples_list }}
+                    {{ if .Params.examples }}
                       <p>The following examples demonstrate various approaches for using the <strong>{{ .Params.resource }}</strong> resource in recipes:</p>
-                      {{ .Params.examples }}
+                      {{ .Params.examples | markdownify }}
                     {{ else }}
                       <p>This resource does not have any examples.</p>
                   {{ end }}


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

The resources examples don't display on the resources reference page. This fixes it.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
