### PR TITLE
Change node.set in examples

### DIFF
--- a/content/debug.md
+++ b/content/debug.md
@@ -226,7 +226,7 @@ And others are defined in an attributes file:
 
 ```ruby
 default[:test][:source]  = 'attributes default'
-set[:test][:source]      = 'attributes normal'
+normal[:test][:source]      = 'attributes normal'
 override[:test][:source] = 'attributes override'
 ```
 

--- a/themes/docs-new/layouts/shortcodes/chef_shell_example_hello_world.md
+++ b/themes/docs-new/layouts/shortcodes/chef_shell_example_hello_world.md
@@ -84,7 +84,7 @@ an attribute with the following syntax:
 
 ```bash
 chef:recipe_mode > attributes_mode
-  chef:attributes > set[:hello] = "ohai2u-again"
+  chef:attributes > default[:hello] = "ohai2u-again"
     => "ohai2u-again"
   chef:attributes >
 ```


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### Description

node.set was deprecated in 13 and removed in 14. This PR updates the code examples.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
