### PR TITLE
Resource updates from automation

### DIFF
--- a/data/infra/resources/remote_directory.yaml
+++ b/data/infra/resources/remote_directory.yaml
@@ -41,6 +41,8 @@ syntax_full_properties_list:
   `mode`, `overwrite`, `owner`, `path`, `purge`, `recursive`, and `source` are the
   properties available to this resource."
 actions_list:
+  :nothing:
+    shortcode: resources_common_actions_nothing.md
   :create:
     markdown: Default. Create a directory and/or the contents of that directory. If
       a directory or its contents already exist (but does not match), update that
@@ -50,8 +52,6 @@ actions_list:
       it does not exist.
   :delete:
     markdown: Delete a directory, including the contents of that directory.
-  :nothing:
-    shortcode: resources_common_actions_nothing.md
 properties_list:
 - property: cookbook
   ruby_type: String

--- a/data/infra/resources/remote_file.yaml
+++ b/data/infra/resources/remote_file.yaml
@@ -52,6 +52,8 @@ syntax_full_properties_list:
   `use_etag`, `use_last_modified`, and `verifications` are the properties available
   to this resource."
 actions_list:
+  :nothing:
+    shortcode: resources_common_actions_nothing.md
   :create:
     markdown: Default. Create a file. If a file already exists (but does not match),
       update that file to match.
@@ -60,8 +62,6 @@ actions_list:
       nothing happens.
   :delete:
     markdown: Delete a file.
