### PR TITLE
Demo of possible docs versioning

### DIFF
--- a/content/alpha_client.md
+++ b/content/alpha_client.md
@@ -1,0 +1,39 @@
++++
+title = "Client Docs Test"
+draft = false
+
+[chef_product]
+product_key = "chef-client"
+versions= [16.5, 16.4, 16.3]
+
+[menu]
+  [menu.overview]
+    title = "Client Docs Test"
+    identifier = "overview/alpha_client.md Client Docs Test"
+    parent = "overview"
+    weight = 4
++++
+
+Proident laboris labore eiusmod sint consequat aute nulla elit mollit in elit commodo amet. Dolor fugiat voluptate occaecat anim voluptate irure veniam ullamco. Eiusmod aliquip dolor sit sit.
+
+{{< docs_version version="chef-client-16.5">}}
+**Content for chef-client-16.5**
+
+Eiusmod laborum quis aliqua non occaecat. Commodo velit enim consequat sint sunt est officia ex dolor do ut quis nisi ad. Deserunt tempor officia reprehenderit qui do.
+{{< /docs_version >}}
+
+
+{{< docs_version version="chef-client-16.4">}}
+**Content for chef-client-16.4**
+
+Ullamco eu dolore minim nulla laborum exercitation minim quis pariatur nisi pariatur. Nostrud dolor mollit minim irure et est amet adipisicing id do. Ut eiusmod adipisicing culpa eiusmod labore cillum cupidatat amet irure enim. Laboris minim veniam irure voluptate nisi aliqua. Laboris ea officia officia ipsum fugiat tempor aliqua velit esse veniam aliqua. Elit minim eiusmod id exercitation commodo aliqua eu incididunt veniam laborum veniam ad. Culpa ex nostrud est non velit consectetur incididunt dolor consectetur ea.
+{{< /docs_version >}}
+
+
+{{< docs_version version="chef-client-16.3">}}
+**Content for chef-client-16.3**
+
+Incididunt labore est amet non fugiat veniam nostrud. Nulla dolor eu consequat dolore mollit consectetur consectetur ea qui est sit dolor qui. Amet dolore proident aute irure pariatur anim et deserunt consequat officia laborum eiusmod. Sint non laborum mollit nisi ullamco ea duis Lorem cupidatat eu.
+{{< /docs_version >}}
+
+Sunt aute exercitation id consequat eiusmod aliqua aliqua voluptate velit. Pariatur anim enim veniam tempor adipisicing. Qui nostrud exercitation laborum dolore. Deserunt nisi aliqua dolore voluptate dolore eiusmod eu sunt veniam proident. Amet culpa sint occaecat in enim Lorem consectetur. Ex aliquip consequat nostrud ad adipisicing non.

