### PR TITLE
Version docs for server

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -86,6 +86,9 @@ notAlternative = true
   tag = "tags"
   resource = "resources"
 
+[params.product_version]
+[params.product_version.chef-server]
+versions = ["13_2", "14_0"]
 
 [module]
 

--- a/content/chef_client_overview.md
+++ b/content/chef_client_overview.md
@@ -43,7 +43,7 @@ executable can be run as a daemon.
 ## Related Content
 
 -   [Chef Infra Client (executable)](/ctl_chef_client/)
--   [Chef Infra Server](/server_overview/)
+-   [Chef Infra Server](/server/)
 -   [Cookbooks](/cookbooks/)
 -   [Nodes](/nodes/)
 -   [Run Lists](/run_lists/)

--- a/content/chef_overview.md
+++ b/content/chef_overview.md
@@ -26,7 +26,7 @@ aliases = ["/chef_overview.html"]
     Chef Infra. The Chef Infra Client is installed on each node and is
     used to configure the node to its desired state.
 -   **Chef Infra Server** acts as [a hub for configuration
-    data](/server_overview/). Chef Infra Server stores cookbooks,
+    data](/server/). Chef Infra Server stores cookbooks,
     the policies that are applied to nodes, and metadata that describes
     each registered node that is being managed by Chef. Nodes use the
     Chef Infra Client to ask the Chef Infra Server for configuration

--- a/content/fips.md
+++ b/content/fips.md
@@ -92,7 +92,7 @@ FIPS mode.
 To enable FIPS manually for the Chef Infra Server, can add `fips true`
 to the `/etc/opscode/chef-server.rb` and reconfigure. For more
 configuration information see [Chef
-Server](/config_rb_server_optional_settings/).
+Server](/server/config_rb_server_optional_settings/).
 
 ## How to enable FIPS mode for the Chef Infra Client
 

