### PR TITLE
fix expeditor subscription to automate docs

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -21,7 +21,7 @@ subscriptions:
     - bash:.expeditor/update_hugo_modules.sh
   - workload: artifact_published:stable:inspec:*
     actions:
-      - bash:.expeditor/update_hugo_modules.sh
-  - workload: project_promoted:automate:acceptance:*
+    - bash:.expeditor/update_hugo_modules.sh
+  - workload: project_promoted:chef/automate:master:acceptance:*
     actions:
-      - bash:.expeditor/update_hugo_modules.sh
+    - bash:.expeditor/update_hugo_modules.sh


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This should fix the subscription to Automate when it has a new release.

### Definition of Done

### Issues Resolved

Expeditor hasn't been running the Hugo module update script when Automate has a new release.

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
