### PR TITLE
change date format in page footer

### DIFF
--- a/themes/docs-new/layouts/partials/footer.html
+++ b/themes/docs-new/layouts/partials/footer.html
@@ -12,7 +12,7 @@
           <li><a href="https://www.chef.io/cookie-policy/" target="_blank">Cookie Policy</a></li>
         </ul>
         {{ if and (ne .Kind "taxonomy") (ne .Kind "taxonomyTerm") (ne .Kind "404")}}
-          <p class="modified">Page Last Modified: {{ .Lastmod }}</p>
+          <p class="modified">Page Last Modified: {{ dateFormat "January 2, 2006" .Lastmod }}</p>
         {{ end }}
         <p class="legal">Copyright &copy; {{ now.Format "2006" }} Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.</p>
       </div>


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description
Change date format from `2021-02-22 14:07:50 -0800 -0800` to `February 22, 2021`.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