--- a/content/alpha_server.md
+++ b/content/alpha_server.md
@@ -1,0 +1,63 @@
++++
+title = "Server Docs Test"
+draft = false
+
+[chef_product]
+product_key = "chef-server"
+versions=[13.2, 13.1, 13.0]
+
+[menu]
+  [menu.overview]
+    title = "Server Docs Test"
+    identifier = "overview/alpha_server.md Server Docs Version Test"
+    parent = "overview"
+    weight = 2
++++
+
+Proident laboris labore eiusmod sint consequat aute nulla elit mollit in elit commodo amet. Dolor fugiat voluptate occaecat anim voluptate irure veniam ullamco. Eiusmod aliquip dolor sit sit.
+
+## Heading 1
+
+{{< docs_version version="chef-server-13.2">}}
+**Content for chef-server-13.2**
+
+Eiusmod laborum quis aliqua non occaecat. Commodo velit enim consequat sint sunt est officia ex dolor do ut quis nisi ad. Deserunt tempor officia reprehenderit qui do.
+{{< /docs_version >}}
+
+
+{{< docs_version version="chef-server-13.1">}}
+**Content for chef-server-13.1**
+
+Ullamco eu dolore minim nulla laborum exercitation minim quis pariatur nisi pariatur. Nostrud dolor mollit minim irure et est amet adipisicing id do. Ut eiusmod adipisicing culpa eiusmod labore cillum cupidatat amet irure enim. Laboris minim veniam irure voluptate nisi aliqua. Laboris ea officia officia ipsum fugiat tempor aliqua velit esse veniam aliqua. Elit minim eiusmod id exercitation commodo aliqua eu incididunt veniam laborum veniam ad. Culpa ex nostrud est non velit consectetur incididunt dolor consectetur ea.
+{{< /docs_version >}}
+
+
+{{< docs_version version="chef-server-13.0">}}
+**Content for chef-server-13.0**
+
+Incididunt labore est amet non fugiat veniam nostrud. Nulla dolor eu consequat dolore mollit consectetur consectetur ea qui est sit dolor qui. Amet dolore proident aute irure pariatur anim et deserunt consequat officia laborum eiusmod. Sint non laborum mollit nisi ullamco ea duis Lorem cupidatat eu.
+{{< /docs_version >}}
+
+Sunt aute exercitation id consequat eiusmod aliqua aliqua voluptate velit. Pariatur anim enim veniam tempor adipisicing. Qui nostrud exercitation laborum dolore. Deserunt nisi aliqua dolore voluptate dolore eiusmod eu sunt veniam proident. Amet culpa sint occaecat in enim Lorem consectetur. Ex aliquip consequat nostrud ad adipisicing non.
+
+## Heading 2
+
+{{< docs_version version="chef-server-13.2">}}
+**More Content for chef-server-13.2**
+
+Mollit est ipsum magna commodo magna occaecat do proident laborum ex. Pariatur commodo id esse velit labore cillum consequat. Magna ullamco tempor amet nulla in commodo pariatur culpa ullamco minim.
+{{< /docs_version >}}
+
+
+{{< docs_version version="chef-server-13.1">}}
+**More Content for chef-server-13.1**
+
+Dolor est adipisicing in ullamco occaecat irure fugiat ut laborum eiusmod occaecat nulla. Consectetur ipsum ea et non consectetur nostrud pariatur consequat anim consectetur fugiat cupidatat. Laborum nisi fugiat in sunt laboris amet et. Amet quis elit aute esse. Veniam adipisicing nulla in exercitation id.
+{{< /docs_version >}}
+
+
+{{< docs_version version="chef-server-13.0">}}
+**More Content for chef-server-13.0**
+
+Fugiat fugiat anim qui sit magna incididunt exercitation aliquip dolore non proident ex magna sunt. Esse aute dolore sint consequat amet pariatur sit irure anim tempor velit id laboris cillum. Pariatur Lorem cupidatat deserunt nulla mollit aute officia qui ipsum pariatur amet adipisicing.
+{{< /docs_version >}}

--- a/themes/docs-new/assets/js/version_docs.js
+++ b/themes/docs-new/assets/js/version_docs.js
@@ -1,0 +1,88 @@
+// Fetch the given URL parameters
+$.urlParam = function(name){
+  var results = new RegExp('[\?&]' + name + '=([^]*)').exec(window.location.href);
+  if (results==null){
+      return null;
+  }
+  else{
+      return results[1] || 0;
+  }
+}
+
+var version = $.urlParam('v');
+console.log(version)
+
+
+var id = document.getElementById("chef_product_version_select");
+var versionList = id.getElementsByTagName("OPTION");
+// console.log(versionList)
+for (var i = 0; i < versionList.length; i++) {
+  console.log(versionList[i].value)
+  if (versionList[i].dataset.product == "chef-automate"){
+    versionList[i].innerHTML = "Chef Automate " + versionList[i].dataset.version;
+  }
+  else if (versionList[i].dataset.product == "chef-client"){
+    versionList[i].innerHTML = "Chef Infra Client " + versionList[i].dataset.version;
+  }
+  else if (versionList[i].dataset.product == "chef-server"){
+    versionList[i].innerHTML = "Chef Infra Server " + versionList[i].dataset.version;
+  }
+}
+
+
+var default_version = document.getElementById("chef_product_version_select").dataset.defaultVersion;
+  // console.log(default_version)
+
+var currentVersion = default_version;
+
+versioned_text_blocks = document.getElementsByClassName("chef-product-version")
+for (var i = 0; i < versioned_text_blocks.length; i++) {
+  versioned_text = versioned_text_blocks[i];
+  versioned_text_version = versioned_text_blocks[i].classList[1];
+  //console.log(versioned_text_version);
+  //console.log(versioned_text.style);
+
+  if (versioned_text_version === default_version) {
+    versioned_text.style.display = "block";
+  } else {
+    versioned_text.style.display = "none";
+  }
+}
+
+document.getElementsByClassName("chef-product-version")
+
+
+function changeDefaultVersion(versionInput){
+  var default_version = versionInput;
+};
+
+document.getElementById("chef_product_version_select").onchange = function() {
+  var changeValue = this.value;
+  // var urlVersion = $.urlParam('v');
+  console.log('New version -->' + changeValue)
+
+  // if (urlVersion === null){
+  //   window.location.href = window.location.href + "?v=" + changeValue;
+  // } else {
+  //   window.location.href = window.location.href.replace(urlVersion, changeValue);
+  // };
+
+  if (changeValue == currentVersion){
+    console.log( "Selection didn't change version: " + this.value);
+  } else {
+    oldVersion = currentVersion;
+    currentVersion = changeValue;
+
+    displayText = document.getElementsByClassName(currentVersion);
+
+    for(var i = 0; i < displayText.length; i++) {
+      displayText[i].style.display = 'block';
+    }
+
+    hideText = document.getElementsByClassName(oldVersion);
+
+    for(var i = 0; i < hideText.length; i++) {
+      hideText[i].style.display = 'none';
+    }
+  }
+};

