### PR TITLE
Changed to reflect default cookbook generate behavior to policyfile

### DIFF
--- a/content/ctl_chef.md
+++ b/content/ctl_chef.md
@@ -430,7 +430,7 @@ This subcommand has the following options:
 `-P`, `--policy`
 
 :   Create a Policyfile in the cookbook instead of a Berksfile.
-    value: enabled.
+    Default: enabled.
 
 `-h`, `--help`
 

--- a/content/ctl_chef.md
+++ b/content/ctl_chef.md
@@ -397,7 +397,7 @@ This subcommand has the following options:
 `-b`, `--berks`
 
 :   Create a Berksfile in the cookbook. Default: disabled. Optional.
-    must be specified to override the default creation of a policyfile
+    Use to create a berksfile by overriding default creation of a Policyfile.
     instead of a berksfile.
 
 `-C COPYRIGHT`, `--copyright COPYRIGHT`

--- a/content/ctl_chef.md
+++ b/content/ctl_chef.md
@@ -429,7 +429,7 @@ This subcommand has the following options:
 
 `-P`, `--policy`
 
-:   Create a Policyfile in the cookbook instead of a Berksfile. Default
+:   Create a Policyfile in the cookbook instead of a Berksfile.
     value: enabled.
 
 `-h`, `--help`

--- a/content/ctl_chef.md
+++ b/content/ctl_chef.md
@@ -396,8 +396,9 @@ This subcommand has the following options:
 
 `-b`, `--berks`
 
-:   Create a Berksfile in the cookbook. Default value: enabled. This is
-    disabled if the `--policy` option is given.
+:   Create a Berksfile in the cookbook. Default value: disabled. This value
+    must be specified to override the default creation of a policyfile
+    instead of a berksfile.
 
 `-C COPYRIGHT`, `--copyright COPYRIGHT`
 
@@ -430,7 +431,7 @@ This subcommand has the following options:
 `-P`, `--policy`
 
 :   Create a Policyfile in the cookbook instead of a Berksfile. Default
-    value: disabled.
+    value: enabled.
 
 `-h`, `--help`
 

--- a/content/ctl_chef.md
+++ b/content/ctl_chef.md
@@ -398,7 +398,6 @@ This subcommand has the following options:
 
 :   Create a Berksfile in the cookbook. Default: disabled. Optional.
     Use to create a berksfile by overriding default creation of a Policyfile.
-    instead of a berksfile.
 
 `-C COPYRIGHT`, `--copyright COPYRIGHT`
 

--- a/content/ctl_chef.md
+++ b/content/ctl_chef.md
@@ -396,7 +396,7 @@ This subcommand has the following options:
 
 `-b`, `--berks`
 
-:   Create a Berksfile in the cookbook. Default value: disabled. This value
+:   Create a Berksfile in the cookbook. Default: disabled. Optional.
     must be specified to override the default creation of a policyfile
     instead of a berksfile.
 


### PR DESCRIPTION
### Description

Correcting the cookbook generate doc to align with the default behavior of generating a policyfile instead of a berksfile

### Definition of Done

### Issues Resolved

None

