### PR TITLE
Kg/update link

### DIFF
--- a/content/platform_overview.md
+++ b/content/platform_overview.md
@@ -165,7 +165,7 @@ security frameworks, such as Center for Internet Security (CIS)
 benchmarks, included as part of Chef Automate.
 
 For information on the integrated reporting capabilities in Chef
-Automate, see [Compliance Overview](/chef_automate_compliance/).
+Automate, see [Compliance Overview](/automate/reports/).
 
 ### High availability
 


### PR DESCRIPTION
Updates a link to Automate docs that pointed to the old Automate 1 docs.