--- a/content/install_chef_air_gap.md
+++ b/content/install_chef_air_gap.md
@@ -302,7 +302,7 @@ Supermarket.
 4.  Retrieve Supermarket's OAuth 2.0 client credentials:
 
     Depending on your Chef Infra Server version and configuration (see
-    [chef-server.rb](/config_rb_server_optional_settings/#config-rb-server-insecure-addon-compat)),
+    [chef-server.rb](/server/config_rb_server_optional_settings/#config-rb-server-insecure-addon-compat)),
     this can be retrieved via [chef-server-ctl oc-id-show-app
     supermarket](/ctl_chef_server/#ctl-chef-server-oc-id-show-app)
     or is located in `/etc/opscode/oc-id-applications/supermarket.json`:

--- a/content/install_server.md
+++ b/content/install_server.md
@@ -137,8 +137,8 @@ your `/etc/opscode/chef-server.rb` file by following the process below:
     ```
 
 For more information on configuring your Chef Infra Server, see
-[chef-server.rb Settings](/config_rb_server/) and [chef-server.rb
-Optional Settings](/config_rb_server_optional_settings/).
+[chef-server.rb Settings](/server/config_rb_server/) and [chef-server.rb
+Optional Settings](/server/config_rb_server_optional_settings/).
 
 ## High Availability
 

--- a/content/install_server_pre.md
+++ b/content/install_server_pre.md
@@ -35,7 +35,7 @@ The following platforms are not tested by Chef Software:
 ## Capacity Planning
 
 Read the [guidance around capacity
-planning](/server_overview/#capacity-planning) for information about
+planning](/server/#capacity-planning) for information about
 how to choose the right topology for the Chef Infra Server.
 
 ## Hardware Requirements

--- a/content/install_supermarket.md
+++ b/content/install_supermarket.md
@@ -96,7 +96,7 @@ To configure Chef Supermarket to use Chef Identity, do the following:
 4.  Retrieve Supermarket's OAuth 2.0 client credentials:
 
     Depending on your Chef Infra Server version and configuration (see
-    [chef-server.rb](/config_rb_server_optional_settings/#config-rb-server-insecure-addon-compat)),
+    [chef-server.rb](/server/config_rb_server_optional_settings/#config-rb-server-insecure-addon-compat)),
     this can be retrieved via [chef-server-ctl oc-id-show-app
     supermarket](/ctl_chef_server/#ctl-chef-server-oc-id-show-app)
     or is located in `/etc/opscode/oc-id-applications/supermarket.json`:

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -331,7 +331,7 @@ This release:
     -   `bookshelf['enable_request_logging']`
 
     See the [Chef server optional
-    settings](/config_rb_server_optional_settings/) guide for
+    settings](server/config_rb_server_optional_settings/) guide for
     additional details
 
 -   `chef-server-ctl reconfigure` fixes permissions on gems with an
@@ -339,7 +339,7 @@ This release:
 
 -   Makes the display of the welcome page configurable via the
     `nginx['show_welcome_page']` setting. See the [Chef server optional
-    settings](/config_rb_server_optional_settings/) guide for
+    settings](/server/config_rb_server_optional_settings/) guide for
     additional details
 
 -   Infers the current database migration level and necessary upgrades
@@ -380,7 +380,7 @@ The following items are new for Chef server 12.17.3:
     poisoning attacks by ensuring that nginx only responds to requests
     with host headers that match the configured FQDN for the given
     machine. See Chef server's [optional nginx
-    settings](/config_rb_server_optional_settings/#nginx) for
+    settings](/server/config_rb_server_optional_settings/#nginx) for
     additional details
 
 See the [change
@@ -1574,7 +1574,7 @@ Some `opscode_solr` settings are imported automatically, such as heap,
 new size, and Java options, but many settings are ignored. If your
 Enterprise Chef configuration is highly tuned for Apache Solr, review
 [these configuration
-settings](/config_rb_server_optional_settings/#opscode-solr4) before
+settings](/server/config_rb_server_optional_settings/#opscode-solr4) before
 re-tuning Apache Solr for Chef server version 12.
 
 ### External PostgreSQL

--- a/content/runbook/server_security.md
+++ b/content/runbook/server_security.md
@@ -70,7 +70,7 @@ sudo chef-server-ctl reconfigure
 ```
 
 For more information about the server configuration file, see
-[chef-server.rb](/config_rb_server/).
+[chef-server.rb](/server/config_rb_server/).
 
 ### Manual Installation
 
@@ -118,7 +118,7 @@ than 64 characters.
 
 The following example shows how the Chef Infra Server sets up and
 configures SSL certificates for Nginx. The cipher suite used by Nginx
-[is configurable](/config_rb_server/#ssl-protocols) using the
+[is configurable](/server/config_rb_server/#ssl-protocols) using the
 `ssl_protocols` and `ssl_ciphers` settings.
 
 ```ruby

--- a/content/server/_index.md
+++ b/content/server/_index.md
@@ -2,17 +2,17 @@
 title = "Chef Infra Server Overview"
 draft = false
 
-aliases = ["/server_overview.html", "/server_components.html"]
+aliases = ["/server_overview.html", "/server_components.html", "/server_overview/"]
 
 [menu]
   [menu.infra]
     title = "Chef Infra Server Overview"
-    identifier = "chef_infra/concepts/server_overview.md Chef Infra Server Overview"
+    identifier = "chef_infra/concepts/Chef Infra Server Overview"
     parent = "chef_infra/concepts"
     weight = 20
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/server_overview.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/server/_index.md)
 
 {{% chef_server %}}
 
@@ -23,7 +23,7 @@ aliases = ["/server_overview.html", "/server_components.html"]
 The Chef Infra Server can be configured via the
 `/etc/opscode/chef-server.rb` file. Whenever this file is modified, the
 `chef-server-ctl reconfigure` command must be run to apply the changes.
-See the [Chef Infra Server settings](/config_rb_server/) guide for
+See the [Chef Infra Server settings](/server/config_rb_server/) guide for
 additional information.
 
 {{< /note >}}

--- a/content/server/config_rb_server.md
+++ b/content/server/config_rb_server.md
@@ -1,0 +1,15 @@
++++
+title = "chef-server.rb Settings"
+draft = false
+
+version_docs_product = "chef-server"
+
+aliases = ["/config_rb_server.html", "/config_rb_server_14/"]
+
+[menu]
+  [menu.infra]
+    title = "chef-server.rb Settings"
+    identifier = "chef_infra/managing_chef_infra_server/config_rb_server.md chef-server.rb"
+    parent = "chef_infra/managing_chef_infra_server"
+    weight = 160
++++

--- a/content/server/config_rb_server_optional_settings.md
+++ b/content/server/config_rb_server_optional_settings.md
@@ -1,0 +1,15 @@
++++
+title = "chef-server.rb Optional Settings"
+draft = false
+
+aliases = ["/config_rb_server_optional_settings.html", "/config_rb_server_optional_settings_14/"]
+
+version_docs_product = "chef-server"
+
+[menu]
+  [menu.infra]
+    title = "Chef Infra Server Optional Settings"
+    identifier = "chef_infra/managing_chef_infra_server/config_rb_server_optional_settings.md Chef Infra Server Optional Settings"
+    parent = "chef_infra/managing_chef_infra_server"
+    weight = 170
++++

--- a/content/server/config_rb_server_optional_settings.md
+++ b/content/server/config_rb_server_optional_settings.md
@@ -2,7 +2,7 @@
 title = "chef-server.rb Optional Settings"
 draft = false
 
-aliases = ["/config_rb_server_optional_settings.html", "/config_rb_server_optional_settings_14/"]
+aliases = ["/config_rb_server_optional_settings.html", "/config_rb_server_optional_settings_14/", "/config_rb_optional_settings/"]
 
 version_docs_product = "chef-server"
 

--- a/content/server/v13_2/config_rb_server.md
+++ b/content/server/v13_2/config_rb_server.md
@@ -33,7 +33,7 @@ Infra Server in larger installations.
 {{< note >}}
 
 Review the full list of [optional
-settings](/config_rb_server_optional_settings/) that can be added to
+settings](/server/config_rb_server_optional_settings/) that can be added to
 the chef-server.rb file. Many of these optional settings should not be
 added without first consulting with Chef support.
 

--- a/content/server/v13_2/config_rb_server.md
+++ b/content/server/v13_2/config_rb_server.md
@@ -1,32 +1,23 @@
 +++
-title = "chef-server.rb 13 Settings"
-draft = false
-
-aliases = ["/config_rb_server.html"]
-
-[menu]
-  [menu.infra]
-    title = "chef-server.rb 13 Settings"
-    identifier = "chef_infra/managing_chef_infra_server/config_rb_server.md chef-server.rb"
-    parent = "chef_infra/managing_chef_infra_server"
-    weight = 160
+title = "chef-server.rb Settings"
+version = "13_2"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/config_rb_server.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/server/v13_2/config_rb_server.md)
 
-{{% config_rb_server_summary %}}
+{{< reusable_text_versioned file="config_rb_server_summary">}}
 
 ## Use Conditions
 
-{{% config_add_condition %}}
+{{< reusable_text_versioned file="config_add_condition">}}
 
 ## Recommended Settings
 
-{{% server_tuning_general %}}
+{{< reusable_text_versioned file="server_tuning_general">}}
 
 ### NGINX SSL Protocols
 
-{{% server_tuning_nginx %}}
+{{< reusable_text_versioned file="server_tuning_nginx">}}
 
 ## Optional Settings
 
@@ -35,7 +26,7 @@ Infra Server in larger installations.
 
 {{< note >}}
 
-{{% notes_config_rb_server_must_reconfigure %}}
+{{< reusable_text_versioned file="notes_config_rb_server_must_reconfigure">}}
 
 {{< /note >}}
 
@@ -50,11 +41,11 @@ added without first consulting with Chef support.
 
 ### bookshelf
 
-{{% server_tuning_bookshelf %}}
+{{< reusable_text_versioned file="server_tuning_bookshelf">}}
 
 {{< warning >}}
 
-{{% notes_server_aws_cookbook_storage %}}
+{{< reusable_text_versioned file="notes_server_aws_cookbook_storage">}}
 
 {{< /warning >}}
 
@@ -72,7 +63,7 @@ tuning effort for the **opscode-account** service:
 
 ### opscode-erchef
 
-{{% server_tuning_erchef %}}
+{{< reusable_text_versioned file="server_tuning_erchef">}}
 
 #### Data Collector
 
@@ -90,27 +81,27 @@ application:
 
 ### opscode-expander
 
-{{% server_tuning_expander %}}
+{{< reusable_text_versioned file="server_tuning_expander">}}
 
 ### opscode-solr4
 
-{{% server_tuning_solr %}}
+{{< reusable_text_versioned file="server_tuning_solr">}}
 
 #### Available Memory
 
-{{% server_tuning_solr_available_memory %}}
+{{< reusable_text_versioned file="server_tuning_solr_available_memory">}}
 
 #### Large Node Sizes
 
-{{% server_tuning_solr_large_node_sizes %}}
+{{< reusable_text_versioned file="server_tuning_solr_large_node_sizes">}}
 
 #### Update Frequency
 
-{{% server_tuning_solr_update_frequency %}}
+{{< reusable_text_versioned file="server_tuning_solr_update_frequency">}}
 
 ### postgresql
 
-{{% server_tuning_postgresql %}}
+{{< reusable_text_versioned file="server_tuning_postgresql">}}
 
 `postgresql['sslmode']`
 

--- a/content/server/v13_2/config_rb_server_optional_settings.md
+++ b/content/server/v13_2/config_rb_server_optional_settings.md
@@ -1,20 +1,10 @@
 +++
-title = "chef-server.rb 14 Optional Settings"
-draft = false
-
-aliases = ["/config_rb_server_optional_settings_14.html"]
-
-[menu]
-  [menu.infra]
-    title = "Chef Infra Server 14 Optional Settings"
-    identifier = "chef_infra/managing_chef_infra_server_14/config_rb_server_optional_settings_14.md Chef Infra Server Optional Settings"
-    parent = "chef_infra/managing_chef_infra_server"
-    weight = 170
+title = "chef-server.rb 13 Optional Settings"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/config_rb_server_optional_settings.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/server/v13_2/config_rb_server_optional_settings.md)
 
-{{% config_rb_server_summary %}}
+{{< reusable_text_versioned file="config_rb_server_summary" >}}
 
 ## Settings
 
@@ -23,7 +13,7 @@ in the chef-server.rb file.
 
 {{< note >}}
 
-{{% notes_config_rb_server_must_reconfigure %}}
+{{< reusable_text_versioned file="notes_config_rb_server_must_reconfigure" >}}
 
 {{< /note >}}
 
@@ -121,11 +111,11 @@ This configuration file has the following general settings:
 
 ### bookshelf
 
-{{% server_services_bookshelf %}}
+{{< reusable_text_versioned file="server_services_bookshelf" >}}
 
 {{< note >}}
 
-{{% notes_server_aws_cookbook_storage %}}
+{{< reusable_text_versioned file="notes_server_aws_cookbook_storage" >}}
 
 {{< /note >}}
 
@@ -137,7 +127,7 @@ This configuration file has the following settings for `bookshelf`:
     location, such as Amazon EC2. See [AWS external bookshelf
     settings](/server_overview/#external-bookshelf-settings) for
     more information on configuring external bookshelf. Default value:
-    **generated**. As of Chef Infra Server 12.14, this is no longer the
+    **generated**. As of Chef Server 12.14, this is no longer the
     preferred command.
 
     Please use `chef-server-ctl set-secret bookshelf access_key_id` from
@@ -204,7 +194,7 @@ This configuration file has the following settings for `bookshelf`:
     as Amazon EC2. See [AWS external bookshelf
     settings](/server_overview/#external-bookshelf-settings) for
     more information on configuring external bookshelf. Default value:
-    **generated**. As of Chef Infra Server 12.14, this is no longer the
+    **generated**. As of Chef Server 12.14, this is no longer the
     preferred command.
 
     Please use `chef-server-ctl set-secret bookshelf secret_access_key`
@@ -264,7 +254,7 @@ This configuration file has the following settings for `bootstrap`:
 ### compliance forwarding
 
 The configuration file has the following settings for forwarding
-`compliance` requests using the Chef Infra Server authentication system.
+`compliance` requests using the chef server authentication system.
 
 `profiles['root_url']`
 
@@ -330,14 +320,14 @@ This configuration file has the following settings for `data_collector`:
     `/data-collector` to the configured Chef Automate
     `data_collector['root_url']`. Note that *this route* does not check
     the request signature and add the right data_collector token, but
-    just proxies the Chef Automate endpoint **as-is**. Default value: `nil`.
+    just proxies the Automate endpoint **as-is**. Default value: `nil`.
 
 `data_collector['token']`
 
 :   Legacy configuration for shared data collector security token. When
     configured, the token will be passed as an HTTP header named
     `x-data-collector-token` which the server can choose to accept or
-    reject. As of Chef Infra Server 12.14, this is no longer the preferred
+    reject. As of Chef Server 12.14, this is no longer the preferred
     command.
 
     Please use `chef-server-ctl set-secret data_collector token` from
@@ -429,6 +419,24 @@ This configuration file has the following settings for `estatsd`:
 `estatsd['vip']`
 
 :   The virtual IP address. Default value: `'127.0.0.1'`.
+
+### jetty
+
+This configuration file has the following settings for `jetty`:
+
+`jetty['enable']`
+
+:   Enable a service. Default value: `'false'`. This value should not be
+    modified.
+
+`jetty['log_directory']`
+
+:   The directory in which log data is stored. The default value is the
+    recommended value. Default value:
+
+    ```ruby
+    '/var/opt/opscode/opscode-solr4/jetty/logs'
+    ```
 
 ### lb / lb_internal
 
@@ -576,7 +584,7 @@ And for the internal load balancers:
 
 ### ldap
 
-{{% config_rb_server_settings_ldap %}}
+{{< reusable_text_versioned file="config_rb_server_settings_ldap" >}}
 
 ### nginx
 
@@ -835,7 +843,7 @@ This configuration file has the following settings for `nginx`:
 
 ### oc_bifrost
 
-{{% server_services_bifrost %}}
+{{< reusable_text_versioned file="server_services_bifrost" >}}
 
 This configuration file has the following settings for `oc_bifrost`:
 
@@ -1012,7 +1020,7 @@ This configuration file has the following settings for `oc-chef-pedant`:
 
 ### oc-id
 
-{{% server_services_oc_id %}}
+{{< reusable_text_versioned file="server_services_oc_id" >}}
 
 This configuration file has the following settings for `oc-id`:
 
@@ -1045,7 +1053,7 @@ This configuration file has the following settings for `oc-id`:
 
 `oc_id['email_from_address']`
 
-:   New in Chef Infra Server 12.12.
+:   New in Chef Server 12.12.
 
     Outbound email address. Defaults to the `'from_email'` value.
 
@@ -1066,7 +1074,7 @@ This configuration file has the following settings for `oc-id`:
 
 `oc_id['origin']`
 
-:   New in Chef Infra Server 12.12.
+:   New in Chef Server 12.12.
 
     The FQDN for the server that is sending outbound email. Defaults to
     the `'api_fqdn'` value, which is the FQDN for the Chef Infra Server.
@@ -1212,7 +1220,7 @@ This configuration file has the following settings for
 
 ### opscode-erchef
 
-{{% server_services_erchef %}}
+{{< reusable_text_versioned file="server_services_erchef" >}}
 
 This configuration file has the following settings for `opscode-erchef`:
 
@@ -1414,7 +1422,7 @@ This configuration file has the following settings for `opscode-erchef`:
 
 `opscode_erchef['strict_search_result_acls']`
 
-:   {{% settings_strict_search_result_acls %}}
+:   {{< reusable_text_versioned file="settings_strict_search_result_acls" >}}
 
 `opscode_erchef['udp_socket_pool_size']`
 
@@ -1432,108 +1440,216 @@ This configuration file has the following settings for `opscode-erchef`:
 
 :   The virtual IP address. Default value: `127.0.0.1`.
 
-### Elasticsearch
+### opscode-expander
 
-This configuration file has the following settings for `elasticsearch`:
+{{< reusable_text_versioned file="server_services_expander" >}}
 
-`elasticsearch['enable']`
+This configuration file has the following settings for
+`opscode-expander`:
 
-: Enable a service. Default value: `true`.
+`opscode_expander['consumer_id']`
 
-`elasticsearch['dir']`
+:   The identity of the consumer to which messages are published.
+    Default value: `default`.
 
-: The working directory. The default value is the recommended value. Default value: `/var/opt/opscode/elasticsearch`
+`opscode_expander['dir']`
 
-`elasticsearch['data_dir']`
+:   The working directory. The default value is the recommended value.
+    Default value:
 
-:The paths used to store data. Default value: `/var/opt/opscode/elasticsearch/data`
+    ```ruby
+    /var/opt/opscode/opscode-expander
+    ```
 
-`elasticsearch['plugins_directory']`
+`opscode_expander['enable']`
 
-: The default location of the plugins directory depends on which package you install. Default value: `/var/opt/opscode/elasticsearch/plugins`
+:   Enable a service. Default value: `true`.
 
-`elasticsearch['scripts_directory']`
+`opscode_expander['log_directory']`
 
-:The default location of the scripts directory depends on which package you install. Default value: `/var/opt/opscode/elasticsearch/scripts`
+:   The directory in which log data is stored. The default value is the
+    recommended value. Default value:
 
-`elasticsearch['temp_directory']`
+    ```ruby
+    /var/log/opscode/opscode-expander
+    ```
 
-: By default, Elasticsearch uses a private temporary directory that the startup script creates immediately below the system temporary directory. Default value: `/var/opt/opscode/elasticsearch/tmp`
+`opscode_expander['log_rotation']`
 
-`elasticsearch['log_directory']`
+:   The log rotation policy for this service. Log files are rotated when
+    they exceed `file_maxbytes`. The maximum number of log files in the
+    rotation is defined by `num_to_keep`. Default value:
 
-: The directory in which log data is stored. The default value is the recommended value. Default value: `/var/log/opscode/elasticsearch`
+    ```ruby
+    { 'file_maxbytes' => 104857600, 'num_to_keep' => 10 }
+    ```
 
-`elasticsearch['log_rotation']['file_maxbytes']`
+`opscode_expander['nodes']`
 
-: The log rotation policy for this service. Log files are rotated when they exceed file_maxbytes. Default value for 'file_maxbytes': `104857600`
+:   The number of allowed worker processes. Default value: `2`.
 
-`elasticsearch['log_rotation']['num_to_keep']`
+`opscode_expander['reindexer_log_directory']`
 
-: The log rotation policy for this service. The maximum number of log files in the rotation is defined by num_to_keep.  Default value for 'num_to_keep': => `10`
+:   The directory in which `opscode-expander-reindexer` logs files are
+    located. Default value:
 
-`elasticsearch['vip']`
+    ```ruby
+    /var/log/opscode/opscode-expander-reindexer
+    ```
 
-: The virtual IP address for the machine on which Apache Solr is running. Default value: `127.0.0.1`
+### opscode-solr4
 
-`elasticsearch['listen']`
+{{< reusable_text_versioned file="server_services_solr4" >}}
 
-: The IP address for the machine on which Apache Solr is running. Default value: `127.0.0.1`
+This configuration file has the following settings for `opscode-solr4`:
 
-`elasticsearch['port']`
+`opscode_solr4['auto_soft_commit']`
 
-: The port on which the service is to listen. Default value: `9200`
+:   The maximum number of documents before a soft commit is triggered.
+    Default value: `1000`.
 
-`elasticsearch['enable_gc_log']`
+`opscode_solr4['commit_interval']`
 
-: Enable or disable GC logging. Default value: `false`
+:   The frequency (in seconds) at which node objects are added to the
+    Apache Solr search index. This value should be tuned carefully. When
+    data is committed to the Apache Solr index, all incoming updates are
+    blocked. If the duration between updates is too short, it is
+    possible for the rate at which updates are asked to occur to be
+    faster than the rate at which objects can be actually committed.
+    Default value: `60000` (every 60 seconds).
 
-`elasticsearch['initial_cluster_join_timeout']`
+`opscode_solr4['data_dir']`
 
-: Default value: `90`
+:   The directory in which on-disk data is stored. The default value is
+    the recommended value. Default value:
 
-`elasticsearch['jvm_opts']`
+    ```ruby
+    /var/opt/opscode/opscode-solr4/data
+    ```
 
-: Default values are set based on [JVM configuration options](https://github.com/elastic/elasticsearch/blob/6.8/distribution/src/config/jvm.options).
+`opscode_solr4['dir']`
 
-{{< note >}}
+:   The working directory. The default value is the recommended value.
+    Default value:
 
-Each item in this list will be placed as is into the java_opts config file. Entries are set in chef-server.rb as:
+    ```ruby
+    /var/opt/opscode/opscode-solr4
+    ```
 
-```ruby
- elasticsearch.jvm_opts = [
-  "-xoption1",
-  "-xoption2",
-  ...
-  "optionN"
- ]
-```
+`opscode_solr4['enable']`
 
-{{< /note >}}
+:   Enable a service. Default value: `true`.
 
-`elasticsearch['heap_size']`
+`opscode_solr4['heap_size']`
 
-: The amount of memory (in MBs) available to Elasticsearch. If there is not enough memory available, search queries made by nodes to Elasticsearch may fail. The amount of memory that must be available also depends on the number of nodes in the organization, the frequency of search queries, and other characteristics that are unique to each organization. In general, as the number of nodes increases, so does the amount of memory. The default value should work for many organizations with fewer than 25 nodes. For an organization with several hundred nodes, the amount of memory that is required often exceeds 3GB. Default value is is equivalent to 25% of the system memory or 1024 MB, whichever is greater.
+:   The amount of memory (in MBs) available to Apache Solr. If there is
+    not enough memory available, search queries made by nodes to Apache
+    Solr may fail. The amount of memory that must be available also
+    depends on the number of nodes in the organization, the frequency of
+    search queries, and other characteristics that are unique to each
+    organization. In general, as the number of nodes increases, so does
+    the amount of memory. The default value should work for many
+    organizations with fewer than 25 nodes. For an organization with
+    several hundred nodes, the amount of memory that is required often
+    exceeds 3GB. Default value: `nil`, which is equivalent to 25% of the
+    system memory or 1024 (MB, but this setting is specified as an
+    integer number of MB in EC11), whichever is smaller.
 
-{{< note >}}
+`opscode_solr4['ip_address']`
 
-If new_size or heap_size is also specified directly in java_opts, it will be ignored in favor of the chef-server.rb values or the defaults as calculated here. Only use chef-server.rb to set heap and new sizes. Learn more about [Elasticsearch heap-size](https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html). It will error out if the system memory is less than 4 GB. This value is bounded between 1 GB - 28 GB.
+:   The IP address for the machine on which Apache Solr is running.
+    Default value: `127.0.0.1`.
 
-{{< /note >}}
+`opscode_solr4['java_opts']`
 
-`elasticsearch['new_size']`
+:   A Hash of `JAVA_OPTS` environment variables to be set.
+    (`-XX:NewSize` is configured using the `new_size` setting.) Default
+    value: `' '` (empty).
 
-: Defaults to the larger of 1/16th the heap_size and 32 MB.
+`opscode_solr4['log_directory']`
 
-{{< note >}}
+:   The directory in which log data is stored. The default value is the
+    recommended value. Default value:
 
-If new_size or heap_size is also specified directly in java_opts, it will be ignored in favor of the chef-server.rb values or the defaults as calculated here.  Only use chef-server.rb to set heap and new sizes. Learn more about [Elasticsearch heap-size documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html).
+    ```ruby
+    /var/log/opscode/opscode-solr4
+    ```
 
-{{< /note >}}
+`opscode_solr4['log_gc']`
+
+:   New in Chef Server 12.12.
+
+    Enable or disable GC logging. Default is `true`.
+
+`opscode_solr4['log_rotation']`
+
+:   The log rotation policy for this service. Log files are rotated when
+    they exceed `file_maxbytes`. The maximum number of log files in the
+    rotation is defined by `num_to_keep`. Default value:
+
+    ```ruby
+    { 'file_maxbytes' => 104857600, 'num_to_keep' => 10 }
+    ```
+
+`opscode_solr4['max_commit_docs']`
+
+:   The frequency (in documents) at which node objects are added to the
+    Apache Solr search index. This value should be tuned carefully. When
+    data is committed to the Apache Solr index, all incoming updates are
+    blocked. If the duration between updates is too short, it is
+    possible for the rate at which updates are asked to occur to be
+    faster than the rate at which objects can be actually committed.
+    Default value: `1000` (every 1000 documents).
+
+`opscode_solr4['max_field_length']`
+
+:   The maximum field length (in number of tokens/terms). If a field
+    length exceeds this value, Apache Solr may not be able to complete
+    building the index. Default value: `100000` (increased from the
+    Apache Solr default value of `10000`).
+
+`opscode_solr4['max_merge_docs']`
+
+:   The maximum number of index segments allowed before they are merged
+    into a single index. Default value: `2147483647`.
+
+`opscode_solr4['merge_factor']`
+
+:   The maximum number of document updates that can be stored in memory
+    before being flushed and added to the current index segment. Default
+    value: `15`.
+
+`opscode_solr4['new_size']`
+
+:   Configure the `-XX:NewSize` `JAVA_OPTS` environment variable.
+    Default value: `nil`.
+
+`opscode_solr4['poll_seconds']`
+
+:   The frequency (in seconds) at which the secondary machine polls the
+    primary. Default value: `20`.
+
+`opscode_solr4['port']`
+
+:   The port on which the service is to listen. Default value: `8983`.
+
+`opscode_solr4['ram_buffer_size']`
+
+:   The size (in megabytes) of the RAM buffer. When document updates
+    exceed this amout, pending updates are flushed. Default value:
+    `100`.
+
+`opscode_solr4['url']`
+
+:   Default value: `'http://localhost:8983/solr'`.
+
+`opscode_solr4['vip']`
+
+:   The virtual IP address. Default value: `127.0.0.1`.
 
 ### postgresql
 
-{{% server_services_postgresql %}}
+{{< reusable_text_versioned file="server_services_postgresql" >}}
 
 This configuration file has the following settings for `postgresql`:
 
@@ -1719,9 +1835,224 @@ This configuration file has the following settings for `postgresql`:
 :   The size (in megabytes) of allowed in-memory sorting. Default value:
     `8MB`.
 
+### rabbitmq
+
+{{< reusable_text_versioned file="server_services_rabbitmq" >}}
+
+This configuration file has the following settings for `rabbitmq`:
+
+`rabbitmq['actions_exchange']`
+
+:   The name of the exchange to which Chef actions publishes actions
+    data. Default value: `'actions'`.
+
+`rabbitmq['actions_password']`
+
+:   Legacy configuration setting for the password of the `actions_user`.
+    Default value: **generated**.
+
+    To override the default value, use the [Secrets
+    Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
+    command: `chef-server-ctl set-actions-password`.
+
+`rabbitmq['actions_user']`
+
+:   The user with permission to publish actions data. Default value:
+    `'actions'`.
+
+`rabbitmq['actions_vhost']`
+
+:   The virtual host to which Chef actions publishes actions data.
+    Default value: `'/analytics'`.
+
+`rabbitmq['analytics_max_length']`
+
+:   The maximum number of messages that can be queued before RabbitMQ
+    automatically drops messages from the front of the queue to make
+    room for new messages. Default value: `10000`.
+
+`rabbitmq['consumer_id']`
+
+:   The identity of the consumer to which messages are published.
+    Default value: `'hotsauce'`.
+
+`rabbitmq['data_dir']`
+
+:   The directory in which on-disk data is stored. The default value is
+    the recommended value. Default value:
+    `'/var/opt/opscode/rabbitmq/db'`.
+
+`rabbitmq['dir']`
+
+:   The working directory. The default value is the recommended value.
+    Default value: `'/var/opt/opscode/rabbitmq'`.
+
+`rabbitmq['drop_on_full_capacity']`
+
+:   Specify if messages will stop being sent to the RabbitMQ queue when
+    it is at capacity. Default value: `true`.
+
+`rabbitmq['enable']`
+
+:   Enable a service. Default value: `true`.
+
+`rabbitmq['log_directory']`
+
+:   The directory in which log data is stored. The default value is the
+    recommended value. Default value: `'/var/log/opscode/rabbitmq'`.
+
+`rabbitmq['log_rotation']`
+
+:   The log rotation policy for this service. Log files are rotated when
+    they exceed `file_maxbytes`. The maximum number of log files in the
+    rotation is defined by `num_to_keep`. Default value:
+
+    ```ruby
+    { 'file_maxbytes' => 104857600, 'num_to_keep' => 10 }
+    ```
+
+`rabbitmq['management_enabled']`
+
+:   Specify if the rabbitmq-management plugin is enabled. Default value:
+    `true`.
+
+`rabbitmq['management_password']`
+
+:   Legacy configuration setting for rabbitmq-management plugin
+    password. Default value: **generated**.
+
+    To override the default value, use the [Secrets
+    Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
+    command: `chef-server-ctl set-secret rabbitmq management_password`.
+
+`rabbitmq['management_port']`
+
+:   The rabbitmq-management plugin port. Default value: `15672`.
+
+`rabbitmq['management_user']`
+
+:   The rabbitmq-management plugin user. Default value: `'rabbitmgmt'`.
+
+`rabbitmq['node_ip_address']`
+
+:   The bind IP address for RabbitMQ. Default value: `'127.0.0.1'`.
+
+`rabbitmq['node_port']`
+
+:   The port on which the service is to listen. Default value: `'5672'`.
+
+`rabbitmq['nodename']`
+
+:   The unique identifier of the node. Default value: `'rabbit@localhost'`.
+
+`rabbitmq['password']`
+
+:   Legacy configuration setting for the password for the RabbitMQ user.
+    Default value: **generated**.
+
+    To override the default value, use the [Secrets
+    Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
+    command: `chef-server-ctl set-secret rabbitmq password`.
+
+`rabbitmq['prevent_erchef_startup_on_full_capacity']`
+
+:   Specify if the Chef Infra Server will start when the monitored
+    RabbitMQ queue is full. Default value: `false`.
+
+`rabbitmq['queue_at_capacity_affects_overall_status']`
+
+:   Specify if the `_status` endpoint in the Chef Infra Server API will
+    fail if the monitored queue is at capacity. Default value: `false`.
+
+`rabbitmq['queue_length_monitor_enabled']`
+
+:   Specify if the queue length monitor is enabled. Default value:
+    `true`.
+
+`rabbitmq['queue_length_monitor_millis']`
+
+:   The frequency (in milliseconds) at which the length of the RabbitMQ
+    queue is checked. Default value: `30000`.
+
+`rabbitmq['queue_length_monitor_timeout_millis']`
+
+:   The timeout (in milliseconds) at which calls to the queue length
+    monitor will stop if the Chef Infra Server is overloaded. Default
+    value: `5000`.
+
+`rabbitmq['queue_length_monitor_queue']`
+
+:   The RabbitMQ queue that is observed by queue length monitor. Default
+    value: `'alaska'`.
+
+`rabbitmq['queue_length_monitor_vhost']`
+
+:   The virtual host for the RabbitMQ queue that is observed by queue
+    length monitor. Default value: `'/analytics'`.
+
+`rabbitmq['rabbit_mgmt_http_cull_interval']`
+
+:   The maximum cull interval (in seconds) for the HTTP connection pool
+    that is used by the rabbitmq-management plugin. Default value: `60`.
+
+`rabbitmq['rabbit_mgmt_http_init_count']`
+
+:   The initial worker count for the HTTP connection pool that is used
+    by the rabbitmq-management plugin. Default value: `25`.
+
+`rabbitmq['rabbit_mgmt_http_max_age']`
+
+:   The maximum connection worker age (in seconds) for the HTTP
+    connection pool that is used by the rabbitmq-management plugin.
+    Default value: `70`.
+
+`rabbitmq['rabbit_mgmt_http_max_connection_duration']`
+
+:   The maximum connection duration (in seconds) for the HTTP connection
+    pool that is used by the rabbitmq-management plugin. Default value:
+    `70`.
+
+`rabbitmq['rabbit_mgmt_http_max_count']`
+
+:   The maximum worker count for the HTTP connection pool that is used
+    by the rabbitmq-management plugin. Default value: `100`.
+
+`rabbitmq['rabbit_mgmt_ibrowse_options']`
+
+:   An array of comma-separated key-value pairs of ibrowse options for
+    the HTTP connection pool that is used by the rabbitmq-management
+    plugin. Default value: `'{connect_timeout, 10000}'`.
+
+`rabbitmq['rabbit_mgmt_timeout']`
+
+:   The timeout for the HTTP connection pool that is used by the
+    rabbitmq-management plugin. Default value: `30000`.
+
+`rabbitmq['reindexer_vhost']`
+
+:   Default value: `'/reindexer'`.
+
+`rabbitmq['ssl_versions']`
+
+:   The SSL versions used by the rabbitmq-management plugin. (See
+    [RabbitMQ TLS support](https://www.rabbitmq.com/ssl.html) for more
+    information.) Default value: `['tlsv1.2', 'tlsv1.1']`.
+
+`rabbitmq['user']`
+
+:   Default value: `'chef'`.
+
+`rabbitmq['vhost']`
+
+:   Default value: `'/chef'`.
+
+`rabbitmq['vip']`
+
+:   The virtual IP address. Default value: `'127.0.0.1'`.
+
 ### redis_lb
 
-{{% server_services_redis %}}
+{{< reusable_text_versioned file="server_services_redis" >}}
 
 This configuration file has the following settings for `redis_lb`:
 

--- a/content/server/v13_2/config_rb_server_optional_settings.md
+++ b/content/server/v13_2/config_rb_server_optional_settings.md
@@ -125,7 +125,7 @@ This configuration file has the following settings for `bookshelf`:
 
 :   The access key identifier. This may point at an external storage
     location, such as Amazon EC2. See [AWS external bookshelf
-    settings](/server_overview/#external-bookshelf-settings) for
+    settings](/server/#aws-settings) for
     more information on configuring external bookshelf. Default value:
     **generated**. As of Chef Server 12.14, this is no longer the
     preferred command.
@@ -192,7 +192,7 @@ This configuration file has the following settings for `bookshelf`:
 
 :   The secret key. This may point at an external storage location, such
     as Amazon EC2. See [AWS external bookshelf
-    settings](/server_overview/#external-bookshelf-settings) for
+    settings](/server/#aws-settings) for
     more information on configuring external bookshelf. Default value:
     **generated**. As of Chef Server 12.14, this is no longer the
     preferred command.
@@ -237,7 +237,7 @@ This configuration file has the following settings for `bookshelf`:
 
 :   The virtual IP address. This may point at an external storage
     location, such as Amazon EC2. See [AWS external bookshelf
-    settings](/server_overview/#external-bookshelf-settings) for
+    settings](/server/#aws-settings) for
     more information on configuring external bookshelf. Default value:
     `127.0.0.1`.
 
@@ -1384,7 +1384,7 @@ This configuration file has the following settings for `opscode-erchef`:
 :   The name of the Amazon Simple Storage Service (S3) bucket. This may
     point at external storage locations, such as Amazon EC2. See [AWS
     external bookshelf
-    settings](/server_overview/#external-bookshelf-settings) for
+    settings](/server/#aws-settings) for
     more information on configuring external bookshelf.
 
 `opscode_erchef['s3_parallel_ops_fanout']`

--- a/content/server/v13_2/index.md
+++ b/content/server/v13_2/index.md
@@ -1,0 +1,3 @@
++++
+headless = true
++++

--- a/content/server/v13_2/reusable_text/config_add_condition.md
+++ b/content/server/v13_2/reusable_text/config_add_condition.md
@@ -1,0 +1,13 @@
+Use a `case` statement to apply different values based on whether the
+setting exists on the front-end or back-end servers. Add code to the
+server configuration file similar to the following:
+
+```ruby
+role_name = ChefServer['servers'][node['fqdn']]['role']
+case role_name
+when 'backend'
+  # backend-specific configuration here
+when 'frontend'
+  # frontend-specific configuration here
+end
+```

--- a/content/server/v13_2/reusable_text/config_rb_server_settings_ldap.md
+++ b/content/server/v13_2/reusable_text/config_rb_server_settings_ldap.md
@@ -1,0 +1,199 @@
+
+&nbsp;
+
+<div class="admonition-warning">
+
+<p class="admonition-warning-title">Warning</p>
+
+<div class="admonition-warning-text">
+
+The following settings **MUST** be in the config file for LDAP
+authentication to Active Directory to work:
+
+-   `base_dn`
+-   `bind_dn`
+-   `group_dn`
+-   `host`
+
+If those settings are missing, you will get authentication errors and be
+unable to proceed.
+
+</div>
+
+</div>
+
+This configuration file has the following settings for `ldap`:
+
+`ldap['base_dn']`
+
+:   The root LDAP node under which all other nodes exist in the
+    directory structure. For Active Directory, this is typically
+    `cn=users` and then the domain. For example:
+
+    ```ruby
+    'OU=Employees,OU=Domain users,DC=example,DC=com'
+    ```
+
+    Default value: `nil`.
+
+`ldap['bind_dn']`
+
+:   The distinguished name used to bind to the LDAP server. The user the
+    Chef Infra Server will use to perform LDAP searches. This is often
+    the administrator or manager user. This user needs to have read
+    access to all LDAP users that require authentication. The Chef Infra
+    Server must do an LDAP search before any user can log in. Many
+    Active Directory and LDAP systems do not allow an anonymous bind. If
+    anonymous bind is allowed, leave the `bind_dn` and `bind_password`
+    settings blank. If anonymous bind is not allowed, a user with `READ`
+    access to the directory is required. This user must be specified as
+    an LDAP distinguished name similar to:
+
+    ```ruby
+    'CN=user,OU=Employees,OU=Domainuser,DC=example,DC=com'
+    ```
+
+    <div class="admonition-note">
+    <p class="admonition-note-title">Note</p>
+    <div class="admonition-note-text">
+
+    If you need to escape characters in a distinguished name, such as
+    when using Active Directory, they must be [escaped with a backslash
+    escape
+    character](https://social.technet.microsoft.com/wiki/contents/articles/5312.active-directory-characters-to-escape.aspx).
+
+    ```ruby
+    'CN=example\\user,OU=Employees,OU=Domainuser,DC=example,DC=com'
+    ```
+
+    </div>
+    </div>
+
+    Default value: `nil`.
+
+`ldap['bind_password']`
+
+:   Legacy configuration for the password of the binding user. The
+    password for the user specified by `ldap['bind_dn']`. Leave this
+    value and `ldap['bind_dn']` unset if anonymous bind is sufficient.
+    Default value: `nil`. As of Chef Server 12.14, this is no longer the
+    preferred command.
+
+    Please use `chef-server-ctl set-secret ldap bind_password` from the
+    [Secrets
+    Management](/ctl_chef_server.html#ctl-chef-server-secrets-management)
+    commands.
+
+    ```bash
+    chef-server-ctl set-secret ldap bind_password
+    Enter ldap bind_password:    (no terminal output)
+    Re-enter ldap bind_password: (no terminal output)
+    ```
+
+    Remove a set password via
+
+    ```bash
+    chef-server-ctl remove-secret ldap bind_password
+    ```
+
+`ldap['group_dn']`
+
+:   The distinguished name for a group. When set to the distinguished
+    name of a group, only members of that group can log in. This feature
+    filters based on the `memberOf` attribute and only works with LDAP
+    servers that provide such an attribute. In OpenLDAP, the `memberOf`
+    overlay provides this attribute. For example, if the value of the
+    `memberOf` attribute is `CN=abcxyz,OU=users,DC=company,DC=com`, then
+    use:
+
+    ```ruby
+    ldap['group_dn'] = 'CN=abcxyz,OU=users,DC=company,DC=com'
+    ```
+
+`ldap['host']`
+
+:   The name (or IP address) of the LDAP server. The hostname of the
+    LDAP or Active Directory server. Be sure the Chef Infra Server is
+    able to resolve any host names. Default value: `ldap-server-host`.
+
+`ldap['login_attribute']`
+
+:   The LDAP attribute that holds the user's login name. Use to specify
+    the Chef Infra Server user name for an LDAP user. Default value:
+    `sAMAccountName`.
+
+`ldap['port']`
+
+:   An integer that specifies the port on which the LDAP server listens.
+    The default value is an appropriate value for most configurations.
+    Default value: `389` or `636` when `ldap['encryption']` is set to
+    `:simple_tls`.
+
+`ldap['ssl_enabled']`
+
+:   Cause the Chef Infra Server to connect to the LDAP server using SSL.
+    Default value: `false`. Must be `false` when `ldap['tls_enabled']`
+    is `true`.
+
+    <div class="admonition-note">
+    <p class="admonition-note-title">Note</p>
+    <div class="admonition-note-text">
+
+    It's recommended that you enable SSL for Active Directory.
+
+    </div>
+    </div>
+
+    <div class="admonition-note">
+    <p class="admonition-note-title">Note</p>
+    <div class="admonition-note-text">
+
+    Previous versions of the Chef Infra Server used the
+    `ldap['ssl_enabled']` setting to first enable SSL, and then the
+    `ldap['encryption']` setting to specify the encryption type. These
+    settings are deprecated.
+
+    </div>
+    </div>
+
+`ldap['system_adjective']`
+
+:   A descriptive name for the login system that is displayed to users
+    in the Chef Infra Server management console. If a value like
+    "corporate" is used, then the Chef management console user interface
+    will display strings like "the corporate login server", "corporate
+    login", or "corporate password." Default value: `AD/LDAP`.
+
+    <div class="admonition-warning">
+    <p class="admonition-warning-title">Warning</p>
+    <div class="admonition-warning-text">
+
+    This setting is **not** used by the Chef Infra Server. It is used
+    only by the Chef management console.
+
+    </div>
+    </div>
+
+`ldap['timeout']`
+
+:   The amount of time (in seconds) to wait before timing out. Default
+    value: `60000`.
+
+`ldap['tls_enabled']`
+
+:   Enable TLS. When enabled, communication with the LDAP server is done
+    via a secure SSL connection on a dedicated port. When `true`,
+    `ldap['port']` is also set to `636`. Default value: `false`. Must be
+    `false` when `ldap['ssl_enabled']` is `true`.
+
+    <div class="admonition-note">
+    <p class="admonition-note-title">Note</p>
+    <div class="admonition-note-text">
+
+    Previous versions of the Chef Infra Server used the
+    `ldap['ssl_enabled']` setting to first enable SSL, and then the
+    `ldap['encryption']` setting to specify the encryption type. These
+    settings are deprecated.
+
+    </div>
+    </div>

--- a/content/server/v13_2/reusable_text/config_rb_server_summary.md
+++ b/content/server/v13_2/reusable_text/config_rb_server_summary.md
@@ -1,0 +1,8 @@
+The `/etc/opscode/chef-server.rb` file contains all of the non-default
+configuration settings used by the Chef Infra Server. The default
+settings are built into the Chef Infra Server configuration and should
+only be added to the `chef-server.rb` file to apply non-default values.
+These configuration settings are processed when the
+`chef-server-ctl reconfigure` command is run. The `chef-server.rb` file
+is a Ruby file, which means that conditional statements can be used
+within it.

--- a/content/server/v13_2/reusable_text/notes_config_rb_server_must_reconfigure.md
+++ b/content/server/v13_2/reusable_text/notes_config_rb_server_must_reconfigure.md
@@ -1,0 +1,6 @@
+When changes are made to the chef-server.rb file the Chef Infra Server
+must be reconfigured by running the following command:
+
+```bash
+chef-server-ctl reconfigure
+```

--- a/content/server/v13_2/reusable_text/notes_server_aws_cookbook_storage.md
+++ b/content/server/v13_2/reusable_text/notes_server_aws_cookbook_storage.md
@@ -1,0 +1,3 @@
+To [configure the server for external cookbook
+storage](/server_overview.html#aws-settings), updates are made to
+settings for both the **bookshelf** and **opscode-erchef** services.

--- a/content/server/v13_2/reusable_text/notes_server_aws_cookbook_storage.md
+++ b/content/server/v13_2/reusable_text/notes_server_aws_cookbook_storage.md
@@ -1,3 +1,3 @@
 To [configure the server for external cookbook
-storage](/server_overview.html#aws-settings), updates are made to
+storage](/server/#aws-settings), updates are made to
 settings for both the **bookshelf** and **opscode-erchef** services.

--- a/content/server/v13_2/reusable_text/server_services_bifrost.md
+++ b/content/server/v13_2/reusable_text/server_services_bifrost.md
@@ -1,0 +1,2 @@
+The **oc_bifrost** service ensures that every request to view or manage
+objects stored on the Chef Infra Server is authorized.

--- a/content/server/v13_2/reusable_text/server_services_bookshelf.md
+++ b/content/server/v13_2/reusable_text/server_services_bookshelf.md
@@ -1,0 +1,4 @@
+The **bookshelf** service is an Amazon Simple Storage Service
+(S3)-compatible service that is used to store cookbooks, including all
+of the files---recipes, templates, and so on---that are associated with
+each cookbook.

--- a/content/server/v13_2/reusable_text/server_services_erchef.md
+++ b/content/server/v13_2/reusable_text/server_services_erchef.md
@@ -1,0 +1,11 @@
+The **opscode-erchef** service is an Erlang-based service that is used
+to handle Chef Infra Server API requests to the following areas within
+the Chef Infra Server:
+
+-   Cookbooks
+-   Data bags
+-   Environments
+-   Nodes
+-   Roles
+-   Sandboxes
+-   Search

--- a/content/server/v13_2/reusable_text/server_services_expander.md
+++ b/content/server/v13_2/reusable_text/server_services_expander.md
@@ -1,0 +1,3 @@
+The **opscode-expander** service is used to process data (pulled from
+the **rabbitmq** service's message queue) so that it can be properly
+indexed by the **opscode-solr4** service.

--- a/content/server/v13_2/reusable_text/server_services_oc_id.md
+++ b/content/server/v13_2/reusable_text/server_services_oc_id.md
@@ -1,0 +1,6 @@
+The **oc-id** service enables OAuth 2.0 authentication to the Chef Infra
+Server by external applications, including Chef Supermarket. OAuth 2.0
+uses token-based authentication, where external applications use tokens
+that are issued by the **oc-id** provider. No special
+credentials---`webui_priv.pem` or privileged keys---are stored on the
+external application.

--- a/content/server/v13_2/reusable_text/server_services_postgresql.md
+++ b/content/server/v13_2/reusable_text/server_services_postgresql.md
@@ -1,0 +1,1 @@
+The **postgresql** service is used to store node, object, and user data.

--- a/content/server/v13_2/reusable_text/server_services_rabbitmq.md
+++ b/content/server/v13_2/reusable_text/server_services_rabbitmq.md
@@ -1,0 +1,3 @@
+The **rabbitmq** service is used to provide the message queue that is
+used by the Chef Infra Server to get search data to Apache Solr so that
+it can be indexed for search.

--- a/content/server/v13_2/reusable_text/server_services_redis.md
+++ b/content/server/v13_2/reusable_text/server_services_redis.md
@@ -1,0 +1,2 @@
+Key-value store used in conjunction with Nginx to route requests and
+populate request data used by the Chef Infra Server.

--- a/content/server/v13_2/reusable_text/server_services_solr4.md
+++ b/content/server/v13_2/reusable_text/server_services_solr4.md
@@ -1,0 +1,4 @@
+The **opscode-solr4** service is used to create the search indexes used
+for searching objects like nodes, data bags, and cookbooks. (This
+service ensures timely search results via the Chef Infra Server API;
+data that is used by the Chef platform is stored in PostgreSQL.)

--- a/content/server/v13_2/reusable_text/server_tuning_bookshelf.md
+++ b/content/server/v13_2/reusable_text/server_tuning_bookshelf.md
@@ -1,0 +1,6 @@
+The following setting is often modified from the default as part of the
+tuning effort for the **bookshelf** service:
+
+`bookshelf['vip']`
+
+:   The virtual IP address. Default value: `node['fqdn']`.

--- a/content/server/v13_2/reusable_text/server_tuning_erchef.md
+++ b/content/server/v13_2/reusable_text/server_tuning_erchef.md
@@ -1,0 +1,22 @@
+The following settings are often modified from the default as part of
+the tuning effort for the **opscode-erchef** service:
+
+`opscode_erchef['db_pool_size']`
+
+:   The number of open connections to PostgreSQL that are maintained by
+    the service. If failures indicate that the **opscode-erchef**
+    service ran out of connections, try increasing the
+    `postgresql['max_connections']` setting. If failures persist, then
+    increase this value (in small increments) and also increase the
+    value for `postgresql['max_connections']`. Default value: `20`.
+
+`opscode_erchef['s3_url_ttl']`
+
+:   The amount of time (in seconds) before connections to the server
+    expire. If Chef Infra Client runs are timing out, increase this
+    setting to `3600`, and then adjust again if necessary. Default
+    value: `900`.
+
+`opscode_erchef['strict_search_result_acls']`
+
+: {{< reusable_text_versioned "settings_strict_search_result_acls" >}}

--- a/content/server/v13_2/reusable_text/server_tuning_expander.md
+++ b/content/server/v13_2/reusable_text/server_tuning_expander.md
@@ -1,0 +1,12 @@
+The following setting is often modified from the default as part of the
+tuning effort for the **opscode-expander** service:
+
+`opscode_expander['nodes']`
+
+:   The number of allowed worker processes. The **opscode-expander**
+    service runs on the back-end and feeds data to the **opscode-solr**
+    service, which creates and maintains search data used by the Chef
+    Infra Server. Additional memory may be required by these worker
+    processes depending on the frequency and volume of Chef Infra Client
+    runs across the organization, but only if the back-end machines have
+    available CPU and RAM. Default value: `2`.

--- a/content/server/v13_2/reusable_text/server_tuning_general.md
+++ b/content/server/v13_2/reusable_text/server_tuning_general.md
@@ -1,0 +1,26 @@
+The following settings are typically added to the server configuration
+file (no equal sign is necessary to set the value):
+
+`api_fqdn`
+
+:   The FQDN for the Chef Infra Server. This setting is not in the
+    server configuration file by default. When added, its value should
+    be equal to the FQDN for the service URI used by the Chef Infra
+    Server. For example: `api_fqdn "chef.example.com"`.
+
+`bootstrap`
+
+:   Default value: `true`.
+
+`ip_version`
+
+:   Use to set the IP version: `"ipv4"` or `"ipv6"`. When set to
+    `"ipv6"`, the API listens on IPv6 and front end and back end
+    services communicate via IPv6 when a high availability configuration
+    is used. When configuring for IPv6 in a high availability
+    configuration, be sure to set the netmask on the IPv6 `backend_vip`
+    attribute. Default value: `"ipv4"`.
+
+`notification_email`
+
+:   Default value: `info@example.com`.

--- a/content/server/v13_2/reusable_text/server_tuning_nginx.md
+++ b/content/server/v13_2/reusable_text/server_tuning_nginx.md
@@ -1,0 +1,72 @@
+The following settings are often modified from the default as part of
+the tuning effort for the **nginx** service and to configure the Chef
+Infra Server to use SSL certificates:
+
+`nginx['ssl_certificate']`
+
+:   The SSL certificate used to verify communication over HTTPS. Default
+    value: `nil`.
+
+`nginx['ssl_certificate_key']`
+
+:   The certificate key used for SSL communication. Default value:
+    `nil`.
+
+`nginx['ssl_ciphers']`
+
+:   The list of supported cipher suites that are used to establish a
+    secure connection. To favor AES256 with ECDHE forward security, drop
+    the `RC4-SHA:RC4-MD5:RC4:RSA` prefix. For example:
+
+    ```ruby
+    nginx['ssl_ciphers'] =  "HIGH:MEDIUM:!LOW:!kEDH: \
+                             !aNULL:!ADH:!eNULL:!EXP: \
+                             !SSLv2:!SEED:!CAMELLIA: \
+                             !PSK"
+    ```
+
+`nginx['ssl_protocols']`
+
+:   The SSL protocol versions that are enabled. SSL 3.0 is supported by
+    the Chef Infra Server; however, SSL 3.0 is an obsolete and insecure
+    protocol. Transport Layer Security (TLS)---TLS 1.0, TLS 1.1, and TLS
+    1.2---has effectively replaced SSL 3.0, which provides for
+    authenticated version negotiation between Chef Infra Client and Chef
+    Infra Server, which ensures the latest version of the TLS protocol
+    is used. For the highest possible security, it is recommended to
+    disable SSL 3.0 and allow all versions of the TLS protocol. For
+    example:
+
+    ```ruby
+    nginx['ssl_protocols'] = 'TLSv1 TLSv1.1 TLSv1.2'
+    ```
+
+<div class="admonition-note">
+
+<p class="admonition-note-title">Note</p>
+
+<div class="admonition-note-text">
+
+See <https://www.openssl.org/docs/man1.0.2/man1/ciphers.html> for more
+information about the values used with the `nginx['ssl_ciphers']` and
+`nginx['ssl_protocols']` settings.
+
+
+
+</div>
+
+</div>
+
+For example, after copying the SSL certificate files to the Chef Infra
+Server, update the `nginx['ssl_certificate']` and
+`nginx['ssl_certificate_key']` settings to specify the paths to those
+files, and then (optionally) update the `nginx['ssl_ciphers']` and
+`nginx['ssl_protocols']` settings to reflect the desired level of
+hardness for the Chef Infra Server:
+
+```ruby
+nginx['ssl_certificate'] = '/etc/pki/tls/private/name.of.pem'
+nginx['ssl_certificate_key'] = '/etc/pki/tls/private/name.of.key'
+nginx['ssl_ciphers'] = 'HIGH:MEDIUM:!LOW:!kEDH:!aNULL:!ADH:!eNULL:!EXP:!SSLv2:!SEED:!CAMELLIA:!PSK'
+nginx['ssl_protocols'] = 'TLSv1 TLSv1.1 TLSv1.2'
+```

--- a/content/server/v13_2/reusable_text/server_tuning_postgresql.md
+++ b/content/server/v13_2/reusable_text/server_tuning_postgresql.md
@@ -1,0 +1,35 @@
+The following setting is often modified from the default as part of the tuning effort for the **postgresql** service:
+
+`postgresql['max_connections']`
+
+:   The maximum number of allowed concurrent connections. This value should only be tuned when the `opscode_erchef['db_pool_size']` value used by the **opscode-erchef** service is modified. Default value: `350`.
+    If there are more than two front end machines in a cluster, the
+    `postgresql['max_connections']` setting should be increased. The
+    increased value depends on the number of machines in the front end,
+    but also the number of services that are running on each of these
+    machines.
+
+    -   Each front end machine always runs the **oc_bifrost** and
+        **opscode-erchef** services.
+    -   The Reporting add-on adds the **reporting** service.
+    -   The Chef Push Jobs service adds the **push_jobs** service.
+
+    Each of these services requires 25 connections, above the default
+    value.
+
+    Use the following formula to help determine what the increased value
+    should be:
+
+    ```ruby
+    new_value = current_value + [
+                (# of front end machines - 2) * (25 * # of services)
+             ]
+    ```
+
+    For example, if the current value is 350, there are four front end
+    machines, and all add-ons are installed, then the formula looks
+    like:
+
+    ```ruby
+    550 = 350 + [(4 - 2) * (25 * 4)]
+    ```

--- a/content/server/v13_2/reusable_text/server_tuning_solr.md
+++ b/content/server/v13_2/reusable_text/server_tuning_solr.md
@@ -1,0 +1,3 @@
+The following sections describe ways of tuning the **opscode-solr4**
+service to improve performance around large node sizes, available
+memory, and update frequencies.

--- a/content/server/v13_2/reusable_text/server_tuning_solr_available_memory.md
+++ b/content/server/v13_2/reusable_text/server_tuning_solr_available_memory.md
@@ -1,0 +1,27 @@
+Use the following configuration setting to help ensure that Apache Solr
+does not run out of memory:
+
+`opscode_solr4['heap_size']`
+
+:   The amount of memory (in MBs) available to Apache Solr. If there is
+    not enough memory available, search queries made by nodes to Apache
+    Solr may fail. The amount of memory that must be available also
+    depends on the number of nodes in the organization, the frequency of
+    search queries, and other characteristics that are unique to each
+    organization. In general, as the number of nodes increases, so does
+    the amount of memory.
+
+If Apache Solr is running out of memory, the
+`/var/log/opscode/opscode-solr4/current` log file will contain a message
+similar to:
+
+```bash
+SEVERE: java.lang.OutOfMemoryError: Java heap space
+```
+
+The default value for `opscode_solr4['heap_size']` should work for many
+organizations, especially those with fewer than 25 nodes. For
+organizations with more than 25 nodes, set this value to 25% of system
+memory or `1024`, whichever is smaller. For very large configurations,
+increase this value to 25% of system memory or `4096`, whichever is
+smaller. This value should not exceed `8192`.

--- a/content/server/v13_2/reusable_text/server_tuning_solr_large_node_sizes.md
+++ b/content/server/v13_2/reusable_text/server_tuning_solr_large_node_sizes.md
@@ -1,0 +1,59 @@
+The maximum field length setting for Apache Solr should be greater than
+any expected node object file sizes in order for them to be successfully
+added to the search index. If a node object file is greater than the
+maximum field length, the node object will be indexed up to the maximum,
+but the part of the file past that limit will not be indexed. If this
+occurs, it will seem as if nodes disappear from the search index. To
+ensure that large node file sizes are indexed properly, verify the
+following configuration settings:
+
+`nginx['client_max_body_size']`
+
+:   The maximum accepted body size for a client request, as indicated by
+    the `Content-Length` request header. When the maximum accepted body
+    size is greater than this value, a `413 Request Entity Too Large`
+    error is returned. Default value: `250m`.
+
+and
+
+`opscode_erchef['max_request_size']`
+
+:   When the request body size is greater than this value, a 413 Request
+    Entity Too Large error is returned. Default value: `2000000`.
+
+to ensure that those settings are not part of the reasons for incomplete
+indexing, and then update the following setting so that its value is
+greater than the expected node file sizes:
+
+`opscode_solr4['max_field_length']`
+
+:   The maximum field length (in number of tokens/terms). If a field
+    length exceeds this value, Apache Solr may not be able to complete
+    building the index. Default value: `100000` (increased from the
+    Apache Solr default value of `10000`).
+
+Use the `wc` command to get the byte count of a large node object file.
+For example:
+
+```bash
+wc -c NODE_NAME.json
+```
+
+and then ensure there is a buffer beyond that value. For example, verify
+the size of the largest node object file:
+
+```bash
+wc -c nodebsp2016.json
+```
+
+which returns `154516`. Update the `opscode_solr4['max_field_length']`
+setting to have a value greater than the returned value. For example:
+`180000`.
+
+If you don't have a node object file available then you can get an
+approximate size of the node data by running the following command on a
+node.
+
+```bash
+ohai | wc -c
+```

--- a/content/server/v13_2/reusable_text/server_tuning_solr_update_frequency.md
+++ b/content/server/v13_2/reusable_text/server_tuning_solr_update_frequency.md
@@ -1,0 +1,24 @@
+At the end of every Chef Infra Client run, the node object is saved to
+the Chef Infra Server. From the Chef Infra Server, each node object is
+then added to the `SOLR` search index. This process is asynchronous. By
+default, node objects are committed to the search index every 60 seconds
+or per 1000 node objects, whichever occurs first.
+
+When data is committed to the Apache Solr index, all incoming updates
+are blocked. If the duration between updates is too short, it is
+possible for the rate at which updates are asked to occur to be faster
+than the rate at which objects can be actually committed.
+
+Use the following configuration setting to improve the indexing
+performance of node objects:
+
+`opscode_solr4['commit_interval']`
+
+:   The frequency (in seconds) at which node objects are added to the
+    Apache Solr search index. Default value: `60000` (every 60 seconds).
+
+`opscode_solr4['max_commit_docs']`
+
+:   The frequency (in documents) at which node objects are added to the
+    Apache Solr search index. Default value: `1000` (every 1000
+    documents).

--- a/content/server/v13_2/reusable_text/settings_strict_search_result_acls.md
+++ b/content/server/v13_2/reusable_text/settings_strict_search_result_acls.md
@@ -1,0 +1,28 @@
+Use to specify that search results only return objects to which an actor
+(user, client, etc.) has read access, as determined by ACL settings.
+This affects all searches. When `true`, the performance of the Chef
+management console may increase because it enables the Chef management
+console to skip redundant ACL checks. To ensure the Chef management
+console is configured properly, after this setting has been applied with
+a `chef-server-ctl reconfigure` run `chef-manage-ctl reconfigure` to
+ensure the Chef management console also picks up the setting. Default
+value: `false`.
+
+<div class="admonition-warning">
+
+<p class="admonition-warning-title">Warning</p>
+
+<div class="admonition-warning-text">
+
+When `true`, `opscode_erchef['strict_search_result_acls']` affects all
+search results and any actor (user, client, etc.) that does not have
+read access to a search result will not be able to view it. For example,
+this could affect search results returned during a Chef Infra Client
+runs if a Chef Infra Client does not have permission to read the
+information.
+
+
+
+</div>
+
+</div>

--- a/content/server/v14_0/config_rb_server.md
+++ b/content/server/v14_0/config_rb_server.md
@@ -32,7 +32,7 @@ Infra Server in larger installations.
 {{< note >}}
 
 Review the full list of [optional
-settings](/config_rb_server_optional_settings/) that can be added to
+settings](/server/config_rb_server_optional_settings/) that can be added to
 the chef-server.rb file. Many of these optional settings should not be
 added without first consulting with Chef support.
 

--- a/content/server/v14_0/config_rb_server.md
+++ b/content/server/v14_0/config_rb_server.md
@@ -1,32 +1,22 @@
 +++
-title = "chef-server.rb 14 Settings"
-draft = false
-
-aliases = ["/config_rb_server.html"]
-
-[menu]
-  [menu.infra]
-    title = "chef-server.rb 14 Settings"
-    identifier = "chef_infra/managing_chef_infra_server/config_rb_server_14.md chef-server-14.rb"
-    parent = "chef_infra/managing_chef_infra_server"
-    weight = 160
+title = "chef-server.rb Settings"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/config_rb_server.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/server/v14_0/config_rb_server.md)
 
-{{% config_rb_server_summary %}}
+{{< reusable_text_versioned file="config_rb_server_summary">}}
 
 ## Use Conditions
 
-{{% config_add_condition %}}
+{{< reusable_text_versioned file="config_add_condition">}}
 
 ## Recommended Settings
 
-{{% server_tuning_general %}}
+{{< reusable_text_versioned file="server_tuning_general">}}
 
 ### NGINX SSL Protocols
 
-{{% server_tuning_nginx %}}
+{{< reusable_text_versioned file="server_tuning_nginx">}}
 
 ## Optional Settings
 
@@ -35,7 +25,7 @@ Infra Server in larger installations.
 
 {{< note >}}
 
-{{% notes_config_rb_server_must_reconfigure %}}
+{{< reusable_text_versioned file="notes_config_rb_server_must_reconfigure">}}
 
 {{< /note >}}
 
@@ -50,11 +40,11 @@ added without first consulting with Chef support.
 
 ### bookshelf
 
-{{% server_tuning_bookshelf %}}
+{{< reusable_text_versioned file="server_tuning_bookshelf">}}
 
 {{< warning >}}
 
-{{% notes_server_aws_cookbook_storage %}}
+{{< reusable_text_versioned file="notes_server_aws_cookbook_storage">}}
 
 {{< /warning >}}
 
@@ -72,7 +62,7 @@ tuning effort for the **opscode-account** service:
 
 ### opscode-erchef
 
-{{% server_tuning_erchef %}}
+{{< reusable_text_versioned file="server_tuning_erchef">}}
 
 #### Data Collector
 
@@ -90,7 +80,7 @@ application:
 
 ### postgresql
 
-{{% server_tuning_postgresql %}}
+{{< reusable_text_versioned file="server_tuning_postgresql">}}
 
 `postgresql['sslmode']`
 

--- a/content/server/v14_0/config_rb_server_optional_settings.md
+++ b/content/server/v14_0/config_rb_server_optional_settings.md
@@ -1,24 +1,10 @@
 +++
-title = "chef-server.rb 13 Optional Settings"
-draft = false
-
-aliases = ["/config_rb_server_optional_settings.html"]
-
-[menu]
-  [menu.infra]
-    title = "Chef Infra Server 13 Optional Settings"
-    identifier = "chef_infra/managing_chef_infra_server/config_rb_server_optional_settings.md Chef Infra Server Optional Settings"
-    parent = "chef_infra/managing_chef_infra_server"
-    weight = 170
+title = "chef-server.rb 14 Optional Settings"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/config_rb_server_optional_settings.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/server/v14_0/config_rb_server_optional_settings.md)
 
-{{< warning >}}
-This documentation covers Chef Infra Server 13. For Chef Infra Server 14, use the [Chef Infra Server 14 Optional Settings](https://docs.chef.io/chef_infra/managing_chef_infra_server/config_rb_server_optional_settings_14.html) documentation.
-{{< /warning >}}
-
-{{% config_rb_server_summary %}}
+{{< reusable_text_versioned file="config_rb_server_summary" >}}
 
 ## Settings
 
@@ -27,7 +13,7 @@ in the chef-server.rb file.
 
 {{< note >}}
 
-{{% notes_config_rb_server_must_reconfigure %}}
+{{< reusable_text_versioned file="notes_config_rb_server_must_reconfigure" >}}
 
 {{< /note >}}
 
@@ -125,11 +111,11 @@ This configuration file has the following general settings:
 
 ### bookshelf
 
-{{% server_services_bookshelf %}}
+{{< reusable_text_versioned file="server_services_bookshelf" >}}
 
 {{< note >}}
 
-{{% notes_server_aws_cookbook_storage %}}
+{{< reusable_text_versioned file="notes_server_aws_cookbook_storage" >}}
 
 {{< /note >}}
 
@@ -141,7 +127,7 @@ This configuration file has the following settings for `bookshelf`:
     location, such as Amazon EC2. See [AWS external bookshelf
     settings](/server_overview/#external-bookshelf-settings) for
     more information on configuring external bookshelf. Default value:
-    **generated**. As of Chef Server 12.14, this is no longer the
+    **generated**. As of Chef Infra Server 12.14, this is no longer the
     preferred command.
 
     Please use `chef-server-ctl set-secret bookshelf access_key_id` from
@@ -208,7 +194,7 @@ This configuration file has the following settings for `bookshelf`:
     as Amazon EC2. See [AWS external bookshelf
     settings](/server_overview/#external-bookshelf-settings) for
     more information on configuring external bookshelf. Default value:
-    **generated**. As of Chef Server 12.14, this is no longer the
+    **generated**. As of Chef Infra Server 12.14, this is no longer the
     preferred command.
 
     Please use `chef-server-ctl set-secret bookshelf secret_access_key`
@@ -268,7 +254,7 @@ This configuration file has the following settings for `bootstrap`:
 ### compliance forwarding
 
 The configuration file has the following settings for forwarding
-`compliance` requests using the chef server authentication system.
+`compliance` requests using the Chef Infra Server authentication system.
 
 `profiles['root_url']`
 
@@ -334,14 +320,14 @@ This configuration file has the following settings for `data_collector`:
     `/data-collector` to the configured Chef Automate
     `data_collector['root_url']`. Note that *this route* does not check
     the request signature and add the right data_collector token, but
-    just proxies the Automate endpoint **as-is**. Default value: `nil`.
+    just proxies the Chef Automate endpoint **as-is**. Default value: `nil`.
 
 `data_collector['token']`
 
 :   Legacy configuration for shared data collector security token. When
     configured, the token will be passed as an HTTP header named
     `x-data-collector-token` which the server can choose to accept or
-    reject. As of Chef Server 12.14, this is no longer the preferred
+    reject. As of Chef Infra Server 12.14, this is no longer the preferred
     command.
 
     Please use `chef-server-ctl set-secret data_collector token` from
@@ -433,24 +419,6 @@ This configuration file has the following settings for `estatsd`:
 `estatsd['vip']`
 
 :   The virtual IP address. Default value: `'127.0.0.1'`.
-
-### jetty
-
-This configuration file has the following settings for `jetty`:
-
-`jetty['enable']`
-
-:   Enable a service. Default value: `'false'`. This value should not be
-    modified.
-
-`jetty['log_directory']`
-
-:   The directory in which log data is stored. The default value is the
-    recommended value. Default value:
-
-    ```ruby
-    '/var/opt/opscode/opscode-solr4/jetty/logs'
-    ```
 
 ### lb / lb_internal
 
@@ -598,7 +566,7 @@ And for the internal load balancers:
 
 ### ldap
 
-{{% config_rb_server_settings_ldap %}}
+{{< reusable_text_versioned file="config_rb_server_settings_ldap" >}}
 
 ### nginx
 
@@ -857,7 +825,7 @@ This configuration file has the following settings for `nginx`:
 
 ### oc_bifrost
 
-{{% server_services_bifrost %}}
+{{< reusable_text_versioned file="server_services_bifrost" >}}
 
 This configuration file has the following settings for `oc_bifrost`:
 
@@ -1034,7 +1002,7 @@ This configuration file has the following settings for `oc-chef-pedant`:
 
 ### oc-id
 
-{{% server_services_oc_id %}}
+{{< reusable_text_versioned file="server_services_oc_id" >}}
 
 This configuration file has the following settings for `oc-id`:
 
@@ -1067,7 +1035,7 @@ This configuration file has the following settings for `oc-id`:
 
 `oc_id['email_from_address']`
 
-:   New in Chef Server 12.12.
+:   New in Chef Infra Server 12.12.
 
     Outbound email address. Defaults to the `'from_email'` value.
 
@@ -1088,7 +1056,7 @@ This configuration file has the following settings for `oc-id`:
 
 `oc_id['origin']`
 
-:   New in Chef Server 12.12.
+:   New in Chef Infra Server 12.12.
 
     The FQDN for the server that is sending outbound email. Defaults to
     the `'api_fqdn'` value, which is the FQDN for the Chef Infra Server.
@@ -1234,7 +1202,7 @@ This configuration file has the following settings for
 
 ### opscode-erchef
 
-{{% server_services_erchef %}}
+{{< reusable_text_versioned file="server_services_erchef" >}}
 
 This configuration file has the following settings for `opscode-erchef`:
 
@@ -1436,7 +1404,7 @@ This configuration file has the following settings for `opscode-erchef`:
 
 `opscode_erchef['strict_search_result_acls']`
 
-:   {{% settings_strict_search_result_acls %}}
+:   {{< reusable_text_versioned file="settings_strict_search_result_acls" >}}
 
 `opscode_erchef['udp_socket_pool_size']`
 
@@ -1454,216 +1422,108 @@ This configuration file has the following settings for `opscode-erchef`:
 
 :   The virtual IP address. Default value: `127.0.0.1`.
 
-### opscode-expander
+### Elasticsearch
 
-{{% server_services_expander %}}
+This configuration file has the following settings for `elasticsearch`:
 
-This configuration file has the following settings for
-`opscode-expander`:
+`elasticsearch['enable']`
 
-`opscode_expander['consumer_id']`
+: Enable a service. Default value: `true`.
 
-:   The identity of the consumer to which messages are published.
-    Default value: `default`.
+`elasticsearch['dir']`
 
-`opscode_expander['dir']`
+: The working directory. The default value is the recommended value. Default value: `/var/opt/opscode/elasticsearch`
 
-:   The working directory. The default value is the recommended value.
-    Default value:
+`elasticsearch['data_dir']`
 
-    ```ruby
-    /var/opt/opscode/opscode-expander
-    ```
+:The paths used to store data. Default value: `/var/opt/opscode/elasticsearch/data`
 
-`opscode_expander['enable']`
+`elasticsearch['plugins_directory']`
 
-:   Enable a service. Default value: `true`.
+: The default location of the plugins directory depends on which package you install. Default value: `/var/opt/opscode/elasticsearch/plugins`
 
-`opscode_expander['log_directory']`
+`elasticsearch['scripts_directory']`
 
-:   The directory in which log data is stored. The default value is the
-    recommended value. Default value:
+:The default location of the scripts directory depends on which package you install. Default value: `/var/opt/opscode/elasticsearch/scripts`
 
-    ```ruby
-    /var/log/opscode/opscode-expander
-    ```
+`elasticsearch['temp_directory']`
 
-`opscode_expander['log_rotation']`
+: By default, Elasticsearch uses a private temporary directory that the startup script creates immediately below the system temporary directory. Default value: `/var/opt/opscode/elasticsearch/tmp`
 
-:   The log rotation policy for this service. Log files are rotated when
-    they exceed `file_maxbytes`. The maximum number of log files in the
-    rotation is defined by `num_to_keep`. Default value:
+`elasticsearch['log_directory']`
 
-    ```ruby
-    { 'file_maxbytes' => 104857600, 'num_to_keep' => 10 }
-    ```
+: The directory in which log data is stored. The default value is the recommended value. Default value: `/var/log/opscode/elasticsearch`
 
-`opscode_expander['nodes']`
+`elasticsearch['log_rotation']['file_maxbytes']`
 
-:   The number of allowed worker processes. Default value: `2`.
+: The log rotation policy for this service. Log files are rotated when they exceed file_maxbytes. Default value for 'file_maxbytes': `104857600`
 
-`opscode_expander['reindexer_log_directory']`
+`elasticsearch['log_rotation']['num_to_keep']`
 
-:   The directory in which `opscode-expander-reindexer` logs files are
-    located. Default value:
+: The log rotation policy for this service. The maximum number of log files in the rotation is defined by num_to_keep.  Default value for 'num_to_keep': => `10`
 
-    ```ruby
-    /var/log/opscode/opscode-expander-reindexer
-    ```
+`elasticsearch['vip']`
 
-### opscode-solr4
+: The virtual IP address for the machine on which Apache Solr is running. Default value: `127.0.0.1`
 
-{{% server_services_solr4 %}}
+`elasticsearch['listen']`
 
-This configuration file has the following settings for `opscode-solr4`:
+: The IP address for the machine on which Apache Solr is running. Default value: `127.0.0.1`
 
-`opscode_solr4['auto_soft_commit']`
+`elasticsearch['port']`
 
-:   The maximum number of documents before a soft commit is triggered.
-    Default value: `1000`.
+: The port on which the service is to listen. Default value: `9200`
 
-`opscode_solr4['commit_interval']`
+`elasticsearch['enable_gc_log']`
 
-:   The frequency (in seconds) at which node objects are added to the
-    Apache Solr search index. This value should be tuned carefully. When
-    data is committed to the Apache Solr index, all incoming updates are
-    blocked. If the duration between updates is too short, it is
-    possible for the rate at which updates are asked to occur to be
-    faster than the rate at which objects can be actually committed.
-    Default value: `60000` (every 60 seconds).
+: Enable or disable GC logging. Default value: `false`
 
-`opscode_solr4['data_dir']`
+`elasticsearch['initial_cluster_join_timeout']`
 
-:   The directory in which on-disk data is stored. The default value is
-    the recommended value. Default value:
+: Default value: `90`
 
-    ```ruby
-    /var/opt/opscode/opscode-solr4/data
-    ```
+`elasticsearch['jvm_opts']`
 
-`opscode_solr4['dir']`
+: Default values are set based on [JVM configuration options](https://github.com/elastic/elasticsearch/blob/6.8/distribution/src/config/jvm.options).
 
-:   The working directory. The default value is the recommended value.
-    Default value:
+{{< note >}}
 
-    ```ruby
-    /var/opt/opscode/opscode-solr4
-    ```
+Each item in this list will be placed as is into the java_opts config file. Entries are set in chef-server.rb as:
 
-`opscode_solr4['enable']`
+```ruby
+ elasticsearch.jvm_opts = [
+  "-xoption1",
+  "-xoption2",
+  ...
+  "optionN"
+ ]
+```
 
-:   Enable a service. Default value: `true`.
+{{< /note >}}
 
-`opscode_solr4['heap_size']`
+`elasticsearch['heap_size']`
 
-:   The amount of memory (in MBs) available to Apache Solr. If there is
-    not enough memory available, search queries made by nodes to Apache
-    Solr may fail. The amount of memory that must be available also
-    depends on the number of nodes in the organization, the frequency of
-    search queries, and other characteristics that are unique to each
-    organization. In general, as the number of nodes increases, so does
-    the amount of memory. The default value should work for many
-    organizations with fewer than 25 nodes. For an organization with
-    several hundred nodes, the amount of memory that is required often
-    exceeds 3GB. Default value: `nil`, which is equivalent to 25% of the
-    system memory or 1024 (MB, but this setting is specified as an
-    integer number of MB in EC11), whichever is smaller.
+: The amount of memory (in MBs) available to Elasticsearch. If there is not enough memory available, search queries made by nodes to Elasticsearch may fail. The amount of memory that must be available also depends on the number of nodes in the organization, the frequency of search queries, and other characteristics that are unique to each organization. In general, as the number of nodes increases, so does the amount of memory. The default value should work for many organizations with fewer than 25 nodes. For an organization with several hundred nodes, the amount of memory that is required often exceeds 3GB. Default value is is equivalent to 25% of the system memory or 1024 MB, whichever is greater.
 
-`opscode_solr4['ip_address']`
+{{< note >}}
 
-:   The IP address for the machine on which Apache Solr is running.
-    Default value: `127.0.0.1`.
+If new_size or heap_size is also specified directly in java_opts, it will be ignored in favor of the chef-server.rb values or the defaults as calculated here. Only use chef-server.rb to set heap and new sizes. Learn more about [Elasticsearch heap-size](https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html). It will error out if the system memory is less than 4 GB. This value is bounded between 1 GB - 28 GB.
 
-`opscode_solr4['java_opts']`
+{{< /note >}}
 
-:   A Hash of `JAVA_OPTS` environment variables to be set.
-    (`-XX:NewSize` is configured using the `new_size` setting.) Default
-    value: `' '` (empty).
+`elasticsearch['new_size']`
 
-`opscode_solr4['log_directory']`
+: Defaults to the larger of 1/16th the heap_size and 32 MB.
 
-:   The directory in which log data is stored. The default value is the
-    recommended value. Default value:
+{{< note >}}
 
-    ```ruby
-    /var/log/opscode/opscode-solr4
-    ```
+If new_size or heap_size is also specified directly in java_opts, it will be ignored in favor of the chef-server.rb values or the defaults as calculated here.  Only use chef-server.rb to set heap and new sizes. Learn more about [Elasticsearch heap-size documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html).
 
-`opscode_solr4['log_gc']`
-
-:   New in Chef Server 12.12.
-
-    Enable or disable GC logging. Default is `true`.
-
-`opscode_solr4['log_rotation']`
-
-:   The log rotation policy for this service. Log files are rotated when
-    they exceed `file_maxbytes`. The maximum number of log files in the
-    rotation is defined by `num_to_keep`. Default value:
-
-    ```ruby
-    { 'file_maxbytes' => 104857600, 'num_to_keep' => 10 }
-    ```
-
-`opscode_solr4['max_commit_docs']`
-
-:   The frequency (in documents) at which node objects are added to the
-    Apache Solr search index. This value should be tuned carefully. When
-    data is committed to the Apache Solr index, all incoming updates are
-    blocked. If the duration between updates is too short, it is
-    possible for the rate at which updates are asked to occur to be
-    faster than the rate at which objects can be actually committed.
-    Default value: `1000` (every 1000 documents).
-
-`opscode_solr4['max_field_length']`
-
-:   The maximum field length (in number of tokens/terms). If a field
-    length exceeds this value, Apache Solr may not be able to complete
-    building the index. Default value: `100000` (increased from the
-    Apache Solr default value of `10000`).
-
-`opscode_solr4['max_merge_docs']`
-
-:   The maximum number of index segments allowed before they are merged
-    into a single index. Default value: `2147483647`.
-
-`opscode_solr4['merge_factor']`
-
-:   The maximum number of document updates that can be stored in memory
-    before being flushed and added to the current index segment. Default
-    value: `15`.
-
-`opscode_solr4['new_size']`
-
-:   Configure the `-XX:NewSize` `JAVA_OPTS` environment variable.
-    Default value: `nil`.
-
-`opscode_solr4['poll_seconds']`
-
-:   The frequency (in seconds) at which the secondary machine polls the
-    primary. Default value: `20`.
-
-`opscode_solr4['port']`
-
-:   The port on which the service is to listen. Default value: `8983`.
-
-`opscode_solr4['ram_buffer_size']`
-
-:   The size (in megabytes) of the RAM buffer. When document updates
-    exceed this amout, pending updates are flushed. Default value:
-    `100`.
-
-`opscode_solr4['url']`
-
-:   Default value: `'http://localhost:8983/solr'`.
-
-`opscode_solr4['vip']`
-
-:   The virtual IP address. Default value: `127.0.0.1`.
+{{< /note >}}
 
 ### postgresql
 
-{{% server_services_postgresql %}}
+{{< reusable_text_versioned file="server_services_postgresql" >}}
 
 This configuration file has the following settings for `postgresql`:
 
@@ -1849,224 +1709,9 @@ This configuration file has the following settings for `postgresql`:
 :   The size (in megabytes) of allowed in-memory sorting. Default value:
     `8MB`.
 
-### rabbitmq
-
-{{% server_services_rabbitmq %}}
-
-This configuration file has the following settings for `rabbitmq`:
-
-`rabbitmq['actions_exchange']`
-
-:   The name of the exchange to which Chef actions publishes actions
-    data. Default value: `'actions'`.
-
-`rabbitmq['actions_password']`
-
-:   Legacy configuration setting for the password of the `actions_user`.
-    Default value: **generated**.
-
-    To override the default value, use the [Secrets
-    Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
-    command: `chef-server-ctl set-actions-password`.
-
-`rabbitmq['actions_user']`
-
-:   The user with permission to publish actions data. Default value:
-    `'actions'`.
-
-`rabbitmq['actions_vhost']`
-
-:   The virtual host to which Chef actions publishes actions data.
-    Default value: `'/analytics'`.
-
-`rabbitmq['analytics_max_length']`
-
-:   The maximum number of messages that can be queued before RabbitMQ
-    automatically drops messages from the front of the queue to make
-    room for new messages. Default value: `10000`.
-
-`rabbitmq['consumer_id']`
-
-:   The identity of the consumer to which messages are published.
-    Default value: `'hotsauce'`.
-
-`rabbitmq['data_dir']`
-
-:   The directory in which on-disk data is stored. The default value is
-    the recommended value. Default value:
-    `'/var/opt/opscode/rabbitmq/db'`.
-
-`rabbitmq['dir']`
-
-:   The working directory. The default value is the recommended value.
-    Default value: `'/var/opt/opscode/rabbitmq'`.
-
-`rabbitmq['drop_on_full_capacity']`
-
-:   Specify if messages will stop being sent to the RabbitMQ queue when
-    it is at capacity. Default value: `true`.
-
-`rabbitmq['enable']`
-
-:   Enable a service. Default value: `true`.
-
-`rabbitmq['log_directory']`
-
-:   The directory in which log data is stored. The default value is the
-    recommended value. Default value: `'/var/log/opscode/rabbitmq'`.
-
-`rabbitmq['log_rotation']`
-
-:   The log rotation policy for this service. Log files are rotated when
-    they exceed `file_maxbytes`. The maximum number of log files in the
-    rotation is defined by `num_to_keep`. Default value:
-
-    ```ruby
-    { 'file_maxbytes' => 104857600, 'num_to_keep' => 10 }
-    ```
-
-`rabbitmq['management_enabled']`
-
-:   Specify if the rabbitmq-management plugin is enabled. Default value:
-    `true`.
-
-`rabbitmq['management_password']`
-
-:   Legacy configuration setting for rabbitmq-management plugin
-    password. Default value: **generated**.
-
-    To override the default value, use the [Secrets
-    Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
-    command: `chef-server-ctl set-secret rabbitmq management_password`.
-
-`rabbitmq['management_port']`
-
-:   The rabbitmq-management plugin port. Default value: `15672`.
-
-`rabbitmq['management_user']`
-
-:   The rabbitmq-management plugin user. Default value: `'rabbitmgmt'`.
-
-`rabbitmq['node_ip_address']`
-
-:   The bind IP address for RabbitMQ. Default value: `'127.0.0.1'`.
-
-`rabbitmq['node_port']`
-
-:   The port on which the service is to listen. Default value: `'5672'`.
-
-`rabbitmq['nodename']`
-
-:   The unique identifier of the node. Default value: `'rabbit@localhost'`.
-
-`rabbitmq['password']`
-
-:   Legacy configuration setting for the password for the RabbitMQ user.
-    Default value: **generated**.
-
-    To override the default value, use the [Secrets
-    Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
-    command: `chef-server-ctl set-secret rabbitmq password`.
-
-`rabbitmq['prevent_erchef_startup_on_full_capacity']`
-
-:   Specify if the Chef Infra Server will start when the monitored
-    RabbitMQ queue is full. Default value: `false`.
-
-`rabbitmq['queue_at_capacity_affects_overall_status']`
-
-:   Specify if the `_status` endpoint in the Chef Infra Server API will
-    fail if the monitored queue is at capacity. Default value: `false`.
-
-`rabbitmq['queue_length_monitor_enabled']`
-
-:   Specify if the queue length monitor is enabled. Default value:
-    `true`.
-
-`rabbitmq['queue_length_monitor_millis']`
-
-:   The frequency (in milliseconds) at which the length of the RabbitMQ
-    queue is checked. Default value: `30000`.
-
-`rabbitmq['queue_length_monitor_timeout_millis']`
-
-:   The timeout (in milliseconds) at which calls to the queue length
-    monitor will stop if the Chef Infra Server is overloaded. Default
-    value: `5000`.
-
-`rabbitmq['queue_length_monitor_queue']`
-
-:   The RabbitMQ queue that is observed by queue length monitor. Default
-    value: `'alaska'`.
-
-`rabbitmq['queue_length_monitor_vhost']`
-
-:   The virtual host for the RabbitMQ queue that is observed by queue
-    length monitor. Default value: `'/analytics'`.
-
-`rabbitmq['rabbit_mgmt_http_cull_interval']`
-
-:   The maximum cull interval (in seconds) for the HTTP connection pool
-    that is used by the rabbitmq-management plugin. Default value: `60`.
-
-`rabbitmq['rabbit_mgmt_http_init_count']`
-
-:   The initial worker count for the HTTP connection pool that is used
-    by the rabbitmq-management plugin. Default value: `25`.
-
-`rabbitmq['rabbit_mgmt_http_max_age']`
-
-:   The maximum connection worker age (in seconds) for the HTTP
-    connection pool that is used by the rabbitmq-management plugin.
-    Default value: `70`.
-
-`rabbitmq['rabbit_mgmt_http_max_connection_duration']`
-
-:   The maximum connection duration (in seconds) for the HTTP connection
-    pool that is used by the rabbitmq-management plugin. Default value:
-    `70`.
-
-`rabbitmq['rabbit_mgmt_http_max_count']`
-
-:   The maximum worker count for the HTTP connection pool that is used
-    by the rabbitmq-management plugin. Default value: `100`.
-
-`rabbitmq['rabbit_mgmt_ibrowse_options']`
-
-:   An array of comma-separated key-value pairs of ibrowse options for
-    the HTTP connection pool that is used by the rabbitmq-management
-    plugin. Default value: `'{connect_timeout, 10000}'`.
-
-`rabbitmq['rabbit_mgmt_timeout']`
-
-:   The timeout for the HTTP connection pool that is used by the
-    rabbitmq-management plugin. Default value: `30000`.
-
-`rabbitmq['reindexer_vhost']`
-
-:   Default value: `'/reindexer'`.
-
-`rabbitmq['ssl_versions']`
-
-:   The SSL versions used by the rabbitmq-management plugin. (See
-    [RabbitMQ TLS support](https://www.rabbitmq.com/ssl.html) for more
-    information.) Default value: `['tlsv1.2', 'tlsv1.1']`.
-
-`rabbitmq['user']`
-
-:   Default value: `'chef'`.
-
-`rabbitmq['vhost']`
-
-:   Default value: `'/chef'`.
-
-`rabbitmq['vip']`
-
-:   The virtual IP address. Default value: `'127.0.0.1'`.
-
 ### redis_lb
 
-{{% server_services_redis %}}
+{{< reusable_text_versioned file="server_services_redis" >}}
 
 This configuration file has the following settings for `redis_lb`:
 

--- a/content/server/v14_0/config_rb_server_optional_settings.md
+++ b/content/server/v14_0/config_rb_server_optional_settings.md
@@ -125,7 +125,7 @@ This configuration file has the following settings for `bookshelf`:
 
 :   The access key identifier. This may point at an external storage
     location, such as Amazon EC2. See [AWS external bookshelf
-    settings](/server_overview/#external-bookshelf-settings) for
+    settings](/server/#aws-settings) for
     more information on configuring external bookshelf. Default value:
     **generated**. As of Chef Infra Server 12.14, this is no longer the
     preferred command.
@@ -192,7 +192,7 @@ This configuration file has the following settings for `bookshelf`:
 
 :   The secret key. This may point at an external storage location, such
     as Amazon EC2. See [AWS external bookshelf
-    settings](/server_overview/#external-bookshelf-settings) for
+    settings](/server/#aws-settings) for
     more information on configuring external bookshelf. Default value:
     **generated**. As of Chef Infra Server 12.14, this is no longer the
     preferred command.
@@ -237,7 +237,7 @@ This configuration file has the following settings for `bookshelf`:
 
 :   The virtual IP address. This may point at an external storage
     location, such as Amazon EC2. See [AWS external bookshelf
-    settings](/server_overview/#external-bookshelf-settings) for
+    settings](/server/#aws-settings) for
     more information on configuring external bookshelf. Default value:
     `127.0.0.1`.
 
@@ -1366,7 +1366,7 @@ This configuration file has the following settings for `opscode-erchef`:
 :   The name of the Amazon Simple Storage Service (S3) bucket. This may
     point at external storage locations, such as Amazon EC2. See [AWS
     external bookshelf
-    settings](/server_overview/#external-bookshelf-settings) for
+    settings](/server/#aws-settings) for
     more information on configuring external bookshelf.
 
 `opscode_erchef['s3_parallel_ops_fanout']`

--- a/content/server/v14_0/index.md
+++ b/content/server/v14_0/index.md
@@ -1,0 +1,3 @@
++++
+headless = true
++++

--- a/content/server/v14_0/reusable_text/config_add_condition.md
+++ b/content/server/v14_0/reusable_text/config_add_condition.md
@@ -1,0 +1,13 @@
+Use a `case` statement to apply different values based on whether the
+setting exists on the front-end or back-end servers. Add code to the
+server configuration file similar to the following:
+
+```ruby
+role_name = ChefServer['servers'][node['fqdn']]['role']
+case role_name
+when 'backend'
+  # backend-specific configuration here
+when 'frontend'
+  # frontend-specific configuration here
+end
+```

--- a/content/server/v14_0/reusable_text/config_rb_server_settings_ldap.md
+++ b/content/server/v14_0/reusable_text/config_rb_server_settings_ldap.md
@@ -1,0 +1,199 @@
+
+&nbsp;
+
+<div class="admonition-warning">
+
+<p class="admonition-warning-title">Warning</p>
+
+<div class="admonition-warning-text">
+
+The following settings **MUST** be in the config file for LDAP
+authentication to Active Directory to work:
+
+-   `base_dn`
+-   `bind_dn`
+-   `group_dn`
+-   `host`
+
+If those settings are missing, you will get authentication errors and be
+unable to proceed.
+
+</div>
+
+</div>
+
+This configuration file has the following settings for `ldap`:
+
+`ldap['base_dn']`
+
+:   The root LDAP node under which all other nodes exist in the
+    directory structure. For Active Directory, this is typically
+    `cn=users` and then the domain. For example:
+
+    ```ruby
+    'OU=Employees,OU=Domain users,DC=example,DC=com'
+    ```
+
+    Default value: `nil`.
+
+`ldap['bind_dn']`
+
+:   The distinguished name used to bind to the LDAP server. The user the
+    Chef Infra Server will use to perform LDAP searches. This is often
+    the administrator or manager user. This user needs to have read
+    access to all LDAP users that require authentication. The Chef Infra
+    Server must do an LDAP search before any user can log in. Many
+    Active Directory and LDAP systems do not allow an anonymous bind. If
+    anonymous bind is allowed, leave the `bind_dn` and `bind_password`
+    settings blank. If anonymous bind is not allowed, a user with `READ`
+    access to the directory is required. This user must be specified as
+    an LDAP distinguished name similar to:
+
+    ```ruby
+    'CN=user,OU=Employees,OU=Domainuser,DC=example,DC=com'
+    ```
+
+    <div class="admonition-note">
+    <p class="admonition-note-title">Note</p>
+    <div class="admonition-note-text">
+
+    If you need to escape characters in a distinguished name, such as
+    when using Active Directory, they must be [escaped with a backslash
+    escape
+    character](https://social.technet.microsoft.com/wiki/contents/articles/5312.active-directory-characters-to-escape.aspx).
+
+    ```ruby
+    'CN=example\\user,OU=Employees,OU=Domainuser,DC=example,DC=com'
+    ```
+
+    </div>
+    </div>
+
+    Default value: `nil`.
+
+`ldap['bind_password']`
+
+:   Legacy configuration for the password of the binding user. The
+    password for the user specified by `ldap['bind_dn']`. Leave this
+    value and `ldap['bind_dn']` unset if anonymous bind is sufficient.
+    Default value: `nil`. As of Chef Server 12.14, this is no longer the
+    preferred command.
+
+    Please use `chef-server-ctl set-secret ldap bind_password` from the
+    [Secrets
+    Management](/ctl_chef_server.html#ctl-chef-server-secrets-management)
+    commands.
+
+    ```bash
+    chef-server-ctl set-secret ldap bind_password
+    Enter ldap bind_password:    (no terminal output)
+    Re-enter ldap bind_password: (no terminal output)
+    ```
+
+    Remove a set password via
+
+    ```bash
+    chef-server-ctl remove-secret ldap bind_password
+    ```
+
+`ldap['group_dn']`
+
+:   The distinguished name for a group. When set to the distinguished
+    name of a group, only members of that group can log in. This feature
+    filters based on the `memberOf` attribute and only works with LDAP
+    servers that provide such an attribute. In OpenLDAP, the `memberOf`
+    overlay provides this attribute. For example, if the value of the
+    `memberOf` attribute is `CN=abcxyz,OU=users,DC=company,DC=com`, then
+    use:
+
+    ```ruby
+    ldap['group_dn'] = 'CN=abcxyz,OU=users,DC=company,DC=com'
+    ```
+
+`ldap['host']`
+
+:   The name (or IP address) of the LDAP server. The hostname of the
+    LDAP or Active Directory server. Be sure the Chef Infra Server is
+    able to resolve any host names. Default value: `ldap-server-host`.
+
+`ldap['login_attribute']`
+
+:   The LDAP attribute that holds the user's login name. Use to specify
+    the Chef Infra Server user name for an LDAP user. Default value:
+    `sAMAccountName`.
+
+`ldap['port']`
+
+:   An integer that specifies the port on which the LDAP server listens.
+    The default value is an appropriate value for most configurations.
+    Default value: `389` or `636` when `ldap['encryption']` is set to
+    `:simple_tls`.
+
+`ldap['ssl_enabled']`
+
+:   Cause the Chef Infra Server to connect to the LDAP server using SSL.
+    Default value: `false`. Must be `false` when `ldap['tls_enabled']`
+    is `true`.
+
+    <div class="admonition-note">
+    <p class="admonition-note-title">Note</p>
+    <div class="admonition-note-text">
+
+    It's recommended that you enable SSL for Active Directory.
+
+    </div>
+    </div>
+
+    <div class="admonition-note">
+    <p class="admonition-note-title">Note</p>
+    <div class="admonition-note-text">
+
+    Previous versions of the Chef Infra Server used the
+    `ldap['ssl_enabled']` setting to first enable SSL, and then the
+    `ldap['encryption']` setting to specify the encryption type. These
+    settings are deprecated.
+
+    </div>
+    </div>
+
+`ldap['system_adjective']`
+
+:   A descriptive name for the login system that is displayed to users
+    in the Chef Infra Server management console. If a value like
+    "corporate" is used, then the Chef management console user interface
+    will display strings like "the corporate login server", "corporate
+    login", or "corporate password." Default value: `AD/LDAP`.
+
+    <div class="admonition-warning">
+    <p class="admonition-warning-title">Warning</p>
+    <div class="admonition-warning-text">
+
+    This setting is **not** used by the Chef Infra Server. It is used
+    only by the Chef management console.
+
+    </div>
+    </div>
+
+`ldap['timeout']`
+
+:   The amount of time (in seconds) to wait before timing out. Default
+    value: `60000`.
+
+`ldap['tls_enabled']`
+
+:   Enable TLS. When enabled, communication with the LDAP server is done
+    via a secure SSL connection on a dedicated port. When `true`,
+    `ldap['port']` is also set to `636`. Default value: `false`. Must be
+    `false` when `ldap['ssl_enabled']` is `true`.
+
+    <div class="admonition-note">
+    <p class="admonition-note-title">Note</p>
+    <div class="admonition-note-text">
+
+    Previous versions of the Chef Infra Server used the
+    `ldap['ssl_enabled']` setting to first enable SSL, and then the
+    `ldap['encryption']` setting to specify the encryption type. These
+    settings are deprecated.
+
+    </div>
+    </div>

--- a/content/server/v14_0/reusable_text/config_rb_server_summary.md
+++ b/content/server/v14_0/reusable_text/config_rb_server_summary.md
@@ -1,0 +1,8 @@
+The `/etc/opscode/chef-server.rb` file contains all of the non-default
+configuration settings used by the Chef Infra Server. The default
+settings are built into the Chef Infra Server configuration and should
+only be added to the `chef-server.rb` file to apply non-default values.
+These configuration settings are processed when the
+`chef-server-ctl reconfigure` command is run. The `chef-server.rb` file
+is a Ruby file, which means that conditional statements can be used
+within it.

--- a/content/server/v14_0/reusable_text/notes_config_rb_server_must_reconfigure.md
+++ b/content/server/v14_0/reusable_text/notes_config_rb_server_must_reconfigure.md
@@ -1,0 +1,6 @@
+When changes are made to the chef-server.rb file the Chef Infra Server
+must be reconfigured by running the following command:
+
+```bash
+chef-server-ctl reconfigure
+```

--- a/content/server/v14_0/reusable_text/notes_server_aws_cookbook_storage.md
+++ b/content/server/v14_0/reusable_text/notes_server_aws_cookbook_storage.md
@@ -1,0 +1,3 @@
+To [configure the server for external cookbook
+storage](/server_overview.html#aws-settings), updates are made to
+settings for both the **bookshelf** and **opscode-erchef** services.

--- a/content/server/v14_0/reusable_text/notes_server_aws_cookbook_storage.md
+++ b/content/server/v14_0/reusable_text/notes_server_aws_cookbook_storage.md
@@ -1,3 +1,3 @@
 To [configure the server for external cookbook
-storage](/server_overview.html#aws-settings), updates are made to
+storage](/server/#aws-settings), updates are made to
 settings for both the **bookshelf** and **opscode-erchef** services.

--- a/content/server/v14_0/reusable_text/server_services_bifrost.md
+++ b/content/server/v14_0/reusable_text/server_services_bifrost.md
@@ -1,0 +1,2 @@
+The **oc_bifrost** service ensures that every request to view or manage
+objects stored on the Chef Infra Server is authorized.

--- a/content/server/v14_0/reusable_text/server_services_bookshelf.md
+++ b/content/server/v14_0/reusable_text/server_services_bookshelf.md
@@ -1,0 +1,4 @@
+The **bookshelf** service is an Amazon Simple Storage Service
+(S3)-compatible service that is used to store cookbooks, including all
+of the files---recipes, templates, and so on---that are associated with
+each cookbook.

--- a/content/server/v14_0/reusable_text/server_services_erchef.md
+++ b/content/server/v14_0/reusable_text/server_services_erchef.md
@@ -1,0 +1,11 @@
+The **opscode-erchef** service is an Erlang-based service that is used
+to handle Chef Infra Server API requests to the following areas within
+the Chef Infra Server:
+
+-   Cookbooks
+-   Data bags
+-   Environments
+-   Nodes
+-   Roles
+-   Sandboxes
+-   Search

--- a/content/server/v14_0/reusable_text/server_services_expander.md
+++ b/content/server/v14_0/reusable_text/server_services_expander.md
@@ -1,0 +1,3 @@
+The **opscode-expander** service is used to process data (pulled from
+the **rabbitmq** service's message queue) so that it can be properly
+indexed by the **opscode-solr4** service.

--- a/content/server/v14_0/reusable_text/server_services_oc_id.md
+++ b/content/server/v14_0/reusable_text/server_services_oc_id.md
@@ -1,0 +1,6 @@
+The **oc-id** service enables OAuth 2.0 authentication to the Chef Infra
+Server by external applications, including Chef Supermarket. OAuth 2.0
+uses token-based authentication, where external applications use tokens
+that are issued by the **oc-id** provider. No special
+credentials---`webui_priv.pem` or privileged keys---are stored on the
+external application.

--- a/content/server/v14_0/reusable_text/server_services_postgresql.md
+++ b/content/server/v14_0/reusable_text/server_services_postgresql.md
@@ -1,0 +1,1 @@
+The **postgresql** service is used to store node, object, and user data.

--- a/content/server/v14_0/reusable_text/server_services_rabbitmq.md
+++ b/content/server/v14_0/reusable_text/server_services_rabbitmq.md
@@ -1,0 +1,3 @@
+The **rabbitmq** service is used to provide the message queue that is
+used by the Chef Infra Server to get search data to Apache Solr so that
+it can be indexed for search.

--- a/content/server/v14_0/reusable_text/server_services_redis.md
+++ b/content/server/v14_0/reusable_text/server_services_redis.md
@@ -1,0 +1,2 @@
+Key-value store used in conjunction with Nginx to route requests and
+populate request data used by the Chef Infra Server.

--- a/content/server/v14_0/reusable_text/server_services_solr4.md
+++ b/content/server/v14_0/reusable_text/server_services_solr4.md
@@ -1,0 +1,4 @@
+The **opscode-solr4** service is used to create the search indexes used
+for searching objects like nodes, data bags, and cookbooks. (This
+service ensures timely search results via the Chef Infra Server API;
+data that is used by the Chef platform is stored in PostgreSQL.)

--- a/content/server/v14_0/reusable_text/server_tuning_bookshelf.md
+++ b/content/server/v14_0/reusable_text/server_tuning_bookshelf.md
@@ -1,0 +1,6 @@
+The following setting is often modified from the default as part of the
+tuning effort for the **bookshelf** service:
+
+`bookshelf['vip']`
+
+:   The virtual IP address. Default value: `node['fqdn']`.

--- a/content/server/v14_0/reusable_text/server_tuning_erchef.md
+++ b/content/server/v14_0/reusable_text/server_tuning_erchef.md
@@ -1,0 +1,22 @@
+The following settings are often modified from the default as part of
+the tuning effort for the **opscode-erchef** service:
+
+`opscode_erchef['db_pool_size']`
+
+:   The number of open connections to PostgreSQL that are maintained by
+    the service. If failures indicate that the **opscode-erchef**
+    service ran out of connections, try increasing the
+    `postgresql['max_connections']` setting. If failures persist, then
+    increase this value (in small increments) and also increase the
+    value for `postgresql['max_connections']`. Default value: `20`.
+
+`opscode_erchef['s3_url_ttl']`
+
+:   The amount of time (in seconds) before connections to the server
+    expire. If Chef Infra Client runs are timing out, increase this
+    setting to `3600`, and then adjust again if necessary. Default
+    value: `900`.
+
+`opscode_erchef['strict_search_result_acls']`
+
+: {{< reusable_text_versioned "settings_strict_search_result_acls" >}}

--- a/content/server/v14_0/reusable_text/server_tuning_expander.md
+++ b/content/server/v14_0/reusable_text/server_tuning_expander.md
@@ -1,0 +1,12 @@
+The following setting is often modified from the default as part of the
+tuning effort for the **opscode-expander** service:
+
+`opscode_expander['nodes']`
+
+:   The number of allowed worker processes. The **opscode-expander**
+    service runs on the back-end and feeds data to the **opscode-solr**
+    service, which creates and maintains search data used by the Chef
+    Infra Server. Additional memory may be required by these worker
+    processes depending on the frequency and volume of Chef Infra Client
+    runs across the organization, but only if the back-end machines have
+    available CPU and RAM. Default value: `2`.

--- a/content/server/v14_0/reusable_text/server_tuning_general.md
+++ b/content/server/v14_0/reusable_text/server_tuning_general.md
@@ -1,0 +1,26 @@
+The following settings are typically added to the server configuration
+file (no equal sign is necessary to set the value):
+
+`api_fqdn`
+
+:   The FQDN for the Chef Infra Server. This setting is not in the
+    server configuration file by default. When added, its value should
+    be equal to the FQDN for the service URI used by the Chef Infra
+    Server. For example: `api_fqdn "chef.example.com"`.
+
+`bootstrap`
+
+:   Default value: `true`.
+
+`ip_version`
+
+:   Use to set the IP version: `"ipv4"` or `"ipv6"`. When set to
+    `"ipv6"`, the API listens on IPv6 and front end and back end
+    services communicate via IPv6 when a high availability configuration
+    is used. When configuring for IPv6 in a high availability
+    configuration, be sure to set the netmask on the IPv6 `backend_vip`
+    attribute. Default value: `"ipv4"`.
+
+`notification_email`
+
+:   Default value: `info@example.com`.

--- a/content/server/v14_0/reusable_text/server_tuning_nginx.md
+++ b/content/server/v14_0/reusable_text/server_tuning_nginx.md
@@ -1,0 +1,72 @@
+The following settings are often modified from the default as part of
+the tuning effort for the **nginx** service and to configure the Chef
+Infra Server to use SSL certificates:
+
+`nginx['ssl_certificate']`
+
+:   The SSL certificate used to verify communication over HTTPS. Default
+    value: `nil`.
+
+`nginx['ssl_certificate_key']`
+
+:   The certificate key used for SSL communication. Default value:
+    `nil`.
+
+`nginx['ssl_ciphers']`
+
+:   The list of supported cipher suites that are used to establish a
+    secure connection. To favor AES256 with ECDHE forward security, drop
+    the `RC4-SHA:RC4-MD5:RC4:RSA` prefix. For example:
+
+    ```ruby
+    nginx['ssl_ciphers'] =  "HIGH:MEDIUM:!LOW:!kEDH: \
+                             !aNULL:!ADH:!eNULL:!EXP: \
+                             !SSLv2:!SEED:!CAMELLIA: \
+                             !PSK"
+    ```
+
+`nginx['ssl_protocols']`
+
+:   The SSL protocol versions that are enabled. SSL 3.0 is supported by
+    the Chef Infra Server; however, SSL 3.0 is an obsolete and insecure
+    protocol. Transport Layer Security (TLS)---TLS 1.0, TLS 1.1, and TLS
+    1.2---has effectively replaced SSL 3.0, which provides for
+    authenticated version negotiation between Chef Infra Client and Chef
+    Infra Server, which ensures the latest version of the TLS protocol
+    is used. For the highest possible security, it is recommended to
+    disable SSL 3.0 and allow all versions of the TLS protocol. For
+    example:
+
+    ```ruby
+    nginx['ssl_protocols'] = 'TLSv1 TLSv1.1 TLSv1.2'
+    ```
+
+<div class="admonition-note">
+
+<p class="admonition-note-title">Note</p>
+
+<div class="admonition-note-text">
+
+See <https://www.openssl.org/docs/man1.0.2/man1/ciphers.html> for more
+information about the values used with the `nginx['ssl_ciphers']` and
+`nginx['ssl_protocols']` settings.
+
+
+
+</div>
+
+</div>
+
+For example, after copying the SSL certificate files to the Chef Infra
+Server, update the `nginx['ssl_certificate']` and
+`nginx['ssl_certificate_key']` settings to specify the paths to those
+files, and then (optionally) update the `nginx['ssl_ciphers']` and
+`nginx['ssl_protocols']` settings to reflect the desired level of
+hardness for the Chef Infra Server:
+
+```ruby
+nginx['ssl_certificate'] = '/etc/pki/tls/private/name.of.pem'
+nginx['ssl_certificate_key'] = '/etc/pki/tls/private/name.of.key'
+nginx['ssl_ciphers'] = 'HIGH:MEDIUM:!LOW:!kEDH:!aNULL:!ADH:!eNULL:!EXP:!SSLv2:!SEED:!CAMELLIA:!PSK'
+nginx['ssl_protocols'] = 'TLSv1 TLSv1.1 TLSv1.2'
+```

--- a/content/server/v14_0/reusable_text/server_tuning_postgresql.md
+++ b/content/server/v14_0/reusable_text/server_tuning_postgresql.md
@@ -1,0 +1,35 @@
+The following setting is often modified from the default as part of the tuning effort for the **postgresql** service:
+
+`postgresql['max_connections']`
+
+:   The maximum number of allowed concurrent connections. This value should only be tuned when the `opscode_erchef['db_pool_size']` value used by the **opscode-erchef** service is modified. Default value: `350`.
+    If there are more than two front end machines in a cluster, the
+    `postgresql['max_connections']` setting should be increased. The
+    increased value depends on the number of machines in the front end,
+    but also the number of services that are running on each of these
+    machines.
+
+    -   Each front end machine always runs the **oc_bifrost** and
+        **opscode-erchef** services.
+    -   The Reporting add-on adds the **reporting** service.
+    -   The Chef Push Jobs service adds the **push_jobs** service.
+
+    Each of these services requires 25 connections, above the default
+    value.
+
+    Use the following formula to help determine what the increased value
+    should be:
+
+    ```ruby
+    new_value = current_value + [
+                (# of front end machines - 2) * (25 * # of services)
+             ]
+    ```
+
+    For example, if the current value is 350, there are four front end
+    machines, and all add-ons are installed, then the formula looks
+    like:
+
+    ```ruby
+    550 = 350 + [(4 - 2) * (25 * 4)]
+    ```

--- a/content/server/v14_0/reusable_text/server_tuning_solr.md
+++ b/content/server/v14_0/reusable_text/server_tuning_solr.md
@@ -1,0 +1,3 @@
+The following sections describe ways of tuning the **opscode-solr4**
+service to improve performance around large node sizes, available
+memory, and update frequencies.

--- a/content/server/v14_0/reusable_text/server_tuning_solr_available_memory.md
+++ b/content/server/v14_0/reusable_text/server_tuning_solr_available_memory.md
@@ -1,0 +1,27 @@
+Use the following configuration setting to help ensure that Apache Solr
+does not run out of memory:
+
+`opscode_solr4['heap_size']`
+
+:   The amount of memory (in MBs) available to Apache Solr. If there is
+    not enough memory available, search queries made by nodes to Apache
+    Solr may fail. The amount of memory that must be available also
+    depends on the number of nodes in the organization, the frequency of
+    search queries, and other characteristics that are unique to each
+    organization. In general, as the number of nodes increases, so does
+    the amount of memory.
+
+If Apache Solr is running out of memory, the
+`/var/log/opscode/opscode-solr4/current` log file will contain a message
+similar to:
+
+```bash
+SEVERE: java.lang.OutOfMemoryError: Java heap space
+```
+
+The default value for `opscode_solr4['heap_size']` should work for many
+organizations, especially those with fewer than 25 nodes. For
+organizations with more than 25 nodes, set this value to 25% of system
+memory or `1024`, whichever is smaller. For very large configurations,
+increase this value to 25% of system memory or `4096`, whichever is
+smaller. This value should not exceed `8192`.

--- a/content/server/v14_0/reusable_text/server_tuning_solr_large_node_sizes.md
+++ b/content/server/v14_0/reusable_text/server_tuning_solr_large_node_sizes.md
@@ -1,0 +1,59 @@
+The maximum field length setting for Apache Solr should be greater than
+any expected node object file sizes in order for them to be successfully
+added to the search index. If a node object file is greater than the
+maximum field length, the node object will be indexed up to the maximum,
+but the part of the file past that limit will not be indexed. If this
+occurs, it will seem as if nodes disappear from the search index. To
+ensure that large node file sizes are indexed properly, verify the
+following configuration settings:
+
+`nginx['client_max_body_size']`
+
+:   The maximum accepted body size for a client request, as indicated by
+    the `Content-Length` request header. When the maximum accepted body
+    size is greater than this value, a `413 Request Entity Too Large`
+    error is returned. Default value: `250m`.
+
+and
+
+`opscode_erchef['max_request_size']`
+
+:   When the request body size is greater than this value, a 413 Request
+    Entity Too Large error is returned. Default value: `2000000`.
+
+to ensure that those settings are not part of the reasons for incomplete
+indexing, and then update the following setting so that its value is
+greater than the expected node file sizes:
+
+`opscode_solr4['max_field_length']`
+
+:   The maximum field length (in number of tokens/terms). If a field
+    length exceeds this value, Apache Solr may not be able to complete
+    building the index. Default value: `100000` (increased from the
+    Apache Solr default value of `10000`).
+
+Use the `wc` command to get the byte count of a large node object file.
+For example:
+
+```bash
+wc -c NODE_NAME.json
+```
+
+and then ensure there is a buffer beyond that value. For example, verify
+the size of the largest node object file:
+
+```bash
+wc -c nodebsp2016.json
+```
+
+which returns `154516`. Update the `opscode_solr4['max_field_length']`
+setting to have a value greater than the returned value. For example:
+`180000`.
+
+If you don't have a node object file available then you can get an
+approximate size of the node data by running the following command on a
+node.
+
+```bash
+ohai | wc -c
+```

--- a/content/server/v14_0/reusable_text/server_tuning_solr_update_frequency.md
+++ b/content/server/v14_0/reusable_text/server_tuning_solr_update_frequency.md
@@ -1,0 +1,24 @@
+At the end of every Chef Infra Client run, the node object is saved to
+the Chef Infra Server. From the Chef Infra Server, each node object is
+then added to the `SOLR` search index. This process is asynchronous. By
+default, node objects are committed to the search index every 60 seconds
+or per 1000 node objects, whichever occurs first.
+
+When data is committed to the Apache Solr index, all incoming updates
+are blocked. If the duration between updates is too short, it is
+possible for the rate at which updates are asked to occur to be faster
+than the rate at which objects can be actually committed.
+
+Use the following configuration setting to improve the indexing
+performance of node objects:
+
+`opscode_solr4['commit_interval']`
+
+:   The frequency (in seconds) at which node objects are added to the
+    Apache Solr search index. Default value: `60000` (every 60 seconds).
+
+`opscode_solr4['max_commit_docs']`
+
+:   The frequency (in documents) at which node objects are added to the
+    Apache Solr search index. Default value: `1000` (every 1000
+    documents).

--- a/content/server/v14_0/reusable_text/settings_strict_search_result_acls.md
+++ b/content/server/v14_0/reusable_text/settings_strict_search_result_acls.md
@@ -1,0 +1,28 @@
+Use to specify that search results only return objects to which an actor
+(user, client, etc.) has read access, as determined by ACL settings.
+This affects all searches. When `true`, the performance of the Chef
+management console may increase because it enables the Chef management
+console to skip redundant ACL checks. To ensure the Chef management
+console is configured properly, after this setting has been applied with
+a `chef-server-ctl reconfigure` run `chef-manage-ctl reconfigure` to
+ensure the Chef management console also picks up the setting. Default
+value: `false`.
+
+<div class="admonition-warning">
+
+<p class="admonition-warning-title">Warning</p>
+
+<div class="admonition-warning-text">
+
+When `true`, `opscode_erchef['strict_search_result_acls']` affects all
+search results and any actor (user, client, etc.) that does not have
+read access to a search result will not be able to view it. For example,
+this could affect search results returned during a Chef Infra Client
+runs if a Chef Infra Client does not have permission to read the
+information.
+
+
+
+</div>
+
+</div>

--- a/content/terraform.md
+++ b/content/terraform.md
@@ -16,7 +16,7 @@ draft = false
 
 ## Chef Infra Provisioner
 
-The [Terraform Chef Provisioner](https://www.terraform.io/docs/provisioners/chef.html) bootstraps Terraform, provisioned with Chef Infra via SSH or WinRM, and configures them to work with a [Chef Infra Server](/server_overview/). Standard bootstrap options such as Chef Infra versions, secrets, proxies, and assigning run lists via Policyfiles or Roles and Environments are all supported. The referenced documentation provides a complete list of supported options and an example of usage. HashiCorp provides support for the [Terraform Chef Provisioner](https://www.terraform.io/docs/provisioners/chef.html) and it is not officially supported by Chef Software.
+The [Terraform Chef Provisioner](https://www.terraform.io/docs/provisioners/chef.html) bootstraps Terraform, provisioned with Chef Infra via SSH or WinRM, and configures them to work with a [Chef Infra Server](/server/). Standard bootstrap options such as Chef Infra versions, secrets, proxies, and assigning run lists via Policyfiles or Roles and Environments are all supported. The referenced documentation provides a complete list of supported options and an example of usage. HashiCorp provides support for the [Terraform Chef Provisioner](https://www.terraform.io/docs/provisioners/chef.html) and it is not officially supported by Chef Software.
 
 ### Terraform and Chef Solo
 

--- a/hugo_readme.md
+++ b/hugo_readme.md
@@ -1,0 +1,181 @@
+# Configuring Hugo
+
+## Versioning Documentation
+
+We can provide versioned documentation for the following Chef products:
+
+- Chef Desktop
+- Chef Infra Client
+- Chef Infra Server
+- Chef InSpec
+- Chef Habitat
+- Chef Workstation
+
+This site requires several subdirectories, files, and parameters to build and display
+documentation for several versions of a product.
+
+### Parameters
+
+In the site `config.toml` file, set the `params.product_version` setting to the
+product and versions that Hugo should build. Each `versions` parameter
+is a list with the major and minor version numbers separated by an underscore.
+For example:
+
+```
+[params.product_version]
+[params.product_version.chef-server]
+versions = ["14_0", "13_2"]
+[params.product_version.chef]
+versions = ["16_6", "16_5", "16_4"]
+```
+
+Note that Hugo will only build documentation for the versions listed in this parameter
+even if other versions are included in the content.
+
+### File Organization
+
+Hugo requires several files and subdirectories to provide
+documentation for multiple versions of a product. They are:
+
+- A product subdirectory within `content`.
+- Markdown pages within that product subdirectory.
+- Versioned subdirectories within that product subdirectory.
+- `index.md` files within the versioned subdirectories.
+- Markdown pages within the versioned subdirectories that have the same file names
+  as the Markdown pages in the product subdirectory.
+- A `reusable_text` subdirectory within each versioned subdirectory.
+- Reusable text files that could be used across multiple pages of a version of the
+  documentation.
+
+Below is an example of what that file structure should look like.
+
+```
+content
+  |- <PRODUCT>
+    |- <page_name>.md
+    |- <other_page_name>.md
+    |- ...
+    |- v<X1>_<Y1>
+      |- index.md
+      |- <page_name>.md
+      |- <other_page_name>.md
+      |- ....
+      |- reusable_text
+        |- <reusable_text_file1>.md
+        |- <reusable_text_file2>.md
+        |- ...
+    |- v<X2>_<Y2>
+      |- index.md
+      |- <page_name>.md
+      |- <other_page_name>.md
+      |- ....
+      |- reusable_text
+        |- <reusable_text_file1>.md
+        |- <reusable_text_file2>.md
+        |- ...
+  |- <OTHER_PRODUCT>
+    |-....
+```
+
+#### Product Directory
+
+All documentation that will be versioned must be contained within a product subdirectory
+within the `content` directory. Most of these directories already exist. Valid directory
+names are:
+
+- `client`
+- `server`
+- `workstation`
+- `inspec`
+- `habitat`
+- `desktop`
+
+#### Markdown Pages
+
+Each page that is versioned must have the `version_docs_product` parameter set to
+a relevant product. For example:
+
+`version_docs_product = "chef-server"`
+
+The possible values for this parameter are:
+
+- `chef`
+- `chef-server`
+- `chef-workstation`
+- `desktop-config`
+- `inspec`
+- `habitat`
+
+All other page configuration metadata (menu configuration, aliases, page title, draft)
+should be included in the frontmatter as it normally exists in other pages. The
+rest of the page should be blank.
+
+**Note**
+
+Pages within a product directory don't have to be versioned. For example,
+a product introduction would contain content that's relevant to all versions of a product.
+Hugo will render the content in a page without the `version_docs_product` parameter
+like any other un-versioned page.
+
+#### Version Subdirectories
+
+All of the content that Hugo uses to build the versioned pages is stored within versioned
+subdirectories. They are named after the major and minor version
+numbers of a product in this format: `v<MAJOR>_<MINOR>`. For example, `v12_2` or `v16_0`.
+
+#### `index.md`
+
+Each versioned subdirectory must have an `index.md` file, but not an `_index.md` file.
+Add `headless = true` to the frontmatter of the index page. The rest of the index page
+should be blank.
+
+See Hugo's documentation on [page bundles](https://gohugo.io/content-management/page-bundles/)
+for the difference between an `_index.md` file and an `index.md` file.
+
+Adding `headless = true` makes the directory a headless bundle. See Hugo's documentation
+for more information about [headless bundles](https://gohugo.io/content-management/page-bundles/#headless-bundle).
+
+#### Versioned Pages
+
+Each page with the `version_docs_product` parameter set in its frontmatter must have
+matching pages with the exact same file name in each of the version subdirectories.
+
+These versioned pages contain the text that will be added to the parent page.
+
+The pages don't require any frontmatter, although adding `title` and `version` parameters
+can be helpful if you are editing multiple pages at the same time.
+
+#### Reusable Text
+
+We often need blocks of text that are identical from one page to the next. Add
+these reusable text files to the `reusable_text` directory within each version
+directory.
+
+To add a reusable text file to a page, use the `reusable_text_versioned` shortcode by adding
+`{{< reusable_text_versioned file="<FILENAME>" >}}` to the text of the versioned Markdown page.
+Ommit the `.md` suffix from the filename in the `file` parameter.
+
+### Behind the Scenes
+
+When Hugo finds a page with the `version_docs_product` parameter, it takes the
+value of that parameter and looks for the matching value in the `params.product_version`
+parameter in the site's `config.toml` file. It grabs the version numbers for that product
+and looks for subdirectories with matching version numbers. From the versioned
+subdirectories, it grabs the content from the file with the same name as the original file.
+
+Hugo renders the content from those versioned files inside `<div>` sections and adds
+a `class` attribute with the product and version number.
+
+Hugo also renders a table of contents for each versioned file, also within `<div>`
+sections with a `class` attribute of the product and version number.
+
+Hugo automatically generates heading `id` attributes for each heading on a page.
+On a normal page, if Hugo is presented with several headings that have the same
+text, it will add a suffix to the end of each subsequent heading `id`. However,
+this does not work if Hugo generates one page using contents from multiple pages.
+This means that headings with the same text will have headings with the same `id`
+value.
+
+To fix this, the partials that process this content automatically add a version
+number suffix to each heading `id` attribute. The heading links in the table of
+contents are also modified so they'll properly link to the correct headings.

--- a/themes/docs-new/assets/js/chef-hugo.js
+++ b/themes/docs-new/assets/js/chef-hugo.js
@@ -1,7 +1,7 @@
 (function (win, doc,$) {
   $(doc).foundation();
 
-  $(".prose > :header").each(function () {
+  $(".prose > :header" ).add(".chef-product-version > :header" ) .each(function () {
     $(this).append("<a href=\"\#" + $(this).attr("id") + "\"><i class=\"fas fa-link\"></i></a>");
   });
 

--- a/themes/docs-new/assets/js/version-docs.js
+++ b/themes/docs-new/assets/js/version-docs.js
@@ -1,0 +1,101 @@
+
+// Display text divs with parentClass class and displayClass class
+// Hide other text divs with just parentClass class
+displayHideTextBlocks = function(displayClass, parentClass){
+  for (var i = 0; i < parentClass.length; i++) {
+    versionedText = parentClass[i];
+    versionedTextVersion = parentClass[i].classList[1];
+
+    if (versionedTextVersion === displayClass) {
+      versionedText.style.display = "block";
+    } else {
+      versionedText.style.display = "none";
+    }
+  }
+}
+
+// Display correct product/version in dropdown list
+changeDropdownListValue = function(version){
+  var opts = dropdownId.options.length;
+  for (var i=0; i<opts; i++){
+      if (dropdownId.options[i].value == version){
+          dropdownId.options[i].selected = true;
+          break;
+      }
+  }
+}
+
+// Fetch the given URL product version
+$.urlParam = function(name){
+  var results = new RegExp('[\?&]' + name + '=([^]*)').exec(window.location.href);
+  if (results==null){
+      return null;
+  }
+  else {
+      return results[1] || 0;
+  }
+}
+
+// User changes product/version with dropdown list menu:
+// which changes text divs that are shown, sets version in localstorage
+// and adds version to url.
+selectProductVersion = function() {
+  var changeValue = dropdownId.options[dropdownId.selectedIndex].value;
+  displayHideTextBlocks(changeValue, versionedTextBlocks);
+  localStorage.setItem(docsProductVersionKey, changeValue);
+  urlAppend = "?view=" + changeValue;
+  history.replaceState(window.location.href, '', urlAppend);
+};
+
+if (document.querySelector("#chef-product-version-dropdown")) {
+
+  var chefProductKey = document.querySelector("#chef-product-version-dropdown").dataset.chefProductKey;
+  var defaultVersion = document.querySelector("#chef-product-version-dropdown").dataset.defaultVersion
+  var versionedTextBlocks = document.getElementsByClassName("chef-product-version");
+  var dropdownId = document.getElementById("chef-product-version-dropdown-select");
+  var docsProductVersionKey = ("chef-docs-product-" + chefProductKey)
+  var urlVersion = $.urlParam('view');
+
+  if (urlVersion == null){
+
+    // Check if page has a product/version stored in Window.localstorage
+    // Display blocks based on the locally stored version or default version and hide others
+    // Check browser support of Window.localstorage
+    if (typeof(Storage) !== "undefined") {
+
+      // Try to get product/version from local storage
+      if (localStorage.getItem(docsProductVersionKey)){
+        // display product/version if in local storage
+        // Set the dropdown list menu to the stored version
+
+        var displayVersion = localStorage.getItem(docsProductVersionKey);
+        displayHideTextBlocks(displayVersion, versionedTextBlocks)
+        changeDropdownListValue(displayVersion)
+
+      } else {
+        // If product/version is not in local storage:
+        // display most recent product/version
+        displayHideTextBlocks(defaultVersion, versionedTextBlocks)
+      };
+
+    } else {
+      // If browser does not support Window.localstorage
+      // Drop a div in between each section of the versioned documentation
+      // Stating something like "The following is documentation for version x.y of <product>."
+      console.log("This browser does not support Window.localstorage")
+    };
+
+  } else {
+    urlVersion = urlVersion.split("#")[0]
+    displayHideTextBlocks(urlVersion, versionedTextBlocks)
+    changeDropdownListValue(urlVersion)
+    if (typeof(Storage) !== "undefined") {
+      localStorage.setItem(docsProductVersionKey, urlVersion);
+    } else {
+      // If browser does not support Window.localstorage
+      // Drop a div in between each section of the versioned documentation
+      // Stating something like "The following is documentation for version x.y of <product>."
+      console.log("This browser does not support Window.localstorage")
+    };
+  };
+};

--- a/themes/docs-new/assets/sass/typography/_prose.scss
+++ b/themes/docs-new/assets/sass/typography/_prose.scss
@@ -42,6 +42,31 @@
       margin-top: 1rem;
     }
   }
+  #chef-product-version-dropdown{
+    margin: -12px 0 26px 0;
+    &-label {
+      display: inline-block;
+      font-style: bold;
+      font-size: 1.25rem;
+    }
+    &-select {
+      display: inline-block;
+      width: auto;
+      border-radius: $border-radius-base;
+    }
+  }
+  .chef-product-version{
+    &-not-newest{
+      background-color: $ash;
+      padding: 1rem;
+      margin: 1.5rem;
+      border: 1px solid lightgray;
+      border-radius: $border-radius-base;
+      p {
+        margin: 0;
+      }
+    }
+  }
 }
 
 .responsive-table {

--- a/themes/docs-new/layouts/_default/baseof.html
+++ b/themes/docs-new/layouts/_default/baseof.html
@@ -16,25 +16,28 @@
       <div class="grid-x">
 
         <div class="cell position-left off-canvas-absolute reveal-for-medium col-sidebar" id="left-nav-on-canvas" data-off-canvas data-transition="overlap" >
-            {{ partial "sidebar-on-canvas" . }}
+          {{ partial "sidebar-on-canvas" . }}
         </div>
 
         <div id="main-content" class="cell off-canvas-content cell auto" data-off-canvas-content>
-            {{ block "main" . }}
-            {{ end }}
+          {{ block "main" . }}
+          {{ end }}
         </div>
 
         {{ $headers := findRE "<h[12].*?>(.|\n])+?</h[12]>" .Content }}
-        {{ if or (and (ge (len $headers) 1) (ne .Params.toc false )) (isset .Params "release_notes") }}
-          <div class="cell off-canvas position-right toc off-canvas-absolute reveal-for-large" id="onCanvasRightTOC" data-off-canvas >
-            {{ if .Params.toc_layout }}
+        {{ if or (and (ge (len $headers) 1) (ne .Params.toc false )) (isset .Params "release_notes") (.Params.version_docs_product)}}
+          {{ if .Params.toc_layout }}
+            <div class="cell off-canvas position-right toc off-canvas-absolute reveal-for-large" id="onCanvasRightTOC" data-off-canvas >
               {{ partial .Params.toc_layout . }}
-            {{ else }}
+            </div>
+          {{ else if (.Params.version_docs_product)}}
+            {{ partial "versioned-docs-toc" . }}
+          {{ else }}
+            <div class="cell off-canvas position-right toc off-canvas-absolute reveal-for-large" id="onCanvasRightTOC" data-off-canvas >
               {{ partial "table-of-contents" . }}
-            {{ end }}
-          </div>
+            </div>
+          {{ end }}
         {{ end }}
-
       </div>
     </div>
   </div>

--- a/themes/docs-new/layouts/_default/single.html
+++ b/themes/docs-new/layouts/_default/single.html
@@ -3,15 +3,30 @@
 <div class="col-content">
   <div id="{{ anchorize ( .Title )}}"><h1>{{ .Title }}</h1></div>
 
+  {{ if .Params.version_docs_product }}
+    <button type="button" class="TOC-button hide-for-large" data-toggle="offCanvasRightTOC" data-close="left-nav-off-canvas">
+      <i class="fas fa-bars"></i> Table of Contents
+    </button>
+    {{ partial "versioned-docs-dropdown" . }}
+  {{ end }}
+
   {{ $headers := findRE "<h[12].*?>(.|\n])+?</h[12]>" .Content }}
+
   {{ if and (ge (len $headers) 1) (ne .Params.toc false )}}
+
     <button type="button" class="TOC-button hide-for-large hide-for-print" data-toggle="offCanvasRightTOC" data-close="left-nav-off-canvas">
       <i class="fas fa-bars"></i> Table of Contents
     </button>
+
   {{ end }}
-    <div class="prose">
+
+  <div class="prose">
+    {{ if .Params.version_docs_product }}
+      {{ partial "versioned-docs-content" . }}
+    {{ else }}
       {{ .Content }}
-    </div>
+    {{ end }}
   </div>
+</div>
 </main>
 {{ end }}

--- a/themes/docs-new/layouts/partials/javascript.html
+++ b/themes/docs-new/layouts/partials/javascript.html
@@ -11,7 +11,8 @@
 {{- $copycodebutton := resources.Get "js/copy-code-button.js" }}
 {{- $chefHugo := resources.Get "js/chef-hugo.js" }}
 {{- $resourceNote := resources.Get "js/resource-note.js" }}
-{{- $customJs := slice $segment $omnitruck $copycodebutton $chefHugo $resourceNote | resources.Concat "js/custom-bundle.js" | minify | fingerprint }}
+{{- $versionDocs := resources.Get "js/version-docs.js" }}
+{{- $customJs := slice $segment $omnitruck $copycodebutton $chefHugo $resourceNote $versionDocs | resources.Concat "js/custom-bundle.js" | minify | fingerprint }}
 <script src="{{ $customJs.Permalink }}" type="text/javascript"></script>
 <script type="text/javascript">
   (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){

--- a/themes/docs-new/layouts/partials/versioned-docs-content.html
+++ b/themes/docs-new/layouts/partials/versioned-docs-content.html
@@ -1,0 +1,53 @@
+{{ $product := .Params.version_docs_product }}
+{{ $baseDir := .File.Dir }}
+{{ $splitBaseDir := trim $baseDir "/" }}
+{{ $LogicalName := .File.LogicalName }}
+
+{{$formalProductName := ""}}
+{{ if eq $product "chef" }}
+  {{ $formalProductName = "Chef Infra Client" }}
+{{ else if eq $product "chef-server" }}
+  {{ $formalProductName = "Chef Infra Server" }}
+{{ else if eq $product "chef-workstation" }}
+  {{ $formalProductName = "Chef Workstation" }}
+{{ else if eq $product "inspec" }}
+  {{ $formalProductName = "Chef InSpec" }}
+{{ else if eq $product "habitat" }}
+  {{ $formalProductName = "Chef Habitat" }}
+{{ else if eq $product "desktop-config" }}
+  {{ $formalProductName = "Chef Desktop" }}
+{{ else if eq $product "product_a" }}
+  {{ $formalProductName = "Product A" }}
+{{ else if eq $product "product_b" }}
+  {{ $formalProductName = "Product B" }}
+{{ else }}
+  {{ errorf "No matching product name. Current valid version_docs_product values are chef-server, chef, chef-workstation, inspec, habitat, and desktop-config." }}
+{{ end }}
+
+{{ $versions := index .Site.Params.product_version $product }}
+{{ range $version_index, $version := (sort $versions.versions "value" "desc") }}
+  {{ $versionDir := delimit (slice "v" $version) "" }}
+  {{/* $filePath := path.Join (slice "/" $splitBaseDir $versionDir $LogicalName) "/" */}}
+  {{ $filePath := path.Join (slice "/" $splitBaseDir $versionDir) "/" }}
+
+  {{ if not ($.Site.GetPage $filePath) }}
+    {{ errorf "File does not exist %q." $filePath }}
+  {{ end }}
+  {{ with $.Site.GetPage $filePath }}
+    <div class="chef-product-version {{$product}}_{{$version}}">
+      {{ if gt $version_index 0 }}
+      <div class="chef-product-version-not-newest">
+        <p><strong>Note:</strong> You are viewing documentation for an older version of <span class="chef-product-version-name">{{$formalProductName}}</span>.</p>
+      </div>
+      {{ end }}
+
+      {{ with (index (.Resources.Match $LogicalName) 0) }}
+        {{ $pageText := .Content }}
+        {{ $replacementID := delimit (slice `<$1-` $version `"`) "" }}
+        {{ $pageText := replaceRE `<(h\d id="[\w\-]+)"` $replacementID $pageText }}
+        {{ safeHTML $pageText }}
+      {{ end }}
+
+    </div>
+  {{ end }}
+{{ end }}

--- a/themes/docs-new/layouts/partials/versioned-docs-dropdown.html
+++ b/themes/docs-new/layouts/partials/versioned-docs-dropdown.html
@@ -1,0 +1,42 @@
+{{ $product := .Params.version_docs_product }}
+
+{{$formalProductName := ""}}
+{{ if eq $product "chef" }}
+  {{ $formalProductName = "Chef Infra Client" }}
+{{ else if eq $product "chef-server" }}
+  {{ $formalProductName = "Chef Infra Server" }}
+{{ else if eq $product "chef-workstation" }}
+  {{ $formalProductName = "Chef Workstation" }}
+{{ else if eq $product "inspec" }}
+  {{ $formalProductName = "Chef InSpec" }}
+{{ else if eq $product "habitat" }}
+  {{ $formalProductName = "Chef Habitat" }}
+{{ else if eq $product "desktop-config" }}
+  {{ $formalProductName = "Chef Desktop" }}
+{{ else if eq $product "product_a" }}
+  {{ $formalProductName = "Product A" }}
+{{ else if eq $product "product_b" }}
+  {{ $formalProductName = "Product B" }}
+{{ else }}
+  {{ $formalProductName = "Name Missing" }}
+{{ end }}
+
+{{ $versions := index .Site.Params.product_version $product }}
+
+{{ $sorted_versions := sort $versions.versions "value" "desc" }}
+
+{{ $float_versions := slice }}
+{{ range sort $versions.versions "value" "desc" }}
+  {{$float_versions = $float_versions | append (float (replaceRE "_" "." . )) }}
+{{ end }}
+
+<div id="chef-product-version-dropdown" data-chef-product-key="{{ $product }}" data-default-version="{{ $product }}_{{ (index $sorted_versions 0) }}">
+  <label id="chef-product-version-dropdown-label" for="chef_product">Version:</label>
+  <select id="chef-product-version-dropdown-select" name="chef_product" onchange="selectProductVersion()" >
+    {{ range $version_index, $float_version := $float_versions }}
+      <option data-product="{{ $product }}" data-version="{{ lang.NumFmt 1 $float_version }}" value="{{ $product }}_{{ index $sorted_versions $version_index }}">
+        {{$formalProductName}} {{ lang.NumFmt 1 $float_version }}
+      </option>
+    {{ end }}
+  </select>
+</div>

--- a/themes/docs-new/layouts/partials/versioned-docs-toc.html
+++ b/themes/docs-new/layouts/partials/versioned-docs-toc.html
@@ -1,0 +1,63 @@
+{{ $pageTitle := delimit (slice "<a href=\"#" ( anchorize .Title) "\">" .Title "</a>") "" }}
+{{ $tocContents := "" }}
+{{ $product := .Params.version_docs_product }}
+{{ $baseDir := .File.Dir }}
+{{ $splitBaseDir := trim $baseDir "/" }}
+{{ $LogicalName := .File.LogicalName }}
+
+{{ $versions := index .Site.Params.product_version .Params.version_docs_product }}
+{{ $headersExist := false }}
+{{ range $versions.versions }}
+  {{ $newTOC := "" }}
+
+  {{ $version := . }}
+  {{ $versionDir := delimit (slice "v" $version) "" }}
+  {{ $filePath := path.Join (slice "/" $splitBaseDir $versionDir) "/" }}
+
+  {{ with $.Site.GetPage $filePath }}
+    {{ with (index (.Resources.Match $LogicalName) 0) }}
+      {{ $headers := findRE "<h[12].*?>(.|\n])+?</h[12]>" .Content }}
+      {{ if ge (len $headers) 1 }}
+        {{ $headersExist = true }}
+
+        {{ $newTOC = delimit (slice `<div class="chef-product-version ` $product "_" $version `">` ) "" }}
+        {{ $newTOC = delimit (slice $newTOC .Page.TableOfContents) "" }}
+        {{ $newTOC = delimit (slice $newTOC "</div>") "" }}
+        {{ $replacementID := delimit (slice `$1-` $version `">`) "" }}
+        {{ $newTOC := replaceRE `(<a href="#[\w\-]+)\">` $replacementID $newTOC }}
+
+        {{ $tocContents = delimit (slice $tocContents $newTOC) "" }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ if $headersExist }}
+<div class="cell off-canvas position-right toc off-canvas-absolute reveal-for-large" id="onCanvasRightTOC" data-off-canvas >
+  <aside class="sticky sidebar" data-sticky data-top-anchor="utility-bar:bottom" data-btm-anchor="footer:top">
+    <div class="TableOfContents">
+      <span>
+        <strong>
+          <h4 class="mini-toc-header">Table Of Contents</h4>
+        </strong>
+        <button class="close-button hide-for-large" aria-label="Close menu" type="button" data-close>
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </span>
+      {{ $pageTitle }}
+      {{- safeHTML $tocContents -}}
+    </div>
+  </aside>
+</div>
+
+
+<div class="off-canvas position-right toc off-canvas-absolute hide-for-large" id="offCanvasRightTOC" data-off-canvas
+data-transition="overlap">
+  <strong>
+    <h4 class="mini-toc-header">Table Of Contents</h4>
+  </strong>
+    {{ $pageTitle }}
+    {{- safeHTML $tocContents -}}
+</div>
+{{ end }}
+
+

--- a/themes/docs-new/layouts/shortcodes/reusable_text_versioned.html
+++ b/themes/docs-new/layouts/shortcodes/reusable_text_versioned.html
@@ -1,0 +1,33 @@
+{{ $page_file_path := $.Page.File.Path }}
+{{ $parent_page_file := $.Page.File.LogicalName }}
+{{ $path := replaceRE $parent_page_file "" $page_file_path }}
+
+{{ $reusable_text_file := print "content/" $path "reusable_text/" (.Get "file") ".md" }}
+{{ $reusable_text_content := readFile $reusable_text_file }}
+
+{{/* The code below handles reusable files that call for content from other reusable files */}}
+
+{{ if in $reusable_text_content "reusable_text_versioned" }}
+  {{ $more_reusable_text := newScratch }}
+  {{ $more_reusable_text.Set "text" "" }}
+  {{ range split (readFile $reusable_text_file) "\n"}}
+    {{ if in . "reusable_text_versioned" }}
+
+      {{ $more_reusable_text_match := index (findRE `{{< reusable_text_versioned \"([\w|-|_]+)\" >}}` . ) 0 }}
+      {{ $more_reusable_text_file := replaceRE `{{< reusable_text_versioned \"([\w|-|_]+)\" >}}` "$1" $more_reusable_text_match}}
+      {{ $more_reusable_text_file = print "content/" $path "reusable_text/" $more_reusable_text_file ".md" }}
+      {{ $more_reusable_text_content := readFile $more_reusable_text_file }}
+      {{ $newLineText := replaceRE $more_reusable_text_match $more_reusable_text_content . }}
+      {{ $more_reusable_text.Add "text" $newLineText }}
+      {{ $more_reusable_text.Add "text" "\n" }}
+
+    {{ else }}
+      {{ $more_reusable_text.Add "text" . }}
+      {{ $more_reusable_text.Add "text" "\n" }}
+    {{ end }}
+  {{ end }}
+
+  {{ $more_reusable_text.Get "text" | markdownify }}
+{{ else }}
+  {{ markdownify $reusable_text_content }}
+{{ end }}


### PR DESCRIPTION
### Description

Provide documentation for multiple versions of a product on one page.

### Definition of Done

This adds:
- two pages for Chef Server that have content for two versions of Chef Server
- JS to hide and display the versions
- Hugo partials to generate the content
- subdirectories to store content for each version
- a readme
- migrate content from `server_overview.md` to `server/_index.md`
- update links to relevant pages

See pages:
https://deploy-preview-2712--chef-web-docs.netlify.app/server/
https://deploy-preview-2712--chef-web-docs.netlify.app/server/config_rb_server/
https://deploy-preview-2712--chef-web-docs.netlify.app/server/config_rb_server_optional_settings/

~~One issue that must be resolved before this is merged is that there's no content in https://deploy-preview-2712--chef-web-docs.netlify.app/server/.~~

~~We could add a redirect to another page, or add an `_index.md` to `content/server` with text from another page that's about server. For example, the `server_overview.md` page.~~

### Issues Resolved

chef/release-engineering#1283

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
