### PR TITLE
Fixes for expeditor artifact_published script

### DIFF
--- a/.expeditor/update_hugo_modules_artifact_published.sh
+++ b/.expeditor/update_hugo_modules_artifact_published.sh
@@ -2,7 +2,6 @@
 
 set -eoux pipefail
 
-
 branch="expeditor/update_docs_${EXPEDITOR_PRODUCT_KEY}_${EXPEDITOR_VERSION}"
 git checkout -b "$branch"
 
@@ -13,19 +12,18 @@ git checkout -b "$branch"
 if [ "${EXPEDITOR_PRODUCT_KEY}" == "chef-workstation" ]; then
   subdirectory="docs-chef-io"
   org="chef"
+  tag_prefix=""
 elif [ "${EXPEDITOR_PRODUCT_KEY}" == "inspec" ]; then
   subdirectory="docs-chef-io"
   org="inspec"
-elif [ "${EXPEDITOR_PRODUCT_KEY}" == "habitat" ]; then
-  subdirectory="components/docs-chef-io"
-  org="habitat-sh"
+  tag_prefix="v"
 fi
 
 # Update the semver version of the documentation module that chef-web-docs will
 # use to build the docs from.
 # See https://gohugo.io/hugo-modules/use-modules/#update-one-module
 
-hugo mod get "github.com/${org}/${EXPEDITOR_PRODUCT_KEY}/${subdirectory}@v${EXPEDITOR_VERSION}"
+hugo mod get "github.com/${org}/${EXPEDITOR_PRODUCT_KEY}/${subdirectory}@${tag_prefix}${EXPEDITOR_VERSION}"
 hugo mod tidy
 
 # Update the vendored files in chef-web-docs

