### PR TITLE
also change the versioned_content layout

### DIFF
--- a/themes/docs-new/layouts/partials/versioned-docs-content.html
+++ b/themes/docs-new/layouts/partials/versioned-docs-content.html
@@ -24,8 +24,21 @@
   {{ errorf "No matching product name. Current valid version_docs_product values are chef-server, chef, chef-workstation, inspec, habitat, and desktop-config." }}
 {{ end }}
 
-{{ $versions := index .Site.Params $product }}
-{{ range $version_index, $version := (sort $versions.versions "value" "desc") }}
+{{ $versions := index .Site.Params $product "versions" }}
+
+{{ $float_string_versions := slice }}
+{{ range $versions }}
+  {{ $float_string_versions = $float_string_versions | append (replaceRE "_" "." . ) }}
+{{ end }}
+
+{{ $float_string_versions = sort $float_string_versions "value" "desc" }}
+
+{{ $sorted_versions := slice }}
+{{ range $float_string_versions }}
+  {{ $sorted_versions = $sorted_versions | append (replaceRE "\\." "_" . ) }}
+{{ end }}
+
+{{ range $version_index, $version := $sorted_versions }}
   {{ $versionDir := delimit (slice "v" $version) "" }}
   {{ $filePath := path.Join (slice "/" $splitBaseDir $versionDir) "/" }}
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

I also have to adjust the versioned content layout to handle major version numbers properly. Without this it could add the note warning that the user is looking at an older version of the docs to a more recent version. This will sort things properly. 


https://deploy-preview-2971--chef-web-docs.netlify.app/server/config_rb_server/
https://deploy-preview-2971--chef-web-docs.netlify.app/server/config_rb_server_optional_settings/


### Definition of Done

### Issues Resolved

#2966

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