-  :nothing:
-    shortcode: resources_common_actions_nothing.md
   :touch:
     markdown: Touch a file. This updates the access (atime) and file modification
       (mtime) times for a file. (This action may be used with this resource, but is

--- a/data/infra/resources/timezone.yaml
+++ b/data/infra/resources/timezone.yaml
@@ -26,7 +26,7 @@ actions_list:
   :nothing:
     shortcode: resources_common_actions_nothing.md
   :set:
-    markdown: Set the system timezone.
+    markdown: Set the system timezone
 properties_list:
 - property: timezone
   ruby_type: String

--- a/data/infra/resources/user_ulimit.yaml
+++ b/data/infra/resources/user_ulimit.yaml
@@ -43,12 +43,12 @@ syntax_full_properties_list:
   `stack_hard_limit`, `stack_limit`, `stack_soft_limit`, `username`, and `virt_limit`
   are the properties available to this resource."
 actions_list:
+  :nothing:
+    shortcode: resources_common_actions_nothing.md
   :create:
     markdown: Create a ulimit configuration file
   :delete:
-    markdown: Delete a ulimit configuration file
-  :nothing:
-    shortcode: resources_common_actions_nothing.md
+    markdown: Delete an existing ulimit configuration file
 properties_list:
 - property: core_hard_limit
   ruby_type: String, Integer

--- a/data/infra/resources/windows_ad_join.yaml
+++ b/data/infra/resources/windows_ad_join.yaml
@@ -17,7 +17,6 @@ syntax_full_code_block: |-
     ou_path              String
     reboot               Symbol # default value: :immediate
     reboot_delay         Integer # default value: 0
-    sensitive            true, false # default value: true
     workgroup_name       String
     action               Symbol # defaults to :join if not specified
   end
@@ -31,12 +30,12 @@ syntax_full_properties_list:
   `reboot_delay`, `sensitive`, and `workgroup_name` are the properties available to
   this resource."
 actions_list:
-  :join:
-    markdown: Default. Join the Active Directory domain.
-  :leave:
-    markdown: Leave an Active Directory domain and re-join a workgroup.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :join:
+    markdown: Join the Active Directory domain
+  :leave:
+    markdown: Leave an Active Directory domain and re-join a workgroup
 properties_list:
 - property: domain_name
   ruby_type: String
@@ -83,12 +82,6 @@ properties_list:
   new_in: '16.5'
   description_list:
   - markdown: The amount of time (in minutes) to delay a reboot request.
-- property: sensitive
-  ruby_type: true, false
-  required: false
-  default_value: 'true'
-  description_list:
-  - markdown: 
 - property: workgroup_name
   ruby_type: String
   required: false

--- a/data/infra/resources/windows_audit_policy.yaml
+++ b/data/infra/resources/windows_audit_policy.yaml
@@ -34,7 +34,7 @@ actions_list:
   :nothing:
     shortcode: resources_common_actions_nothing.md
   :set:
-    markdown: Configure an audit policy.
+    markdown: Configure an audit policy
 properties_list:
 - property: audit_base_directories
   ruby_type: true, false

--- a/data/infra/resources/windows_auto_run.yaml
+++ b/data/infra/resources/windows_auto_run.yaml
@@ -24,12 +24,12 @@ syntax_full_properties_list:
 - "`args`, `path`, `program_name`, and `root` are the properties available to this
   resource."
 actions_list:
-  :create:
-    markdown: Create an item to be run at login.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :create:
+    markdown: Create an item to be run at login
   :remove:
-    markdown: Remover an item that was previously configured to run at login.
+    markdown: Remove an item that was previously configured to run at login
 properties_list:
 - property: args
   ruby_type: String

--- a/data/infra/resources/windows_certificate.yaml
+++ b/data/infra/resources/windows_certificate.yaml
@@ -31,18 +31,18 @@ syntax_full_properties_list:
 - "`cert_path`, `exportable`, `pfx_password`, `private_key_acl`, `source`, `store_name`,
   and `user_store` are the properties available to this resource."
 actions_list:
-  :acl_add:
-    markdown: Adds read-only entries to a certificate's private key ACL.
-  :create:
-    markdown: Creates or updates a certificate.
-  :delete:
-    markdown: Deletes a certificate.
-  :fetch:
-    markdown: Fetches a certificate.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :create:
+    markdown: Creates or updates a certificate
+  :acl_add:
+    markdown: Adds read-only entries to a certificate's private key ACL
+  :delete:
+    markdown: Deletes a certificate
+  :fetch:
+    markdown: Fetches a certificate
   :verify:
-    markdown: Verifies a certificate.
+    markdown: Verifies a certificate and logs the result
 properties_list:
 - property: cert_path
   ruby_type: String
@@ -89,7 +89,8 @@ properties_list:
   required: false
   default_value: 'false'
   description_list:
-  - markdown: Use the user store of the local machine store if set to false.
+  - markdown: 'Use the `CurrentUser` store instead of the default `LocalMachine` store.
+      Note: Prior to chef-client. 16.10 this property was ignored.'
 examples: |
   **Add PFX cert to local machine personal store and grant accounts read-only access to private key**
 

--- a/data/infra/resources/windows_dfs_folder.yaml
+++ b/data/infra/resources/windows_dfs_folder.yaml
@@ -25,12 +25,12 @@ syntax_full_properties_list:
 - "`description`, `folder_path`, `namespace_name`, and `target_path` are the properties
   available to this resource."
 actions_list:
-  :create:
-    markdown: Creates the folder in dfs namespace. Default.
-  :delete:
-    markdown: Deletes the folder in the dfs namespace.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :create:
+    markdown: Creates the folder in dfs namespace
+  :delete:
+    markdown: Deletes the folder in the dfs namespace
 properties_list:
 - property: description
   ruby_type: String

--- a/data/infra/resources/windows_dfs_namespace.yaml
+++ b/data/infra/resources/windows_dfs_namespace.yaml
@@ -27,12 +27,12 @@ syntax_full_properties_list:
 - "`change_users`, `description`, `full_users`, `namespace_name`, `read_users`, and
   `root` are the properties available to this resource."
 actions_list:
-  :create:
-    markdown: Creates the dfs namespace on the server. Default.
-  :delete:
-    markdown: Deletes a DFS Namespace including the directory on disk.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :create:
+    markdown: Creates the dfs namespace on the server
+  :delete:
+    markdown: Deletes a DFS Namespace including the directory on disk
 properties_list:
 - property: change_users
   ruby_type: Array

--- a/data/infra/resources/windows_dfs_server.yaml
+++ b/data/infra/resources/windows_dfs_server.yaml
@@ -25,10 +25,10 @@ syntax_full_properties_list:
 - "`enable_site_costed_referrals`, `ldap_timeout_secs`, `prefer_login_dc`, `sync_interval_secs`,
   and `use_fqdn` are the properties available to this resource."
 actions_list:
-  :configure:
-    markdown: Configure DFS settings
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :configure:
+    markdown: Configure DFS settings
 properties_list:
 - property: enable_site_costed_referrals
   ruby_type: true, false

--- a/data/infra/resources/windows_dns_record.yaml
+++ b/data/infra/resources/windows_dns_record.yaml
@@ -25,12 +25,12 @@ syntax_full_properties_list:
 - "`dns_server`, `record_name`, `record_type`, `target`, and `zone` are the properties
   available to this resource."
 actions_list:
-  :create:
-    markdown: Creates and updates the DNS entry.
-  :delete:
-    markdown: Deletes a DNS entry.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :create:
+    markdown: Creates and updates the DNS entry
+  :delete:
+    markdown: Deletes a DNS entry
 properties_list:
 - property: dns_server
   ruby_type: String

--- a/data/infra/resources/windows_dns_zone.yaml
+++ b/data/infra/resources/windows_dns_zone.yaml
@@ -24,12 +24,12 @@ syntax_full_properties_list:
 - "`replication_scope`, `server_type`, and `zone_name` are the properties available
   to this resource."
 actions_list:
-  :create:
-    markdown: Creates and updates a DNS Zone. Default.
-  :delete:
-    markdown: Deletes a DNS Zone.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :create:
+    markdown: Creates and updates a DNS Zone
+  :delete:
+    markdown: Deletes a DNS Zone
 properties_list:
 - property: replication_scope
   ruby_type: String

--- a/data/infra/resources/windows_shortcut.yaml
+++ b/data/infra/resources/windows_shortcut.yaml
@@ -26,10 +26,10 @@ syntax_full_properties_list:
 - "`arguments`, `cwd`, `description`, `iconlocation`, `shortcut_name`, and `target`
   are the properties available to this resource."
 actions_list:
-  :create:
-    markdown: Default. Create or modify a Windows shortcut.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :create:
+    markdown: Create or modify a Windows shortcut
 properties_list:
 - property: arguments
   ruby_type: String

--- a/data/infra/resources/windows_uac.yaml
+++ b/data/infra/resources/windows_uac.yaml
@@ -28,10 +28,10 @@ syntax_full_properties_list:
   `prompt_on_secure_desktop`, and `require_signed_binaries` are the properties available
   to this resource."
 actions_list:
-  :configure:
-    markdown: Configures UAC by setting registry keys at `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System`.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :configure:
+    markdown: Configures UAC by setting registry keys at `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System`
 properties_list:
 - property: consent_behavior_admins
   ruby_type: Symbol

--- a/data/infra/resources/windows_user_privilege.yaml
+++ b/data/infra/resources/windows_user_privilege.yaml
@@ -24,16 +24,17 @@ syntax_full_properties_list:
   the desired state."
 - "`principal`, `privilege`, and `users` are the properties available to this resource."
 actions_list:
-  :add:
-    markdown: Add a user privilege
-  :clear:
-    markdown: Clear all user privileges
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :add:
+    markdown: Add a user privilege
+  :set:
+    markdown: Set the privileges that are listed in the `privilege` property for only
+      the users listed in the `users` property
+  :clear:
+    markdown: Clear all user privileges
   :remove:
     markdown: Remove a user privilege
-  :set:
-    markdown: Set the privileges that are listed in the `privilege` property for only the users listed in the `users` property.
 properties_list:
 - property: principal
   ruby_type: String

--- a/data/infra/resources/windows_workgroup.yaml
+++ b/data/infra/resources/windows_workgroup.yaml
@@ -12,7 +12,6 @@ syntax_full_code_block: |-
   windows_workgroup 'name' do
     password            String
     reboot              Symbol # default value: :immediate
-    sensitive           true, false # default value: true
     user                String
     workgroup_name      String # default value: 'name' unless specified
     action              Symbol # defaults to :join if not specified
@@ -26,10 +25,10 @@ syntax_full_properties_list:
 - "`password`, `reboot`, `sensitive`, `user`, and `workgroup_name` are the properties
   available to this resource."
 actions_list:
-  :join:
-    markdown: Update the workgroup.
   :nothing:
     shortcode: resources_common_actions_nothing.md
+  :join:
+    markdown: Update the workgroup.
 properties_list:
 - property: password
   ruby_type: String


### PR DESCRIPTION
1) We're not double documenting sensitive anymore
2) Action descriptions are flowing from the codebase now. There's a good chunk that need to be moved into the code, but once done some resources are 100% automated now.

Signed-off-by: Tim Smith <tsmith@chef.io>