### PR TITLE
change font size for code blocks

### DIFF
--- a/themes/docs-new/assets/sass/typography/_code.scss
+++ b/themes/docs-new/assets/sass/typography/_code.scss
@@ -2,7 +2,7 @@ code {
   background-color: $code-background;
   border: 1px solid $ash;
   border-radius: $border-radius-base;
-  font-size: 0.8rem;
+  font-size: 0.9em;
   display: inline;
   max-width: 100%;
 }


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This fixes the font size for code blocks. It switches from rems to ems, which will style inline code in headings better.

For example, [this heading](https://docs.chef.io/config_rb_backend/#postgresql-settings-given-to-postgresqlconf) looks weird. Here's the [same heading](https://deploy-preview-2716--chef-web-docs.netlify.app/config_rb_backend/#postgresql-settings-given-to-postgresqlconf) with the font style change.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
