### PR TITLE
add product metadata to each page

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -3,6 +3,7 @@ title = "{{ replace .Name "-" " " | title }}"
 draft = true
 
 gh_repo = "chef-web-docs"
+product = []
 
 [menu]
   [menu.docs]

--- a/content/_index.md
+++ b/content/_index.md
@@ -3,4 +3,7 @@ title = "Chef Documentation"
 draft = false
 st_robots = "noindex, follow"
 toc = false
+
+[cascade]
+  product = ["client"]
 +++

--- a/content/api_omnitruck.md
+++ b/content/api_omnitruck.md
@@ -1,10 +1,9 @@
 +++
 title = "Omnitruck API"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/api_omnitruck.html"]
+product = ["automate", "client", "server", "habitat", "inspec", "workstation"]
 
 [menu]
   [menu.overview]

--- a/content/attribute_arrays.md
+++ b/content/attribute_arrays.md
@@ -2,6 +2,7 @@
 title = "Attribute Arrays"
 description = "Define multiple attributes in an array or hash and deep merge"
 draft = false
+gh_repo = "chef-web-docs"
 
 [menu]
   [menu.infra]
@@ -9,8 +10,6 @@ draft = false
     identifier = "chef_infra/cookbook_reference/attributes/attribute_arrays Attribute Arrays"
     parent = "chef_infra/cookbook_reference/attributes"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/attribute_arrays.md)
 
 Attributes are typically defined in cookbooks, recipes, roles, and
 environments. These attributes are rolled-up to the node level during a

--- a/content/attribute_precedence.md
+++ b/content/attribute_precedence.md
@@ -1,6 +1,7 @@
 +++
 title = "Attribute Precedence"
 draft = false
+gh_repo = "chef-web-docs"
 
 [menu]
   [menu.infra]
@@ -8,8 +9,6 @@ draft = false
     identifier = "chef_infra/cookbook_reference/attributes/attribute_precedence"
     parent = "chef_infra/cookbook_reference/attributes"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-web-docs/blob/master/content/attribute_precedence.md)
 
 {{% node_attribute_precedence %}}
 

--- a/content/aws_marketplace.md
+++ b/content/aws_marketplace.md
@@ -6,6 +6,8 @@ gh_repo = "chef-web-docs"
 
 aliases = ["/aws_marketplace.html"]
 
+product = ["client", "workstation"]
+
 [menu]
   [menu.infra]
     title = "AWS Marketplace"

--- a/content/azure_cwa_cloud_shell.md
+++ b/content/azure_cwa_cloud_shell.md
@@ -1,10 +1,10 @@
 +++
 title = "Chef Workstation in Azure Cloud Shell"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/azure_cwa_cloud_shell.html"]
