### PR TITLE
Add Expeditor config for Habitat Docs

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -25,7 +25,7 @@ subscriptions:
   - workload: project_promoted:chef/automate:master:acceptance:*
     actions:
     - bash:.expeditor/update_hugo_modules_project_promoted.sh
-  - workload: project_promoted:habitat:acceptance:*
+  - workload: project_promoted:habitat:current:*
     actions:
     - bash:.expeditor/update_hugo_modules_project_promoted.sh
   - workload: pull_request_merged:chef/effortless:master:*

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -25,6 +25,9 @@ subscriptions:
   - workload: project_promoted:chef/automate:master:acceptance:*
     actions:
     - bash:.expeditor/update_hugo_modules_project_promoted.sh
+  - workload: project_promoted:habitat:acceptance:*
+    actions:
+    - bash:.expeditor/update_hugo_modules_project_promoted.sh
   - workload: pull_request_merged:chef/effortless:master:*
     actions:
     - bash:.expeditor/update_hugo_modules_pull_request_merged.sh:

--- a/.expeditor/update_hugo_modules_project_promoted.sh
+++ b/.expeditor/update_hugo_modules_project_promoted.sh
@@ -56,7 +56,7 @@ hugo mod vendor
 # - github.com/chef/chef-web-docs/blob/master/_vendor/github.com/habitat-sh/habitat/components/docs-chef-io/content/habitat/service_templates.md
 
 if [[ "${EXPEDITOR_PROJECT}" == *"habitat"* ]]; then
-  curl https://packages.chef.io/files/${EXPEDITOR_TARGET_CHANNEL}/habitat/latest/generated-documentation.tar.gz
+  curl --silent --output generated-documentation.tar.gz https://packages.chef.io/files/${EXPEDITOR_TARGET_CHANNEL}/habitat/latest/generated-documentation.tar.gz
   tar xvzf generated-documentation.tar.gz -C _vendor/github.com/habitat-sh/habitat/components/docs-chef-io/content/habitat
   rm generated-documentation.tar.gz
 fi


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This PR does two things:
- updates the expeditor config to watch for Habitat being promoted
- updates the project promoted script to handle Habitat docs content

The project promoted script will handle docs content from the Hab repo as normal. 
Then it will pull down content from https://packages.chef.io/files/<channel>/habitat/latest/generated-documentation.tar.gz and then overwrite the matching files in the `_vendor` directory

### Definition of Done

### Issues Resolved

habitat-sh/habitat#7993
habitat-sh/habitat#7925

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
