### PR TITLE
Update list template to page single page template

### DIFF
--- a/themes/docs-new/layouts/_default/list.html
+++ b/themes/docs-new/layouts/_default/list.html
@@ -1,4 +1,17 @@
 {{ define "main" }}
-<h1>{{ .Title }}</h1>
-{{ .Content }}
+<main id="main-content-col" tabindex="-1">
+<div class="col-content">
+  <div id="{{ anchorize ( .Title )}}"><h1>{{ .Title }}</h1></div>
+
+  {{ $headers := findRE "<h[12].*?>(.|\n])+?</h[12]>" .Content }}
+  {{ if and (ge (len $headers) 1) (ne .Params.toc false )}}
+    <button type="button" class="TOC-button hide-for-large" data-toggle="offCanvasRightTOC" data-close="left-nav-off-canvas">
+      <i class="fas fa-bars"></i> Table of Contents
+    </button>
+  {{ end }}
+    <div class="prose">
+      {{ .Content }}
+    </div>
+  </div>
+</main>
 {{ end }}


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This will makes the list page template match the single page template so the two types of pages will have the same content.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
