### PR TITLE
Consolidate two resource parameters into multi_package_resource param

### DIFF
--- a/content/resources/apt_package/_index.md
+++ b/content/resources/apt_package/_index.md
@@ -1,7 +1,6 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: true
-properties_multiple_packages: true
+multi_package_resource: true
 resources_common_guards: true
 resources_common_notification: true
 resources_common_properties: true

--- a/content/resources/dnf_package/_index.md
+++ b/content/resources/dnf_package/_index.md
@@ -1,7 +1,7 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: true
-properties_multiple_packages: true
+
+multi_package_resource: true
 resources_common_guards: true
 resources_common_notification: true
 resources_common_properties: true

--- a/content/resources/homebrew_package/_index.md
+++ b/content/resources/homebrew_package/_index.md
@@ -1,7 +1,7 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: true
-properties_multiple_packages: true
+
+multi_package_resource: true
 resources_common_guards: true
 resources_common_notification: true
 resources_common_properties: true

--- a/content/resources/package/_index.md
+++ b/content/resources/package/_index.md
@@ -317,7 +317,7 @@ properties_list:
   description_list:
   - markdown: The version of a package to be installed or upgraded.
 properties_shortcode: null
-properties_multiple_packages: true
+multi_package_resource: true
 resource_directory_recursive_directories: false
 resources_common_atomic_update: false
 properties_resources_common_windows_security: false

--- a/content/resources/pacman_package/_index.md
+++ b/content/resources/pacman_package/_index.md
@@ -1,7 +1,7 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: true
-properties_multiple_packages: true
+
+multi_package_resource: true
 resources_common_guards: true
 resources_common_notification: true
 resources_common_properties: true

--- a/content/resources/yum_package/_index.md
+++ b/content/resources/yum_package/_index.md
@@ -1,7 +1,7 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: true
-properties_multiple_packages: true
+
+multi_package_resource: true
 resources_common_guards: true
 resources_common_notification: true
 resources_common_properties: true

--- a/content/resources/zypper_package/_index.md
+++ b/content/resources/zypper_package/_index.md
@@ -1,7 +1,7 @@
 ---
 resource_reference: true
-common_resource_functionality_multiple_packages: true
-properties_multiple_packages: true
+
+multi_package_resource: true
 resources_common_guards: true
 resources_common_notification: true
 resources_common_properties: true

--- a/infra_resources_readme.md
+++ b/infra_resources_readme.md
@@ -1,32 +1,32 @@
-# Resource page yaml files
+# Infra Resource page YAML files
 
 The resource pages and [resource reference page](/resources/)
-are generated using yaml data located in `chef-web-docs/content/resources`.
-The yaml data is generated directly from the Chef Infra code.
-Each resource page has its own subdirectory and the yaml data is stored in 
-an `_index.md` page. For example, the apt package resource data is stored in 
+are generated using YAML data located in `chef-web-docs/content/resources`.
+The YAML data is generated directly from the Chef Infra code.
+Each resource page has its own subdirectory and the YAML data is stored in
+an `_index.md` page. For example, the apt package resource data is stored in
 `chef-web-docs/content/resources/apt_package/_index.md`.
 
-The templates that generate those resource pages are found in 
-`chef-web-docs/layouts/resources`. The templates that generate the tables of 
-contents for the resource are stored in `chef-web-docs/layouts/partials`. 
+The templates that generate those resource pages are found in
+`chef-web-docs/layouts/resources`. The templates that generate the tables of
+contents for the resource are stored in `chef-web-docs/layouts/partials`.
 
 There are two template types, terms and list. The terms template is used to generate
 the [resources reference page](/resources/) and the list
 template generates the individual resource pages, for example
 https://docs.chef.io/resources/apt_package/.
 
