### PR TITLE
Fix style guide edit on github link

### DIFF
--- a/content/style_guide.md
+++ b/content/style_guide.md
@@ -12,8 +12,7 @@ aliases = ["/style_guide.html"]
     weight = 40
 +++
 
-[\[edit on
-GitHub\]](https://github.com/chef/chef-web-docs/blob/master/chef_master/source/style_guide.rst)
+[\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/style_guide.md)
 
 The Chef reference documentation is written using Markdown and built with Hugo.
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Replace the old RST "Edit on GitHub" link. 

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
