### PR TITLE
Add example from RFC097 of pulling a policyfile lock from a Git location

### DIFF
--- a/themes/docs-new/layouts/shortcodes/policyfile_rb_settings.md
+++ b/themes/docs-new/layouts/shortcodes/policyfile_rb_settings.md
@@ -163,6 +163,12 @@ A `Policyfile.rb` file may contain the following settings:
     include_policy 'NAME', path: './foo.lock.json'
     ```
 
+    Pull the policyfile lock `foo.lock.json` from the `example/foo` Git repository on the `git.example.com` Git server.
+
+    ```ruby
+    include_policy 'NAME', git: 'https://git.example.com/example/foo', path: 'foo.lock.json'
+    ```
+
     Pull the policyfile lock from `./bar.lock.json` with revision ID
     'revision1'.
 


### PR DESCRIPTION
### Description

Add example from [RFC097](https://github.com/chef/chef-rfc/blob/master/rfc097-policyfile-includes.md) of pulling a policyfile lock from a Git location. 

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
