### PR TITLE
Create a pipeline for triggering during head of channel promotions

### DIFF
--- a/.expeditor/buildkite/update_hugo_modules_project_promoted.sh
+++ b/.expeditor/buildkite/update_hugo_modules_project_promoted.sh
@@ -2,21 +2,30 @@
 
 set -eoux pipefail
 
+# Both of these values should be set when this script is executed in the
+# `head_of_channel_project_promoted` pipeline and triggered via the
+# `trigger_pipeline` built-in action. See more at:
+#
+#   https://expeditor.chef.io/docs/patterns/bash-scripts/#env-vars
+#
+project="${EXPEDITOR_PROJECT:?You must manually set the EXPEDITOR_PROJECT environment variable to an existing project name.}"
+target_channel="${EXPEDITOR_TARGET_CHANNEL:?You must manually set the EXPEDITOR_TARGET_CHANNEL environment variable to a valid channel name.}"
+
 # different chef product repos have their documentation in different subdirectories
 # this variable has to be defined so we can copy content from the proper subdirectory
 # that contains the docs content and properly execute the `hugo mod get` command.
 
-if [[ "${EXPEDITOR_PROJECT}" == *"automate"* ]]; then
+if [[ "${project}" == *"automate"* ]]; then
   org="chef"
   product_key="automate"
   subdirectory="components/docs-chef-io"
-  manifest="https://packages.chef.io/files/${EXPEDITOR_TARGET_CHANNEL}/automate/latest/manifest.json"
+  manifest="https://packages.chef.io/files/${target_channel}/automate/latest/manifest.json"
   git_sha="$(curl -s $manifest | jq -r -c ".git_sha")"
-elif [[ "${EXPEDITOR_PROJECT}" == *"habitat"* ]]; then
+elif [[ "${project}" == *"habitat"* ]]; then
   org="habitat-sh"
   product_key="habitat"
   subdirectory="components/docs-chef-io"
-  manifest="https://packages.chef.io/files/${EXPEDITOR_TARGET_CHANNEL}/habitat/latest/manifest.json"
+  manifest="https://packages.chef.io/files/${target_channel}/habitat/latest/manifest.json"
   git_sha="$(curl -s $manifest | jq -r -c ".sha")"
 fi
 
@@ -55,8 +64,8 @@ hugo mod vendor
 # - github.com/chef/chef-web-docs/blob/master/_vendor/github.com/habitat-sh/habitat/components/docs-chef-io/content/habitat/habitat_cli.md
 # - github.com/chef/chef-web-docs/blob/master/_vendor/github.com/habitat-sh/habitat/components/docs-chef-io/content/habitat/service_templates.md
 
-if [[ "${EXPEDITOR_PROJECT}" == *"habitat"* ]]; then
-  curl --silent --output generated-documentation.tar.gz https://packages.chef.io/files/${EXPEDITOR_TARGET_CHANNEL}/habitat/latest/generated-documentation.tar.gz
+if [[ "${project}" == *"habitat"* ]]; then
+  curl --silent --output generated-documentation.tar.gz https://packages.chef.io/files/${target_channel}/habitat/latest/generated-documentation.tar.gz
   tar xvzf generated-documentation.tar.gz -C _vendor/github.com/habitat-sh/habitat/components/docs-chef-io/content/habitat
   rm generated-documentation.tar.gz
 fi

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -12,6 +12,9 @@ pipelines:
   - verify:
       description: Pull Request validation tests
       public: true
+  - head_of_channel_project_promoted:
+      description: Updates Hugo Modules when a "head of channel" project is promoted
+      public: false
 
 subscriptions:
   # This will update version of the Chef product Hugo module

--- a/.expeditor/head_of_channel_project_promoted.pipeline.yml
+++ b/.expeditor/head_of_channel_project_promoted.pipeline.yml
@@ -1,0 +1,16 @@
+steps:
+
+  - label: ":hugo: update hugo modules"
+    command:
+      - .expeditor/buildkite/update_hugo_modules_project_promoted.sh
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+    expeditor:
+      secrets:
+        GITHUB_TOKEN:
+          account: github/chef
+          field: token
+      executor:
+        docker:


### PR DESCRIPTION
For projects that use the "head of channel" promotion pattern (e.g. Automate and Habitat) we cannot leverage subscriptions configured in this repo as many of the promotions tasks that are executed in said promotions will not be complete when our bash script is executed (think updating project manifests).

In order to work around this we will create a new pipeline which can be triggered (using Expeditor's `trigger_pipeline`) as one of the actions in the `project_promoted` workload subscription in the actual projects being promoted. Although it's not ideal that our projects which use the "head of channel" promotion pattern will need to know about `chef/chef-web-docs` this approach avoids nasty workaround like `sleep` statements in our bash script.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