--- a/_vendor/github.com/inspec/inspec/docs-chef-io/content/inspec/plugins.md
+++ b/_vendor/github.com/inspec/inspec/docs-chef-io/content/inspec/plugins.md
@@ -60,8 +60,7 @@ inspec plugin install inspec-some-plugin
 inspec plugin install train-some-plugin
 ```
 
-For more details on what the `plugin` command can do, see the [online help](/inspec/cli/#plugin),
-or run `inspec plugin help`.
+For more details on what the `plugin` command can do, run `inspec plugin help`.
 
 ## How do I use a different Gem server?
 
@@ -78,7 +77,7 @@ inspec plugin install --source https://my.private.server inspec-private-plugin
 ### Chef InSpec Plugins
 
 For details on how to author a Chef InSpec Plugin, see the
-[developer documentation](https://github.com/inspec/inspec/blob/master/docs/dev/plugins.md)
+[developer documentation](https://github.com/inspec/inspec/blob/master/dev-docs/plugins.md)
 
 ### Train Plugins
 

--- a/_vendor/github.com/inspec/inspec/docs-chef-io/content/inspec/profiles.md
+++ b/_vendor/github.com/inspec/inspec/docs-chef-io/content/inspec/profiles.md
@@ -63,7 +63,7 @@ Each profile must have an `inspec.yml` file that defines the following informati
 - Use `inspec_version` to place SemVer constraints on the version of Chef InSpec that the profile can run under.
 - Use `supports` to specify a list of supported platform targets.
 - Use `depends` to define a list of profiles on which this profile depends.
-- Use `attributes` to define a list of attributes you can use in your controls.
+- Use `inputs` to define a list of inputs you can use in your controls.
 
 `name` is required; all other profile settings are optional. For example:
 

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/chef/desktop-config/docs-chef-io v0.0.0-20200929171526-d4cef8a736df
 # github.com/chef/chef-workstation/docs-chef-io v0.0.0-20201117053328-bd5157f59094
 # github.com/chef/effortless/docs-chef-io v0.0.0-20200930175149-51c187882fba
-# github.com/inspec/inspec/docs-chef-io v0.0.0-20201022004754-2d19011d6648
+# github.com/inspec/inspec/docs-chef-io v0.0.0-20201111103656-23ac60e7ae85
 # github.com/chef/automate/components/docs-chef-io v0.0.0-20201109055604-3d88cc006f1d
 # github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20201105224549-ce890e79d550

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,13 @@ go 1.14
 
 require (
 	github.com/chef/automate/components/docs-chef-io v0.0.0-20201109055604-3d88cc006f1d // indirect
+	github.com/chef/chef-workstation v0.0.0-20201117215019-2a59d0a67f2d // indirect
 	github.com/chef/chef-workstation/docs-chef-io v0.0.0-20201117053328-bd5157f59094 // indirect
 	github.com/chef/desktop-config/docs-chef-io v0.0.0-20200929171526-d4cef8a736df // indirect
 	github.com/chef/effortless/docs-chef-io v0.0.0-20200930175149-51c187882fba // indirect
 	github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20201105224549-ce890e79d550 // indirect
-	github.com/inspec/inspec/docs-chef-io v0.0.0-20201022004754-2d19011d6648 // indirect
+	github.com/inspec/inspec v4.23.15+incompatible // indirect
+	github.com/inspec/inspec/docs-chef-io v0.0.0-20201111103656-23ac60e7ae85 // indirect
 )
 
 //replace github.com/chef/effortless/docs-chef-io => ../effortless/docs-chef-io

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,10 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chef/automate/components/docs-chef-io v0.0.0-20201109055604-3d88cc006f1d h1:coFSEOCtaHx60EI4MTlKlE03X4JNE6mjv8Qyuyf+mfU=
 github.com/chef/automate/components/docs-chef-io v0.0.0-20201109055604-3d88cc006f1d/go.mod h1:juvLC7Rt33YOCgJ5nnfl4rWZRAbSwqjTbWmcAoA0LtU=
+github.com/chef/chef-workstation v0.0.0-20201117053328-bd5157f59094 h1:uFTh50pHYzKL2O3EkYxn0z7XoJnTGzW0zhs55jZBIwg=
+github.com/chef/chef-workstation v0.0.0-20201117053328-bd5157f59094/go.mod h1:KZ1lmUGHzTKhRuHdDhB/I2ZEbet++4OTuABWlYb9MlQ=
+github.com/chef/chef-workstation v0.0.0-20201117215019-2a59d0a67f2d h1:5N5bg0pSjE96iQD/1qloI197XSVgC6Rl0dtdQe/rAyE=
+github.com/chef/chef-workstation v0.0.0-20201117215019-2a59d0a67f2d/go.mod h1:KZ1lmUGHzTKhRuHdDhB/I2ZEbet++4OTuABWlYb9MlQ=
 github.com/chef/chef-workstation/docs-chef-io v0.0.0-20201117053328-bd5157f59094 h1:6K8GLIvfFJtTpRGn4JRAFkuSTLnEnRPinpPFQ/8b5Fs=
 github.com/chef/chef-workstation/docs-chef-io v0.0.0-20201117053328-bd5157f59094/go.mod h1:gvoh6ov1YU98CVzBEWzEZeCLTRunfQ6r1VO7M3LFE9U=
 github.com/chef/desktop-config/docs-chef-io v0.0.0-20200929171526-d4cef8a736df h1:tOwLfqjSj5y3rubKlIOBHLtmQy5vceQGuMkpw6WdcbU=
@@ -29,8 +33,12 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20201105224549-ce890e79d550 h1:bhuO73+lOV9g9T33c+UwpHnuqA2+0qrorKzfM4KNrnY=
 github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20201105224549-ce890e79d550/go.mod h1:luAy42opPrAM/T6hsqDyW3CNBaAMgy+a6l0+oi8sw8U=
-github.com/inspec/inspec/docs-chef-io v0.0.0-20201022004754-2d19011d6648 h1:nhB0xLmdFnTZEWB1UlT7KnQ3a0s91pl26SugXk5qAnA=
-github.com/inspec/inspec/docs-chef-io v0.0.0-20201022004754-2d19011d6648/go.mod h1:oudFvipU0DTMkp8+MiwdUGerVEoWcJG0MQciDEOd6G8=
+github.com/inspec/inspec v4.23.15+incompatible h1:wAN0+INYbx3a5jCWTBhfQBVEtQN3ZshOJxGgHaLNNYM=
+github.com/inspec/inspec v4.23.15+incompatible/go.mod h1:SIjoxlQcQphYvY1Zzjh7iawaymQaMKfgtp35uAOByIM=
+github.com/inspec/inspec v4.23.19+incompatible h1:hBkuu4WulwBDtGlfODN/ca48W3uatmFNB39lAZdJ3so=
+github.com/inspec/inspec v4.23.19+incompatible/go.mod h1:SIjoxlQcQphYvY1Zzjh7iawaymQaMKfgtp35uAOByIM=
+github.com/inspec/inspec/docs-chef-io v0.0.0-20201111103656-23ac60e7ae85 h1:Jj47+Vof1GPW3AyqT3kaw4jgynlBPzLxpbN0u8ulXZs=
+github.com/inspec/inspec/docs-chef-io v0.0.0-20201111103656-23ac60e7ae85/go.mod h1:oudFvipU0DTMkp8+MiwdUGerVEoWcJG0MQciDEOd6G8=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=


### PR DESCRIPTION
### Description

This fixes a few minor issues.

1. The InSpec repo tag version numbers are preceded by a `v`, but the Workstation version numbers aren't. This script wasn't working with Workstation as a result.
    This adds a "tag_prefix" variable to handle that.

1. Removes the Habitat part of the artifact published script because the Habitat docs are updated using project promoted.

1. The InSpec docs haven't been updated in a bit, so this pulls in a few changes.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
