### PR TITLE
Add distro name for Ubuntu 20.04 for APT repos

### DIFF
--- a/content/packages.md
+++ b/content/packages.md
@@ -86,6 +86,7 @@ To set up an Apt package repository for Debian and Ubuntu platforms:
     -   For Debian 10: `buster`
     -   For Ubuntu 16.04: `xenial`
     -   For Ubuntu 18.04: `bionic`
+    -   For Ubuntu 20.04: `focal`
 
 4.  Update the package repository list:
 


### PR DESCRIPTION
Add `focal` distro name for Ubuntu 20.04 when configuring Chef APT repos

### Check List

- [ y] Spell Check
- [ n] Local build
- [ n] Examine the local build
- [ ?] All tests pass

Signed-off-by: Richard Nixon <rnixon@chef.io>