--- a/themes/docs-new/assets/sass/typography/_prose.scss
+++ b/themes/docs-new/assets/sass/typography/_prose.scss
@@ -42,6 +42,18 @@
       margin-top: 1rem;
     }
   }
+  #chef_product_version{
+    margin: -12px 0 26px 0;
+    &_label {
+      display: inline-block;
+      font-style: bold;
+      font-size: 1.25rem;
+    }
+    &_select {
+      display: inline-block;
+      width: auto;
+    }
+  }
 }
 
 .responsive-table {

--- a/themes/docs-new/layouts/_default/single.html
+++ b/themes/docs-new/layouts/_default/single.html
@@ -2,6 +2,21 @@
 <main id="main-content-col" tabindex="-1">
 <div class="col-content">
   <div id="{{ anchorize ( .Title )}}"><h1>{{ .Title }}</h1></div>
+  
+  {{ with .Params.chef_product }}
+  <div id="chef_product_version" >
+    <label id="chef_product_version_label" for="chef_product">Version:</label>
+    {{ $product := index . "product_key" }}
+    {{ $versions := sort (index . "versions") "value" "desc" }}
+    <select id="chef_product_version_select" data-default-version="{{ $product }}-{{ lang.NumFmt 1 (index $versions 0) }}" name="chef_product" >
+    {{ range $versions }}
+      <option data-product="{{ $product }}" data-version="{{ lang.NumFmt 1 . }}" value="{{ $product }}-{{lang.NumFmt 1 .}}">
+        {{ $product }} {{ . }}
+      </option>
+    {{ end }}
+    </select>
+  </div>
+  {{ end }}
 
   {{ $headers := findRE "<h[12].*?>(.|\n])+?</h[12]>" .Content }}
   {{ if and (ge (len $headers) 1) (ne .Params.toc false )}}

--- a/themes/docs-new/layouts/partials/javascript.html
+++ b/themes/docs-new/layouts/partials/javascript.html
@@ -11,7 +11,8 @@
 {{- $copycodebutton := resources.Get "js/copy-code-button.js" }}
 {{- $chefHugo := resources.Get "js/chef-hugo.js" }}
 {{- $resourceNote := resources.Get "js/resource-note.js" }}
-{{- $customJs := slice $segment $omnitruck $copycodebutton $chefHugo $resourceNote | resources.Concat "js/custom-bundle.js" | minify | fingerprint }}
+{{- $versionDocs := resources.Get "js/version_docs.js" }}
+{{- $customJs := slice $segment $omnitruck $copycodebutton $chefHugo $resourceNote $versionDocs | resources.Concat "js/custom-bundle.js" | minify | fingerprint }}
 <script src="{{ $customJs.Permalink }}" type="text/javascript"></script>
 <script type="text/javascript">
   (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){

--- a/themes/docs-new/layouts/shortcodes/docs_version.html
+++ b/themes/docs-new/layouts/shortcodes/docs_version.html
@@ -1,0 +1,3 @@
+<div class="chef-product-version {{ .Get "version" }}">
+  {{ .Inner | markdownify }}
+</div>


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Demo to a possible way of versioning the docs.

Each page can have sections of text that are versioned using a `docs_version` shortcode, e.g.:

```
{{< docs_version version="chef-client-16.5">}}
Text related to Chef Infra Client 16.5.

{{< /docs_version >}}

{{< docs_version version="chef-client-16.4">}}
Text related to Chef Infra Client 16.4.

{{< /docs_version >}}
```

The frontmatter of each page would have:

```
[chef_product]
product_key = "chef-client"
versions= [16.5, 16.4]
```

This would add a drop down list that would allow the user to select the docs for the version of software that they're using.

Through the magic of JavaScript and CSS, only the relevant sections of text would be visible.

Right now this doesn't save the product version locally, but I can add that functionality if we end up doing this. 

#### Previews

https://deploy-preview-2671--chef-web-docs.netlify.app/alpha_server/
https://deploy-preview-2671--chef-web-docs.netlify.app/alpha_client/

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
