### PR TITLE
Update ignore vendor make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ serve: assets
 	hugo server --buildDrafts --noHTTPCache --buildFuture
 
 serve_ignore_vendor: assets
-	hugo server --buildDrafts --noHTTPCache --buildFuture --ignoreVendor
+	hugo server --buildDrafts --noHTTPCache --buildFuture --ignoreVendorPaths github.com/**
 
 lint: assets
 	hugo -D


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Update makefile command.
Hugo has deprecated `--ignoreVendor` and replaced it with `--ignoreVendorPaths` which takes a glob pattern.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
