### PR TITLE
Remove extra menu entry

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -243,10 +243,6 @@ weight = 60
 ## End Main Menu ##
 ####
 
-[[menu.server]]
-title = "Chef Infra Server"
-identifier = "server"
-
 ####
 # Overview Menu
 ####


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

Removes an extra `[menu.server]` entry from the `config.toml`

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
