### PR TITLE
Improve WS nav

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -895,7 +895,7 @@ identifier = "chef_workstation"
   title = "Chef Workstation Tools"
   identifier = "chef_workstation/chef_workstation_tools"
   parent = "chef_workstation"
-  weight = 40
+  weight = 90
 
     [[menu.workstation]]
     title = "chef (executable)"


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### Description

In tandem with https://github.com/chef/chef-workstation/pull/1800/, this PR makes the WS nav consistent with the consolidated site nav style and also makes it easier to follow.

* Bumps Chef Workstation Tools to bottom of nav, to the "reference" location. Does not rename entry.



### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