-For more general information about lists and terms templates see Hugo's 
+For more general information about lists and terms templates see Hugo's
 [taxonomy template documentation](https://gohugo.io/templates/taxonomy-templates/).
 
-For general information about yaml see the official [yaml website](https://yaml.org/).
+For general information about YAML see the official [YAML website](https://yaml.org/).
 
-## yaml data
+## YAML data
 
-The yaml data is contained in a markdown page and surrounded by opening and closing
-dashes `---`. 
+The YAML data is contained in a markdown page and surrounded by opening and closing
+dashes `---`.
 
-The data in those files can be split into three categories: page metadata, 
+The data in those files can be split into three categories: page metadata,
 resource data, and shortcodes.
 
 ### Page metadata
@@ -36,7 +36,7 @@ resource data, and shortcodes.
 This is the title of the page as it appears at the top of its page or at the top of
 its section in the resource reference page. For example, `apt_package resource`.
 
-**resource** 
+**resource**
 
 This is the name of the resource. For example, `apt_package`.
 
@@ -46,13 +46,13 @@ Hugo will not render the page if set to `true`.
 
 **aliases**
 
-Pages that you want to redirect to the page that you are editing. See Hugo's 
+Pages that you want to redirect to the page that you are editing. See Hugo's
 [aliases documentation](https://gohugo.io/content-management/urls/#aliases).
 
 **menu/docs**
 
 This section provides information that will add the page to the left navigation
-menu. Delete this entire section if you want to remove a page from the left 
+menu. Delete this entire section if you want to remove a page from the left
 navigation menu.
 
 See the example at the bottom of this section.
@@ -60,12 +60,12 @@ See the example at the bottom of this section.
 - title
 
 	The name of the page as it appears in the left navigation menu.
-	
+
 - identifier
 
-	The unique identifier for the page. No two pages in the left navigation menu 
-	can have the same identifier. For this reason we've adopted the convention of 
-	creating identifiers that start with the path of the page in the left navigation 
+	The unique identifier for the page. No two pages in the left navigation menu
+	can have the same identifier. For this reason we've adopted the convention of
+	creating identifiers that start with the path of the page in the left navigation
 	menu followed by a space and then the name of the page itself.
 
 - parent
@@ -98,10 +98,10 @@ appear in https://docs.chef.io/resources/page_name/. Values are `true` or `false
 
 **robots**
 
-This adds meta robots directions to a page that instruct search engines crawlers 
-how to crawl a page. Valid values are `noindex` and `nofollow`, separated by a comma. This is 
-useful for removing a page from [Swiftype](https://swiftype.com/documentation/site-search/crawler-configuration/meta-tags#robots_meta) 
-and Google search results. See the [robotstxt.org](https://www.robotstxt.org/meta.html) 
+This adds meta robots directions to a page that instruct search engines crawlers
+how to crawl a page. Valid values are `noindex` and `nofollow`, separated by a comma. This is
+useful for removing a page from [Swiftype](https://swiftype.com/documentation/site-search/crawler-configuration/meta-tags#robots_meta)
+and Google search results. See the [robotstxt.org](https://www.robotstxt.org/meta.html)
 site for more information about meta robots tags.
 
 If this is deleted or left blank Hugo will use the site robots parameter in the
@@ -111,13 +111,13 @@ If this is deleted or left blank Hugo will use the site robots parameter in the
 
 **resource_description_list**
 
-This is a list of content that will build the introductory description section of each 
-resource page. Markdown, notes, warnings, and shortcodes can be added to the list. 
-Notes and warnings can include Markdown or shortcode content. 
+This is a list of content that will build the introductory description section of each
+resource page. Markdown, notes, warnings, and shortcodes can be added to the list.
+Notes and warnings can include Markdown or shortcode content.
 
 This content will display on the page in the same order that it appears in the list.
 
-Example: 
+Example:
 
 ```
 resource_description_list:
@@ -129,7 +129,7 @@ resource_description_list:
 
 **resource_new_in**
 
-This will add **New in Chef Infra Client X.Y** to the description of the 
+This will add **New in Chef Infra Client X.Y** to the description of the
 resource page. The text won't appear if value is blank.
 
 Example:
@@ -140,7 +140,7 @@ resource_new_in: 14.0
 
 **syntax_description**
 
-A short introductory description in Markdown that explains the syntax of the resource and includes 
+A short introductory description in Markdown that explains the syntax of the resource and includes
 an example code block.
 
 For example:
@@ -208,7 +208,7 @@ actions_list:
 
 **properties_shortcode**
 
-The properties section of some resource pages is a shortcode. This will display 
+The properties section of some resource pages is a shortcode. This will display
 the shortcode specified in lieu of describing the properties using ``properties_list``.
 
 **properties_list**
@@ -225,23 +225,23 @@ This is a list of each property in a resource.
 
 - required
 
-  `True` or `False`. Indicates if the property is required by the resource and 
+  `True` or `False`. Indicates if the property is required by the resource and
   adds ``REQUIRED`` to the description of the property.
 
 - default_value
 
 	The default value of the property.
-	
+
 - new_in
 
 	The version of Chef Infra Client that this property was introduced in.
 
 - description_list
 
-	A list of content used to describe the property. Valid keys are `markdown`, 
-	`note`, `warning`, and `shortcode`. Notes and warnings can have markdown or 
+	A list of content used to describe the property. Valid keys are `markdown`,
+	`note`, `warning`, and `shortcode`. Notes and warnings can have markdown or
 	shortcode content.
-	
+
 	This content will display on the page in the same order that it appears in the list.
 
 For example:
@@ -255,74 +255,68 @@ properties_list:
   new_in: 14.0
   description_list:
   - markdown: Some text describing the property.
-	- note: 
+	- note:
 		- shortcode: shortcode_file.md
-	- warning: 
+	- warning:
 		- markdown: Markdown text warning the user about the propery.
 ```
 
-**examples_list**
+**examples**
 
-Each example starts with a heading, which is bolded on its resource page, followed by 
-blocks of text that describe and demonstrate how the resource works. 
+Each example should start with a bolded heading followed by
+blocks of text that describe and demonstrate how the resource works.
 
-- example_heading
 
-	The heading for each example which will be bolded on the resource page.
+    examples: |
+      **Update the Apt repository at a specified interval**:
 
-- text_blocks
+      ```ruby
+      apt_update 'all platforms' do
+        frequency 86400
+        action :periodic
+      end
+      ```
 
-	A list of text blocks that describe and demonstrate each example. Valid keys for 
-	the text blocks are `shortcode`, `note`, `code_block`, and `markdown`. Notes only
-	accept markdown text.
+      **Update the Apt repository at the start of a Chef Infra Client run**:
 
-	This content will display on the page in the same order that it appears in 
-	the `text_blocks` list.
-
-For example:
-
-```
-examples_list:
-- example_heading: Set an environment variable
-  text_blocks:
-  - code_block: "windows_env 'ComSpec' do\n  value \"C:\\\\Windows\\\\system32\\\\\
-      cmd.exe\"\nend"
-```
+      ```ruby
+      apt_update 'update'
+      ```
 
 ### Shortcodes
 
-These values, if set to `true`, will display sections of text that include headings 
+These values, if set to `true`, will display sections of text that include headings
 followed by text from various shortcodes.
 
 **handler_types**
 
-Only used in the chef handler resource. This adds the **Handler Types** section 
+Only used in the chef handler resource. This adds the **Handler Types** section
 to this resource page.
 
 **registry_key**
 
-Only used in the registry key resource. This adds the **Registry Key Path Separators** 
+Only used in the registry key resource. This adds the **Registry Key Path Separators**
 and **Recipe DSL Methods** sections to resource page.
 
 **nameless_apt_update**
 
-Only used in the apt update resource. Adds the **Nameless** section to the 
+Only used in the apt update resource. Adds the **Nameless** section to the
 apt update resource page.
 
 **nameless_build_essential**
 
-Only used in the build essential resource. Adds the **Nameless** section to the 
+Only used in the build essential resource. Adds the **Nameless** section to the
 build essential resource page.
 
 **resource_package_options**
 
 Only used in the package resource page. Adds the **Gem Package Options** section to the resource page.
 
-**properties_multiple_packages**
+**multi_package_resource**
 
-Used in the dnf package, package, and zypper package resource pages. Adds 
-the **Multiple Packages** section to the Properties section of the resource page.
-
+Used in the apt, dnf, homebrew, package, pacman, yum, and zypper package resource
+pages. Adds the **Multiple Packages** section to the Common Resource Functionality and
+Properties sections of the resource page.
 
 **resource_directory_recursive_directories**
 
@@ -331,109 +325,103 @@ section to the Properties section of the resource page.
 
 **resources_common_atomic_update**
 
-Used in the cookbook file, file, remote file, and template resource pages. Adds 
+Used in the cookbook file, file, remote file, and template resource pages. Adds
 the **Atomic File Updates** section to the Properties section of the resource page.
 
 **properties_resources_common_windows_security**
 
-Used in the cookbook file, directory, file, remote file, and template resource 
+Used in the cookbook file, directory, file, remote file, and template resource
 pages. Adds the **Windows File Security** section to the Properties section of the
 resource page.
 
 **remote_file_prevent_re_downloads**
 
-Used in the remote file resource page. Adds the **Prevent Re-downloads** section 
+Used in the remote file resource page. Adds the **Prevent Re-downloads** section
 to the Properties section of the resource page.
 
 **remote_file_unc_path**
 
-Used in the remote file resource page. Adds the **Access a remote UNC path on Windows** section 
+Used in the remote file resource page. Adds the **Access a remote UNC path on Windows** section
 to the Properties section of the resource page.
 
 **ps_credential_helper**
 
-Used in the dsc script resource page. Adds the **ps_credential Helper** section 
+Used in the dsc script resource page. Adds the **ps_credential Helper** section
 to the Properties section of the resource page.
 
 **ruby_style_basics_chef_log**
 
-Used in the log resource page. Adds the **Log Entries** section 
+Used in the log resource page. Adds the **Log Entries** section
 to the resource page.
 
 **debug_recipes_chef_shell**
 
-Used in the breakpoint resource page. Adds the **Debug Recipes with chef-shell** 
+Used in the breakpoint resource page. Adds the **Debug Recipes with chef-shell**
 section to the resource page.
 
 **template_requirements**
 
-Used in the template resource page. Adds the **Debug Recipes with chef-shell** 
+Used in the template resource page. Adds the **Debug Recipes with chef-shell**
 section to the Properties section of the resource page.
 
 **resources_common_properties**
 
-Used in several resource pages. Adds the **Common Properties** section to the 
+Used in several resource pages. Adds the **Common Properties** section to the
 Common Resource Functionality section of the resource page.
 
 **resources_common_notification**
 
-Used in several resource pages. Adds the **Notifications** section to the 
+Used in several resource pages. Adds the **Notifications** section to the
 Common Resource Functionality section of the resource page.
 
 **resources_common_guards**
 
-Used in several resource pages. Adds the **Guards** section to the 
+Used in several resource pages. Adds the **Guards** section to the
 Common Resource Functionality section of the resource page.
-
-**common_resource_functionality_multiple_packages**
-
-Used in the apt package and yum package resource pages. Adds the 
-**Multiple Packages** section to the Common Resource Functionality section of 
-the resource page.
 
 **resources_common_guard_interpreter**
 
-Used in the script resource page. Adds the **Guard Interpreter** section to the 
+Used in the script resource page. Adds the **Guard Interpreter** section to the
 Common Resource Functionality section of the resource page.
 
 **remote_directory_recursive_directories**
 
-Used in the remote directory resource page. Adds the **Recursive Directories** 
+Used in the remote directory resource page. Adds the **Recursive Directories**
 section to the Common Resource Functionality section of the resource page.
 
 **common_resource_functionality_resources_common_windows_security**
 
-Used in the remote directory resource page. Adds the **Windows File Security** 
+Used in the remote directory resource page. Adds the **Windows File Security**
 section to the Common Resource Functionality section of the resource page.
 
 **handler_custom**
 
-Used in the chef handler resource page. Adds the **Custom Handlers** 
+Used in the chef handler resource page. Adds the **Custom Handlers**
 section to the resource page.
 
 **cookbook_file_specificity**
 
-Used in the cookbook file resource page. Adds the **File Specificity** 
+Used in the cookbook file resource page. Adds the **File Specificity**
 section to the resource page.
 
 **unit_file_verification**
 
-Used in the systemd_unit resource page. Adds the **Unit File Verification** 
+Used in the systemd_unit resource page. Adds the **Unit File Verification**
 section to the resource page.
 
 ## Resource page tables of contents
 
-The tables of contents templates for the resource pages are located in 
+The tables of contents templates for the resource pages are located in
 `chef-web-docs/layouts/partials`.
 
-The tables of contents for the resource reference page and the individual resource 
-pages are generated in the same way that the resource reference 
-page and the individual resources pages are created. Hugo crawls through the resource 
-yaml files and builds an unordered list listing each H1 through H3 heading. This 
-means that if a section of content is added or removed from the resource page 
-templates, then those headings also have to be added or removed to the respective 
+The tables of contents for the resource reference page and the individual resource
+pages are generated in the same way that the resource reference
+page and the individual resources pages are created. Hugo crawls through the resource
+YAML files and builds an unordered list listing each H1 through H3 heading. This
+means that if a section of content is added or removed from the resource page
+templates, then those headings also have to be added or removed to the respective
 tables of contents templates.
 
 Failure to update the resource page table of contents templates
-may lead to links that don't link to the proper content, links that don't work properly, 
+may lead to links that don't link to the proper content, links that don't work properly,
 or content that isn't linked to in the table of contents.

--- a/layouts/partials/resource_list_toc.html
+++ b/layouts/partials/resource_list_toc.html
@@ -73,10 +73,10 @@
     <li>
       <a href="#properties">Properties</a>
 
-      {{ if .Params.properties_multiple_packages }}
+      {{ if .Params.multi_package_resource }}
       <ul>
         <li>
-          <a href="#multiple-packages">Multiple Packages</a>
+          <a href="#multiple-packages-properties">Multiple Packages</a>
         </li>
       </ul>
       {{ end }}
@@ -202,7 +202,7 @@
 			</li>
 		{{ end }}
 		
-		{{ if or (.Params.resources_common_properties ) ( .Params.resources_common_notification ) ( .Params.resources_common_guards ) ( .Params.common_resource_functionality_multiple_packages ) (  .Params.resources_common_guard_interpreter ) (  .Params.remote_directory_recursive_directories ) ( .Params.common_resource_functionality_resources_common_windows_security )}}
+		{{ if or (.Params.resources_common_properties ) ( .Params.resources_common_notification ) ( .Params.resources_common_guards ) ( .Params.multi_package_resource ) (  .Params.resources_common_guard_interpreter ) (  .Params.remote_directory_recursive_directories ) ( .Params.common_resource_functionality_resources_common_windows_security )}}
 	    <li>
 	      <a href="#functionality">Common Resource Functionality</a>
 
@@ -224,9 +224,9 @@
 	      </ul>
 	      {{ end }}
 
-	      {{ if .Params.common_resource_functionality_multiple_packages }}
+	      {{ if .Params.multi_package_resource }}
 	      <ul>
-	        <li><a href="#multiple-packages">Multiple Packages</a></li>
+	        <li><a href="#multiple-packages-common">Multiple Packages</a></li>
 	      </ul>
 	      {{ end }}
 

--- a/layouts/partials/resource_terms_toc.html
+++ b/layouts/partials/resource_terms_toc.html
@@ -37,8 +37,11 @@
 {{ $resources_common_guardsID := newScratch }}
 {{ $resources_common_guardsID.Set "Value" 0 }}
 
-{{ $common_resource_functionality_multiple_packagesID := newScratch }}
-{{ $common_resource_functionality_multiple_packagesID.Set "Value" 0 }}
+{{ $common_resource_functionality_multiple_packages_propertiesID := newScratch }}
+{{ $common_resource_functionality_multiple_packages_propertiesID.Set "Value" 0 }}
+
+{{ $common_resource_functionality_multiple_packages_commonID := newScratch }}
+{{ $common_resource_functionality_multiple_packages_commonID.Set "Value" 0 }}
 
 {{ $resources_common_guard_interpreterID := newScratch }}
 {{ $resources_common_guard_interpreterID.Set "Value" 0 }}
@@ -219,10 +222,10 @@
 		        <li>
 		          <a href="#properties-{{ $PropertiesID.Get "Value"}}">Properties</a>
 
-		          {{ if .Params.properties_multiple_packages }}
-		          {{ $common_resource_functionality_multiple_packagesID.Add "Value" 1 }}
+		          {{ if .Params.multi_package_resource }}
+		          {{ $common_resource_functionality_multiple_packages_propertiesID.Add "Value" 1 }}
 		          <ul>
-		            <li><a href="#multiple-packages-{{ $common_resource_functionality_multiple_packagesID.Get "Value" }}">Multiple
+		            <li><a href="#multiple-packages-properties-{{ $common_resource_functionality_multiple_packages_propertiesID.Get "Value" }}">Multiple
 		                Packages</a></li>
 		          </ul>
 		          {{ end }}
@@ -350,7 +353,7 @@
 							</li>
 						{{ end }}
 						
-						{{ if or (.Params.resources_common_properties ) ( .Params.resources_common_notification ) ( .Params.resources_common_guards ) ( .Params.common_resource_functionality_multiple_packages ) (  .Params.resources_common_guard_interpreter ) (  .Params.remote_directory_recursive_directories ) ( .Params.common_resource_functionality_resources_common_windows_security )}}
+						{{ if or (.Params.resources_common_properties ) ( .Params.resources_common_notification ) ( .Params.resources_common_guards ) ( .Params.multi_package_resource ) (  .Params.resources_common_guard_interpreter ) (  .Params.remote_directory_recursive_directories ) ( .Params.common_resource_functionality_resources_common_windows_security )}}
 		        <li>
 		          {{ $FunctionalityID.Add "Value" 1 }}
 		          <a href="#functionality-{{ $FunctionalityID.Get "Value" }}">Common Resource Functionality</a>
@@ -379,10 +382,10 @@
 		          </ul>
 		          {{ end }}
 
-		          {{ if .Params.common_resource_functionality_multiple_packages }}
-		          {{ $common_resource_functionality_multiple_packagesID.Add "Value" 1 }}
+		          {{ if .Params.multi_package_resource }}
+		          {{ $common_resource_functionality_multiple_packages_commonID.Add "Value" 1 }}
 		          <ul>
-		            <li><a href="#multiple-packages-{{ $common_resource_functionality_multiple_packagesID.Get "Value" }}">Multiple
+		            <li><a href="#multiple-packages-common-{{ $common_resource_functionality_multiple_packages_commonID.Get "Value" }}">Multiple
 		                Packages</a></li>
 		          </ul>
 		          {{ end }}

--- a/layouts/resources/list.html
+++ b/layouts/resources/list.html
@@ -506,8 +506,8 @@
                   <p>This resource does not have any properties.</p>
                 {{ end }}
 
-              {{ if .Params.properties_multiple_packages }}
-                <h3 id="multiple-packages">Multiple Packages</h3>
+              {{ if .Params.multi_package_resource }}
+                <h3 id="multiple-packages-properties">Multiple Packages</h3>
                 {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_multiple_packages.md" | markdownify }}
               {{ end }}
 
@@ -657,7 +657,7 @@
               <!-------------- Common Resource Functionality ------------------->
 
 
-              {{ if or (.Params.resources_common_properties ) ( .Params.resources_common_notification ) ( .Params.resources_common_guards ) ( .Params.common_resource_functionality_multiple_packages ) (  .Params.resources_common_guard_interpreter ) (  .Params.remote_directory_recursive_directories ) ( .Params.common_resource_functionality_resources_common_windows_security )}}
+              {{ if or (.Params.resources_common_properties ) ( .Params.resources_common_notification ) ( .Params.resources_common_guards ) ( .Params.multi_package_resource ) (  .Params.resources_common_guard_interpreter ) (  .Params.remote_directory_recursive_directories ) ( .Params.common_resource_functionality_resources_common_windows_security )}}
                 <br>
                 <h2 id = "functionality">Common Resource Functionality</h2>
                 <hr>
@@ -710,8 +710,8 @@
 
                 {{ end }}
 
-                {{ if .Params.common_resource_functionality_multiple_packages }}
-                  <h3 id="multiple-packages">Multiple Packages</h3>
+                {{ if .Params.multi_package_resource }}
+                  <h3 id="multiple-packages-common">Multiple Packages</h3>
 
                   {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_multiple_packages.md" | markdownify }}
 

--- a/layouts/resources/terms.html
+++ b/layouts/resources/terms.html
@@ -55,8 +55,11 @@
         {{ $resources_common_guardsID := newScratch }}
         {{ $resources_common_guardsID.Set "Value" 0 }}
 
-        {{ $common_resource_functionality_multiple_packagesID := newScratch }}
-        {{ $common_resource_functionality_multiple_packagesID.Set "Value" 0 }}
+        {{ $common_resource_functionality_multiple_packages_propertiesID := newScratch }}
+        {{ $common_resource_functionality_multiple_packages_propertiesID.Set "Value" 0 }}
+
+        {{ $common_resource_functionality_multiple_packages_commonID := newScratch }}
+        {{ $common_resource_functionality_multiple_packages_commonID.Set "Value" 0 }}
 
         {{ $resources_common_guard_interpreterID := newScratch }}
         {{ $resources_common_guard_interpreterID.Set "Value" 0 }}
@@ -828,9 +831,9 @@
                       <p>This resource does not have any properties.</p>
                     {{ end }}
 
-                    {{ if .Params.properties_multiple_packages }}
-                      {{ $common_resource_functionality_multiple_packagesID.Add "Value" 1 }}
-                      <h3 id="multiple-packages-{{ $common_resource_functionality_multiple_packagesID.Get "Value" }}">Multiple Packages</h3>
+                    {{ if .Params.multi_package_resource }}
+                      {{ $common_resource_functionality_multiple_packages_propertiesID.Add "Value" 1 }}
+                      <h3 id="multiple-packages-properties-{{ $common_resource_functionality_multiple_packages_propertiesID.Get "Value" }}">Multiple Packages</h3>
                       {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_multiple_packages.md" | markdownify }}
                     {{ end }}
 
@@ -980,7 +983,7 @@
 
                     <!-------------- Common Resource Functionality ------------------->
 
-                    {{ if or (.Params.resources_common_properties ) ( .Params.resources_common_notification ) ( .Params.resources_common_guards ) ( .Params.common_resource_functionality_multiple_packages ) (  .Params.resources_common_guard_interpreter ) (  .Params.remote_directory_recursive_directories ) ( .Params.common_resource_functionality_resources_common_windows_security )}}
+                    {{ if or (.Params.resources_common_properties ) ( .Params.resources_common_notification ) ( .Params.resources_common_guards ) ( .Params.multi_package_resource ) (  .Params.resources_common_guard_interpreter ) (  .Params.remote_directory_recursive_directories ) ( .Params.common_resource_functionality_resources_common_windows_security )}}
                       <br>
                       {{ $FunctionalityID.Add "Value" 1 }}
                       <h2 id = "functionality-{{ $FunctionalityID.Get "Value" }}">Common Resource Functionality</h2>
@@ -1034,9 +1037,9 @@
 
                       {{ end }}
 
-                      {{ if .Params.common_resource_functionality_multiple_packages }}
-                        {{ $common_resource_functionality_multiple_packagesID.Add "Value" 1 }}
-                        <h3 id="multiple-packages-{{ $common_resource_functionality_multiple_packagesID.Get "Value" }}">Multiple Packages</h3>
+                      {{ if .Params.multi_package_resource }}
+                        {{ $common_resource_functionality_multiple_packages_commonID.Add "Value" 1 }}
+                        <h3 id="multiple-packages-common-{{ $common_resource_functionality_multiple_packages_commonID.Get "Value" }}">Multiple Packages</h3>
 
                         {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_multiple_packages.md" | markdownify }}
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Consolidates two resource parameters, `common_resource_functionality_multiple_packages` and `properties_multiple_packages`, into one parameter, `multi_package_resource`.

Double check that the **package** resource is correct. It had the `properties_multiple_packages` param but not the `common_resource_functionality_multiple_packages` param.

### Definition of Done

### Issues Resolved

#2731

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
