### PR TITLE
Chef Backend release notes - DO NOT MERGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,8 @@ front matter. For example, `release_notes = "inspec"`.
 
 This will overwrite all content on that page.
 
+The product value comes from the Product Key in the [Product Matrix](https://github.com/chef/mixlib-install/blob/master/PRODUCT_MATRIX.md).
+
 ## Sending feedback
 
 We love getting feedback. You can use:

--- a/content/release_notes_automate.md
+++ b/content/release_notes_automate.md
@@ -6,6 +6,6 @@ release_notes = "automate"
 [menu]
   [menu.release_notes]
     title = "Chef Automate"
-    identifier = "release_notes/release_notes.md Chef Automate"
+    identifier = "release_notes/release_notes_automate.md Chef Automate"
     parent = "release_notes"
 +++

--- a/content/release_notes_backend.md
+++ b/content/release_notes_backend.md
@@ -1,0 +1,11 @@
++++
+title = "Chef Backend: Version"
+draft = false
+release_notes = "chef-backend"
+
+[menu]
+  [menu.release_notes]
+    title = "Chef Backend"
+    identifier = "release_notes/release_notes_backend.md Chef Backend"
+    parent = "release_notes"
++++

--- a/content/release_notes_workstation.md
+++ b/content/release_notes_workstation.md
@@ -6,6 +6,6 @@ release_notes = "chef-workstation"
 [menu]
   [menu.release_notes]
     title = "Chef Workstation"
-    identifier = "release_notes/release_notes.md Chef Workstation"
+    identifier = "release_notes/release_notes_workstation.md Chef Workstation"
     parent = "release_notes"
 +++

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -98,6 +98,7 @@
             <h4><i class="far fa-sticky-note"></i>Release Notes</h4>
             <ul>
               <li><a href="/release_notes_automate/">Chef Automate</a></li>
+              <li><a href="/release_notes_backend/">Chef Backend</a></li>
               <li><a href="/release_notes_client/">Chef Infra Client</a></li>
               <li><a href="/release_notes_server/">Chef Infra Server</a></li>
               <li><a href="/release_notes_inspec/">Chef InSpec</a></li>


### PR DESCRIPTION
### Description

Adds streamlined release notes for Chef Backend.

Release note Markdown files for Chef Backend have not been added to packages.chef.io yet. We can merge this as soon as they are.

https://deploy-preview-2640--chef-web-docs.netlify.app/release_notes_backend/

### Definition of Done

### Issues Resolved

chef/release-engineering#1275

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
