### PR TITLE
Show custom TOC layouts overlay in narrow screen sizes

### DIFF
--- a/themes/docs-new/layouts/_default/baseof.html
+++ b/themes/docs-new/layouts/_default/baseof.html
@@ -42,7 +42,7 @@
     </div>
   </div>
 
-  {{ if or (and (ge (len $headers) 1) (ne .Params.toc false )) (isset .Params "release_notes") }}
+  {{ if or (and (ge (len $headers) 1) (ne .Params.toc false )) (isset .Params "release_notes") (.Params.version_docs_product) (.Params.toc_layout)}}
 
     <div class="off-canvas position-right toc off-canvas-absolute hide-for-large hide-for-print" id="offCanvasRightTOC" data-off-canvas
       data-transition="overlap">


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

The TOC layout isn't appearing for pages with a custom TOC when a screen is set to a narrow width.
This makes sure they appear.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
