### PR TITLE
Update the server upgrade page for EOY EOLs

### DIFF
--- a/content/upgrade_server.md
+++ b/content/upgrade_server.md
@@ -231,7 +231,7 @@ Chef Manage is a management console for  data bags, attributes, run-lists, roles
 
 Chef Infra Server 13 and 14 support the Chef Manage add-on. This add-on is [deprecated](https://docs.chef.io/versions/#deprecated-products-and-versions) and will reach [EOL](https://docs.chef.io/versions/#deprecated-products-and-versions) on December 31, 2021. After upgrading Chef Infra Server, reinstall the add-on and then reconfigure Chef Infra Server and the add-on.
 
-### Use Downloads
+### Use Downloads.chef.io
 
 {{% ctl_chef_server_install_features_download %}}
 

--- a/content/upgrade_server.md
+++ b/content/upgrade_server.md
@@ -62,11 +62,13 @@ For more information on password generation, including a list of supported add-o
 
 If you are running a Chef Infra Server relese prior to 12.3.0 please contact Chef Support for additional guidance on upgrading your Chef Infra Server installation.
 
-## Standalone Upgrade
+## Chef Infra Server 14 Upgrade Process
+
+### Standalone Server
 
 {{% server_upgrade_duration %}}
 
-### Standalone Upgrade Steps
+#### Standalone Upgrade Steps
 
 1. Back up your Chef Infra Server data before starting the upgrade process using [knife-ec-backup](https://github.com/chef/knife-ec-backup).
 
@@ -126,13 +128,13 @@ If you are running a Chef Infra Server relese prior to 12.3.0 please contact Che
     chef-server-ctl cleanup
     ```
 
-## Chef Backend Upgrade
+### Chef Backend Install
 
 The Chef Infra Server can operate in a high availability configuration that provides automated load balancing and failover for stateful components in the system architecture.
 
 To upgrade your Chef Backend installation, see [High Availability: Upgrade to Chef Backend 2](/upgrade_server_ha_v2/).
 
-## Tiered Upgrade
+### Tiered Install
 
 This section describes the upgrade process from a tiered server configuration.
 
@@ -145,7 +147,7 @@ For the latest information on setting up a highly-available server cluster, see 
 
 {{< /note >}}
 
-## Tiered Upgrade Steps
+### Tiered Upgrade Steps
 
 To upgrade to Chef Infra Server on a tiered Chef Infra Server configuration, do the following:
 
@@ -225,16 +227,16 @@ To upgrade to Chef Infra Server on a tiered Chef Infra Server configuration, do 
    chef-server-ctl cleanup
    ```
 
-## Upgrading Manage Add-On
+### Upgrading Manage Add-On
 
 Chef Manage is a management console for  data bags, attributes, run-lists, roles, environments, and cookbooks from a web user interface.
 
 Chef Infra Server 13 and 14 support the Chef Manage add-on. This add-on is [deprecated](https://docs.chef.io/versions/#deprecated-products-and-versions) and will reach [EOL](https://docs.chef.io/versions/#deprecated-products-and-versions) on December 31, 2021. After upgrading Chef Infra Server, reinstall the add-on and then reconfigure Chef Infra Server and the add-on.
 
-### Use Downloads.chef.io
+#### Use Downloads.chef.io
 
 {{% ctl_chef_server_install_features_download %}}
 
-### Use Local Packages
+#### Use Local Packages
 
 {{% ctl_chef_server_install_features_manual %}}

--- a/content/upgrade_server.md
+++ b/content/upgrade_server.md
@@ -16,6 +16,12 @@ aliases = ["/upgrade_server.html"]
 
 Each new release of Chef Infra Server improves reliability and updates 3rd party components to ensure the security of the server. It is important to keep Chef Infra Server up to date in order to ensure the secure and reliable operation of Chef Infra in your organization.
 
+{{< warning >}}
+
+Before upgrading a production server make sure to upgrade a test server to confirm the process.
+
+{{< /warning >}}
+
 ## Upgrade Matrix
 
 If running a Chef Infra Server 12.17.15 or later you can upgrade directly to the latest releases of Chef Infra Server 14. If you are running a release prior to 12.17.15 you must perform a stepped upgrade as outlined below.
@@ -34,12 +40,6 @@ Supported Release
 : Chef Infra Server 13 and later are currently supported Chef Software releases. Earlier releases are no longer supported as of 12/31/2020. For more information about supported Chef Software see the [Supported Versions](https://docs.chef.io/versions/#supported-commercial-distributions) documentation.
 
 ### Upgrading to 14.x
-
-{{< warning >}}
-
-Before upgrading a production server make sure to upgrade a test server to confirm the process.
-
-{{< /warning >}}
 
 Chef Infra Server 14 uses Elasticsearch as its search index.
 {{% server_upgrade_duration %}}

--- a/content/upgrade_server.md
+++ b/content/upgrade_server.md
@@ -14,7 +14,11 @@ aliases = ["/upgrade_server.html"]
     weight = 120
 +++
 
-## Chef Infra Server Upgrade Matrix
+Each new release of Chef Infra Server improves reliability and updates 3rd party components to ensure the security of the server. It is important to keep Chef Infra Server up to date in order to ensure the secure and reliable operation of Chef Infra in your organization.
+
+## Upgrade Paths
+
+If running a Chef Infra Server 12.17.15 or later you can upgrade directly to the latest releases of Chef Infra Server 14. If you are running a release prior to 12.17.15 you must perform a stepped upgrade as outlined below.
 
 | Running Version | Upgrade To Version | Requires License | Supported Version |
 |---------|---------|------|-----------|
@@ -29,15 +33,13 @@ Requires License
 Supported Release
 : Chef Infra Server 13 and later are currently supported Chef Software releases. Earlier releases are no longer supported as of 12/31/2020. For more information about supported Chef Software see the [Supported Versions](https://docs.chef.io/versions/#supported-commercial-distributions) documentation.
 
-## Upgrading to Chef Infra Server
-
 Three upgrade scenarios exist for upgrades from Chef Infra Server 12.17.15 to Chef Infra Server 13 or 14:
 
 - [Standalone](/upgrade_server/#standalone-upgrade)
 - [Chef Backend (HA)](/upgrade_server/#chef-backend-upgrade)
 - [Tiered](/upgrade_server/#tiered-upgrade)
 
-### Chef Infra Server 14
+### Upgrading to Chef Infra Server 14
 
 {{< warning >}}
 
@@ -50,7 +52,7 @@ Chef Infra Server 14 uses Elasticsearch as its search index.
 
 The Chef Infra Server 14 upgrade does not reindex existing external Elasticsearch installations.
 
-### Chef Infra Server 12.17.15 or Later
+### Upgrading to Chef Infra Server 12.17.15
 
 {{< warning >}}
 Upgrade Chef Infra Server and any add-ons to compatible versions before setting `insecure_addon_compat` to `false`.

--- a/content/upgrade_server.md
+++ b/content/upgrade_server.md
@@ -16,7 +16,7 @@ aliases = ["/upgrade_server.html"]
 
 Each new release of Chef Infra Server improves reliability and updates 3rd party components to ensure the security of the server. It is important to keep Chef Infra Server up to date in order to ensure the secure and reliable operation of Chef Infra in your organization.
 
-## Upgrade Paths
+## Upgrade Matrix
 
 If running a Chef Infra Server 12.17.15 or later you can upgrade directly to the latest releases of Chef Infra Server 14. If you are running a release prior to 12.17.15 you must perform a stepped upgrade as outlined below.
 
@@ -50,7 +50,7 @@ Before upgrading a production server make sure to upgrade a test server to confi
 Chef Infra Server 14 uses Elasticsearch as its search index.
 {{% server_upgrade_duration %}}
 
-The Chef Infra Server 14 upgrade does not reindex existing external Elasticsearch installations.
+The Chef Infra Server 14 upgrade does not automatically reindex existing external Elasticsearch installations.
 
 ### Upgrading to Chef Infra Server 12.17.15
 
@@ -63,6 +63,10 @@ If you are using Chef Infra Server without add-ons, or if you are using the late
 and Chef Infra Server will write all credentials to a single location.
 
 For more information on password generation, including a list of supported add-on versions, see [Chef Infra Server Credentials Management](/server_security/#chef-infra-server-credentials-management).
+
+### Upgrading to Chef Infra Server 12.3.0
+
+If you are running Chef Infra Server 11 please contact Chef Support for additional guidance on upgrading your Chef Infra Server installation.
 
 ## Standalone Upgrade
 

--- a/content/upgrade_server.md
+++ b/content/upgrade_server.md
@@ -39,7 +39,7 @@ Three upgrade scenarios exist for upgrades from Chef Infra Server 12.17.15 to Ch
 - [Chef Backend (HA)](/upgrade_server/#chef-backend-upgrade)
 - [Tiered](/upgrade_server/#tiered-upgrade)
 
-### Upgrading to Chef Infra Server 14
+### Upgrading to 14.x
 
 {{< warning >}}
 
@@ -52,7 +52,7 @@ Chef Infra Server 14 uses Elasticsearch as its search index.
 
 The Chef Infra Server 14 upgrade does not automatically reindex existing external Elasticsearch installations.
 
-### Upgrading to Chef Infra Server 12.17.15
+### Upgrading to 12.17.15
 
 {{< warning >}}
 Upgrade Chef Infra Server and any add-ons to compatible versions before setting `insecure_addon_compat` to `false`.
@@ -64,7 +64,7 @@ and Chef Infra Server will write all credentials to a single location.
 
 For more information on password generation, including a list of supported add-on versions, see [Chef Infra Server Credentials Management](/server_security/#chef-infra-server-credentials-management).
 
-### Upgrading to Chef Infra Server 12.3.0
+### Upgrading to 12.3.0
 
 If you are running Chef Infra Server 11 please contact Chef Support for additional guidance on upgrading your Chef Infra Server installation.
 

--- a/content/upgrade_server.md
+++ b/content/upgrade_server.md
@@ -16,18 +16,18 @@ aliases = ["/upgrade_server.html"]
 
 ## Chef Infra Server Upgrade Matrix
 
-| Running Version | Upgrade Version | License | Version Support |
+| Running Version | Upgrade To Version | Requires License | Supported Version |
 |---------|---------|------|-----------|
 | 13 | 14 | Yes | Yes |
-| 12.17.15 | 14 | Yes | Yes |
+| 12.17.15 | 14 | Yes | No |
 | 12.3.0 | 12.17.15 | No | No |
 | 11 | 12.3.0 | No | No |
 
-License
-: Chef Infra Server 13 and 14 are governed by the [Chef License](https://docs.chef.io/chef_license_accept/#chef-infra-server). You will be required to accept these terms when using Chef Infra Server 13 or 14 for the first time by entering `Yes` when prompted.
+Requires License
+: Chef Infra Server 13 and later are governed by the [Chef EULA](/chef_license). You will be required to accept these terms when using Chef Infra Server for the first time by entering `Yes` when prompted.
 
-Version Support
-: Chef Infra Server 13 and 14 are supported Chef Software distributions. Earlier versions are no longer supported. For more information about supported Chef Software see the [Supported Versions](https://docs.chef.io/versions/#supported-commercial-distributions) documentation.
+Supported Release
+: Chef Infra Server 13 and later are currently supported Chef Software releases. Earlier releases are no longer supported as of 12/31/2020. For more information about supported Chef Software see the [Supported Versions](https://docs.chef.io/versions/#supported-commercial-distributions) documentation.
 
 ## Upgrading to Chef Infra Server
 
@@ -41,7 +41,7 @@ Three upgrade scenarios exist for upgrades from Chef Infra Server 12.17.15 to Ch
 
 {{< warning >}}
 
-Do not upgrade your production server. First, upgrade in your test server, and then upgrade your production server.
+Before upgrading a production server make sure to upgrade a test server to confirm the process.
 
 {{< /warning >}}
 
@@ -225,15 +225,11 @@ To upgrade to Chef Infra Server on a tiered Chef Infra Server configuration, do 
    chef-server-ctl cleanup
    ```
 
-## Upgrading Add-ons
+## Upgrading Manage Add-On
 
-Chef Infra Server 13 and 14 supports Chef Manage and Push Jobs. Both of these add-ons are [deprecated](https://docs.chef.io/versions/#deprecated-products-and-versions). Push Jobs will reach EOL on December 31, 2020 and Chef Manage will reach EOL on December 31, 2021. After upgrading Chef Infra Server, reinstall the add-on and then reconfigure Chef Infra Server and the add-on.
+Chef Manage is a management console for  data bags, attributes, run-lists, roles, environments, and cookbooks from a web user interface.
 
-Chef Manage
-: Chef Manage is deprecated and will reach [EOL](https://docs.chef.io/versions/#deprecated-products-and-versions) on December 31, 2021. Chef Manage is a management console for  data bags, attributes, run-lists, roles, environments, and cookbooks from a web user interface
-
-Push Jobs
-: Push Jobs deprecated and will reach [EOL](https://docs.chef.io/versions/#deprecated-products-and-versions) on December 31, 2020. Chef Push Jobs is an extension of the Chef Infra Server that allows for running jobs against nodes independently of a Chef Infra Client run.
+Chef Infra Server 13 and 14 support the Chef Manage add-on. This add-on is [deprecated](https://docs.chef.io/versions/#deprecated-products-and-versions) and will reach [EOL](https://docs.chef.io/versions/#deprecated-products-and-versions) on December 31, 2021. After upgrading Chef Infra Server, reinstall the add-on and then reconfigure Chef Infra Server and the add-on.
 
 ### Use Downloads
 

--- a/content/upgrade_server.md
+++ b/content/upgrade_server.md
@@ -60,7 +60,7 @@ For more information on password generation, including a list of supported add-o
 
 ### Upgrading to 12.3.0
 
-If you are running Chef Infra Server 11 please contact Chef Support for additional guidance on upgrading your Chef Infra Server installation.
+If you are running a Chef Infra Server relese prior to 12.3.0 please contact Chef Support for additional guidance on upgrading your Chef Infra Server installation.
 
 ## Standalone Upgrade
 

--- a/content/upgrade_server.md
+++ b/content/upgrade_server.md
@@ -41,7 +41,7 @@ Supported Release
 
 ### Upgrading to 14.x
 
-Chef Infra Server 14 uses Elasticsearch as its search index.
+Chef Infra Server 14 moved from Solr to Elasticsearch as its search index.
 {{% server_upgrade_duration %}}
 
 The Chef Infra Server 14 upgrade does not automatically reindex existing external Elasticsearch installations.

--- a/content/upgrade_server.md
+++ b/content/upgrade_server.md
@@ -33,12 +33,6 @@ Requires License
 Supported Release
 : Chef Infra Server 13 and later are currently supported Chef Software releases. Earlier releases are no longer supported as of 12/31/2020. For more information about supported Chef Software see the [Supported Versions](https://docs.chef.io/versions/#supported-commercial-distributions) documentation.
 
-Three upgrade scenarios exist for upgrades from Chef Infra Server 12.17.15 to Chef Infra Server 13 or 14:
-
-- [Standalone](/upgrade_server/#standalone-upgrade)
-- [Chef Backend (HA)](/upgrade_server/#chef-backend-upgrade)
-- [Tiered](/upgrade_server/#tiered-upgrade)
-
 ### Upgrading to 14.x
 
 {{< warning >}}


### PR DESCRIPTION
Rework the version table for clarify
Remove Push jobs as it goes EOL at the EOY
Update Chef Server 12 to be considered EOL since it also goes EOL at the end of the year
Clarify that Chef Infra Server 13 requires EULA acceptance and link to the right place

Signed-off-by: Tim Smith <tsmith@chef.io>