### PR TITLE
Fix suse platform family name

### DIFF
--- a/content/infra_language/checking_platforms.md
+++ b/content/infra_language/checking_platforms.md
@@ -248,7 +248,7 @@ where:
 <td><code>solaris2</code> platform</td>
 </tr>
 <tr class="odd">
-<td><code>sles</code></td>
+<td><code>suse</code></td>
 <td><code>opensuse_leap</code>, <code>suse</code>, and <code>sled</code> platforms</td>
 </tr>
 <tr class="even">


### PR DESCRIPTION
### Description

The `suse` platform family was documented as `sles`. This is not true at least for Chef 14.

### Definition of Done

### Issues Resolved

None, should I create one first?

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
