### PR TITLE
readFile_shortcode can look in two different dirs depending on where …

### DIFF
--- a/themes/docs-new/layouts/shortcodes/readFile_shortcode.html
+++ b/themes/docs-new/layouts/shortcodes/readFile_shortcode.html
@@ -1,1 +1,7 @@
-{{ readFile (delimit (slice "themes/docs-new/layouts/shortcodes/" (.Get "file")) "") | markdownify }}
+{{ $file := (delimit (slice "themes/docs-new/layouts/shortcodes/" (.Get "file")) "") }}
+{{ if fileExists $file}}
+  {{ readFile $file | markdownify }}
+{{ else }}
+  {{ $file := (delimit (slice "chef-web-docs/themes/docs-new/layouts/shortcodes/" (.Get "file")) "") }}
+  {{ readFile $file | markdownify }}
+{{ end }}


### PR DESCRIPTION
…it's run from

Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Make readFile_shortcode look for a shortcode in:
 - `themes/docs-new/layouts/shortcodes/`
or 
- `chef-web-docs/themes/docs-new/layouts/shortcodes/`

### Definition of Done

As it currently exists, it works just fine for all content in chef-web-docs. But, when hugo docs are tested in another repo (chef-workstation or desktop-config), the shortcodes are all located in `chef-web-docs/themes/docs-new/layouts/shortcodes/` so it currently doesn't work if someone (me) wants to preview docs in one of the repos.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
