### PR TITLE
change versioned docs layouts so they can handle major version numbers

### DIFF
--- a/themes/docs-new/layouts/partials/versioned-docs-content.html
+++ b/themes/docs-new/layouts/partials/versioned-docs-content.html
@@ -27,7 +27,6 @@
 {{ $versions := index .Site.Params $product }}
 {{ range $version_index, $version := (sort $versions.versions "value" "desc") }}
   {{ $versionDir := delimit (slice "v" $version) "" }}
-  {{/* $filePath := path.Join (slice "/" $splitBaseDir $versionDir $LogicalName) "/" */}}
   {{ $filePath := path.Join (slice "/" $splitBaseDir $versionDir) "/" }}
 
   {{ if not ($.Site.GetPage $filePath) }}

--- a/themes/docs-new/layouts/partials/versioned-docs-dropdown.html
+++ b/themes/docs-new/layouts/partials/versioned-docs-dropdown.html
@@ -21,21 +21,26 @@
   {{ $formalProductName = "Name Missing" }}
 {{ end }}
 
-{{ $versions := index .Site.Params $product }}
+{{ $versions := index .Site.Params $product "versions" }}
 
-{{ $sorted_versions := sort $versions.versions "value" "desc" }}
+{{ $float_string_versions := slice }}
+{{ range $versions }}
+  {{ $float_string_versions = $float_string_versions | append (replaceRE "_" "." . ) }}
+{{ end }}
 
-{{ $float_versions := slice }}
-{{ range sort $versions.versions "value" "desc" }}
-  {{$float_versions = $float_versions | append (float (replaceRE "_" "." . )) }}
+{{ $float_string_versions = sort $float_string_versions "value" "desc" }}
+
+{{ $sorted_versions := slice }}
+{{ range $float_string_versions }}
+  {{ $sorted_versions = $sorted_versions | append (replaceRE "\\." "_" . ) }}
 {{ end }}
 
 <div id="chef-product-version-dropdown" data-chef-product-key="{{ $product }}" data-default-version="{{ $product }}_{{ (index $sorted_versions 0) }}">
   <label id="chef-product-version-dropdown-label" for="chef_product">Version:</label>
   <select id="chef-product-version-dropdown-select" name="chef_product" onchange="selectProductVersion()" >
-    {{ range $version_index, $float_version := $float_versions }}
-      <option data-product="{{ $product }}" data-version="{{ lang.NumFmt 1 $float_version }}" value="{{ $product }}_{{ index $sorted_versions $version_index }}">
-        {{$formalProductName}} {{ lang.NumFmt 1 $float_version }}
+    {{ range $version_index, $float_version := $float_string_versions }}
+      <option data-product="{{ $product }}" data-version="{{  $float_version }}" value="{{ $product }}_{{ index $sorted_versions $version_index }}">
+        {{$formalProductName}} {{ $float_version }}
       </option>
     {{ end }}
   </select>


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This modifies how the versioned docs layout works so it will handle version numbers that are major/minor and just major. Currently it will take a major version number and put it after major/minor version numbers. 

This will put those numbers in the proper order.

This PR doesn't change anything with the way these pages are generated, but these are the relevant pages:
https://deploy-preview-2968--chef-web-docs.netlify.app/server/config_rb_server/
https://deploy-preview-2968--chef-web-docs.netlify.app/server/config_rb_server_optional_settings/

### Definition of Done

### Issues Resolved

#2966

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
