### PR TITLE
Pull in an exact version of the docs at project promotion time

### DIFF
--- a/.expeditor/update_hugo_modules_artifact_published.sh
+++ b/.expeditor/update_hugo_modules_artifact_published.sh
@@ -25,7 +25,7 @@ fi
 # use to build the docs from.
 # See https://gohugo.io/hugo-modules/use-modules/#update-one-module
 
-hugo mod get github.com/$org/"${EXPEDITOR_PRODUCT_KEY}"/$subdirectory
+hugo mod get "github.com/${org}/${EXPEDITOR_PRODUCT_KEY}/${subdirectory}@v${EXPEDITOR_VERSION}"
 hugo mod tidy
 
 # Update the vendored files in chef-web-docs

--- a/.expeditor/update_hugo_modules_project_promoted.sh
+++ b/.expeditor/update_hugo_modules_project_promoted.sh
@@ -2,15 +2,26 @@
 
 set -eoux pipefail
 
+# different chef product repos have their documentation in different subdirectories
+# this variable has to be defined so we can copy content from the proper subdirectory
+# that contains the docs content and properly execute the `hugo mod get` command.
 
-branch="expeditor/update_docs_chef_automate"
+if [[ "${EXPEDITOR_PROJECT}" == *"automate"* ]]; then
+  org="chef"
+  product_key="automate"
+  subdirectory="components/docs-chef-io"
+  manifest="https://packages.chef.io/files/${EXPEDITOR_TARGET_CHANNEL}/automate/latest/manifest.json"
+  git_sha="$(curl -s $manifest | jq -r -c ".git_sha")"
+fi
+
+branch="expeditor/update_docs_${produt_key}_${git_sha}"
 git checkout -b "$branch"
 
 # Update the semver version of the documentation module that chef-web-docs will
 # use to build the docs from.
 # See https://gohugo.io/hugo-modules/use-modules/#update-one-module
 
-hugo mod get github.com/chef/automate/components/docs-chef-io
+hugo mod get "github.com/${org}/${product_key}/${subdirectory}@${git_sha}"
 hugo mod tidy
 
 # Update the vendored files in chef-web-docs
@@ -26,7 +37,7 @@ git add .
 # audit of our codebase that no DCO sign-off is needed for this sort of PR since
 #it contains no intellectual property
 
-dco_safe_git_commit "Bump Hugo module chef/automate to latest release."
+dco_safe_git_commit "Bump Hugo module $product_key to latest $EXPEDITOR_TARGET_CHANNEL release ($git_sha)."
 
 open_pull_request
 


### PR DESCRIPTION
This change ensures we are vendoring in the exact version that was promoted of the documentation source....instead of what the latest on the default branch of the project.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