+
+product = ["client", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/chef_install_script.md
+++ b/content/chef_install_script.md
@@ -1,10 +1,9 @@
 +++
 title = "Chef Software Install Script"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/install_omnibus.html", "/install_omnibus/"]
+product = ["automate", "client", "server", "habitat", "inspec", "workstation"]
 
 [menu]
   [menu.overview]

--- a/content/chef_license.md
+++ b/content/chef_license.md
@@ -1,10 +1,9 @@
 +++
 title = "About Chef Licenses"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/chef_license.html"]
+product = ["automate", "client", "server", "habitat", "inspec", "workstation"]
 
 [menu]
   [menu.overview]

--- a/content/chef_license_accept.md
+++ b/content/chef_license_accept.md
@@ -5,6 +5,7 @@ draft = false
 gh_repo = "chef-web-docs"
 
 aliases = ["/chef_license_accept.html"]
+product = ["automate", "client", "server", "habitat", "inspec", "workstation"]
 
 [menu]
   [menu.overview]

--- a/content/chef_overview.md
+++ b/content/chef_overview.md
@@ -1,10 +1,9 @@
 +++
 title = "An Overview of Chef Infra"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/chef_overview.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/chef_repo.md
+++ b/content/chef_repo.md
@@ -1,9 +1,7 @@
 +++
 title = "About the chef-repo"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/chef_repo.html"]
 
 [menu]

--- a/content/chef_search.md
+++ b/content/chef_search.md
@@ -1,10 +1,9 @@
 +++
 title = "About Search"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/chef_search.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/chef_solo.md
+++ b/content/chef_solo.md
@@ -1,9 +1,7 @@
 +++
 title = "chef-solo"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/chef_solo.html"]
 
 [menu]

--- a/content/chef_system_requirements.md
+++ b/content/chef_system_requirements.md
@@ -1,10 +1,9 @@
 +++
 title = "System Requirements"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/chef_system_requirements.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/community.md
+++ b/content/community.md
@@ -1,10 +1,9 @@
 +++
 title = "About the Chef Community"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/community.html"]
+product = []
 
 [menu]
   [menu.overview]

--- a/content/community_contributions.md
+++ b/content/community_contributions.md
@@ -1,10 +1,9 @@
 +++
 title = "Community Contributions"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/community_contributions.html"]
+product = []
 
 [menu]
   [menu.overview]

--- a/content/community_guidelines.md
+++ b/content/community_guidelines.md
@@ -1,10 +1,9 @@
 +++
 title = "Chef Contributor Covenant Code of Conduct"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/community_guidelines.html"]
+product = []
 
 [menu]
   [menu.overview]

--- a/content/compliance/_index.md
+++ b/content/compliance/_index.md
@@ -3,6 +3,8 @@ title = "Chef Compliance"
 draft = false
 
 gh_repo = "chef-web-docs"
+[cascade]
+  product = ["client", "server", "inspec", "habitat"]
 
 [menu]
   [menu.compliance]

--- a/content/config_rb_manage.md
+++ b/content/config_rb_manage.md
@@ -1,11 +1,8 @@
 +++
 title = "manage.rb"
 draft = false
-
 gh_repo = "chef-web-docs"
 robots = "noindex"
-
-
 aliases = ["/config_rb_manage.html"]
 
 [menu]

--- a/content/config_rb_policyfile.md
+++ b/content/config_rb_policyfile.md
@@ -1,10 +1,9 @@
 +++
 title = "Policyfile.rb"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/config_rb_policyfile.html"]
+product = ["client", "server"]
 
 [menu]
   [menu.infra]

--- a/content/config_rb_supermarket.md
+++ b/content/config_rb_supermarket.md
@@ -1,10 +1,9 @@
 +++
 title = "supermarket.rb Settings"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/config_rb_supermarket.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/cookbook_repo.md
+++ b/content/cookbook_repo.md
@@ -1,10 +1,9 @@
 +++
 title = "Cookbook Directory"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/cookbook_repo.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/cookbook_versioning.md
+++ b/content/cookbook_versioning.md
@@ -1,10 +1,9 @@
 +++
 title = "About Cookbook Versioning"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/cookbook_versioning.html", "/cookbook_versions.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/cookbooks.md
+++ b/content/cookbooks.md
@@ -5,6 +5,7 @@ draft = false
 gh_repo = "chef-web-docs"
 
 aliases = ["/cookbooks.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/ctl_manage.md
+++ b/content/ctl_manage.md
@@ -1,12 +1,10 @@
 +++
 title = "chef-manage-ctl (executable)"
 draft = false
-
 gh_repo = "chef-web-docs"
 robots = "noindex"
-
-
 aliases = ["/ctl_manage.html"]
+product = []
 
 [menu]
   [menu.legacy]

--- a/content/ctl_supermarket.md
+++ b/content/ctl_supermarket.md
@@ -1,10 +1,9 @@
 +++
 title = "supermarket-ctl (executable)"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/ctl_supermarket.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/data_bags.md
+++ b/content/data_bags.md
@@ -1,10 +1,9 @@
 +++
 title = "About Data Bags"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/data_bags.html", "/secrets.html", "/secrets/"]
+product = ["client", "server"]
 
 [menu]
   [menu.infra]

--- a/content/debug.md
+++ b/content/debug.md
@@ -1,9 +1,7 @@
 +++
 title = "Debug Recipes, Chef Infra Client Runs"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/debug.html"]
 
 [menu]

--- a/content/dsl_custom_resource.md
+++ b/content/dsl_custom_resource.md
@@ -1,9 +1,7 @@
 +++
 title = "Custom Resource DSL"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/dsl_custom_resource.html"]
 
 [menu]

--- a/content/environments.md
+++ b/content/environments.md
@@ -1,10 +1,9 @@
 +++
 title = "About Environments"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/environments.html"]
+product = ["client", "server"]
 
 [menu]
   [menu.infra]

--- a/content/errors.md
+++ b/content/errors.md
@@ -1,10 +1,9 @@
 +++
 title = "Troubleshooting"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/errors.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/feedback.md
+++ b/content/feedback.md
@@ -1,10 +1,9 @@
 +++
 title = "Send Feedback"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/feedback.html"]
+product = []
 
 [menu]
   [menu.overview]

--- a/content/fips.md
+++ b/content/fips.md
@@ -1,10 +1,9 @@
 +++
 title = "FIPS (Federal Information Processing Standards)"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/fips.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/glossary.md
+++ b/content/glossary.md
@@ -1,10 +1,9 @@
 +++
 title = "Glossary"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/glossary.html"]
+product = ["automate", "client", "server", "habitat", "inspec", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/google.md
+++ b/content/google.md
@@ -1,10 +1,9 @@
 +++
 title = "Chef and Google"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/google.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/infra_language/_index.md
+++ b/content/infra_language/_index.md
@@ -1,10 +1,12 @@
 +++
 title = "About the Chef Infra Language"
 draft = false
-
 gh_repo = "chef-web-docs"
 
 aliases = ["/dsl_recipe.html", "/dsl_recipe"]
+
+[cascade]
+  product = ["client"]
 
 [menu]
   [menu.infra]

--- a/content/install_bootstrap.md
+++ b/content/install_bootstrap.md
@@ -1,10 +1,9 @@
 +++
 title = "Bootstrap a Node"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/install_bootstrap.html"]
+product = ["client", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/install_chef_air_gap.md
+++ b/content/install_chef_air_gap.md
@@ -1,10 +1,9 @@
 +++
 title = "Install Chef in an air-gapped environment"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/install_chef_air_gap.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/install_supermarket.md
+++ b/content/install_supermarket.md
@@ -1,10 +1,9 @@
 +++
 title = "Install Private Supermarket"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/install_supermarket.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/libraries.md
+++ b/content/libraries.md
@@ -1,9 +1,7 @@
 +++
 title = "About Libraries"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/libraries.html"]
 
 [menu]

--- a/content/manage.md
+++ b/content/manage.md
@@ -1,10 +1,9 @@
 +++
 title = "Chef Manage"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/manage.html"]
+product = []
 
 [menu]
   [menu.legacy]

--- a/content/nodes.md
+++ b/content/nodes.md
@@ -1,10 +1,9 @@
 +++
 title = "About Nodes"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/nodes.html"]
+product = ["client", "server"]
 
 [menu]
   [menu.infra]

--- a/content/packages.md
+++ b/content/packages.md
@@ -1,10 +1,9 @@
 +++
 title = "Chef Software Inc Packages"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/packages.html"]
+product = ["automate", "client", "server", "habitat", "inspec", "workstation"]
 
 [menu]
   [menu.overview]

--- a/content/platform_overview.md
+++ b/content/platform_overview.md
@@ -1,10 +1,9 @@
 +++
 title = "Platform Overview"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/platform_overview.html"]
+product = ["automate", "client", "server", "habitat", "inspec", "workstation"]
 
 [menu]
   [menu.overview]

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -1,10 +1,9 @@
 +++
 title = "Platforms"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/platforms.html", "/supported_platforms.html"]
+product = ["automate", "client", "server", "habitat", "inspec", "workstation"]
 
 [menu]
   [menu.overview]

--- a/content/plugin_community.md
+++ b/content/plugin_community.md
@@ -1,13 +1,8 @@
 +++
 title = "Community Plugins"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = "/plugin_community.html"
-
-
-
 +++
 
 This page lists plugins for Ohai plugins and Chef Infra Client handlers

--- a/content/plugin_knife.md
+++ b/content/plugin_knife.md
@@ -1,10 +1,9 @@
 +++
 title = "Knife Cloud Plugins"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/plugin_knife.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/plugin_knife_custom.md
+++ b/content/plugin_knife_custom.md
@@ -1,10 +1,9 @@
 +++
 title = "Writing Custom Knife Plugins"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/plugin_knife_custom.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/policy.md
+++ b/content/policy.md
@@ -1,10 +1,9 @@
 +++
 title = "About Policy"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/policy.html"]
+product = ["client", "server"]
 
 [menu]
   [menu.infra]

--- a/content/policyfile.md
+++ b/content/policyfile.md
@@ -1,10 +1,9 @@
 +++
 title = "About Policyfile"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/policyfile.html"]
+product = ["client", "server"]
 
 [menu]
   [menu.infra]

--- a/content/quick_start.md
+++ b/content/quick_start.md
@@ -1,10 +1,9 @@
 +++
 title = "Quick Start"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/quick_start.html"]
+product = ["client", "server"]
 
 [menu]
   [menu.infra]

--- a/content/recipes.md
+++ b/content/recipes.md
@@ -1,9 +1,7 @@
 +++
 title = "About Recipes"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/recipes.html"]
 
 [menu]

--- a/content/release_notes_automate.md
+++ b/content/release_notes_automate.md
@@ -3,6 +3,7 @@ title = "Chef Automate Release Notes"
 draft = false
 
 release_notes = "automate"
+product = ["automate"]
 
 [menu]
   [menu.release_notes]

--- a/content/release_notes_chefdk.md
+++ b/content/release_notes_chefdk.md
@@ -5,6 +5,7 @@ draft = false
 gh_repo = "chef-web-docs"
 
 aliases = ["/release_notes_chefdk.html"]
+product = []
 +++
 
 This page documents the ChefDK major changes for each release. For

--- a/content/release_notes_client.md
+++ b/content/release_notes_client.md
@@ -1,10 +1,9 @@
 +++
 title = "Release Notes: Chef Infra Client 12.0 - 16.10"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/release_notes.html", "/release_notes_ohai.html", "/release_notes/"]
+product = ["client"]
 
 [menu]
   [menu.release_notes]

--- a/content/release_notes_inspec.md
+++ b/content/release_notes_inspec.md
@@ -3,6 +3,7 @@ title = "Chef InSpec Release Notes"
 draft = false
 
 release_notes = "inspec"
+product = ["inspec"]
 
 [menu]
   [menu.release_notes]

--- a/content/release_notes_manage.md
+++ b/content/release_notes_manage.md
@@ -5,6 +5,7 @@ draft = false
 gh_repo = "chef-web-docs"
 
 aliases = ["/release_notes_manage.html"]
+product = []
 
 [menu]
   [menu.release_notes]

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -1,10 +1,9 @@
 +++
 title = "Release Notes: Chef Infra Server 12.0 - 14.0"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/release_notes_server.html"]
+product = ["server"]
 
 [menu]
   [menu.release_notes]

--- a/content/release_notes_workstation.md
+++ b/content/release_notes_workstation.md
@@ -2,6 +2,7 @@
 title = "Chef Workstation Release Notes"
 draft = false
 release_notes = "chef-workstation"
+product = ["workstation"]
 
 [menu]
   [menu.release_notes]

--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -1,12 +1,14 @@
 +++
 title = "All Infra Resources"
 draft = false
-
 gh_repo = "chef-web-docs"
 
 data_path = ["infra","resources"]
 layout = "infra_resources_all"
 toc_layout = "infra_resources_all_toc"
+
+[cascade]
+  product = ["client"]
 
 [menu]
   [menu.infra]

--- a/content/roles.md
+++ b/content/roles.md
@@ -1,10 +1,9 @@
 +++
 title = "About Roles"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/roles.html"]
+product = ["client", "server"]
 
 [menu]
   [menu.infra]

--- a/content/run_lists.md
+++ b/content/run_lists.md
@@ -1,10 +1,9 @@
 +++
 title = "About Run-lists"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/run_lists.html"]
+product = ["client", "server"]
 
 [menu]
   [menu.infra]

--- a/content/server_configure_saml.md
+++ b/content/server_configure_saml.md
@@ -1,12 +1,10 @@
 +++
 title = "Configuring for SAML Authentication"
 draft = false
-
 gh_repo = "chef-web-docs"
 robots = "noindex"
-
-
 aliases = ["/server_configure_saml.html", "/release/automate/server_configure_saml.html"]
+product = []
 
 [menu]
   [menu.legacy]

--- a/content/server_ldap.md
+++ b/content/server_ldap.md
@@ -1,10 +1,9 @@
 +++
 title = "Active Directory and LDAP"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/server_ldap.html", "/install_server_post.html"]
+product = ["server"]
 
 [menu]
   [menu.legacy]

--- a/content/server_manage_clients.md
+++ b/content/server_manage_clients.md
@@ -1,12 +1,10 @@
 +++
 title = "Manage Client Keys"
 draft = false
-
 gh_repo = "chef-web-docs"
 robots = "noindex"
-
-
 aliases = ["/server_manage_clients.html"]
+product = []
 
 [menu]
   [menu.legacy]

--- a/content/server_manage_cookbooks.md
+++ b/content/server_manage_cookbooks.md
@@ -1,12 +1,10 @@
 +++
 title = "Manage Cookbooks"
 draft = false
-
 gh_repo = "chef-web-docs"
 robots = "noindex"
-
-
 aliases = ["/server_manage_cookbooks.html"]
+product = []
 
 [menu]
   [menu.legacy]

--- a/content/server_manage_data_bags.md
+++ b/content/server_manage_data_bags.md
@@ -1,12 +1,10 @@
 +++
 title = "Manage Data Bags"
 draft = false
-
 gh_repo = "chef-web-docs"
 robots = "noindex"
-
-
 aliases = ["/server_manage_data_bags.html"]
+product = []
 
 [menu]
   [menu.legacy]

--- a/content/server_manage_environments.md
+++ b/content/server_manage_environments.md
@@ -1,12 +1,10 @@
 +++
 title = "Manage Environments"
 draft = false
-
 gh_repo = "chef-web-docs"
 robots = "noindex"
-
-
 aliases = ["/server_manage_environments.html"]
+product = []
 
 [menu]
   [menu.legacy]

--- a/content/server_manage_nodes.md
+++ b/content/server_manage_nodes.md
@@ -1,12 +1,10 @@
 +++
 title = "Manage Nodes"
 draft = false
-
 gh_repo = "chef-web-docs"
 robots = "noindex"
-
-
 aliases = ["/server_manage_nodes.html"]
+product = []
 
 [menu]
   [menu.legacy]

--- a/content/server_manage_roles.md
+++ b/content/server_manage_roles.md
@@ -1,12 +1,10 @@
 +++
 title = "Manage Roles"
 draft = false
-
 gh_repo = "chef-web-docs"
 robots = "noindex"
-
-
 aliases = ["/server_manage_roles.html"]
+product = []
 
 [menu]
   [menu.legacy]

--- a/content/server_orgs.md
+++ b/content/server_orgs.md
@@ -1,10 +1,9 @@
 +++
 title = "Organizations and Groups"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/server_orgs.html", "/auth_authorization.html"]
+product = ["client", "server"]
 
 [menu]
   [menu.legacy]

--- a/content/server_users.md
+++ b/content/server_users.md
@@ -5,6 +5,7 @@ draft = false
 gh_repo = "chef-web-docs"
 
 aliases = ["/server_users.html"]
+product = ["server"]
 
 [menu]
   [menu.legacy]

--- a/content/style_guide.md
+++ b/content/style_guide.md
@@ -1,10 +1,9 @@
 +++
 title = "Documentation Style Guide"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/style_guide.html"]
+product = []
 
 [menu]
   [menu.overview]
@@ -39,10 +38,9 @@ Each page starts with [TOML front matter](https://gohugo.io/content-management/f
 title = "Documentation Style Guide"
 description = "DESCRIPTION"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = "/style_guide.html"
+
 
 [menu]
   [menu.infra]
@@ -66,6 +64,23 @@ Set draft to `true` if you don't want Hugo to build the page.
 ### aliases
 
 Add an alias if you want Hugo to automatically redirect the user from another page to the page you are writing.
+
+### product
+
+`product` is a list of Chef products that are relevant to a page. This list is used to facet search
+results in our documentation search by the product. Each section of the documentation
+has a default product parameter configured using [Front Matter Cascade](https://gohugo.io/content-management/front-matter#front-matter-cascade), however you may want add a product if a page references
+more than one Chef product. For example, if a page in the Chef InSpec documentation describes
+passing data to Chef Automate, you may want to add `product = ["inspec", "automate"]` to the page frontmatter.
+
+Relevant values:
+- `automate`
+- `desktop`
+- `client`
+- `server`
+- `habitat`
+- `inspec`
+- `workstation`
 
 ### menu title
 

--- a/content/supermarket.md
+++ b/content/supermarket.md
@@ -1,10 +1,9 @@
 +++
 title = "Chef Supermarket"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/supermarket.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/supermarket_api.md
+++ b/content/supermarket_api.md
@@ -1,10 +1,9 @@
 +++
 title = "Supermarket API"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/supermarket_api.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/supermarket_backup_restore.md
+++ b/content/supermarket_backup_restore.md
@@ -1,10 +1,9 @@
 +++
 title = "Supermarket Backup and Restore"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/supermarket_backup_restore.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/supermarket_logs.md
+++ b/content/supermarket_logs.md
@@ -1,10 +1,9 @@
 +++
 title = "Supermarket Logs"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/supermarket_logs.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/supermarket_monitor.md
+++ b/content/supermarket_monitor.md
@@ -1,10 +1,9 @@
 +++
 title = "Monitor Supermarket"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/supermarket_monitor.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/supermarket_share_cookbook.md
+++ b/content/supermarket_share_cookbook.md
@@ -1,10 +1,9 @@
 +++
 title = "Share Cookbooks on the Chef Supermarket"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/supermarket_share_cookbook.html"]
+product = ["client", "server", "workstation"]
 
 [menu]
   [menu.infra]

--- a/content/terraform.md
+++ b/content/terraform.md
@@ -3,6 +3,7 @@ title = "Chef and Terraform"
 draft = false
 
 gh_repo = "chef-web-docs"
+product = ["client", "server"]
 
 [menu]
   [menu.infra]

--- a/content/uninstall.md
+++ b/content/uninstall.md
@@ -5,6 +5,7 @@ draft = false
 gh_repo = "chef-web-docs"
 
 aliases = ["/uninstall.html"]
+product = ["workstation", "server"]
 
 [menu]
   [menu.infra]

--- a/content/versions.md
+++ b/content/versions.md
@@ -1,10 +1,9 @@
 +++
 title = "Supported Versions"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/versions.html"]
+product = ["automate", "client", "server", "habitat", "inspec", "workstation"]
 
 [menu]
   [menu.overview]

--- a/content/vmware.md
+++ b/content/vmware.md
@@ -1,10 +1,9 @@
 +++
 title = "Chef and VMware"
 draft = false
-
 gh_repo = "chef-web-docs"
-
 aliases = ["/vmware.html"]
+product = ["workstation"]
 
 [menu]
   [menu.infra]


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This adds product metadata to each page.

Everything in `content` has "client" as a product by default. If a page in content isn't changed, then it's classified as "client".

Everything in Overview > Community has no product.

Everything in Overview > Packages & Platforms has: "automate", "client", "server", "habitat", "inspec", "workstation"

All the Chef Manage docs have no product.

All the cookbook docs are client, server, workstation.



### Definition of Done

### Issues Resolved

#2878

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
