### PR TITLE
Release Notes Swiftype

### DIFF
--- a/content/release_notes_automate.md
+++ b/content/release_notes_automate.md
@@ -1,5 +1,5 @@
 +++
-title = "Chef Automate: Version"
+title = "Chef Automate Release Notes"
 draft = false
 
 release_notes = "automate"

--- a/content/release_notes_inspec.md
+++ b/content/release_notes_inspec.md
@@ -1,5 +1,5 @@
 +++
-title = "Chef InSpec: Version"
+title = "Chef InSpec Release Notes"
 draft = false
 
 release_notes = "inspec"

--- a/content/release_notes_workstation.md
+++ b/content/release_notes_workstation.md
@@ -1,5 +1,5 @@
 +++
-title = "Chef Workstation: Version"
+title = "Chef Workstation Release Notes"
 draft = false
 release_notes = "chef-workstation"
 

--- a/themes/docs-new/assets/js/releases.js
+++ b/themes/docs-new/assets/js/releases.js
@@ -9,30 +9,6 @@ $.urlParam = function(name){
   }
 }
 
-// return formal product name
-function chefProductConverter(chefProductLower){
-  if (chefProductLower === 'inspec'){
-    return 'Chef InSpec'
-  } else if (chefProductLower === 'chef-workstation') {
-    return 'Chef Workstation'
-  } else if (chefProductLower === 'chef-server'){
-    return 'Chef Infra Server'
-  } else if (chefProductLower === 'chef'){
-    return 'Chef Infra Client'
-  } else if (chefProductLower === 'chefdk'){
-    return 'ChefDK'
-  } else if (chefProductLower === 'chef-backend') {
-    return 'Chef Backend'
-  } else if (chefProductLower === 'push-jobs-client') {
-    return 'Push Jobs Client'
-  } else if (chefProductLower === 'push-jobs-server') {
-    return 'Push Jobs Server'
-  } else {
-    var capName = 'Chef ' + chefProductLower.charAt(0).toUpperCase() + chefProductLower.slice(1)
-    return capName
-  }
-}
-
 // Find the index for the object
 function findWithAttr(array, attr, value, product) {
   if (product === 'automate'){
@@ -54,8 +30,6 @@ function findWithAttr(array, attr, value, product) {
 // Load the Release Notes into the page
 function loadReleaseNotesContents(releases, version, product) {
 
-  var productConverted = chefProductConverter(product)
-
   if ( version == null ) {
     var index = releases.length - 1;
   } else {
@@ -72,12 +46,12 @@ function loadReleaseNotesContents(releases, version, product) {
       var friendlyDate = new Date(releases[index]["release_date"]);
       var options = { year: 'numeric', month: 'long', day: 'numeric' };
 
-      $(".col-content").html(html);
-      $(".col-content").prepend("<p><i>Released on " + friendlyDate.toLocaleString('en-US', options) + "</i></p>");
-      $(".col-content").prepend(pageTOCButton)
+      $(".prose").html(html);
+      $(".prose").prepend("<p><i>Released on " + friendlyDate.toLocaleString('en-US', options) + "</i></p>");
+      $(".prose").prepend(pageTOCButton)
 
 
-      $(".col-content").prepend("<h1>" + productConverted + ": Version " + releases[index]["version"] + "</h1>");
+      $(".prose").prepend('<p class="release-notes-version">Version: ' + releases[index]["version"] + "</p>");
     });
   }
   else {
@@ -87,13 +61,13 @@ function loadReleaseNotesContents(releases, version, product) {
     $.get(releaseNoteURL, function(rawReleaseNotes) {
       var html = converter.makeHtml(rawReleaseNotes);
 
-      $(".col-content").html(html);
-      $(".col-content").prepend(pageTOCButton)
-      $(".col-content").prepend("<h1>" + productConverted + ": Version " + releases[index] + "</h1>");
+      $(".prose").html(html);
+      $(".prose").prepend(pageTOCButton)
+      $(".prose").prepend('<p class="release-notes-version">Version: ' + releases[index] + "</p>");
     }).fail( function() {
-      $(".col-content").html("<p>This release does not have any release notes.</p>");
-      $(".col-content").prepend(pageTOCButton)
-      $(".col-content").prepend("<h1>" + productConverted + ": Version " + releases[index] + "</h1>");
+      $(".prose").html("<p>This release does not have any release notes.</p>");
+      $(".prose").prepend(pageTOCButton)
+      $(".prose").prepend('<p class="release-notes-version">Version: ' + releases[index] + "</p>");
     });
   }
 }

--- a/themes/docs-new/assets/sass/typography/_prose.scss
+++ b/themes/docs-new/assets/sass/typography/_prose.scss
@@ -26,6 +26,11 @@
       line-height: 1.5;
     }
   }
+  p.release-notes-version {
+    font-size: 1.24rem;
+    line-height: 1.5;
+    font-weight: 700;
+  }
 }
 
 #main-content{


### PR DESCRIPTION
### Description

This is trying to tackle two semi-related problems at once.

1. The seamless release notes pages don't include the term "Release Notes" in their text, so Swiftype won't return those pages in a search for the term "release notes"

2. When the release notes text is generated, the version number is appended to the end of the page title producing a long-ish title, even longer if we change it from "Chef Workstation: Version x.y.z" to "Chef Workstation Release Notes: Version x.y.z"
 - this replaces the title "Chef Product: Version x.y.z" with "Chef Product Release Notes", and on a second line "Version x.y.z"
 - adds CSS to style "Version x.y.z" so it's readable

### Definition of Done

- Swiftype knows that there are release notes on the seamless release notes pages
- The user can read/find the release notes version easily without having to use a magnifying glass

### Issues Resolved

#2926
### Links

https://deploy-preview-2930--chef-web-docs.netlify.app/release_notes_workstation/
https://deploy-preview-2930--chef-web-docs.netlify.app/release_notes_automate/
https://deploy-preview-2930--chef-web-docs.netlify.app/release_notes_inspec/
