### PR TITLE
install_bootstrap unattended script updates

### DIFF
--- a/content/install_bootstrap.md
+++ b/content/install_bootstrap.md
@@ -429,7 +429,7 @@ bootstrapping Windows and Linux nodes.
 
 #### PowerShell User Data
 
-``` none
+``` powershell
 ## Set host file so the instance knows where to find chef-server
 $hosts = "1.2.3.4 hello.example.com"
 $file = "C:\Windows\System32\drivers\etc\hosts"

--- a/content/install_bootstrap.md
+++ b/content/install_bootstrap.md
@@ -499,13 +499,15 @@ EOF
 NODE_NAME=node-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
 
 # Create client.rb
-/bin/echo 'log_location     STDOUT' >> /etc/chef/client.rb
-/bin/echo -e "chef_server_url  \"https://aut-chef-server/organizations/my-org\"" >> /etc/chef/client.rb
-/bin/echo -e "validation_client_name \"my-org-validator\"" >> /etc/chef/client.rb
-/bin/echo -e "validation_key \"/etc/chef/my_org_validator.pem\"" >> /etc/chef/client.rb
-/bin/echo -e "node_name  \"${NODE_NAME}\"" >> /etc/chef/client.rb
+cat > '/etc/chef/client.rb' << EOF
+og_location     STDOUT' >> /etc/chef/client.rb
+chef_server_url  "https://aut-chef-server/organizations/my-org"
+validation_client_name "my-org-validator"
+validation_key "/etc/chef/my_org_validator.pem"
+node_name  "${NODE_NAME}"
+EOF
 
-sudo chef-client -j /etc/chef/first-boot.json
+chef-client -j /etc/chef/first-boot.json
 ```
 
 It is important that settings in the [client.rb

--- a/content/install_bootstrap.md
+++ b/content/install_bootstrap.md
@@ -445,8 +445,7 @@ Start-Process msiexec.exe -ArgumentList @('/qn', '/lv C:\Windows\Temp\chef-log.t
 
 ## Create first-boot.json
 $firstboot = @{
-   "policy_group" = "my_policy_group"
-   "policy_name" = "my_policy_name"
+   "run_list" = @("role[base]")
 }
 Set-Content -Path c:\chef\first-boot.json -Value ($firstboot | ConvertTo-Json -Depth 10)
 
@@ -491,8 +490,9 @@ curl -L https://omnitruck.chef.io/install.sh | bash || error_exit 'could not ins
 # Create first-boot.json
 cat > "/etc/chef/first-boot.json" << EOF
 {
-   "policy_group": "my_policy_group",
-   "policy_name": "my_policy_name"
+   "run_list" :[
+   "role[base]"
+   ]
 }
 EOF
 

--- a/content/install_bootstrap.md
+++ b/content/install_bootstrap.md
@@ -500,11 +500,11 @@ NODE_NAME=node-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
 
 # Create client.rb
 cat > '/etc/chef/client.rb' << EOF
-og_location     STDOUT' >> /etc/chef/client.rb
-chef_server_url  "https://aut-chef-server/organizations/my-org"
-validation_client_name "my-org-validator"
-validation_key "/etc/chef/my_org_validator.pem"
-node_name  "${NODE_NAME}"
+log_location            STDOUT
+chef_server_url         'https://aut-chef-server/organizations/my-org'
+validation_client_name  'my-org-validator'
+validation_key          '/etc/chef/my_org_validator.pem'
+node_name               "${NODE_NAME}"
 EOF
 
 chef-client -j /etc/chef/first-boot.json

--- a/content/install_bootstrap.md
+++ b/content/install_bootstrap.md
@@ -445,7 +445,8 @@ Start-Process msiexec.exe -ArgumentList @('/qn', '/lv C:\Windows\Temp\chef-log.t
 
 ## Create first-boot.json
 $firstboot = @{
-   "run_list" = @("role[base]")
+   "policy_group" = "my_policy_group"
+   "policy_name" = "my_policy_name"
 }
 Set-Content -Path c:\chef\first-boot.json -Value ($firstboot | ConvertTo-Json -Depth 10)
 
@@ -490,9 +491,8 @@ curl -L https://omnitruck.chef.io/install.sh | bash || error_exit 'could not ins
 # Create first-boot.json
 cat > "/etc/chef/first-boot.json" << EOF
 {
-   "run_list" :[
-   "role[base]"
-   ]
+   "policy_group": "my_policy_group",
+   "policy_name": "my_policy_name"
 }
 EOF
 


### PR DESCRIPTION
### Description

<!--Please describe what this change achieves -->
Changes the following for `install_bootstrap.md`
- updates  powershell code block to type `powershell` for visual rendering.
- updates unattended bash `client.rb` section to use heredoc rather than `echo -e`.  The `echo -e` method causes formatting issues with the `client.rb` file that is rendered with an out-of-the-box MacOS installation, using heredoc works with both MacOS and Linux.
- removes `sudo` from `chef-client` execution at the end of the unattended bootstrap file, this is not required in this context as the entire script must be run with `sudo`

### Definition of Done

### Issues Resolved

### Check List

- [X] Spell Check
- [X] Local build
- [X] Examine the local build
- [] All tests pass
