### PR TITLE
Im/fix tables

### DIFF
--- a/content/attributes.md
+++ b/content/attributes.md
@@ -43,27 +43,27 @@ Infra Client chooses which attribute to apply.
 <tbody>
 <tr class="odd">
 <td><code>default</code></td>
-<td>{{% node_attribute_type_default %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_default.md" >}}</td>
 </tr>
 <tr class="even">
 <td><code>force_default</code></td>
-<td>{{% node_attribute_type_force_default %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_force_default.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><code>normal</code></td>
-<td>{{% node_attribute_type_normal %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_normal.md" >}}</td>
 </tr>
 <tr class="even">
 <td><code>override</code></td>
-<td>{{% node_attribute_type_override %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_override.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><code>force_override</code></td>
-<td>{{% node_attribute_type_force_override %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_force_override.md" >}}</td>
 </tr>
 <tr class="even">
 <td><code>automatic</code></td>
-<td>{{% node_attribute_type_automatic %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_automatic.md" >}}</td>
 </tr>
 </tbody>
 </table>

--- a/content/chef_client_overview.md
+++ b/content/chef_client_overview.md
@@ -30,8 +30,8 @@ executable can be run as a daemon.
 <tbody>
 <tr class="odd">
 <td><p><img src="/images/icon_chef_client.svg" class="align-center" width="100" alt="image" /></p></td>
-<td><p>{{% chef_client_summary %}}</p>
-<p>{{% security_key_pairs_chef_client %}}</p></td>
+<td><p>{{< readFile_shortcode file="chef_client_summary.md" >}}</p>
+<p>{{< readFile_shortcode file="security_key_pairs_chef_client.md" >}}</p></td>
 </tr>
 </tbody>
 </table>

--- a/content/chef_overview.md
+++ b/content/chef_overview.md
@@ -69,7 +69,7 @@ Chef Infra has the following major components:
 <tr class="even">
 <td><p><img src="/images/icon_node.svg" class="align-center" width="100" alt="image" /></p>
 <p><img src="/images/icon_chef_client.svg" class="align-center" width="100" alt="image" /></p></td>
-<td><p>{{% node %}}</p>
+<td><p>{{< readFile_shortcode file="node.md" >}}</p>
 <p>Chef Infra Client is installed on each node that is managed with Chef Infra. Chef Infra Client configures the node locally by performing the tasks specified in the run-list. Chef Infra Client will also pull down any required configuration data from the Chef Infra Server during a Chef Infra Client run.</p></td>
 </tr>
 <tr class="odd">
@@ -122,7 +122,7 @@ Some important tools and components of Chef Workstation include:
 <tbody>
 <tr class="odd">
 <td><img src="/images/icon_devkit.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% chef_workstation %}}</td>
+<td>{{< readFile_shortcode file="chef_workstation.md" >}}</td>
 </tr>
 <tr class="even">
 <td><p><img src="/images/icon_ctl_chef.svg" class="align-center" width="100" alt="image" /></p>
@@ -149,11 +149,11 @@ Some important tools and components of Chef Workstation include:
 </tr>
 <tr class="even">
 <td><img src="/images/icon_kitchen.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% test_kitchen %}}</td>
+<td>{{< readFile_shortcode file="test_kitchen.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><img src="/images/icon_chefspec.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% chefspec_summary %}}</td>
+<td>{{< readFile_shortcode file="chefspec_summary.md" >}}</td>
 </tr>
 </tbody>
 </table>
@@ -187,35 +187,35 @@ Cookbooks are comprised of the following components:
 <tbody>
 <tr class="odd">
 <td><img src="/images/icon_cookbook_attributes.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% cookbooks_attribute %}}</td>
+<td>{{< readFile_shortcode file="cookbooks_attribute.md" >}}</td>
 </tr>
 <tr class="even">
 <td><img src="/images/icon_cookbook_files.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% resource_cookbook_file_summary %}}</td>
+<td>{{< readFile_shortcode file="resource_cookbook_file_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><img src="/images/icon_cookbook_libraries.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% libraries_summary %}}</td>
+<td>{{< readFile_shortcode file="libraries_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><img src="/images/icon_cookbook_metadata.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% cookbooks_metadata %}}</td>
+<td>{{< readFile_shortcode file="cookbooks_metadata.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><p><img src="/images/icon_cookbook_recipes.svg" class="align-center" width="100" alt="image" /></p>
 <p><img src="/images/icon_recipe_dsl.svg" class="align-center" width="100" alt="image" /></p></td>
-<td><p>{{% cookbooks_recipe %}}</p>
+<td><p>{{< readFile_shortcode file="cookbooks_recipe.md" >}}</p>
 <p>The Chef Infra Client will run a recipe only when asked. When the Chef Infra Client runs the same recipe more than once, the results will be the same system state each time. When a recipe is run against a system, but nothing has changed on either the system or in the recipe, the Chef Infra Client won't change anything.</p>
-<p>{{% dsl_recipe_summary %}}</p></td>
+<p>{{< readFile_shortcode file="dsl_recipe_summary.md" >}}</p></td>
 </tr>
 <tr class="even">
 <td><p><img src="/images/icon_cookbook_resources.svg" class="align-center" width="100" alt="image" /></p></td>
-<td><p>{{% resources_common %}}</p>
+<td><p>{{< readFile_shortcode file="resources_common.md" >}}</p>
 <p>Chef has <a href="/resources/">many built-in resources</a> that cover all of the most common actions across all of the most common platforms. You can <a href="/custom_resources/">build your own resources</a> to handle any situation that isn't covered by a built-in resource.</p></td>
 </tr>
 <tr class="odd">
 <td><img src="/images/icon_cookbook_templates.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% template %}}</td>
+<td>{{< readFile_shortcode file="template.md" >}}</td>
 </tr>
 <tr class="even">
 <td><img src="/images/icon_cookbook_tests.svg" class="align-center" width="100" alt="image" /></td>
@@ -250,12 +250,12 @@ The key components of nodes that are under management by Chef include:
 <tbody>
 <tr class="odd">
 <td><p><img src="/images/icon_chef_client.svg" class="align-center" width="100" alt="image" /></p></td>
-<td><p>{{% chef_client_summary %}}</p>
-<p>{{% security_key_pairs_chef_client %}}</p></td>
+<td><p>{{< readFile_shortcode file="chef_client_summary.md" >}}</p>
+<p>{{< readFile_shortcode file="security_key_pairs_chef_client.md" >}}</p></td>
 </tr>
 <tr class="even">
 <td><img src="/images/icon_ohai.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% ohai_summary %}}</td>
+<td>{{< readFile_shortcode file="ohai_summary.md" >}}</td>
 </tr>
 </tbody>
 </table>
@@ -278,15 +278,15 @@ The key components of nodes that are under management by Chef include:
 <tbody>
 <tr class="odd">
 <td><img src="/images/icon_search.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% search %}}</td>
+<td>{{< readFile_shortcode file="search.md" >}}</td>
 </tr>
 <tr class="even">
 <td><img src="/images/icon_manage.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% chef_manager %}}</td>
+<td>{{< readFile_shortcode file="chef_manager.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><img src="/images/icon_data_bags.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% data_bag %}}</td>
+<td>{{< readFile_shortcode file="data_bag.md" >}}</td>
 </tr>
 <tr class="even">
 <td><img src="/images/icon_policy.svg" class="align-center" width="100" alt="image" /></td>
@@ -315,19 +315,19 @@ Some important aspects of policy include:
 <tbody>
 <tr class="odd">
 <td><img src="/images/icon_roles.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% role %}}</td>
+<td>{{< readFile_shortcode file="role.md" >}}</td>
 </tr>
 <tr class="even">
 <td><img src="/images/icon_environments.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% environment %}}</td>
+<td>{{< readFile_shortcode file="environment.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><img src="/images/icon_cookbook_versions.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% cookbooks_version %}}</td>
+<td>{{< readFile_shortcode file="cookbooks_version.md" >}}</td>
 </tr>
 <tr class="even">
 <td><img src="/images/icon_run_lists.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% node_run_list %}}</td>
+<td>{{< readFile_shortcode file="node_run_list.md" >}}</td>
 </tr>
 </tbody>
 </table>

--- a/content/config_json_delivery.md
+++ b/content/config_json_delivery.md
@@ -58,13 +58,13 @@ The structure of the `config.json` file is similar to:
 
 :   **Required**
 
-    {{< shortcode_indent shortcode="delivery_config_json_setting_build_cookbook" >}}
+    {{< readFile_shortcode file="delivery_config_json_setting_build_cookbook.md" >}}
 
 `build_nodes`
 
 :   **Optional**
 
-    {{< shortcode_indent shortcode="delivery_config_json_setting_build_nodes" >}}
+    {{< readFile_shortcode file="delivery_config_json_setting_build_nodes.md" >}}
 
 `delivery-truck`
 
@@ -97,7 +97,7 @@ The structure of the `config.json` file is similar to:
 
 :   **Optional**
 
-    {{< shortcode_indent shortcode="delivery_config_json_setting_dependencies" >}}
+    {{< readFile_shortcode file="delivery_config_json_setting_dependencies.md" >}}
 
 <a id="job-dispatch-config-settings" markdown="1"></a>
 <!-- link from runners.md -->
@@ -230,14 +230,14 @@ The structure of the `config.json` file is similar to:
 
 :   **Optional**
 
-    {{< shortcode_indent shortcode="delivery_config_json_setting_skip_phases" >}}
+    {{< readFile_shortcode file="delivery_config_json_setting_skip_phases.md" >}}
 
 
 `version`
 
 :   **Required**
 
-    {{< shortcode_indent shortcode="delivery_config_json_setting_version" >}}
+    {{< readFile_shortcode file="delivery_config_json_setting_version.md" >}}
 
 {{< note >}}
 

--- a/content/config_rb_server_optional_settings.md
+++ b/content/config_rb_server_optional_settings.md
@@ -1045,7 +1045,7 @@ This configuration file has the following settings for `oc-id`:
 :   A Hash that contains OAuth 2 application information. Default value:
     `{ }`.
 
-    {{< shortcode_indent shortcode="config_ocid_application_hash_supermarket" >}}
+    {{< readFile_shortcode file="config_ocid_application_hash_supermarket.md" >}}
 
 `oc_id['db_pool_size']`
 

--- a/content/cookbooks.md
+++ b/content/cookbooks.md
@@ -51,12 +51,12 @@ files or directories.
 <tr class="odd">
 <td><a href="/recipes/">Recipes</a></td>
 <td>recipes/</td>
-<td>{{% cookbooks_recipe %}}</td>
+<td>{{< readFile_shortcode file="cookbooks_recipe.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/attributes/">Attributes</a></td>
 <td>attributes/</td>
-<td>{{% cookbooks_attribute %}}</td>
+<td>{{< readFile_shortcode file="cookbooks_attribute.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/files/">Files</a></td>

--- a/content/ctl_chef_client.md
+++ b/content/ctl_chef_client.md
@@ -155,7 +155,7 @@ This command has the following options:
 
     **Run-lists**
 
-    {{< shortcode_indent shortcode="node_ctl_run_list" >}}
+    {{< readFile_shortcode file="node_ctl_run_list.md" >}}
 
     **Environments**
 
@@ -187,7 +187,7 @@ This command has the following options:
 
     **All attributes are normal attributes**
 
-    {{< shortcode_indent shortcode="node_ctl_attribute" >}}
+    {{< readFile_shortcode file="node_ctl_attribute.md" >}}
 
     {{< note spaces=4 >}}
 

--- a/content/ctl_chef_solo.md
+++ b/content/ctl_chef_solo.md
@@ -92,7 +92,7 @@ This command has the following options:
 
 :   The path to a file that contains JSON data.
 
-    {{< shortcode_indent shortcode="node_ctl_run_list" >}}
+    {{< readFile_shortcode file="node_ctl_run_list.md" >}}
 
     {{< warning >}}
 

--- a/content/delivery_pipeline.md
+++ b/content/delivery_pipeline.md
@@ -79,31 +79,31 @@ file to tailor the cookbook as needed.
 
 :   **Required**
 
-    {{< shortcode_indent shortcode="delivery_config_json_setting_version" >}}
+    {{< readFile_shortcode file="delivery_config_json_setting_version.md" >}}
 
 `build-cookbook`
 
 :   **Required**
 
-    {{< shortcode_indent shortcode="delivery_config_json_setting_build_cookbook" >}}
+    {{< readFile_shortcode file="delivery_config_json_setting_build_cookbook.md" >}}
 
 `build_nodes`
 
 :   **Optional**
 
-    {{< shortcode_indent shortcode="delivery_config_json_setting_build_nodes" >}}
+    {{< readFile_shortcode file="delivery_config_json_setting_build_nodes.md" >}}
 
 `skip_phases`
 
 :   **Optional**
 
-    {{< shortcode_indent shortcode="delivery_config_json_setting_skip_phases" >}}
+    {{< readFile_shortcode file="delivery_config_json_setting_skip_phases.md" >}}
 
 `dependencies`
 
 :   **Optional**
 
-    {{< shortcode_indent shortcode="delivery_config_json_setting_dependencies" >}}
+    {{< readFile_shortcode file="delivery_config_json_setting_dependencies.md" >}}
 
 {{< note >}}
 

--- a/content/environments.md
+++ b/content/environments.md
@@ -55,11 +55,11 @@ There are two types of attributes that can be used with environments:
 <tbody>
 <tr class="odd">
 <td><code>default</code></td>
-<td>{{% node_attribute_type_default %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_default.md" >}}</td>
 </tr>
 <tr class="even">
 <td><code>override</code></td>
-<td>{{% node_attribute_type_override %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_override.md" >}}</td>
 </tr>
 </tbody>
 </table>

--- a/content/install_chef_air_gap.md
+++ b/content/install_chef_air_gap.md
@@ -81,7 +81,7 @@ dpkg -i chef_13.2.20-1_amd64.deb
 
 The install script should be accessible from your artifact store.
 
-## Chef server
+## Chef Infra Server
 
 In this section you'll install the Chef Infra Server, and create your
 organization and user. Note that in order to configure Supermarket later
@@ -94,7 +94,7 @@ group.
     Server, and then record its location on the file system. The rest of
     these steps assume this location is in the `/tmp` directory.
 
-3.  {{< shortcode_indent shortcode="install_chef_server_install_package">}}
+3.  {{< readFile_shortcode file="install_chef_server_install_package.md" >}}
 
 4.  Run the following to start all of the services:
 
@@ -106,9 +106,9 @@ group.
     that work together to create a functioning system, this step may
     take a few minutes to complete.
 
-5.  {{< shortcode_indent shortcode="ctl_chef_server_user_create_admin">}}
+5.  {{< readFile_shortcode file="ctl_chef_server_user_create_admin.md">}}
 
-6.  {{< shortcode_indent shortcode="ctl_chef_server_org_create_summary">}}
+6.  {{< readFile_shortcode file="ctl_chef_server_org_create_summary.md">}}
 
 ## Chef Workstation
 
@@ -291,7 +291,7 @@ Supermarket.
 
 2.  Update the `/etc/opscode/chef-server.rb` configuration file.
 
-    {{< shortcode_indent shortcode="config_ocid_application_hash_supermarket" >}}
+    {{< readFile_shortcode file="config_ocid_application_hash_supermarket.md" >}}
 
 3.  Reconfigure the Chef Infra Server.
 

--- a/content/install_server.md
+++ b/content/install_server.md
@@ -77,7 +77,7 @@ To install Chef Server:
     Server, and then record its location on the file system. The rest of
     these steps assume this location is in the `/tmp` directory.
 
-3.  {{< shortcode_indent shortcode="install_chef_server_install_package" >}}
+3.  {{< readFile_shortcode file="install_chef_server_install_package.md" >}}
 
 4.  Run the following to start all of the services:
 
@@ -89,9 +89,9 @@ To install Chef Server:
     that work together to create a functioning system, this step may
     take a few minutes to complete.
 
-5.  {{< shortcode_indent shortcode="ctl_chef_server_user_create_admin" >}}
+5.  {{< readFile_shortcode file="ctl_chef_server_user_create_admin.md" >}}
 
-6.  {{< shortcode_indent shortcode="ctl_chef_server_org_create_summary" >}}
+6.  {{< readFile_shortcode file="ctl_chef_server_org_create_summary.md" >}}
 
 ## Update Configuration for Purchased Nodes
 

--- a/content/install_server_ha.md
+++ b/content/install_server_ha.md
@@ -527,6 +527,11 @@ files on disk:
 The following services run on each node in the backend cluster. The user
 account under which the service runs as listed the second column:
 
+
+
+The following services run on each node in the backend cluster. The user
+account under which the service runs as listed the second column:
+
 <table>
 <colgroup>
 <col style="width: 19%" />

--- a/content/install_supermarket.md
+++ b/content/install_supermarket.md
@@ -85,7 +85,7 @@ To configure Chef Supermarket to use Chef Identity, do the following:
 
 2.  Update the `/etc/opscode/chef-server.rb` configuration file.
 
-    {{< shortcode_indent shortcode="config_ocid_application_hash_supermarket" >}}
+    {{< readFile_shortcode file="config_ocid_application_hash_supermarket.md" >}}
 
 3.  Reconfigure the Chef Infra Server.
 

--- a/content/integrate_delivery_bitbucket.md
+++ b/content/integrate_delivery_bitbucket.md
@@ -213,7 +213,7 @@ Workflow:
     for the project. Changes are opened in the Workflow web UI. At this
     point, a corresponding pull request is shown in Bitbucket.
 
-    {{< shortcode_indent shortcode="delivery_cli_init_bitbucket_project" >}}
+    {{< readFile_shortcode file="delivery_cli_init_bitbucket_project.md" >}}
 
 ### Convert Project to Bitbucket
 

--- a/content/nodes.md
+++ b/content/nodes.md
@@ -34,12 +34,12 @@ The key components of nodes that are under management by Chef include:
 <tbody>
 <tr class="odd">
 <td><p><img src="/images/icon_chef_client.svg" class="align-center" width="100" alt="image" /></p></td>
-<td><p>{{% chef_client_summary %}}</p>
-<p>{{% security_key_pairs_chef_client %}}</p></td>
+<td><p>{{< readFile_shortcode file="chef_client_summary.md" >}}</p>
+<p>{{< readFile_shortcode file="security_key_pairs_chef_client.md" >}}</p></td>
 </tr>
 <tr class="even">
 <td><img src="/images/icon_ohai.svg" class="align-center" width="100" alt="image" /></td>
-<td>{{% ohai_summary %}}</td>
+<td>{{< readFile_shortcode file="ohai_summary.md" >}}</td>
 </tr>
 </tbody>
 </table>
@@ -148,27 +148,27 @@ copy on the Chef Infra Server at the end of each Chef Infra Client run.
 <tbody>
 <tr class="odd">
 <td><code>default</code></td>
-<td>{{% node_attribute_type_default %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_default.md" >}}</td>
 </tr>
 <tr class="even">
 <td><code>force_default</code></td>
-<td>{{% node_attribute_type_force_default %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_force_default.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><code>normal</code></td>
-<td>{{% node_attribute_type_normal %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_normal.md" >}}</td>
 </tr>
 <tr class="even">
 <td><code>override</code></td>
-<td>{{% node_attribute_type_override %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_override.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><code>force_override</code></td>
-<td>{{% node_attribute_type_force_override %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_force_override.md" >}}</td>
 </tr>
 <tr class="even">
 <td><code>automatic</code></td>
-<td>{{% node_attribute_type_automatic %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_automatic.md" >}}</td>
 </tr>
 </tbody>
 </table>

--- a/content/plugin_knife.md
+++ b/content/plugin_knife.md
@@ -37,7 +37,7 @@ The following knife plug-ins are maintained by Chef:
 <tbody>
 <tr class="odd">
 <td><a href="https://github.com/chef/knife-azure">knife-azure</a></td>
-<td>{{% knife_azure %}}</td>
+<td>{{< readFile_shortcode file="knife_azure.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="https://github.com/chef/knife-ec2">knife-ec2</a></td>

--- a/content/recipes.md
+++ b/content/recipes.md
@@ -44,27 +44,27 @@ aliases = ["/recipes.html"]
 <tbody>
 <tr class="odd">
 <td><code>default</code></td>
-<td>{{% node_attribute_type_default %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_default.md" >}}</td>
 </tr>
 <tr class="even">
 <td><code>force_default</code></td>
-<td>{{% node_attribute_type_force_default %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_force_default.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><code>normal</code></td>
-<td>{{% node_attribute_type_normal %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_normal.md" >}}</td>
 </tr>
 <tr class="even">
 <td><code>override</code></td>
-<td>{{% node_attribute_type_override %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_override.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><code>force_override</code></td>
-<td>{{% node_attribute_type_force_override %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_force_override.md" >}}</td>
 </tr>
 <tr class="even">
 <td><code>automatic</code></td>
-<td>{{% node_attribute_type_automatic %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_automatic.md" >}}</td>
 </tr>
 </tbody>
 </table>

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -1020,6 +1020,80 @@ with its location information and dependencies:
 }
 ```
 
+
+
+## What's New in 12.4
+
+The following items are new for Chef server 12.4:
+
+-   **/universe endpoint** Use the `/universe` endpoint to retrieve the
+    known collection of cookbooks, and then use it with Berkshelf and
+    Chef Supermarket.
+-   **opscode-expander-reindexer service** The
+    `opscode-expander-reindexer` service is deprecated.
+-   **Global server administrator list** Use the
+    `grant-server-admin-permissions`, `remove-server-admin-permissions`,
+    and `list-server-admins` to manage the list of users who belong to
+    the `server-admins` group.
+
+### /universe
+
+Use the `/universe` endpoint to retrieve the known collection of
+cookbooks, and then use it with Berkshelf and Chef Supermarket.
+
+The `/universe` endpoint has the following methods: `GET`.
+
+### GET
+
+The `GET` method is used to retrieve the universe data.
+
+This method has no parameters.
+
+**Request**
+
+``` none
+GET /universe
+```
+
+**Response**
+
+The response will return an embedded hash, with the name of each
+cookbook as a top-level key. Each cookbook will list each version, along
+with its location information and dependencies:
+
+``` javascript
+{
+  "ffmpeg": {
+    "0.1.0": {
+      "location_path": "http://supermarket.chef.io/api/v1/cookbooks/ffmpeg/0.1.0/download"
+      "location_type": "supermarket",
+      "dependencies": {
+        "git": ">= 0.0.0",
+        "build-essential": ">= 0.0.0",
+        "libvpx": "~> 0.1.1",
+        "x264": "~> 0.1.1"
+      },
+    },
+    "0.1.1": {
+      "location_path": "http://supermarket.chef.io/api/v1/cookbooks/ffmpeg/0.1.1/download"
+      "location_type": "supermarket",
+      "dependencies": {
+        "git": ">= 0.0.0",
+        "build-essential": ">= 0.0.0",
+        "libvpx": "~> 0.1.1",
+        "x264": "~> 0.1.1"
+      },
+    },
+   "pssh": {
+    "0.1.0": {
+      "location_path": "http://supermarket.chef.io/api/v1/cookbooks/pssh.1.0/download"
+      "location_type": "supermarket",
+      "dependencies": {},
+    }
+  }
+}
+```
+
 <table>
 <colgroup>
 <col style="width: 40%" />

--- a/content/roles.md
+++ b/content/roles.md
@@ -44,11 +44,11 @@ There are two types of attributes that can be used with roles:
 <tbody>
 <tr class="odd">
 <td><code>default</code></td>
-<td>{{% node_attribute_type_default %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_default.md" >}}</td>
 </tr>
 <tr class="even">
 <td><code>override</code></td>
-<td>{{% node_attribute_type_override %}}</td>
+<td>{{< readFile_shortcode file="node_attribute_type_override.md" >}}</td>
 </tr>
 </tbody>
 </table>

--- a/content/runbook/server_firewalls_and_ports.md
+++ b/content/runbook/server_firewalls_and_ports.md
@@ -58,13 +58,13 @@ any firewalls that are in use:
 <tr class="odd">
 <td><p>4321</p></td>
 <td><p><strong>bookshelf</strong></p>
-<p>{{% server_services_bookshelf %}}</p></td>
+<p>{{< readFile_shortcode file="server_services_bookshelf.md" >}}</p></td>
 <td><p>no</p></td>
 </tr>
 <tr class="even">
 <td><p>80, 443, 9683</p></td>
 <td><p><strong>nginx</strong></p>
-<p>{{% server_services_nginx %}}</p>
+<p>{{< readFile_shortcode file="server_services_nginx.md" >}}</p>
 {{< note >}}
 <p>Port 9683 is used to internally load balance the <strong>oc_bifrost</strong> service.</p>
 {{< /note >}}</td>
@@ -73,43 +73,43 @@ any firewalls that are in use:
 <tr class="odd">
 <td><p>9463</p></td>
 <td><p><strong>oc_bifrost</strong></p>
-<p>{{% server_services_bifrost %}}</p></td>
+<p>{{< readFile_shortcode file="server_services_bifrost.md" >}}</p></td>
 <td></td>
 </tr>
 <tr class="even">
 <td><p>9090</p></td>
 <td><p><strong>oc-id</strong></p>
-<p>{{% server_services_oc_id %}}</p></td>
+<p>{{< readFile_shortcode file="server_services_oc_id.md" >}}</p></td>
 <td></td>
 </tr>
 <tr class="odd">
 <td><p>8000</p></td>
 <td><p><strong>opscode-erchef</strong></p>
-<p>{{% server_services_erchef %}}</p></td>
+<p>{{< readFile_shortcode file="server_services_erchef.md" >}}</p></td>
 <td></td>
 </tr>
 <tr class="even">
 <td><p>8983</p></td>
 <td><p><strong>opscode-solr4</strong></p>
-<p>{{% server_services_solr4 %}}</p></td>
+<p>{{< readFile_shortcode file="server_services_solr4.md" >}}</p></td>
 <td></td>
 </tr>
 <tr class="odd">
 <td><p>5432</p></td>
 <td><p><strong>postgresql</strong></p>
-<p>{{% server_services_postgresql %}}</p></td>
+<p>{{< readFile_shortcode file="server_services_postgresql.md" >}}</p></td>
 <td></td>
 </tr>
 <tr class="even">
 <td><p>5672</p></td>
 <td><p><strong>rabbitmq</strong></p>
-<p>{{% server_services_rabbitmq %}}</p></td>
+<p>{{< readFile_shortcode file="server_services_rabbitmq.md" >}}</p></td>
 <td></td>
 </tr>
 <tr class="odd">
 <td><p>16379</p></td>
 <td><p><strong>redis_lb</strong></p>
-<p>{{% server_services_redis %}}</p></td>
+<p>{{< readFile_shortcode file="server_services_redis.md" >}}</p></td>
 <td></td>
 </tr>
 </tbody>

--- a/content/server_ldap.md
+++ b/content/server_ldap.md
@@ -55,7 +55,7 @@ the following:
     Availability installation as well as on Chef servers in a standalone
     installation.
 
-    {{< shortcode_indent shortcode="config_rb_server_settings_ldap" >}}
+    {{< readFile_shortcode file="config_rb_server_settings_ldap.md" >}}
 
     {{< note spaces=4 >}}
 
@@ -64,7 +64,7 @@ the following:
 
     {{< /note >}}
 
-3.  {{< shortcode_indent shortcode="install_chef_server_reconfigure" >}}
+3.  {{< readFile_shortcode file="install_chef_server_reconfigure.md" >}}
 
 At this point, all users should be able to use their Active Directory or
 LDAP usernames and passwords to log in to the Chef Infra Server.

--- a/content/server_manage_cookbooks.md
+++ b/content/server_manage_cookbooks.md
@@ -66,27 +66,27 @@ A cookbook can contain the following types of files:
 <tbody>
 <tr class="odd">
 <td>Attributes</td>
-<td>{{% cookbooks_attribute %}}</td>
+<td>{{< readFile_shortcode file="cookbooks_attribute.md" >}}</td>
 </tr>
 <tr class="even">
 <td>Files</td>
-<td>{{% resource_cookbook_file_summary %}}</td>
+<td>{{< readFile_shortcode file="resource_cookbook_file_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td>Libraries</td>
-<td>{{% libraries_summary %}}</td>
+<td>{{< readFile_shortcode file="libraries_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td>Recipes</td>
-<td>{{% cookbooks_recipe %}}</td>
+<td>{{< readFile_shortcode file="cookbooks_recipe.md" >}}</td>
 </tr>
 <tr class="odd">
 <td>Resources</td>
-<td>{{% resources_common %}}</td>
+<td>{{< readFile_shortcode file="resources_common.md" >}}</td>
 </tr>
 <tr class="even">
 <td>Templates</td>
-<td>{{% template %}}</td>
+<td>{{< readFile_shortcode file="template.md" >}}</td>
 </tr>
 </tbody>
 </table>

--- a/content/server_orgs.md
+++ b/content/server_orgs.md
@@ -296,6 +296,12 @@ The `admins` group is assigned the following:
 
 The `billing_admins` group is assigned the following:
 
+
+
+#### billing_admins
+
+The `billing_admins` group is assigned the following:
+
 <table>
 <colgroup>
 <col style="width: 28%" />
@@ -485,6 +491,12 @@ By default, the `public_key_read_access` assigns all members of the
 </tr>
 </tbody>
 </table>
+
+#### users
+
+The `users` group is assigned the following:
+
+
 
 #### users
 

--- a/content/server_overview.md
+++ b/content/server_overview.md
@@ -53,7 +53,7 @@ Chef Infra Server deployment and how they relate to one another.
 </tr>
 <tr class="even">
 <td>Load Balancer</td>
-<td>{{% chef_server_component_nginx %}}</td>
+<td>{{< readFile_shortcode file="chef_server_component_nginx.md" >}}</td>
 </tr>
 <tr class="odd">
 <td>Chef Manage</td>
@@ -61,11 +61,11 @@ Chef Infra Server deployment and how they relate to one another.
 </tr>
 <tr class="even">
 <td>Chef Infra Server</td>
-<td>{{% chef_server_component_erchef %}}</td>
+<td>{{< readFile_shortcode file="chef_server_component_erchef.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><p>Bookshelf</p></td>
-<td><p>{{% chef_server_component_bookshelf %}}</p>
+<td><p>{{< readFile_shortcode file="chef_server_component_bookshelf.md" >}}</p>
 <p>All cookbooks are stored in a dedicated repository.</p></td>
 </tr>
 <tr class="even">
@@ -73,16 +73,16 @@ Chef Infra Server deployment and how they relate to one another.
 <td><p>Messages are sent to the search index using the following components:</p>
 <blockquote>
 <ol>
-<li>{{% chef_server_component_rabbitmq %}}</li>
-<li>{{% chef_server_component_expander %}}</li>
-<li>{{% chef_server_component_solr %}}</li>
+<li>{{< readFile_shortcode file="chef_server_component_rabbitmq.md" >}}</li>
+<li>{{< readFile_shortcode file="chef_server_component_expander.md" >}}</li>
+<li>{{< readFile_shortcode file="chef_server_component_solr.md" >}}</li>
 </ol>
 </blockquote>
 <p>All messages are added to a dedicated search index repository.</p></td>
 </tr>
 <tr class="odd">
 <td>PostgreSQL</td>
-<td>{{% chef_server_component_postgresql %}}</td>
+<td>{{< readFile_shortcode file="chef_server_component_postgresql.md" >}}</td>
 </tr>
 </tbody>
 </table>
@@ -229,11 +229,11 @@ at an external location:
 </tr>
 <tr class="odd">
 <td>Chef Infra Server</td>
-<td>{{% chef_server_component_erchef %}}</td>
+<td>{{< readFile_shortcode file="chef_server_component_erchef.md" >}}</td>
 </tr>
 <tr class="even">
 <td><p>Amazon Simple Storage Service (S3)</p></td>
-<td><p>{{% chef_server_component_bookshelf %}}</p>
+<td><p>{{< readFile_shortcode file="chef_server_component_bookshelf.md" >}}</p>
 <p>This represents external cookbooks storage at Amazon Simple Storage Service (S3).</p></td>
 </tr>
 </tbody>
@@ -362,7 +362,7 @@ Chef Infra Server:
 </tr>
 <tr class="even">
 <td><p>PostgreSQL</p></td>
-<td><p>{{% chef_server_component_postgresql %}}</p>
+<td><p>{{< readFile_shortcode file="chef_server_component_postgresql.md" >}}</p>
 <p>This represents the independently configured set of servers that are running PostgreSQL and are configured to act as the data store for the Chef Infra Server.</p></td>
 </tr>
 </tbody>

--- a/themes/docs-new/layouts/shortcodes/shortcode_indent.html
+++ b/themes/docs-new/layouts/shortcodes/shortcode_indent.html
@@ -1,1 +1,0 @@
-{{- markdownify (readFile (delimit (slice `layouts/shortcodes/` (.Get "shortcode") `.md` ) "")) -}}


### PR DESCRIPTION
### Description

This fixes two things:

- shortcodes in HTML tables weren't being rendered to HTML
  These shortcode calls are replaced with the readFile_shortcode which outputs proper HTML

- removes a redundant shortcode called `shortcode_indent`
  This shortcode is replaced with `readFile_shortcode` which does the exact same thing.


### Definition of Done

### Issues Resolved

chef/release-engineering#1193

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
