### PR TITLE
Remove odd/even classes from HTML tables

### DIFF
--- a/content/api_omnitruck.md
+++ b/content/api_omnitruck.md
@@ -97,73 +97,73 @@ Omnitruck accepts the following platforms:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>AIX</td>
 <td><code>aix</code></td>
 <td><code>powerpc</code></td>
 <td><code>6.1</code>, <code>7.1</code>, <code>7.2</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Amazon Linux</td>
 <td><code>amazon</code></td>
 <td><code>x86_64</code>,<code>aarch64</code></td>
 <td><code>201X, 2</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Cisco IOS XR</td>
 <td><code>ios_xr</code></td>
 <td><code>x86_64</code></td>
 <td><code>6</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Cisco NX-OS</td>
 <td><code>nexus</code></td>
 <td><code>x86_64</code></td>
 <td><code>7</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Debian</td>
 <td><code>debian</code></td>
 <td><code>i386</code>, <code>x86_64</code></td>
 <td><code>6</code>, <code>7</code>, <code>8</code>, <code>9</code>, <code>10</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>FreeBSD</td>
 <td><code>freebsd</code></td>
 <td><code>x86_64</code></td>
 <td><code>9</code>, <code>10</code>, <code>11</code>, <code>12</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>macOS</td>
 <td><code>mac_os_x</code></td>
 <td><code>x86_64</code></td>
 <td><code>10.6</code>, <code>10.7</code>, <code>10.8</code>, <code>10.9</code>, <code>10.10</code>, <code>10.11</code>, <code>10.12</code>, <code>10.13</code>, <code>10.14</code>, <code>10.15</code>, <code>11.0</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Solaris</td>
 <td><code>solaris2</code></td>
 <td><code>i386</code>, <code>sparc</code></td>
 <td><code>5.10</code>, <code>5.11</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>SUSE Linux Enterprise Server</td>
 <td><code>sles</code></td>
 <td><code>x86_64</code>, <code>s390x</code>, <code>aarch64</code></td>
 <td><code>11</code>, <code>12</code>, <code>15</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Red Hat Enterprise Linux / CentOS</td>
 <td><code>el</code></td>
 <td><code>i386</code>, <code>x86_64</code>, <code>ppc64</code>, <code>ppc64le</code>, <code>aarch64</code></td>
 <td><code>5</code>, <code>6</code>, <code>7</code>, <code>8</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Ubuntu</td>
 <td><code>ubuntu</code></td>
 <td><code>i386</code>, <code>x86_64</code>, <code>aarch64</code>, <code>ppc64le</code></td>
 <td><code>10.04</code>, <code>10.10</code>, <code>11.04</code>, <code>11.10</code>, <code>12.04</code>, <code>12.10</code>, <code>13.04</code>, <code>13.10</code>, <code>14.04</code>, <code>14.10</code>, <code>16.04</code>, <code>16.10</code>, <code>17.04</code>, <code>17.10</code>, <code>18.04</code>, <code>20.04</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Microsoft Windows</td>
 <td><code>windows</code></td>
 <td><code>x86_64</code>, <code>i386</code></td>

--- a/content/attribute_types.md
+++ b/content/attribute_types.md
@@ -26,30 +26,29 @@ gh_repo = "chef-web-docs"
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>default</code></td>
 <td>{{< readFile_shortcode file="node_attribute_type_default.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>force_default</code></td>
 <td>{{< readFile_shortcode file="node_attribute_type_force_default.md" >}}</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>normal</code></td>
 <td>{{< readFile_shortcode file="node_attribute_type_normal.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>override</code></td>
 <td>{{< readFile_shortcode file="node_attribute_type_override.md" >}}</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>force_override</code></td>
 <td>{{< readFile_shortcode file="node_attribute_type_force_override.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>automatic</code></td>
 <td>{{< readFile_shortcode file="node_attribute_type_automatic.md" >}}</td>
 </tr>
 </tbody>
 </table>
-

--- a/content/aws_marketplace.md
+++ b/content/aws_marketplace.md
@@ -290,15 +290,15 @@ from the AWS Marketplace:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>443</td>
 <td>HTTPS for Chef Automate</td>
 </tr>
-<tr class="even">
+<tr>
 <td>8989</td>
 <td>Git access for the delivery-cli and workflow</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>22</td>
 <td>SSH</td>
 </tr>

--- a/content/chef_client_overview.md
+++ b/content/chef_client_overview.md
@@ -28,7 +28,7 @@ executable can be run as a daemon.
 <col style="width: 80%" />
 </colgroup>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><img src="/images/icon_chef_client.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>{{< readFile_shortcode file="chef_client_summary.md" >}}</p>
 <p>{{< readFile_shortcode file="security_key_pairs_chef_client.md" >}}</p></td>

--- a/content/chef_client_security.md
+++ b/content/chef_client_security.md
@@ -103,27 +103,27 @@ Use following client.rb settings to manage SSL certificate preferences:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>local_key_generation</code></td>
 <td>Whether the Chef Infra Server or Chef Infra Client generates the private/public key pair. When <code>true</code>, Chef Infra Client generates the key pair, and then sends the public key to the Chef Infra Server. Default value: <code>true</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ssl_ca_file</code></td>
 <td>The file in which the OpenSSL key is saved. Chef Infra Client generates this setting automatically and most users do not need to modify it.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ssl_ca_path</code></td>
 <td>The path to where the OpenSSL key is located. Chef Infra Client generates this setting automatically and most users do not need to modify it.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ssl_client_cert</code></td>
 <td>The OpenSSL X.509 certificate used for mutual certificate validation. This setting is only necessary when mutual certificate validation is configured on the Chef Infra Server. Default value: <code>nil</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ssl_client_key</code></td>
 <td>The OpenSSL X.509 key used for mutual certificate validation. This setting is only necessary when mutual certificate validation is configured on the Chef Infra Server. Default value: <code>nil</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>ssl_verify_mode</code></p></td>
 <td><p>Set the verify mode for HTTPS requests.</p>
 <ul>
@@ -132,7 +132,7 @@ Use following client.rb settings to manage SSL certificate preferences:
 </ul>
 <p>Depending on how OpenSSL is configured, the <code>ssl_ca_path</code> may need to be specified. Default value: <code>:verify_peer</code>.</p></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>verify_api_cert</code></td>
 <td>Verify the SSL certificate on the Chef Infra Server. When <code>true</code>, Chef Infra Client always verifies the SSL certificate. When <code>false</code>, Chef Infra Client uses the value of <code>ssl_verify_mode</code> to determine if the SSL certificate requires verification. Default value: <code>false</code>.</td>
 </tr>

--- a/content/chef_deprecations_client.md
+++ b/content/chef_deprecations_client.md
@@ -110,241 +110,241 @@ of Chef comes out.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_internal_api/">CHEF-0</a></td>
 <td>Many internal APIs have been improved.</td>
 <td>various</td>
 <td>varies</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_json_auto_inflate/">CHEF-1</a></td>
 <td>Consumers of JSON are now required to be explicit in how it is turned in to a Chef object.</td>
 <td>12.7</td>
 <td>13.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_exit_code/">CHEF-2</a></td>
 <td>Chef's exit codes are now defined so that it's easy to understand why Chef exited.</td>
 <td>12.11</td>
 <td>13.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_chef_gem_compile_time/">CHEF-3</a></td>
 <td>When using the <code>chef_gem</code> resource, the phase to install the gem in must be specified.</td>
 <td>12.1</td>
 <td>13.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_attributes/">CHEF-4</a></td>
 <td>Various improvements have been made to attribute syntax.</td>
 <td>various</td>
 <td>varies</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_custom_resource_cleanups/">CHEF-5</a></td>
 <td>Various improvements have been made to custom resource syntax.</td>
 <td>various</td>
 <td>varies</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_easy_install/">CHEF-6</a></td>
 <td>The <code>easy_install</code> resource will be removed.</td>
 <td>12.10</td>
 <td>13.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_verify_file/">CHEF-7</a></td>
 <td>The <code>verify</code> metaproperty's <code>file</code> substitution will be removed.</td>
 <td>12.5</td>
 <td>13.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_supports_property/">CHEF-8</a></td>
 <td>The <code>supports</code> metaproperty will be removed.</td>
 <td>12.14</td>
 <td>13.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_chef_rest/">CHEF-9</a></td>
 <td>The <code>Chef::REST</code> API will be removed.</td>
 <td>12.7</td>
 <td>13.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_dnf_package_allow_downgrade/">CHEF-10</a></td>
 <td>DNF package provider and resource do not require <code>--allow-downgrade</code> anymore.</td>
 <td>12.18</td>
 <td>13.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_property_name_collision/">CHEF-11</a></td>
 <td>An exception will be raised if a resource property conflicts with an already-existing property or method.</td>
 <td>12.19</td>
 <td>13.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_launchd_hash_property/">CHEF-12</a></td>
 <td>An exception will be raised whenever the <code>hash</code> property in the launchd resource is used.</td>
 <td>12.19</td>
 <td>13.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_chef_platform_methods/">CHEF-13</a></td>
 <td>Deprecated <code>Chef::Platform</code> methods</td>
 <td>12.18</td>
 <td>13.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_run_command/">CHEF-14</a></td>
 <td>Deprecation of run_command</td>
 <td>12.18</td>
 <td>13.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_local_listen/">CHEF-18</a></td>
 <td>Deprecation of local mode listening.</td>
 <td>13.1</td>
 <td>15.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_namespace_collisions/">CHEF-19</a></td>
 <td>Deprecation of <code>property_name</code> within actions.</td>
 <td>13.2</td>
 <td>14.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_deploy_resource/">CHEF-20</a></td>
 <td>Deprecation of the <code>deploy</code> resource.</td>
 <td>13.6</td>
 <td>14.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_chocolatey_uninstall/">CHEF-21</a></td>
 <td>Deprecation of the <code>:uninstall</code> action in the <code>chocolatey_package</code> resource.</td>
 <td>13.7</td>
 <td>14.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_erl_call_resource/">CHEF-22</a></td>
 <td>Deprecation of the <code>erl_call</code> resource.</td>
 <td>13.7</td>
 <td>14.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_legacy_hwrp_mixins/">CHEF-23</a></td>
 <td>Deprecation of legacy HWRP mixins.</td>
 <td>12.X</td>
 <td>14.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_epic_fail/">CHEF-24</a></td>
 <td>Deprecation of <code>epic_fail</code> in favor of <code>allow_failure</code></td>
 <td>13.7</td>
 <td>14.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_map_collision/">CHEF-25</a></td>
 <td>Resource(s) in a cookbook collide with the same resource(s) now included in Chef.</td>
 <td>XX.X</td>
 <td>15.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_locale_lc_all/">CHEF-27</a></td>
 <td>Deprecation of lc_all from locale resource</td>
 <td>15.0</td>
 <td>16.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_resource_name_without_provides/">CHEF-31</a></td>
 <td>Deprecation of resource_name declaration without provides</td>
 <td>15.13</td>
 <td>16.2</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_resource_cloning/">CHEF-3694</a></td>
 <td>Resource Cloning will no longer work.</td>
 <td>10.18</td>
 <td>13.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_ohai_legacy_config/">OHAI-1</a></td>
 <td>Ohai::Config removal.</td>
 <td>12.6</td>
 <td>13.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_ohai_sigar_plugins/">OHAI-2</a></td>
 <td>Sigar gem based plugins removal.</td>
 <td>12.19</td>
 <td>13.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_ohai_run_command_helpers/">OHAI-3</a></td>
 <td>run_command and popen4 helper method removal.</td>
 <td>12.8</td>
 <td>13.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_ohai_libvirt_plugin/">OHAI-4</a></td>
 <td>Libvirt plugin attributes changes.</td>
 <td>12.19</td>
 <td>14.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_ohai_windows_cpu/">OHAI-5</a></td>
 <td>Windows CPU plugin attribute changes.</td>
 <td>12.19</td>
 <td>13.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_ohai_digitalocean/">OHAI-6</a></td>
 <td>DigitalOcean plugin attribute changes.</td>
 <td>12.19</td>
 <td>13.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_ohai_amazon_linux/">OHAI-7</a></td>
 <td>Amazon linux moved to the Amazon platform_family.</td>
 <td>13.0</td>
 <td>13.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_ohai_cloud/">OHAI-8</a></td>
 <td>Cloud plugin replaced by the Cloud_V2 plugin.</td>
 <td>13.0</td>
 <td>13.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_ohai_filesystem/">OHAI-9</a></td>
 <td>Filesystem plugin replaced by the Filesystem V2 plugin.</td>
 <td>13.0</td>
 <td>13.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_ohai_v6_plugins/">OHAI-10</a></td>
 <td>Removal of support for Ohai version 6 plugins.</td>
 <td>11.12</td>
 <td>14.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_ohai_cloud_v2/">OHAI-11</a></td>
 <td>Cloud_v2 attribute removal.</td>
 <td>13.1</td>
 <td>14.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_ohai_filesystem_v2/">OHAI-12</a></td>
 <td>Filesystem2 attribute removal.</td>
 <td>13.1</td>
 <td>14.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/deprecations_ohai_ipscopes/">OHAI-13</a></td>
 <td>Removal of IpScopes plugin</td>
 <td>13.2</td>
 <td>14.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/deprecations_ohai_system_profile/">OHAI-14</a></td>
 <td>Removal of system_profile plugin</td>
 <td>14.6</td>

--- a/content/chef_license_accept.md
+++ b/content/chef_license_accept.md
@@ -177,15 +177,15 @@ products when they are distributed as Habitat packages.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Chef Infra Server</td>
 <td>&gt;= 13.0</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Chef Automate</td>
 <td>&gt;= 2.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Supermarket</td>
 <td>&gt;= 4.0</td>
 </tr>

--- a/content/chef_overview.md
+++ b/content/chef_overview.md
@@ -56,33 +56,33 @@ Chef Infra has the following major components:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><img src="/images/icon_workstation.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>One (or more) workstations are configured to allow users to author, test, and maintain cookbooks.</p>
 <p>Workstation systems run the Chef Workstation package which includes tools such as Chef Infra Client, Chef InSpec, Test Kitchen, ChefSpec, Cookstyle, and other tools necessary for developing and testing your infrastructure with Chef products.</p></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><img src="/images/icon_cookbook.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>Cookbooks are uploaded to the Chef Infra Server from these workstations. Some cookbooks are custom to the organization and others are based on community cookbooks available from the Chef Supermarket.</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><img src="/images/icon_ruby.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>Ruby is the programming language that is the authoring syntax for cookbooks. Most recipes are simple patterns (blocks that define properties and values that map to specific configuration items like packages, files, services, templates, and users. The full power of Ruby is available for when you need a programming language.</p></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><img src="/images/icon_node.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>{{< readFile_shortcode file="node.md" >}}</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><img src="/images/icon_chef_client.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>Chef Infra Client is installed on each node that is managed with Chef Infra. Chef Infra Client configures the node locally by performing the tasks specified in the run-list. Chef Infra Client will also pull down any required configuration data from the Chef Infra Server during a Chef Infra Client run.</p></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><img src="/images/icon_chef_server.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>The Chef Infra Server acts as a hub of information. Cookbooks and policy settings are uploaded to the Chef Infra Server by users from workstations.</p>
 <p>The Chef Infra Client accesses the Chef Infra Server from the node on which it's installed to get configuration data, performs searches of historical Chef Infra Client run data, and then pulls down the necessary configuration data. After a Chef Infra Client run is finished, the Chef Infra Client uploads updated run data to the Chef Infra Server.</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_chef_supermarket.svg" class="align-center" width="100" alt="image" /></td>
 <td>Chef Supermarket is the location in which community cookbooks are shared and managed. Cookbooks that are part of the Chef Supermarket may be used by any Chef user. How community cookbooks are used varies from organization to organization.</td>
 </tr>
@@ -125,11 +125,11 @@ Some important tools and components of Chef Workstation include:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_workstation.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="chef_workstation.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><img src="/images/icon_ctl_chef.svg" class="align-center" width="100" alt="image" /></p>
 <p><img src="/images/icon_ctl_knife.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>Chef Workstation includes important command-line tools:</p>
@@ -143,7 +143,7 @@ Some important tools and components of Chef Workstation include:
 <li>Chef Workstation App: for updating and managing your chef tools</li>
 </ul></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><img src="/images/icon_repository.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>The chef-repo is the repository structure in which cookbooks are authored, tested, and maintained:</p>
 <ul>
@@ -152,11 +152,11 @@ Some important tools and components of Chef Workstation include:
 </ul>
 <p>The directory structure within the chef-repo varies. Some organizations prefer to keep all of their cookbooks in a single chef-repo, while other organizations prefer to use a chef-repo for every cookbook.</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_kitchen.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="test_kitchen.md" >}}</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_chefspec.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="chefspec_summary.md" >}}</td>
 </tr>
@@ -190,39 +190,39 @@ Cookbooks are comprised of the following components:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_cookbook_attributes.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="cookbooks_attribute.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_cookbook_files.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="resource_cookbook_file_summary.md" >}}</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_cookbook_libraries.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="libraries_summary.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_cookbook_metadata.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="cookbooks_metadata.md" >}}</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><img src="/images/icon_cookbook_recipes.svg" class="align-center" width="100" alt="image" /></p>
 <p><img src="/images/icon_recipe_dsl.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>{{< readFile_shortcode file="cookbooks_recipe.md" >}}</p>
 <p>The Chef Infra Client will run a recipe only when asked. When the Chef Infra Client runs the same recipe more than once, the results will be the same system state each time. When a recipe is run against a system, but nothing has changed on either the system or in the recipe, the Chef Infra Client won't change anything.</p>
 <p>{{< readFile_shortcode file="infra_lang_summary.md" >}}</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><img src="/images/icon_cookbook_resources.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>{{< readFile_shortcode file="resources_common.md" >}}</p>
 <p>Chef has <a href="/resources/">many built-in resources</a> that cover all of the most common actions across all of the most common platforms. You can <a href="/custom_resources/">build your own resources</a> to handle any situation that isn't covered by a built-in resource.</p></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_cookbook_templates.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="template.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_cookbook_tests.svg" class="align-center" width="100" alt="image" /></td>
 <td>Testing cookbooks improves the quality of those cookbooks by ensuring they are doing what they are supposed to do and that they are authored in a consistent manner. Unit and integration testing validates the recipes in cookbooks. Syntax testing---often called linting---validates the quality of the code itself. The following tools are popular tools used for testing Chef recipes: Test Kitchen, ChefSpec, and Cookstyle.</td>
 </tr>
@@ -253,12 +253,12 @@ The key components of nodes that are under management by Chef include:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><img src="/images/icon_chef_client.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>{{< readFile_shortcode file="chef_client_summary.md" >}}</p>
 <p>{{< readFile_shortcode file="security_key_pairs_chef_client.md" >}}</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_ohai.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="ohai_summary.md" >}}</td>
 </tr>
@@ -281,19 +281,19 @@ The key components of nodes that are under management by Chef include:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_search.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="search.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_manage.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="chef_manager.md" >}}</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_data_bags.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="data_bag.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_policy.svg" class="align-center" width="100" alt="image" /></td>
 <td>Policy defines how business and operational requirements, processes, and production workflows map to objects that are stored on the Chef Infra Server. Policy objects on the Chef Infra Server include roles, environments, and cookbook versions.</td>
 </tr>
@@ -318,19 +318,19 @@ Some important aspects of policy include:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_roles.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="role.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_environments.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="environment.md" >}}</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_cookbook_versions.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="cookbooks_version.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_run_lists.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="node_run_list.md" >}}</td>
 </tr>

--- a/content/chef_repo.md
+++ b/content/chef_repo.md
@@ -34,19 +34,19 @@ The sub-directories in the chef-repo are:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>.chef/</code></td>
 <td>A hidden directory that is used to store validation key files and optionally a <a href="/config_rb/">config.rb</a> file.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>cookbooks/</code></td>
 <td>Contains cookbooks that have been downloaded from the <a href="https://supermarket.chef.io/">Chef Supermarket</a> or created locally.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>data_bags/</code></td>
 <td>Stores data bags (and data bag items) in JSON (.json) format.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>policyfiles/</code></td>
 <td>Stores Policyfiles in Ruby (.rb) format.</td>
 </tr>

--- a/content/chef_search.md
+++ b/content/chef_search.md
@@ -37,23 +37,23 @@ following search indexes are built:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>client</code></td>
 <td>API client</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>DATA_BAG_NAME</code></td>
 <td>A data bag is a global variable that is stored as JSON data and is accessible from a Chef Infra Server. The name of the search index is the name of the data bag. For example, if the name of the data bag was "admins" then a corresponding search query might look something like <code>search(:admins, "*:*")</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>environment</code></td>
 <td>An environment is a way to map an organization's real-life workflow to what can be configured and managed when using Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>node</code></td>
 <td>A node is any server or virtual server that is configured to be maintained by a Chef Infra Client.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>role</code></td>
 <td>A role is a way to define certain patterns and processes that exist across nodes in an organization as belonging to a single job function.</td>
 </tr>
@@ -225,13 +225,13 @@ on the node.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p>Top-level</p></td>
 <td><p>To find a node with a role in the top-level of its run-list, search within the <code>role</code> field (and escaping any special characters with the slash symbol) using the following syntax:</p>
 <pre><code>role:ROLE_NAME</code></pre>
 <p>where <code>role</code> (singular!) indicates the top-level run-list.</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p>Expanded</p></td>
 <td><p>To find a node with a role in an expanded run-list, search within the <code>roles</code> field (and escaping any special characters with the slash symbol) using the following syntax:</p>
 <pre><code>roles:ROLE_NAME</code></pre>
@@ -304,14 +304,14 @@ on the node.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p>In a specified recipe</p></td>
 <td><p>To find a node with a specified recipe in the run-list, search within the <code>run_list</code> field (and escaping any special characters with the slash symbol) using the following syntax:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb1-1"><a href="#cb1-1"></a>search(<span class="st">:node</span>, <span class="st">&#39;run_list:recipe\[foo\:\:bar\]&#39;</span>)</span></code></pre></div>
 <p>where <code>recipe</code> (singular!) indicates the top-level run-list. Variables can be interpolated into search strings using the Ruby alternate quoting syntax:</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb2-1"><a href="#cb2-1"></a>search(<span class="st">:node</span>,<span class="ot"> %Q{</span><span class="st">run_list:&quot;recipe[</span><span class="ot">#{</span>the_recipe<span class="ot">}</span><span class="st">]&quot;</span><span class="ot">}</span> )</span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p>In an expanded run-list</p></td>
 <td><p>To find a node with a recipe in an expanded run-list, search within the <code>recipes</code> field (and escaping any special characters with the slash symbol) using the following syntax:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb3-1"><a href="#cb3-1"></a>recipes<span class="st">:RECIPE_NAME</span></span></code></pre></div>

--- a/content/community_contributions.md
+++ b/content/community_contributions.md
@@ -54,31 +54,31 @@ of issues and bug reports:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Chef Infra Client</td>
 <td><a href="https://github.com/chef/chef">https://github.com/chef/chef</a></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Ohai</td>
 <td><a href="https://github.com/chef/ohai">https://github.com/chef/ohai</a></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Chef Workstation</td>
 <td><a href="https://github.com/chef/chef-workstation">https://github.com/chef/chef-workstation</a></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Chef InSpec</td>
 <td><a href="https://github.com/inspec/inspec">https://github.com/inspec/inspec</a></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Chef Infra Server</td>
 <td><a href="https://github.com/chef/chef-server">https://github.com/chef/chef-server</a></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Chef Habitat</td>
 <td><a href="https://github.com/habitat-sh/habitat">https://github.com/habitat-sh/habitat</a></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Chef Automate</td>
 <td><a href="https://github.com/chef/automate">https://github.com/chef/automate</a></td>
 </tr>

--- a/content/community_guidelines.md
+++ b/content/community_guidelines.md
@@ -169,17 +169,17 @@ the person(s) assigned to each role:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Decider</td>
 <td>Jenny Armstrong-Owen</td>
 <td><a href="mailto:jowen@chef.io">jowen@chef.io</a></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Community Advocate</td>
 <td>Benny Vasquez</td>
 <td><a href="mailto:bvasquez@chef.io">bvasquez@chef.io</a></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Community Advocate</td>
 <td>Robb Kidd</td>
 <td><a href="mailto:rkidd@chef.io">rkidd@chef.io</a></td>

--- a/content/config_rb_metadata.md
+++ b/content/config_rb_metadata.md
@@ -68,27 +68,27 @@ versions. There are a set of operators common to all fields:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Pessimistic (see note below)</td>
 <td><code>~&gt;</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Equal to</td>
 <td><code>=</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Greater than or equal to</td>
 <td><code>&gt;=</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Greater than</td>
 <td><code>&gt;</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Less than</td>
 <td><code>&lt;</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Less than or equal to</td>
 <td><code>&lt;=</code></td>
 </tr>

--- a/content/cookbook_versioning.md
+++ b/content/cookbook_versioning.md
@@ -121,7 +121,7 @@ not provided, `>= 0.0.0` is used as the default.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>depends</code></p></td>
 <td><p>Show that a cookbook has a dependency on another cookbook. Use a version constraint to define dependencies for cookbook versions: <code>&lt;</code> (less than), <code>&lt;=</code> (less than or equal to), <code>=</code> (equal to), <code>&gt;=</code> (greater than or equal to; also known as "optimistically greater than", or "optimistic"), <code>~&gt;</code> (approximately greater than; also known as "pessimistically greater than", or "pessimistic"), or <code>&gt;</code> (greater than). This field requires that a cookbook with a matching name and version exists on the Chef Infra Server. When the match exists, the Chef Infra Server includes the dependency as part of the set of cookbooks that are sent to the node when Chef Infra Client runs. It is very important that the <code>depends</code> field contain accurate data. If a dependency statement is inaccurate, Chef Infra Client may not be able to complete the configuration of the system. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb1-1"><a href="#cb1-1"></a>depends <span class="st">&#39;opscode-base&#39;</span></span></code></pre></div>
@@ -130,11 +130,11 @@ not provided, `>= 0.0.0` is used as the default.
 <p>or:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb3-1"><a href="#cb3-1"></a>depends <span class="st">&#39;runit&#39;</span>, <span class="st">&#39;~&gt; 1.2.3&#39;</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>provides</code></td>
 <td>Add a recipe, definition, or resource that is provided by this cookbook, should the auto-populated list be insufficient.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>supports</code></td>
 <td>Show that a cookbook has a supported platform. Use a version constraint to define dependencies for platform versions: <code>&lt;</code> (less than), <code>&lt;=</code> (less than or equal to), <code>=</code> (equal to), <code>&gt;=</code> (greater than or equal to), <code>~&gt;</code> (approximately greater than), or <code>&gt;</code> (greater than). To specify more than one platform, use more than one <code>supports</code> field, once for each platform.</td>
 </tr>

--- a/content/cookbooks.md
+++ b/content/cookbooks.md
@@ -49,42 +49,42 @@ files or directories.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="/recipes/">Recipes</a></td>
 <td>recipes/</td>
 <td>{{< readFile_shortcode file="cookbooks_recipe.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/attributes/">Attributes</a></td>
 <td>attributes/</td>
 <td>{{< readFile_shortcode file="cookbooks_attribute.md" >}}</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/files/">Files</a></td>
 <td>files/</td>
 <td>A file distribution is a specific type of resource that tells a cookbook how to distribute files, including by node, by platform, or by file version.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/libraries/">Libraries</a></td>
 <td>libraries/</td>
 <td>A library allows the use of arbitrary Ruby code in a cookbook, either as a way to extend the Chef Infra Client language or to implement a new class.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/custom_resources/">Custom Resources</a></td>
 <td>resources/</td>
 <td>A custom resource is an abstract approach for defining a set of actions and (for each action) a set of properties and validation parameters.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/templates/">Templates</a></td>
 <td>templates/</td>
 <td>A template is a file written in markup language that uses Ruby statements to solve complex configuration scenarios.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/ohai_custom/">Ohai Plugins</a></td>
 <td>ohai/</td>
 <td>Custom Ohai plugins can be written to load additional information about your nodes to be used in recipes. This requires Chef Infra Server 12.18.14 or later.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/config_rb_metadata/">Metadata</a></td>
 <td>metadata.rb</td>
 <td>This file contains information about the cookbook such as the cookbook name, description, and <a href="/cookbook_versioning/">version</a>.</td>
@@ -109,11 +109,11 @@ thousands of cookbooks created and maintained by the community:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/chef-cookbooks">Cookbooks Maintained by Chef</a></td>
 <td>Chef maintains a collection of cookbooks that are widely used by the community.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://supermarket.chef.io/cookbooks">Cookbooks Maintained by the Community</a></td>
 <td>The community has authored thousands of cookbooks, ranging from niche cookbooks that are used by only a few organizations to cookbooks that are some of the most popular and are used by nearly everyone.</td>
 </tr>

--- a/content/ctl_chef_client.md
+++ b/content/ctl_chef_client.md
@@ -213,11 +213,11 @@ This command has the following options:
     </tr>
     </thead>
     <tbody>
-    <tr class="odd">
+    <tr>
     <td><code>policy_group</code></td>
     <td>The name of a policy group that exists on the Chef Infra Server.</td>
     </tr>
-    <tr class="even">
+    <tr>
     <td><code>policy_name</code></td>
     <td>The name of a policy, as identified by the <code>name</code> setting in a Policyfile.rb file.</td>
     </tr>
@@ -869,12 +869,12 @@ platform:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>Chef::Provider::Service::Aix</code></td>
 <td><code>service</code></td>
 <td>The provider that is used with the AIX platforms. Use the <code>service</code> short name to start, stop, and restart services with System Resource Controller (SRC).</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>Chef::Provider::Service::AixInit</code></td>
 <td><code>service</code></td>
 <td>The provider that is used to manage BSD-based init services on AIX.</td>

--- a/content/debug.md
+++ b/content/debug.md
@@ -285,7 +285,7 @@ within a recipe may be located:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>ignore_failure</code></td>
 <td>Continue running a recipe if a resource fails for any reason. Default value: <code>false</code>.</td>
 </tr>

--- a/content/environments.md
+++ b/content/environments.md
@@ -52,11 +52,11 @@ There are two types of attributes that can be used with environments:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>default</code></td>
 <td>{{< readFile_shortcode file="node_attribute_type_default.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>override</code></td>
 <td>{{< readFile_shortcode file="node_attribute_type_override.md" >}}</td>
 </tr>
@@ -97,7 +97,7 @@ domain-specific attributes:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>cookbook</code></p></td>
 <td><p>A version constraint for a single cookbook. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb1-1"><a href="#cb1-1"></a>cookbook <span class="st">&#39;couchdb&#39;</span>, <span class="st">&#39;&lt; 11.0.0&#39;</span></span></code></pre></div>
@@ -106,7 +106,7 @@ domain-specific attributes:
 <p>or:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb3-1"><a href="#cb3-1"></a>cookbook <span class="st">&#39;gems&#39;</span>, <span class="st">&#39;~&gt; 1.4&#39;</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>cookbook_versions</code></p></td>
 <td><p>A version constraint for a group of cookbooks. For example:</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb4-1"><a href="#cb4-1"></a>cookbook_versions(</span>
@@ -114,22 +114,22 @@ domain-specific attributes:
 <span id="cb4-3"><a href="#cb4-3"></a>  <span class="st">&#39;my_rails_app&#39;</span> =&gt; <span class="st">&#39;~&gt; 1.2.0&#39;</span></span>
 <span id="cb4-4"><a href="#cb4-4"></a>)</span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>default_attributes</code></p></td>
 <td><p>Optional. A set of attributes to be applied to all nodes, assuming the node does not already have a value for the attribute. This is useful for setting global defaults that can then be overridden for specific nodes. If more than one role attempts to set a default value for the same attribute, the last role applied is the role to set the attribute value. When nested attributes are present, they are preserved. For example, to specify that a node that has the attribute <code>apache2</code> should listen on ports 80 and 443 (unless ports are already specified):</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb5-1"><a href="#cb5-1"></a>default_attributes <span class="st">&#39;apache2&#39;</span> =&gt; { <span class="st">&#39;listen_ports&#39;</span> =&gt;<span class="ot"> %w(</span><span class="st">80 443</span><span class="ot">)</span> }</span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>description</code></p></td>
 <td><p>A description of the functionality that is covered. For example:</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb6-1"><a href="#cb6-1"></a>description <span class="st">&#39;The development environment&#39;</span></span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>name</code></p></td>
 <td><p>A unique name within the organization. Each name must be made up of letters (upper- and lower-case), numbers, underscores, and hyphens: [A-Z][a-z][0-9] and [_-]. Spaces are not allowed. For example:</p>
 <div class="sourceCode" id="cb7"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb7-1"><a href="#cb7-1"></a>name <span class="st">&#39;dev01-24&#39;</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>override_attributes</code></p></td>
 <td><p>Optional. A set of attributes to be applied to all nodes, even if the node already has a value for an attribute. This is useful for ensuring that certain attributes always have specific values. If more than one role attempts to set an override value for the same attribute, the last role applied wins. When nested attributes are present, they are preserved. For example:</p>
 <div class="sourceCode" id="cb8"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb8-1"><a href="#cb8-1"></a>override_attributes <span class="st">&#39;apache2&#39;</span> =&gt; { <span class="st">&#39;max_children&#39;</span> =&gt; <span class="st">&#39;50&#39;</span> }</span></code></pre></div>
@@ -253,11 +253,11 @@ The JSON format has two additional settings:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>chef_type</code></td>
 <td>Always set this to <code>environment</code>. Use this setting for any custom process that consumes environment objects outside of Ruby.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>json_class</code></td>
 <td>Always set this to <code>Chef::Environment</code>. Chef Infra Client uses this setting to auto-inflate an environment object. If objects are being rebuilt outside of Ruby, ignore it.</td>
 </tr>

--- a/content/handlers.md
+++ b/content/handlers.md
@@ -46,11 +46,11 @@ following settings must be added:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>exception_handlers</code></td>
 <td>A list of exception handlers that are available to Chef Infra Client during a Chef Infra Client run.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>report_handlers</code></td>
 <td>A list of report handlers that are available to Chef Infra Client during a Chef Infra Client run.</td>
 </tr>
@@ -107,7 +107,7 @@ following setting:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>start_handlers</code></td>
 <td>A list of start handlers that are available to Chef Infra Client at the start of a Chef Infra Client run.</td>
 </tr>

--- a/content/infra_language/checking_platforms.md
+++ b/content/infra_language/checking_platforms.md
@@ -41,103 +41,103 @@ where:
 </tr>
 </thead>
 <tbody>
-<tr class="even">
+<tr>
 <td><code>aix</code></td>
 <td>IBM AIX</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>alibabalinux</code></td>
 <td>Alibaba Cloud Linux</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>amazon</code></td>
 <td>Amazon Linux</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>arch</code></td>
 <td>Arch Linux</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>clearos</code></td>
 <td>ClearOS</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>cloudlinux</code></td>
 <td>Cloud Linux OS</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>cumulus</code></td>
 <td>NVIDIA Cumulus Linux</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>debian</code></td>
 <td>Debian GNU/Linux</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>fedora</code></td>
 <td>Fedora</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>freebsd</code></td>
 <td>FreeBSD</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>gentoo</code></td>
 <td>Gentoo Linux</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>linuxmint</code></td>
 <td>Linux Mint</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>mac_os_x</code></td>
 <td>macOS</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>netbsd</code></td>
 <td>NetBSD</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>openbsd</code></td>
 <td>OpenBSD</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>openindiana</code></td>
 <td>OpenIndiana</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>opensuseleap</code></td>
 <td>openSUSE leap</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>pidora</code></td>
 <td>Pidora</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>raspbian</code></td>
 <td>Raspberry Pi OS</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>scientific</code></td>
 <td>Scientific Linux</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>solaris2</code></td>
 <td>Oracle Solaris</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>suse</code></td>
 <td>SUSE Enterprise Linux Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ubuntu</code></td>
 <td>Ubuntu Linux</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>windows</code></td>
 <td>Microsoft Windows</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>xenserver</code></td>
 <td>Citrix XenServer</td>
 </tr>
@@ -195,67 +195,67 @@ where:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>aix</code></td>
 <td><code>aix</code> platform.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>alpine</code></td>
 <td><code>alpine</code> platform.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>amazon</code></td>
 <td><code>amazon</code> platform.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>arch</code></td>
 <td><code>arch</code>, <code>manjaro</code>, and <code>antergos</code> platforms.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>debian</code></td>
 <td><code>debian</code>, <code>ubuntu</code>, <code>linuxmint</code>, <code>raspbian</code>, <code>cumulus</code>, <code>kali</code>, <code>sangoma</code>, and <code>pop</code> platforms.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>fedora</code></td>
 <td><code>fedora</code>, <code>pidora</code>, and <code>arista_eos</code> platforms</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>freebsd</code></td>
 <td><code>freebsd</code> platform</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>gentoo</code></td>
 <td><code>gentoo</code> platform</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>mac_os_x</code></td>
 <td><code>mac_os_x</code> platform</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>netbsd</code></td>
 <td><code>netbsd</code> platform</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>openbsd</code></td>
 <td><code>openbsd</code> platform</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>openindiana</code></td>
 <td><code>openindiana</code> platform</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>rhel</code></td>
 <td><code>redhat</code>, <code>centos</code>, <code>oracle</code>, <code>scientific</code>, <code>xenserver</code>, <code>clearos</code>, <code>bigip</code>, <code>parallels</code>, <code>xcp</code>, <code>alibabalinux</code>, and <code>ibm_powerkvm</code> platforms</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>solaris2</code></td>
 <td><code>solaris2</code> platform</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>suse</code></td>
 <td><code>opensuse_leap</code>, <code>suse</code>, and <code>sled</code> platforms</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>windows</code></td>
 <td><code>windows</code> platform</td>
 </tr>

--- a/content/nodes.md
+++ b/content/nodes.md
@@ -31,12 +31,12 @@ The key components of nodes that are under management by Chef include:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><img src="/images/icon_chef_client.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>{{< readFile_shortcode file="chef_client_summary.md" >}}</p>
 <p>{{< readFile_shortcode file="security_key_pairs_chef_client.md" >}}</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_ohai.svg" class="align-center" width="100" alt="image" /></td>
 <td>{{< readFile_shortcode file="ohai_summary.md" >}}</td>
 </tr>

--- a/content/packages.md
+++ b/content/packages.md
@@ -29,11 +29,11 @@ installation methods support the following release channels:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>stable</code></td>
 <td>A build from this channel is an "official" release that has passed full user acceptance testing. Artifacts in this channel are retained indefinitely.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>current</code></td>
 <td>A build from this channel is an "integration" build that has passed full testing, but has not been officially released. Artifacts in this channel are retained for 30 days and then removed automatically.</td>
 </tr>

--- a/content/plugin_community.md
+++ b/content/plugin_community.md
@@ -26,63 +26,63 @@ The following Ohai plugins are available from the open source community:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/demonccc/chef-ohai-plugins/blob/master/dell.rb">dell.rb</a></td>
 <td>Adds some useful Dell server information to Ohai. For example: service tag, express service code, storage info, RAC info, and so on. To use this plugin, OMSA and SMBIOS applications need to be installed.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://bitbucket.org/retr0h/ohai">ipmi.rb</a></td>
 <td>Adds a MAC address and an IP address to Ohai, where available.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/albertsj1/ohai-plugins/blob/master/kvm_extensions.rb">kvm_extensions.rb</a></td>
 <td>Adds extensions for virtualization attributes to provide additional host and guest information for KVM.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/demonccc/chef-ohai-plugins/blob/master/linux/ladvd.rb">ladvd.rb</a></td>
 <td>Adds ladvd information to Ohai, when it exists.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/jespada/ohai-plugins/blob/master/lxc_virtualization.rb">lxc_virtualization.rb</a></td>
 <td>Adds extensions for virtualization attributes to provide host and guest information for Linux containers.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://gist.github.com/1040543">network_addr.rb</a></td>
 <td>Adds extensions for network attributes with additional <code>ipaddrtype_iface</code> attributes to make it semantically easier to retrieve addresses.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/agoddard/ohai-plugins/blob/master/plugins/network_ports.rb">network_ports.rb</a></td>
 <td>Adds extensions for network attributes so that Ohai can detect to which interfaces TCP and UDP ports are bound.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/sbates/Chef-odds-n-ends/blob/master/ohai/parse_host_plugin.rb">parse_host_plugin.rb</a></td>
 <td>Adds the ability to parse a host name using three top-level attribute and five nested attributes.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/stevendanna/ohai-plugins/blob/master/plugins/r.rb">r.rb</a></td>
 <td>Adds the ability to collect basic information about the R Project.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/spheromak/cookbooks/blob/master/ohai/files/default/sysctl.rb">sysctl.rb</a></td>
 <td>Adds sysctl information to Ohai.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/albertsj1/ohai-plugins/blob/master/vserver.rb">vserver.rb</a></td>
 <td>Adds extensions for virtualization attributes to allow a Linux virtual server host and guest information to be used by Ohai.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/cloudant/ohai_plugins/blob/master/wtf.rb">wtf.rb</a></td>
 <td>Adds the irreverent wtfismyip.com service so that Ohai can determine a machine's external IPv4 address and geographical location.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/spheromak/cookbooks/blob/master/ohai/files/default/xenserver.rb">xenserver.rb</a></td>
 <td>Adds extensions for virtualization attributes to load up Citrix XenServer host and guest information.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/timops/ohai-plugins/blob/master/win32_software.rb">win32_software.rb</a></td>
 <td>Adds the ability for Ohai to use Windows Management Instrumentation (WMI) to discover useful information about software that is installed on any node that is running Microsoft Windows.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/timops/ohai-plugins/blob/master/win32_svc.rb">win32_svc.rb</a></td>
 <td>Adds the ability for Ohai to query using Windows Management Instrumentation (WMI) to get information about all services that are registered on a node that is running Microsoft Windows.</td>
 </tr>

--- a/content/plugin_knife.md
+++ b/content/plugin_knife.md
@@ -34,31 +34,31 @@ The following knife plug-ins are maintained by Chef:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/chef/knife-azure">knife-azure</a></td>
 <td>{{< readFile_shortcode file="knife_azure.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/chef/knife-ec2">knife-ec2</a></td>
 <td>Amazon EC2 is a web service that provides resizable compute capacity in the cloud, based on preconfigured operating systems and virtual application software using Amazon Machine Images (AMI). The <code>knife ec2</code> subcommand is used to manage API-driven cloud servers that are hosted by Amazon EC2.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/chef/knife-google">knife-google</a></td>
 <td>Google Compute Engine is a cloud hosting platform that offers scalable and flexible virtual machine computing. The <code>knife google</code> subcommand is used to manage API-driven cloud servers that are hosted by Google Compute Engine.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/chef/knife-openstack">knife-openstack</a></td>
 <td>The <code>knife openstack</code> subcommand is used to manage API-driven cloud servers that are hosted by OpenStack.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/chef/knife-rackspace">knife-rackspace</a></td>
 <td>Rackspace is a cloud-driven platform of virtualized servers that provide services for storage and data, platform and networking, and cloud computing. The <code>knife rackspace</code> subcommand is used to manage API-driven cloud servers that are hosted by Rackspace cloud services</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/chef/knife-vcenter">knife-vcenter</a></td>
 <td>The <code>knife vcenter</code> subcommand is used to provision systems with VMware vCenter.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/chef/knife-vsphere">knife-vsphere</a></td>
 <td>The <code>knife vsphere</code> subcommand is used to provision systems with VMware vSphere.</td>
 </tr>

--- a/content/plugin_knife_custom.md
+++ b/content/plugin_knife_custom.md
@@ -649,15 +649,15 @@ handling user interactions:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>ui.ask(*args, &amp;block)</code></td>
 <td></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ui.ask_question(question, opts={})</code></td>
 <td>Use to ask a user the question contained in <code>question</code>. If <code>:default =&gt; default_value</code> is passed as the second argument, <code>default_value</code> will be used if the user does not provide an answer. This method will respect the <code>--default</code> command-line option.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>ui.color(string, *colors)</code></p></td>
 <td><p>Use to specify a color. For example, from the <code>knife rackspace server list</code> subcommand:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb1-1"><a href="#cb1-1"></a>server_list = [</span>
@@ -678,63 +678,63 @@ handling user interactions:
 <span id="cb2-6"><a href="#cb2-6"></a>  puts <span class="st">&quot;</span><span class="ot">#{</span>ui.color(<span class="st">&quot;SSH Key&quot;</span>, <span class="st">:cyan</span>)<span class="ot">}</span><span class="st">: </span><span class="ot">#{</span>server.key_name<span class="ot">}</span><span class="st">&quot;</span></span>
 <span id="cb2-7"><a href="#cb2-7"></a>print <span class="st">&quot;\n</span><span class="ot">#{</span>ui.color(<span class="st">&quot;Waiting for server&quot;</span>, <span class="st">:magenta</span>)<span class="ot">}</span><span class="st">&quot;</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ui.color?()</code></td>
 <td>Indicates that colored output should be used. (Colored output can only be used when output is sent to a terminal.)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ui.confirm(question, append_instructions=true)</code></td>
 <td>Use to ask a Y/N question. If the user responds with <code>N</code>, immediately exit with status code 3.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ui.edit_data(data, parse_output=true)</code></td>
 <td>Use to edit data. This opens the $EDITOR.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ui.edit_object(klass, name)</code></td>
 <td></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ui.error</code></td>
 <td>Use to present an error to the user.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ui.fatal</code></td>
 <td>Use to present a fatal error to the user.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ui.highline</code></td>
 <td>Use to provide direct access to the <a href="http://highline.rubyforge.org/doc/">Highline object</a> used by many <code>ui</code> methods.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ui.info</code></td>
 <td>Use to present a message to a user.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ui.interchange</code></td>
 <td>Use to determine if the output is a data interchange format such as JSON or YAML.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ui.list(*args)</code></td>
 <td></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ui.msg(message)</code></td>
 <td>Use to present a message to the user.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ui.output(data)</code></td>
 <td>Use to present a data structure to the user. This method will respect the output requested when the <code>-F</code> command-line option is used. The output will use the generic default presenter.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ui.pretty_print(data)</code></td>
 <td>Use to enable pretty-print output for JSON data.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ui.use_presenter(presenter_class)</code></td>
 <td>Use to specify a custom output presenter.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ui.warn(message)</code></td>
 <td>Use to present a warning to the user.</td>
 </tr>

--- a/content/proxies.md
+++ b/content/proxies.md
@@ -77,15 +77,15 @@ environments that use an HTTP proxy:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>http_proxy</code></td>
 <td>The proxy server for HTTP connections. Default value: <code>nil</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>http_proxy_pass</code></td>
 <td>The password for the proxy server when the proxy server is using an HTTP connection. Default value: <code>nil</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>http_proxy_user</code></td>
 <td>The user name for the proxy server when the proxy server is using an HTTP connection. Default value: <code>nil</code>.</td>
 </tr>
@@ -109,15 +109,15 @@ environments that use an HTTPS proxy:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>https_proxy</code></td>
 <td>The proxy server for HTTPS connections. Default value: <code>nil</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>https_proxy_pass</code></td>
 <td>The password for the proxy server when the proxy server is using an HTTPS connection. Default value: <code>nil</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>https_proxy_user</code></td>
 <td>The user name for the proxy server when the proxy server is using an HTTPS connection. Default value: <code>nil</code>.</td>
 </tr>
@@ -141,15 +141,15 @@ environments that use an FTP proxy:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>ftp_proxy</code></td>
 <td>The proxy server for FTP connections.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ftp_proxy_pass</code></td>
 <td>The password for the proxy server when the proxy server is using an FTP connection. Default value: <code>nil</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ftp_proxy_user</code></td>
 <td>The user name for the proxy server when the proxy server is using an FTP connection. Default value: <code>nil</code>.</td>
 </tr>

--- a/content/release_notes_client.md
+++ b/content/release_notes_client.md
@@ -22,7 +22,7 @@ changelog](https://github.com/chef/chef/blob/master/CHANGELOG.md)
 ### Bugfixes
 
 - Resolved installation failures on some Windows systems
-- Fixed the `mount` resource for network mounts using the root level as the device. Thanks [@ramereth](https://github.com/ramereth)! 
+- Fixed the `mount` resource for network mounts using the root level as the device. Thanks [@ramereth](https://github.com/ramereth)!
 - Resolved a Compliance Phase failure with profile names using the `@` symbol.
 
 ### Security
@@ -5216,19 +5216,19 @@ following settings in the client.rb file:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>automatic_attribute_blacklist</code></td>
 <td>A hash that blacklists <code>automatic</code> attributes, preventing blacklisted attributes from being saved. For example: <code>['network/interfaces/eth0']</code>. Default value: <code>nil</code>, all attributes are saved. If the array is empty, all attributes are saved.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>default_attribute_blacklist</code></td>
 <td>A hash that blacklists <code>default</code> attributes, preventing blacklisted attributes from being saved. For example: <code>['filesystem/dev/disk0s2/size']</code>. Default value: <code>nil</code>, all attributes are saved. If the array is empty, all attributes are saved.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>normal_attribute_blacklist</code></td>
 <td>A hash that blacklists <code>normal</code> attributes, preventing blacklisted attributes from being saved. For example: <code>['filesystem/dev/disk0s2/size']</code>. Default value: <code>nil</code>, all attributes are saved. If the array is empty, all attributes are saved.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>override_attribute_blacklist</code></td>
 <td>A hash that blacklists <code>override</code> attributes, preventing blacklisted attributes from being saved. For example: <code>['map - autohome/size']</code>. Default value: <code>nil</code>, all attributes are saved. If the array is empty, all attributes are saved.</td>
 </tr>
@@ -8861,7 +8861,7 @@ The following settings are new for metadata.rb:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>chef_version</code></p></td>
 <td><p>A range of chef-client versions that are supported by this cookbook.</p>
 <p>For example, to match any 12.x version of the chef-client, but not 11.x or 13.x:</p>
@@ -8869,7 +8869,7 @@ The following settings are new for metadata.rb:
 <p>A more complex example where you set both a lower and upper bound of Chef Client version:</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb2-1"><a href="#cb2-1"></a>chef_version <span class="st">&quot;&gt;= 14.2.1&quot;</span>, <span class="st">&quot;&lt; 14.5.1&quot;</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>ohai_version</code></p></td>
 <td><p>A range of chef-client versions that are supported by this cookbook.</p>
 <p>For example, to match any 8.x version of Ohai, but not 7.x or 9.x:</p>
@@ -9475,7 +9475,7 @@ parameters to a property.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>:callbacks</code></p></td>
 <td><p>Use to define a collection of unique keys and values (a ruby hash) for which the key is the error message and the value is a lambda to validate the parameter. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb1-1"><a href="#cb1-1"></a><span class="st">callbacks: </span>{</span>
@@ -9484,7 +9484,7 @@ parameters to a property.
 <span id="cb1-4"><a href="#cb1-4"></a>             }</span>
 <span id="cb1-5"><a href="#cb1-5"></a>           }</span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>:default</code></p></td>
 <td><p>Use to specify the default value for a property. For example:</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb2-1"><a href="#cb2-1"></a><span class="st">default: &#39;a_string_value&#39;</span></span></code></pre></div>
@@ -9493,23 +9493,23 @@ parameters to a property.
 <div class="sourceCode" id="cb5"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb5-1"><a href="#cb5-1"></a><span class="st">default: </span>()</span></code></pre></div>
 <div class="sourceCode" id="cb6"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb6-1"><a href="#cb6-1"></a><span class="st">default: </span>{}</span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>:equal_to</code></p></td>
 <td><p>Use to match a value with <code>==</code>. Use an array of values to match any of those values with <code>==</code>. For example:</p>
 <div class="sourceCode" id="cb7"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb7-1"><a href="#cb7-1"></a><span class="st">equal_to: </span>[<span class="dv">true</span>, <span class="dv">false</span>]</span></code></pre></div>
 <div class="sourceCode" id="cb8"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb8-1"><a href="#cb8-1"></a><span class="st">equal_to: </span>[<span class="st">&#39;php&#39;</span>, <span class="st">&#39;perl&#39;</span>]</span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>:regex</code></p></td>
 <td><p>Use to match a value to a regular expression. For example:</p>
 <div class="sourceCode" id="cb9"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb9-1"><a href="#cb9-1"></a><span class="st">regex: </span>[ <span class="ot">/^([a-z]|[A-Z]|[0-9]|_|-)+$/</span>, <span class="ot">/^\d+$/</span> ]</span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>:required</code></p></td>
 <td><p>Indicates that a property is required. For example:</p>
 <div class="sourceCode" id="cb10"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb10-1"><a href="#cb10-1"></a><span class="st">required: </span><span class="dv">true</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>:respond_to</code></p></td>
 <td><p>Use to ensure that a value has a given method. This can be a single method name or an array of method names. For example:</p>
 <div class="sourceCode" id="cb11"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb11-1"><a href="#cb11-1"></a><span class="st">respond_to: </span>valid_encoding?</span></code></pre></div></td>
@@ -9923,7 +9923,7 @@ The following property is new for the **deploy** resource:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>depth</code></p></td>
 <td><p><strong>Ruby Type:</strong> Integer</p>
 <p>The depth of a git repository, truncated to the specified number of revisions.</p></td>
@@ -9963,11 +9963,11 @@ client.rb file:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>policy_group</code></td>
 <td>The name of a policy group that exists on the Chef server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>policy_name</code></td>
 <td>The name of a policy, as identified by the <code>name</code> setting in a Policyfile.rb file.</td>
 </tr>
@@ -9991,15 +9991,15 @@ of policy files:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>named_run_list</code></td>
 <td>The run-list associated with a policy file.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>policy_group</code></td>
 <td>The name of a policy group that exists on the Chef server. (See "Specify Policy Revision" in this readme for more information.)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>policy_name</code></td>
 <td>The name of a policy, as identified by the <code>name</code> setting in a Policyfile.rb file. (See "Specify Policy Revision" in this readme for more information.)</td>
 </tr>
@@ -10035,11 +10035,11 @@ enable the use of policy files:
     </tr>
     </thead>
     <tbody>
-    <tr class="odd">
+    <tr>
     <td><code>policy_group</code></td>
     <td>The name of a policy group that exists on the Chef server.</td>
     </tr>
-    <tr class="even">
+    <tr>
     <td><code>policy_name</code></td>
     <td>The name of a policy, as identified by the <code>name</code> setting in a Policyfile.rb file.</td>
     </tr>
@@ -10205,7 +10205,7 @@ The following settings have changed:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>log_location</code></td>
 <td>The location of the log file. Possible values: <code>/path/to/log_location</code>, <code>STDOUT</code>, <code>STDERR</code>, <code>Chef::Log::WinEvt.new</code> (Windows Event Logger), or <code>Chef::Log::Syslog.new("chef-client", ::Syslog::LOG_DAEMON)</code> (writes to the syslog daemon facility with the originator set as <code>chef-client</code>). The application log will specify the source as <code>Chef</code>. Default value: <code>STDOUT</code>.</td>
 </tr>
@@ -10230,15 +10230,15 @@ a URL:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>checksum</code></td>
 <td>The SHA-256 checksum of the file. Use to prevent a file from being re-downloaded. When the local file matches the checksum, Chef Client does not download it. Use when a URL is specified by the <code>source</code> attribute.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>remote_file_attributes</code></td>
 <td>A package at a remote location define as a Hash of properties that modifies the properties of the <strong>remote_file</strong> resource.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>source</code></td>
 <td>Optional. The path to a package in the local file system. The location of the package may be at a URL. Default value: the <code>name</code> of the resource block. See "Syntax" section above for more information.</td>
 </tr>
@@ -10699,7 +10699,7 @@ Or add the following setting to the client.rb file:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>listen</code></td>
 <td>Run chef-zero in socketless mode. Set to <code>false</code> to disable port binding and HTTP requests on localhost.</td>
 </tr>
@@ -10951,31 +10951,31 @@ This resource has the following properties:
     </tr>
     </thead>
     <tbody>
-    <tr class="odd">
+    <tr>
     <td><code>Array</code></td>
     <td><code>Object[]</code></td>
     </tr>
-    <tr class="even">
+    <tr>
     <td><code>Chef::Util::Powershell:PSCredential</code></td>
     <td><code>PSCredential</code></td>
     </tr>
-    <tr class="odd">
+    <tr>
     <td><code>False</code></td>
     <td><code>bool($false)</code></td>
     </tr>
-    <tr class="even">
+    <tr>
     <td><code>Fixnum</code></td>
     <td><code>Integer</code></td>
     </tr>
-    <tr class="odd">
+    <tr>
     <td><code>Float</code></td>
     <td><code>Double</code></td>
     </tr>
-    <tr class="even">
+    <tr>
     <td><code>Hash</code></td>
     <td><code>Hashtable</code></td>
     </tr>
-    <tr class="odd">
+    <tr>
     <td><code>True</code></td>
     <td><code>bool($true)</code></td>
     </tr>
@@ -11006,55 +11006,55 @@ This resource has the following properties:
     </tr>
     </thead>
     <tbody>
-    <tr class="odd">
+    <tr>
     <td><code>:archive</code></td>
     <td>Use to <a href="https://msdn.microsoft.com/en-us/powershell/dsc/archiveresource">unpack archive (.zip) files</a>.</td>
     </tr>
-    <tr class="even">
+    <tr>
     <td><code>:environment</code></td>
     <td>Use to <a href="https://msdn.microsoft.com/en-us/powershell/dsc/environmentresource">manage system environment variables</a>.</td>
     </tr>
-    <tr class="odd">
+    <tr>
     <td><code>:file</code></td>
     <td>Use to <a href="https://msdn.microsoft.com/en-us/powershell/dsc/fileresource">manage files and directories</a>.</td>
     </tr>
-    <tr class="even">
+    <tr>
     <td><code>:group</code></td>
     <td>Use to <a href="https://msdn.microsoft.com/en-us/powershell/dsc/groupresource">manage local groups</a>.</td>
     </tr>
-    <tr class="odd">
+    <tr>
     <td><code>:log</code></td>
     <td>Use to <a href="https://msdn.microsoft.com/en-us/powershell/dsc/logresource">log configuration messages</a>.</td>
     </tr>
-    <tr class="even">
+    <tr>
     <td><code>:package</code></td>
     <td>Use to <a href="https://msdn.microsoft.com/en-us/powershell/dsc/packageresource">install and manage packages</a>.</td>
     </tr>
-    <tr class="odd">
+    <tr>
     <td><code>:registry</code></td>
     <td>Use to <a href="https://msdn.microsoft.com/en-us/powershell/dsc/registryresource">manage registry keys and registry key values</a>.</td>
     </tr>
-    <tr class="even">
+    <tr>
     <td><code>:script</code></td>
     <td>Use to <a href="https://msdn.microsoft.com/en-us/powershell/dsc/scriptresource">run PowerShell script blocks</a>.</td>
     </tr>
-    <tr class="odd">
+    <tr>
     <td><code>:service</code></td>
     <td>Use to <a href="https://msdn.microsoft.com/en-us/powershell/dsc/serviceresource">manage services</a>.</td>
     </tr>
-    <tr class="even">
+    <tr>
     <td><code>:user</code></td>
     <td>Use to <a href="https://msdn.microsoft.com/en-us/powershell/dsc/userresource">manage local user accounts</a>.</td>
     </tr>
-    <tr class="odd">
+    <tr>
     <td><code>:windowsfeature</code></td>
     <td>Use to <a href="https://msdn.microsoft.com/en-us/powershell/dsc/windowsfeatureresource">add or remove Windows features and roles</a>.</td>
     </tr>
-    <tr class="even">
+    <tr>
     <td><code>:windowsoptionalfeature</code></td>
     <td>Use to configure Microsoft Windows optional features.</td>
     </tr>
-    <tr class="odd">
+    <tr>
     <td><code>:windowsprocess</code></td>
     <td>Use to <a href="https://msdn.microsoft.com/en-us/powershell/dsc/windowsprocessresource">configure Windows processes</a>.</td>
     </tr>
@@ -11262,23 +11262,23 @@ When Chef Client is run in audit-mode, the following happens:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>chef-client Run ID</strong></td>
 <td>Chef Client run identifier is associated with each audit.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Configure the Node</strong></td>
 <td>If audit-mode is run as part of the full chef-client run, audit-mode occurs after Chef Client has finished converging all resources in the resource collection.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Audit node based on controls in cookbooks</strong></td>
 <td>Each <code>control_group</code> and <code>control</code> block found in any recipe that was part of the run-list of for the node is evaluated, with each expression in each <code>control</code> block verified against the state of the node.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Upload audit data to the Chef server</strong></td>
 <td>When audit-mode mode is complete, the data is uploaded to the Chef server.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Send to Chef Analytics</strong></td>
 <td>Most of this data is passed to the Chef Analytics platform for further analysis, such as rules processing (for notification events triggered by expected or unexpected audit outcomes) and visibility from the actions web user interface.</td>
 </tr>
@@ -11348,21 +11348,21 @@ are available for directories:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>be_directory</code></p></td>
 <td><p>Use to test if directory exists. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb1-1"><a href="#cb1-1"></a>it <span class="st">&#39;should be a directory&#39;</span> <span class="kw">do</span></span>
 <span id="cb1-2"><a href="#cb1-2"></a>  expect(file(<span class="st">&#39;/var/directory&#39;</span>)).to be_directory</span>
 <span id="cb1-3"><a href="#cb1-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>be_linked_to</code></p></td>
 <td><p>Use to test if a subject is linked to the named directory. For example:</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb2-1"><a href="#cb2-1"></a>it <span class="st">&#39;should be linked to the named directory&#39;</span> <span class="kw">do</span></span>
 <span id="cb2-2"><a href="#cb2-2"></a>  expect(file(<span class="st">&#39;/etc/directory&#39;</span>)).to be_linked_to(<span class="st">&#39;/etc/some/other/directory&#39;</span>)</span>
 <span id="cb2-3"><a href="#cb2-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>be_mounted</code></p></td>
 <td><p>Use to test if a directory is mounted. For example:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb3-1"><a href="#cb3-1"></a>it <span class="st">&#39;should be mounted&#39;</span> <span class="kw">do</span></span>
@@ -11403,7 +11403,7 @@ for files:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>be_executable</code></p></td>
 <td><p>Use to test if a file is executable. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb1-1"><a href="#cb1-1"></a>it <span class="st">&#39;should be executable&#39;</span> <span class="kw">do</span></span>
@@ -11422,42 +11422,42 @@ for files:
 <span id="cb4-2"><a href="#cb4-2"></a>  expect(file(<span class="st">&#39;/etc/file&#39;</span>)).to be_executable.by_user(<span class="st">&#39;foo&#39;</span>)</span>
 <span id="cb4-3"><a href="#cb4-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>be_file</code></p></td>
 <td><p>Use to test if a file exists. For example:</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb5-1"><a href="#cb5-1"></a>it <span class="st">&#39;should be a file&#39;</span> <span class="kw">do</span></span>
 <span id="cb5-2"><a href="#cb5-2"></a>  expect(file(<span class="st">&#39;/etc/file&#39;</span>)).to be_file</span>
 <span id="cb5-3"><a href="#cb5-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>be_grouped_into</code></p></td>
 <td><p>Use to test if a file is grouped into the named group. For example:</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb6-1"><a href="#cb6-1"></a>it <span class="st">&#39;should be grouped into foo&#39;</span> <span class="kw">do</span></span>
 <span id="cb6-2"><a href="#cb6-2"></a>  expect(file(<span class="st">&#39;/etc/file&#39;</span>)).to be_grouped_into(<span class="st">&#39;foo&#39;</span>)</span>
 <span id="cb6-3"><a href="#cb6-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>be_linked_to</code></p></td>
 <td><p>Use to test if a subject is linked to the named file. For example:</p>
 <div class="sourceCode" id="cb7"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb7-1"><a href="#cb7-1"></a>it <span class="st">&#39;should be linked to the named file&#39;</span> <span class="kw">do</span></span>
 <span id="cb7-2"><a href="#cb7-2"></a>  expect(file(<span class="st">&#39;/etc/file&#39;</span>)).to be_linked_to(<span class="st">&#39;/etc/some/other/file&#39;</span>)</span>
 <span id="cb7-3"><a href="#cb7-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>be_mode</code></p></td>
 <td><p>Use to test if a file is set to the specified mode. For example:</p>
 <div class="sourceCode" id="cb8"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb8-1"><a href="#cb8-1"></a>it <span class="st">&#39;should be mode 440&#39;</span> <span class="kw">do</span></span>
 <span id="cb8-2"><a href="#cb8-2"></a>  expect(file(<span class="st">&#39;/etc/file&#39;</span>)).to be_mode(<span class="dv">440</span>)</span>
 <span id="cb8-3"><a href="#cb8-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>be_owned_by</code></p></td>
 <td><p>Use to test if a file is owned by the named owner. For example:</p>
 <div class="sourceCode" id="cb9"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb9-1"><a href="#cb9-1"></a>it <span class="st">&#39;should be owned by the root user&#39;</span> <span class="kw">do</span></span>
 <span id="cb9-2"><a href="#cb9-2"></a>  expect(file(<span class="st">&#39;/etc/sudoers&#39;</span>)).to be_owned_by(<span class="st">&#39;root&#39;</span>)</span>
 <span id="cb9-3"><a href="#cb9-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>be_readable</code></p></td>
 <td><p>Use to test if a file is readable. For example:</p>
 <div class="sourceCode" id="cb10"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb10-1"><a href="#cb10-1"></a>it <span class="st">&#39;should be readable&#39;</span> <span class="kw">do</span></span>
@@ -11476,28 +11476,28 @@ for files:
 <span id="cb13-2"><a href="#cb13-2"></a>  expect(file(<span class="st">&#39;/etc/file&#39;</span>)).to be_readable.by_user(<span class="st">&#39;foo&#39;</span>)</span>
 <span id="cb13-3"><a href="#cb13-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>be_socket</code></p></td>
 <td><p>Use to test if a file exists as a socket. For example:</p>
 <div class="sourceCode" id="cb14"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb14-1"><a href="#cb14-1"></a>it <span class="st">&#39;should be a socket&#39;</span> <span class="kw">do</span></span>
 <span id="cb14-2"><a href="#cb14-2"></a>  expect(file(<span class="st">&#39;/var/file.sock&#39;</span>)).to be_socket</span>
 <span id="cb14-3"><a href="#cb14-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>be_symlink</code></p></td>
 <td><p>Use to test if a file exists as a symbolic link. For example:</p>
 <div class="sourceCode" id="cb15"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb15-1"><a href="#cb15-1"></a>it <span class="st">&#39;should be a symlink&#39;</span> <span class="kw">do</span></span>
 <span id="cb15-2"><a href="#cb15-2"></a>  expect(file(<span class="st">&#39;/etc/file&#39;</span>)).to be_symlink</span>
 <span id="cb15-3"><a href="#cb15-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>be_version</code></p></td>
 <td><p>Microsoft Windows only. Use to test if a file is the specified version. For example:</p>
 <div class="sourceCode" id="cb16"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb16-1"><a href="#cb16-1"></a>it <span class="st">&#39;should be version 1.2&#39;</span> <span class="kw">do</span></span>
 <span id="cb16-2"><a href="#cb16-2"></a>  expect(file(<span class="st">&#39;C:\\Windows\\path\\to\\file&#39;</span>)).to be_version(<span class="st">&#39;1.2&#39;</span>)</span>
 <span id="cb16-3"><a href="#cb16-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>be_writable</code></p></td>
 <td><p>Use to test if a file is writable. For example:</p>
 <div class="sourceCode" id="cb17"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb17-1"><a href="#cb17-1"></a>it <span class="st">&#39;should be writable&#39;</span> <span class="kw">do</span></span>
@@ -11516,7 +11516,7 @@ for files:
 <span id="cb20-2"><a href="#cb20-2"></a>  expect(file(<span class="st">&#39;/etc/file&#39;</span>)).to be_writable.by_user(<span class="st">&#39;foo&#39;</span>)</span>
 <span id="cb20-3"><a href="#cb20-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>contain</code></p></td>
 <td><p>Use to test if a file contains specific contents. For example:</p>
 <div class="sourceCode" id="cb21"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb21-1"><a href="#cb21-1"></a>it <span class="st">&#39;should contain docs.chef.io&#39;</span> <span class="kw">do</span></span>
@@ -11544,7 +11544,7 @@ matchers are available:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>be_installed</code></p></td>
 <td><p>Use to test if the named package is installed. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb1-1"><a href="#cb1-1"></a>it <span class="st">&#39;should be installed&#39;</span> <span class="kw">do</span></span>
@@ -11575,7 +11575,7 @@ test if a port is listening. The following matchers are available:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>be_listening</code></p></td>
 <td><p>Use to test if the named port is listening. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb1-1"><a href="#cb1-1"></a>it <span class="st">&#39;should be listening&#39;</span> <span class="kw">do</span></span>
@@ -11624,7 +11624,7 @@ following matchers are available:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>be_enabled</code></p></td>
 <td><p>Use to test if the named service is enabled (i.e. will start up automatically). For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb1-1"><a href="#cb1-1"></a>it <span class="st">&#39;should be enabled&#39;</span> <span class="kw">do</span></span>
@@ -11635,14 +11635,14 @@ following matchers are available:
 <span id="cb2-2"><a href="#cb2-2"></a>  expect(service(<span class="st">&#39;ntpd&#39;</span>)).to be_enabled.with_level(<span class="dv">3</span>)</span>
 <span id="cb2-3"><a href="#cb2-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>be_installed</code></p></td>
 <td><p>Microsoft Windows only. Use to test if the named service is installed on the Microsoft Windows platform. For example:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb3-1"><a href="#cb3-1"></a>it <span class="st">&#39;should be installed&#39;</span> <span class="kw">do</span></span>
 <span id="cb3-2"><a href="#cb3-2"></a>  expect(service(<span class="st">&#39;DNS Client&#39;</span>)).to be_installed</span>
 <span id="cb3-3"><a href="#cb3-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>be_running</code></p></td>
 <td><p>Use to test if the named service is running. For example:</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb4-1"><a href="#cb4-1"></a>it <span class="st">&#39;should be running&#39;</span> <span class="kw">do</span></span>
@@ -11661,14 +11661,14 @@ following matchers are available:
 <span id="cb7-2"><a href="#cb7-2"></a>  expect(service(<span class="st">&#39;ntpd&#39;</span>)).to be_running.under(<span class="st">&#39;upstart&#39;</span>)</span>
 <span id="cb7-3"><a href="#cb7-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>be_monitored_by</code></p></td>
 <td><p>Use to test if the named service is being monitored by the named monitoring application. For example:</p>
 <div class="sourceCode" id="cb8"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb8-1"><a href="#cb8-1"></a>it <span class="st">&#39;should be monitored by&#39;</span> <span class="kw">do</span></span>
 <span id="cb8-2"><a href="#cb8-2"></a>  expect(service(<span class="st">&#39;ntpd&#39;</span>)).to be_monitored_by(<span class="st">&#39;monit&#39;</span>)</span>
 <span id="cb8-3"><a href="#cb8-3"></a><span class="kw">end</span></span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>have_start_mode</code></p></td>
 <td><p>Microsoft Windows only. Use to test if the named service's startup mode is correct on the Microsoft Windows platform. For example:</p>
 <div class="sourceCode" id="cb9"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb9-1"><a href="#cb9-1"></a>it <span class="st">&#39;should start manually&#39;</span> <span class="kw">do</span></span>
@@ -13692,12 +13692,12 @@ platform:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>Chef::Provider::Service::Aix</code></td>
 <td><code>service</code></td>
 <td>The provider that is used with the AIX platforms. Use the <code>service</code> short name to start, stop, and restart services with System Resource Controller (SRC).</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>Chef::Provider::Service::AixInit</code></td>
 <td><code>service</code></td>
 <td>The provider that is used to manage BSD-based init services on AIX.</td>
@@ -14869,7 +14869,7 @@ The following property is new for the **mount** resource:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>fsck_device</code></td>
 <td>The fsck device on the Solaris platform. Default value: <code>-</code>.</td>
 </tr>
@@ -14892,12 +14892,12 @@ The following settings are new:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>issues_url</code></p></td>
 <td><p>The URL for the location in which a cookbook's issue tracking is maintained. This setting is also used by Chef Supermarket. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb1-1"><a href="#cb1-1"></a>source_url <span class="st">&quot;https://github.com/chef-cookbooks/chef-client/issues&quot;</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>source_url</code></p></td>
 <td><p>The URL for the location in which a cookbook's source code is maintained. This setting is also used by Chef Supermarket. For example:</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb2-1"><a href="#cb2-1"></a>source_url <span class="st">&quot;https://github.com/chef-cookbooks/chef-client&quot;</span></span></code></pre></div></td>
@@ -15034,11 +15034,11 @@ The following properties are new for the **user** resource:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>iterations</code></td>
 <td>The number of iterations for a password with a SALTED-SHA512-PBKDF2 shadow hash.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>salt</code></td>
 <td>The salt value for a password shadow hash. macOS version 10.7 uses SALTED-SHA512 and version 10.8 (and higher) uses SALTED-SHA512-PBKDF2 to calculate password shadow hashes.</td>
 </tr>
@@ -15134,19 +15134,19 @@ and now default to `true`:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>disable_event_logger</code></td>
 <td>Enable or disable sending events to the Microsoft Windows "Application" event log. When <code>false</code>, events are sent to the Microsoft Windows "Application" event log at the start and end of a chef-client run, and also if a chef-client run fails. Set to <code>true</code> to disable event logging. Default value: <code>true</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>no_lazy_load</code></td>
 <td>Download all cookbook files and templates at the beginning of Chef Client run. Default value: <code>true</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>file_staging_uses_destdir</code></td>
 <td>How file staging (via temporary files) is done. When <code>true</code>, temporary files are created in the directory in which files will reside. When <code>false</code>, temporary files are created under <code>ENV['TMP']</code>. Default value: <code>true</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>local_key_generation</code></td>
 <td>Use to specify whether the Chef server or chef-client will generate the private/public key pair. When <code>true</code>, Chef Client will generate the key pair, and then send the public key to the Chef server. Default value: <code>true</code>.</td>
 </tr>
@@ -15238,7 +15238,7 @@ The following property is new for the **git** resource:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>environment</code></p></td>
 <td><p>A Hash of environment variables in the form of <code>({"ENV_VARIABLE" =&gt; "VALUE"})</code>. (These variables must exist for a command to be run successfully.)</p>
 {{< note >}}

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -1023,7 +1023,7 @@ By default, the `public_key_read_access` assigns all members of the
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>admins</td>
 <td>no</td>
 <td>no</td>
@@ -1031,7 +1031,7 @@ By default, the `public_key_read_access` assigns all members of the
 <td>no</td>
 <td>no</td>
 </tr>
-<tr class="even">
+<tr>
 <td>clients</td>
 <td>yes</td>
 <td>yes</td>
@@ -1039,7 +1039,7 @@ By default, the `public_key_read_access` assigns all members of the
 <td>yes</td>
 <td>yes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>users</td>
 <td>yes</td>
 <td>yes</td>
@@ -1208,7 +1208,7 @@ with its location information and dependencies:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful. One (or more) cookbooks and associated cookbook version information was returned.</td>
 </tr>
@@ -1648,11 +1648,11 @@ Chef server:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Chef Server</td>
 <td>The Chef server configuration file is updated to point to an independently configured set of servers for PostgreSQL.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><p>PostgreSQL</p></td>
 <td><p>PostgreSQL is the data storage repository for the Chef server.</p>
 <p>This represents the independently configured set of servers that are running PostgreSQL and are configured to act as the data store for the Chef server.</p></td>
@@ -1686,23 +1686,23 @@ configure PostgreSQL for use with the Chef server:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>postgresql['db_superuser']</code></td>
 <td>Required when <code>postgresql['external']</code> is set to <code>true</code>. The PostgreSQL user name. This user must be granted either the <code>CREATE ROLE</code> and <code>CREATE DATABASE</code> permissions in PostgreSQL or be granted <code>SUPERUSER</code> permission. This user must also have an entry in the host-based authentication configuration file used by PostgreSQL (traditionally named <code>pg_hba.conf</code>). Default value: <code>'superuser_userid'</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>postgresql['db_superuser_password']</code></td>
 <td>Required when <code>postgresql['external']</code> is set to <code>true</code>. The password for the user specified by <code>postgresql['db_superuser']</code>. Default value: <code>'the password'</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>postgresql['external']</code></td>
 <td>Required. Set to <code>true</code> to run PostgreSQL external to the Chef server. Must be set once only on a new installation of the Chef server before the first <code>chef-server-ctl reconfigure</code> command is run. If this is set after a reconfigure or set to <code>false</code>, any reconfigure of the Chef server will return an error. Default value: <code>false</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>postgresql['port']</code></td>
 <td>Optional when <code>postgresql['external']</code> is set to <code>true</code>. The port on which the service is to listen. The port used by PostgreSQL if that port is <strong>not</strong> 5432. Default value: <code>5432</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>postgresql['vip']</code></td>
 <td>Required when <code>postgresql['external']</code> is set to <code>true</code>. The virtual IP address. The host for this IP address must be online and reachable from the Chef server via the port specified by <code>postgresql['port']</code>. Set this value to the IP address or hostname for the machine on which external PostgreSQL is located when <code>postgresql['external']</code> is set to <code>true</code>.</td>
 </tr>
@@ -1897,19 +1897,19 @@ The response returns the policy details and is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -1956,19 +1956,19 @@ xxxxx
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -2016,19 +2016,19 @@ The response returns the policy details and is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -2079,27 +2079,27 @@ xxxxx
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>201</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>400</code></td>
 <td>Bad request. The contents of the request are not formatted correctly.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>409</code></td>
 <td>Conflict. The object already exists.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>413</code></td>
 <td>Request entity too large. A request may not be larger than 1000000 bytes.</td>
 </tr>
@@ -2206,19 +2206,19 @@ The response is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -2320,19 +2320,19 @@ The response returns the policy details and is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -2426,19 +2426,19 @@ The response is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -2491,19 +2491,19 @@ The response is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>201</code></td>
 <td>Created. The object was created.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -2555,19 +2555,19 @@ similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -2613,19 +2613,19 @@ The response is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -2682,23 +2682,23 @@ similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>201</code></td>
 <td>Created. The object was created.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -2752,19 +2752,19 @@ The response is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -2817,19 +2817,19 @@ The response is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>201</code></td>
 <td>Created. The object was created.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -2881,19 +2881,19 @@ similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -2939,19 +2939,19 @@ The response is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -3008,23 +3008,23 @@ similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>201</code></td>
 <td>Created. The object was created.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -3093,11 +3093,11 @@ The response groups policies by name and revision and is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
@@ -3175,19 +3175,19 @@ The response is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -3321,19 +3321,19 @@ The response returns the policy details and is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -3439,19 +3439,19 @@ The response is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -3628,23 +3628,23 @@ The response returns the policy details and is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>201</code></td>
 <td>Created. The object was created.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>401</code></td>
 <td>Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>403</code></td>
 <td>Forbidden. The user who made the request is not authorized to perform the action.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>404</code></td>
 <td>Not found. The requested object does not exist.</td>
 </tr>
@@ -3667,7 +3667,7 @@ The following configuration settings are new for the Chef server:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>estatsd['protocol']</code></td>
 <td>Use to send application statistics with StatsD protocol formatting. Set this value to <code>statsd</code> to apply StatsD protocol formatting.</td>
 </tr>
@@ -3883,7 +3883,7 @@ packages can be installed as described below.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p>Chef Manage</p></td>
 <td><p>Use Chef management console to manage data bags, attributes, run-lists, roles, environments, and cookbooks from a web user interface.</p>
 <p>On the Chef server, run:</p>
@@ -4267,11 +4267,11 @@ The following configuration settings are new for Chef server version 12:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>default_orgname</code></td>
 <td>The Chef server API used by the Open Source Chef server does not have an <code>/organizations/ORG_NAME</code> endpoint. Use this setting to ensure that migrated Open Source Chef servers are able to connect to the Chef server API. This value should be the same as the name of the organization that was created during the upgrade from Open Source Chef version 11 to Chef server version 12, which means it will be identical to the <code>ORG_NAME</code> part of the <code>/organizations</code> endpoint in Chef server version 12. Default value: the name of the organization specified during the upgrade process from Open Source Chef 11 to Chef server 12.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>postgresql['log_min_duration_statement']</code></td>
 <td>When to log a slow PostgreSQL query statement. Possible values: <code>-1</code> (disabled, do not log any statements), <code>0</code> (log every statement), or an integer greater than zero. When the integer is greater than zero, this value is the amount of time (in milliseconds) that a query statement must have run before it is logged. Default value: <code>-1</code>.</td>
 </tr>
@@ -4293,7 +4293,7 @@ starting with Chef server version 12:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>api_version</code></td>
 <td>The version of the Chef server. Default value: <code>"12.0.0"</code>.</td>
 </tr>
@@ -4315,11 +4315,11 @@ The following configuration settings are new in Chef server version
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>opscode_erchef['nginx_bookshelf_caching']</code></td>
 <td>Whether Nginx is used to cache cookbooks. When <code>:on</code>, Nginx serves up the cached content instead of forwarding the request. Default value: <code>:off</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>opscode_erchef['s3_url_expiry_window_size']</code></td>
 <td>The frequency at which unique URLs are generated. This value may be a specific amount of time, i.e. <code>15m</code> (fifteen minutes) or a percentage of the value of <code>s3_url_ttl</code>, i.e. <code>10%</code>. Default value: <code>:off</code>.</td>
 </tr>
@@ -4410,11 +4410,11 @@ The following settings are new:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>ldap['ssl_enabled']</code></td>
 <td>Use to enable SSL. Default value: <code>false</code>. Must be <code>false</code> when <code>ldap['tls_enabled']</code> is <code>true</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ldap['tls_enabled']</code></td>
 <td>Use to enable TLS. When enabled, communication with the LDAP server is done via a secure SSL connection on a dedicated port. When <code>true</code>, <code>ldap['port']</code> is also set to <code>636</code>. Default value: <code>false</code>. Must be <code>false</code> when <code>ldap['ssl_enabled']</code> is <code>true</code>.</td>
 </tr>

--- a/content/resource.md
+++ b/content/resource.md
@@ -84,15 +84,15 @@ See these guides for additional information about resources:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="/resource_common/">Common Properties</a></td>
 <td>Provides a detailed list of the common properties that are available in all resources.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="/resources/">Resource Reference</a></td>
 <td>A reference guide that lists both the common and individual options available to every resource that is bundled into Chef.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="/custom_resources/">Custom Resources</a></td>
 <td>Shows you how to create your own Chef resources.</td>
 </tr>

--- a/content/roles.md
+++ b/content/roles.md
@@ -41,11 +41,11 @@ There are two types of attributes that can be used with roles:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>default</code></td>
 <td>{{< readFile_shortcode file="node_attribute_type_default.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>override</code></td>
 <td>{{< readFile_shortcode file="node_attribute_type_override.md" >}}</td>
 </tr>
@@ -75,19 +75,19 @@ Domain-specific Ruby attributes:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>default_attributes</code></p></td>
 <td><p>Optional. A set of attributes to be applied to all nodes, assuming the node does not already have a value for the attribute. This is useful for setting global defaults that can then be overridden for specific nodes. If more than one role attempts to set a default value for the same attribute, the last role applied is the role to set the attribute value. When nested attributes are present, they are preserved. For example, to specify that a node that has the attribute <code>apache2</code> should listen on ports 80 and 443 (unless ports are already specified):</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb1-1"><a href="#cb1-1"></a>default_attributes <span class="st">&#39;apache2&#39;</span> =&gt; {</span>
 <span id="cb1-2"><a href="#cb1-2"></a>  <span class="st">&#39;listen_ports&#39;</span> =&gt; [ <span class="st">&#39;80&#39;</span>, <span class="st">&#39;443&#39;</span> ]</span>
 <span id="cb1-3"><a href="#cb1-3"></a>}</span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>description</code></p></td>
 <td><p>A description of the functionality that is covered. For example:</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb2-1"><a href="#cb2-1"></a>description <span class="st">&#39;The base role for systems that serve HTTP traffic&#39;</span></span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>env_run_lists</code></p></td>
 <td><p>Optional. A list of environments, each specifying a recipe or a role to be applied to that environment. This setting must specify the <code>_default</code> environment. If the <code>_default</code> environment is set to <code>[]</code> or <code>nil</code>, then the run-list is empty. For example:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb3-1"><a href="#cb3-1"></a>env_run_lists <span class="st">&#39;prod&#39;</span> =&gt; [<span class="st">&#39;recipe[apache2]&#39;</span>],</span>
@@ -96,12 +96,12 @@ Domain-specific Ruby attributes:
 <p>Using <code>env_run_lists</code> with roles is discouraged as it can be difficult to maintain over time. Instead, consider using multiple roles to define the required behavior.</p>
 {{< /warning >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>name</code></p></td>
 <td><p>A unique name within the organization. Each name must be made up of letters (upper- and lower-case), numbers, underscores, and hyphens: [A-Z][a-z][0-9] and [_-]. Spaces are not allowed. For example:</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb4-1"><a href="#cb4-1"></a>name <span class="st">&#39;dev01-24&#39;</span></span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>override_attributes</code></p></td>
 <td><p>Optional. A set of attributes to be applied to all nodes, even if the node already has a value for an attribute. This is useful for ensuring that certain attributes always have specific values. If more than one role attempts to set an override value for the same attribute, the last role applied wins. When nested attributes are present, they are preserved. For example:</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb5-1"><a href="#cb5-1"></a>override_attributes <span class="st">&#39;apache2&#39;</span> =&gt; {</span>
@@ -123,7 +123,7 @@ Domain-specific Ruby attributes:
 <span id="cb7-7"><a href="#cb7-7"></a>  }</span>
 <span id="cb7-8"><a href="#cb7-8"></a>)</span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>run_list</code></p></td>
 <td><p>A list of recipes and/or roles to be applied and the order in which they are to be applied. For example, the following run-list:</p>
 <div class="sourceCode" id="cb8"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb8-1"><a href="#cb8-1"></a>run_list <span class="st">&#39;recipe[apache2]&#39;</span>,</span>
@@ -223,11 +223,11 @@ The JSON format has two additional settings:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>chef_type</code></td>
 <td>Always set this to <code>role</code>. Use this setting for any custom process that consumes role objects outside of Ruby.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>json_class</code></td>
 <td>Always set this to <code>Chef::Role</code>. The Chef Infra Client uses this setting to auto-inflate a role object. If objects are being rebuilt outside of Ruby, ignore it.</td>
 </tr>

--- a/content/server_ldap.md
+++ b/content/server_ldap.md
@@ -85,23 +85,23 @@ settings into `ldapsearch` parameters:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>ldap['host']</code> and <code>ldap['port']</code></td>
 <td><code>-H [HOST:PORT]</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ldap['bind_dn']</code></td>
 <td><code>-D [BIND_DN]</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ldap['bind_password']</code></td>
 <td><code>-W</code>; <code>ldapsearch</code> will prompt for this parameter</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ldap['base_dn']</code></td>
 <td><code>-b [BASE_DN]</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ldap['login_attribute']</code></td>
 <td>Defaults to <code>SAMAccountName</code></td>
 </tr>

--- a/content/server_manage_cookbooks.md
+++ b/content/server_manage_cookbooks.md
@@ -62,27 +62,27 @@ A cookbook can contain the following types of files:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Attributes</td>
 <td>{{< readFile_shortcode file="cookbooks_attribute.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Files</td>
 <td>{{< readFile_shortcode file="resource_cookbook_file_summary.md" >}}</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Libraries</td>
 <td>{{< readFile_shortcode file="libraries_summary.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Recipes</td>
 <td>{{< readFile_shortcode file="cookbooks_recipe.md" >}}</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Resources</td>
 <td>{{< readFile_shortcode file="resources_common.md" >}}</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Templates</td>
 <td>{{< readFile_shortcode file="template.md" >}}</td>
 </tr>

--- a/content/server_orgs.md
+++ b/content/server_orgs.md
@@ -29,20 +29,20 @@ role-based access control:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_server_organization.svg" class="align-center" width="100" alt="image" /></td>
 <td>An organization is the top-level entity for role-based access control in the Chef Infra Server. Each organization contains the default groups (<code>admins</code>, <code>clients</code>, and <code>users</code>, plus <code>billing_admins</code> for the hosted Chef Infra Server), at least one user and at least one node (on which the Chef Infra Client is installed). The Chef Infra Server supports multiple organizations. The Chef Infra Server includes a single default organization that is defined during setup. Additional organizations can be created after the initial setup and configuration of the Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><img src="/images/icon_server_groups.svg" class="align-center" width="100" alt="image" /></p></td>
 <td><p>A group is used to define access to object types and objects in the Chef Infra Server and also to assign permissions that determine what types of tasks are available to members of that group who are authorized to perform them. Groups are configured per-organization.</p>
 <p>Individual users who are members of a group will inherit the permissions assigned to the group. The Chef Infra Server includes the following default groups: <code>admins</code>, <code>clients</code>, and <code>users</code>. For users of the hosted Chef Infra Server, an additional default group is provided: <code>billing_admins</code>.</p></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_server_users.svg" class="align-center" width="100" alt="image" /></td>
 <td>A user is any non-administrator human being who will manage data that is uploaded to the Chef Infra Server from a workstation or who will log on to the Chef management console web user interface. The Chef Infra Server includes a single default user that is defined during setup and is automatically assigned to the <code>admins</code> group.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_chef_client.svg" class="align-center" width="100" alt="image" /></td>
 <td>A client is an actor that has permission to access the Chef Infra Server. A client is most often a node (on which the Chef Infra Client runs), but is also a workstation (on which knife runs), or some other machine that is configured to use the Chef Infra Server API. Each request to the Chef Infra Server that is made by a client uses a private key for authentication that must be authorized by the public key on the Chef Infra Server.</td>
 </tr>
@@ -116,11 +116,11 @@ The Chef Infra Server includes the following global permissions:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Create</strong></td>
 <td>Use the <strong>Create</strong> global permission to define which users and groups may create the following server object types: cookbooks, data bags, environments, nodes, roles, and tags. This permission is required for any user who uses the <code>knife [object] create</code> argument to interact with objects on the Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>List</strong></td>
 <td>Use the <strong>List</strong> global permission to define which users and groups may view the following server object types: cookbooks, data bags, environments, nodes, roles, and tags. This permission is required for any user who uses the <code>knife [object] list</code> argument to interact with objects on the Chef Infra Server.</td>
 </tr>
@@ -203,23 +203,23 @@ The Chef Infra Server includes the following default groups:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>admins</code></td>
 <td>The <code>admins</code> group defines the list of users who have administrative rights to all objects and object types for a single organization.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>billing_admins</code></td>
 <td>The <code>billing_admins</code> group defines the list of users who have permission to manage billing information. This permission exists only for the hosted Chef Infra Server.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>clients</code></td>
 <td>The <code>clients</code> group defines the list of nodes on which a Chef Infra Client is installed and under management by Chef. In general, think of this permission as "all of the non-human actors---Chef Infra Client, in nearly every case---that get data from, and/or upload data to, the Chef server". Newly-created Chef Infra Client instances are added to this group automatically.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>public_key_read_access</code></td>
 <td>The <code>public_key_read_access</code> group defines which users and clients have read permissions to key-related endpoints in the Chef Infra Server API.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>users</code></td>
 <td>The <code>users</code> group defines the list of users who use knife and the Chef management console to interact with objects and object types. In general, think of this permission as "all of the non-admin human actors who work with data that is uploaded to and/or downloaded from the Chef server".</td>
 </tr>
@@ -263,7 +263,7 @@ The `admins` group is assigned the following:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>admins</td>
 <td>yes</td>
 <td>yes</td>
@@ -271,7 +271,7 @@ The `admins` group is assigned the following:
 <td>yes</td>
 <td>yes</td>
 </tr>
-<tr class="even">
+<tr>
 <td>clients</td>
 <td>yes</td>
 <td>yes</td>
@@ -279,7 +279,7 @@ The `admins` group is assigned the following:
 <td>yes</td>
 <td>yes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>users</td>
 <td>yes</td>
 <td>yes</td>
@@ -318,7 +318,7 @@ The `billing_admins` group is assigned the following:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>billing_admins</td>
 <td>no</td>
 <td>no</td>
@@ -350,77 +350,77 @@ The `clients` group is assigned the following:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>clients</td>
 <td>no</td>
 <td>no</td>
 <td>no</td>
 <td>no</td>
 </tr>
-<tr class="even">
+<tr>
 <td>cookbooks</td>
 <td>no</td>
 <td>no</td>
 <td>yes</td>
 <td>no</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>cookbook_artifacts</td>
 <td>no</td>
 <td>no</td>
 <td>yes</td>
 <td>no</td>
 </tr>
-<tr class="even">
+<tr>
 <td>data</td>
 <td>no</td>
 <td>no</td>
 <td>yes</td>
 <td>no</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>environments</td>
 <td>no</td>
 <td>no</td>
 <td>yes</td>
 <td>no</td>
 </tr>
-<tr class="even">
+<tr>
 <td>nodes</td>
 <td>yes</td>
 <td>no</td>
 <td>yes</td>
 <td>no</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>organization</td>
 <td>no</td>
 <td>no</td>
 <td>yes</td>
 <td>no</td>
 </tr>
-<tr class="even">
+<tr>
 <td>policies</td>
 <td>no</td>
 <td>no</td>
 <td>yes</td>
 <td>no</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>policy_groups</td>
 <td>no</td>
 <td>no</td>
 <td>yes</td>
 <td>no</td>
 </tr>
-<tr class="even">
+<tr>
 <td>roles</td>
 <td>no</td>
 <td>no</td>
 <td>yes</td>
 <td>no</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>sandboxes</td>
 <td>no</td>
 <td>no</td>
@@ -463,7 +463,7 @@ By default, the `public_key_read_access` assigns all members of the
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>admins</td>
 <td>no</td>
 <td>no</td>
@@ -471,7 +471,7 @@ By default, the `public_key_read_access` assigns all members of the
 <td>no</td>
 <td>no</td>
 </tr>
-<tr class="even">
+<tr>
 <td>clients</td>
 <td>yes</td>
 <td>yes</td>
@@ -479,7 +479,7 @@ By default, the `public_key_read_access` assigns all members of the
 <td>yes</td>
 <td>yes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>users</td>
 <td>yes</td>
 <td>yes</td>
@@ -518,77 +518,77 @@ The `users` group is assigned the following:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>clients</td>
 <td>no</td>
 <td>yes</td>
 <td>yes</td>
 <td>no</td>
 </tr>
-<tr class="even">
+<tr>
 <td>cookbooks</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>cookbook_artifacts</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 </tr>
-<tr class="even">
+<tr>
 <td>data</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>environments</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 </tr>
-<tr class="even">
+<tr>
 <td>nodes</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>organization</td>
 <td>no</td>
 <td>no</td>
 <td>yes</td>
 <td>no</td>
 </tr>
-<tr class="even">
+<tr>
 <td>policies</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>policy_groups</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 </tr>
-<tr class="even">
+<tr>
 <td>roles</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 <td>yes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>sandboxes</td>
 <td>yes</td>
 <td>no</td>
@@ -624,7 +624,7 @@ Infra Server, that Chef Infra Client is added to the `clients` group:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>clients</td>
 <td>yes</td>
 <td>no</td>

--- a/content/supermarket_api.md
+++ b/content/supermarket_api.md
@@ -72,11 +72,11 @@ The response is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful. The cookbook was posted to the Supermarket API.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>400</code></p></td>
 <td><p>The request was unsuccessful. The cookbook was not posted to the Supermarket API. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1"></a><span class="op">{</span></span>
@@ -107,19 +107,19 @@ are sorted. Use the `user` parameter to filter cookbooks by maintainer:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>start</code></td>
 <td>The offset into a list of cookbooks, at which point the list of cookbooks will begin.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>items</code></td>
 <td>The number of items to be returned as a result of the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>order</code></td>
 <td>A token specifying how to order results. Possible values: <code>recently_updated</code>, <code>recently_added</code>, <code>most_downloaded</code>, or <code>most_followed</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>user</code></td>
 <td>The username to filter by. Only cookbooks maintained by this user will be returned.</td>
 </tr>
@@ -193,7 +193,7 @@ began:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful. One or more cookbooks were returned as a result of the search query.</td>
 </tr>
@@ -247,11 +247,11 @@ The response is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful. The cookbook was deleted.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>400</code></p></td>
 <td><p>The request was unsuccessful. The requested cookbook does not exist. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1"></a><span class="op">{</span></span>
@@ -260,7 +260,7 @@ The response is similar to:
 <span id="cb1-4"><a href="#cb1-4"></a>   <span class="st">&quot;error_code&quot;</span><span class="op">:</span> <span class="st">&quot;NOT_FOUND&quot;</span></span>
 <span id="cb1-5"><a href="#cb1-5"></a><span class="op">}</span></span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>403</code></p></td>
 <td><p>Unauthorized. The user who made the request is not authorized to perform the action. The user is not authorized to delete the cookbook. For example:</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1"></a><span class="op">{}</span></span></code></pre></div></td>
@@ -342,11 +342,11 @@ field (being `true`):
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful. The requested cookbook exists.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>400</code></p></td>
 <td><p>The request was unsuccessful. The requested cookbook does not exist. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1"></a><span class="op">{</span></span>
@@ -414,11 +414,11 @@ The response is similar to:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful. The cookbook version was deleted.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>400</code></p></td>
 <td><p>The request was unsuccessful. The requested cookbook or cookbook version does not exist. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1"></a><span class="op">{</span></span>
@@ -427,7 +427,7 @@ The response is similar to:
 <span id="cb1-4"><a href="#cb1-4"></a>   <span class="st">&quot;error_code&quot;</span><span class="op">:</span> <span class="st">&quot;NOT_FOUND&quot;</span></span>
 <span id="cb1-5"><a href="#cb1-5"></a><span class="op">}</span></span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>403</code></p></td>
 <td><p>Unauthorized. The user who made the request is not authorized to perform the action. The user is not authorized to delete the cookbook version. For example:</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1"></a><span class="op">{}</span></span></code></pre></div></td>
@@ -489,11 +489,11 @@ file, its dependencies and platforms it supports and so on:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful. The requested cookbook exists.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>400</code></p></td>
 <td><p>The request was unsuccessful. The requested cookbook does not exist. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1"></a><span class="op">{</span></span>
@@ -530,15 +530,15 @@ number of cookbooks returned:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>q</code></td>
 <td>The search query used to identify a list of items on a Chef Infra Server. This option uses the same syntax as the <code>search</code> subcommand.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>start</code></td>
 <td>The row at which return results begin.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>items</code></td>
 <td>The number of rows to be returned.</td>
 </tr>
@@ -600,7 +600,7 @@ cookbooks began:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful. One or more cookbooks were returned as a result of the search query.</td>
 </tr>
@@ -631,15 +631,15 @@ sorted.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>start</code></td>
 <td>The offset into a list of tools, at which point the list of tools will begin.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>items</code></td>
 <td>The number of items to be returned as a result of the request.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>order</code></td>
 <td>A token specifying how to order results. Possible values: <code>recently_added</code>.</td>
 </tr>
@@ -710,7 +710,7 @@ which the list of returned tools began:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful. One or more tools were returned.</td>
 </tr>
@@ -740,15 +740,15 @@ number of tools returned:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>q</code></td>
 <td>The search query used to identify a list of items on a Chef Infra Server. This option uses the same syntax as the <code>search</code> subcommand.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>start</code></td>
 <td>The row at which return results begin.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>items</code></td>
 <td>The number of rows to be returned.</td>
 </tr>
@@ -805,7 +805,7 @@ began:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful. One or more tools were returned as a result of the search query.</td>
 </tr>
@@ -859,11 +859,11 @@ markdown:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful. The requested tool exists.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>400</code></p></td>
 <td><p>The request was unsuccessful. The requested tool does not exist. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1"></a><span class="op">{</span></span>
@@ -951,7 +951,7 @@ with its location information and dependencies:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>200</code></td>
 <td>OK. The request was successful. One (or more) cookbooks and associated cookbook version information was returned.</td>
 </tr>

--- a/content/versions.md
+++ b/content/versions.md
@@ -80,43 +80,43 @@ announcement](https://blog.chef.io/2019/04/02/chef-software-announces-the-enterp
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Chef Automate</td>
 <td>Latest</td>
 <td>GA</td>
 <td>n/a</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Chef Infra Client</td>
 <td>16.x</td>
 <td>GA</td>
 <td>April 30, 2022</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Chef Infra Server</td>
 <td>14.x</td>
 <td>GA</td>
 <td>n/a</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Chef Habitat</td>
 <td>0.81+</td>
 <td>GA</td>
 <td>n/a</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Chef InSpec</td>
 <td>4.x</td>
 <td>GA</td>
 <td>n/a</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Chef Workstation</td>
 <td>20.x (2020), 21.x (2021)</td>
 <td>GA</td>
 <td>n/a</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Chef Backend</td>
 <td>3.x</td>
 <td>Releasing 2021</td>
@@ -154,7 +154,7 @@ version 2.0.
 </tr>
 </thead>
 <tbody>
-<tr class="even">
+<tr>
 <td>Supermarket</td>
 <td>3.x</td>
 <td>GA</td>
@@ -184,25 +184,25 @@ newer versions or products.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Chef Backend</td>
 <td>2.x</td>
 <td>Deprecated</td>
 <td>December 31, 2021</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Chef Infra Client</td>
 <td>15.x</td>
 <td>Deprecated</td>
 <td>April 30, 2021</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Chef Infra Server</td>
 <td>13.x</td>
 <td>Deprecated</td>
 <td>June 30, 2021</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Chef Manage</td>
 <td>2.5.x+</td>
 <td>Deprecated</td>
@@ -236,99 +236,99 @@ confused with the modern [Chef Compliance offering](/compliance/).
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Analytics</td>
 <td>All</td>
 <td>EOL</td>
 <td>December 31, 2018</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Automate</td>
 <td>1.x</td>
 <td>EOL</td>
 <td>December 31, 2019</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Chef Client</td>
 <td>14 and under</td>
 <td>EOL</td>
 <td>April 30, 2020</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Chef Compliance Server</td>
 <td>All</td>
 <td>EOL</td>
 <td>December 31, 2018</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>ChefDK</td>
 <td>3 and under</td>
 <td>EOL</td>
 <td>April 30, 2020</td>
 </tr>
-<tr class="even">
+<tr>
 <td>ChefDK</td>
 <td>4.x</td>
 <td>EOL</td>
 <td>December 31, 2020</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Chef Infra Server</td>
 <td>12.x</td>
 <td>EOL</td>
 <td>December 31, 2020</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Chef InSpec</td>
 <td>2 and under</td>
 <td>EOL</td>
 <td>December 31, 2019</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Chef InSpec</td>
 <td>3.x</td>
 <td>EOL</td>
 <td>April 30, 2020</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Chef Provisioning</td>
 <td>All</td>
 <td>EOL</td>
 <td>August 31, 2019</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Chef Push Jobs</td>
 <td>All</td>
 <td>EOL</td>
 <td>December 31, 2020</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Chef Replication/Sync</td>
 <td>All</td>
 <td>EOL</td>
 <td>August 31, 2019</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Chef Server DRBD HA</td>
 <td>All</td>
 <td>EOL</td>
 <td>March 31, 2019</td>
 </tr>
 </tbody>
-<tr class="odd">
+<tr>
 <td>Chef Workflow (Delivery)</td>
 <td>All</td>
 <td>EOL</td>
 <td>December 31, 2020</td>
 </tr>
 </tbody>
-<tr class="even">
+<tr>
 <td>Enterprise Chef</td>
 <td>All</td>
 <td>EOL</td>
 <td>December 31, 2018</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Reporting</td>
 <td>All</td>
 <td>EOL</td>

--- a/content/windows.md
+++ b/content/windows.md
@@ -66,7 +66,7 @@ Windows:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Windows</td>
 <td><code>x86</code>, <code>x64</code></td>
 <td><code>8.1</code>, <code>2012</code>, <code>2012 R2</code>, <code>2016</code>, <code>10 (all channels except "insider" builds)</code>, <code>2019 (Long-term servicing channel (LTSC), both Desktop Experience and Server Core)</code></td>
@@ -152,27 +152,27 @@ listed below:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/chef-cookbooks/iis">iis Cookbook</a></td>
 <td>The <code>iis</code> cookbook is used to install and configure Internet Information Services (IIS).</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/chef-cookbooks/iis_urlrewrite">iis_urlrewrite Cookbook</a></td>
 <td>This cookbook downloads and installs the IIS URL Rewrite 2.0 extension into Microsoft Internet Information Server.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/chef-cookbooks/powershell">PowerShell Cookbook</a></td>
 <td>Installs and configures PowerShell 2.0, 3.0, 4.0 or 5.0.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/chef-cookbooks/vcruntime">Microsoft Visual C++ Runtime Cookbook</a></td>
 <td>Installs Microsoft Visual C++ runtime version 6 (2005), 9 (2008), 10 (2010), 11 (2012), 12 (2013), 14 (2015) or 15 (2017) on Windows.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/chef-cookbooks/mingw">Mingw Cookbook</a></td>
 <td>Installs <code>msys/mingw</code> compiler toolchains on windows.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/chef-cookbooks/webpi">Webpi Cookbook</a></td>
 <td>The <code>webpi</code> cookbook is used to run the Microsoft Web Platform Installer (WebPI).</td>
 </tr>

--- a/data/infra/resources/dsc_resource.yaml
+++ b/data/infra/resources/dsc_resource.yaml
@@ -127,7 +127,7 @@ properties_list:
 
       <tbody>
 
-      <tr class="odd">
+      <tr>
 
       <td><code>Array</code></td>
 
@@ -135,7 +135,7 @@ properties_list:
 
       </tr>
 
-      <tr class="even">
+      <tr>
 
       <td><code>Chef::Util::Powershell:PSCredential</code></td>
 
@@ -143,7 +143,7 @@ properties_list:
 
       </tr>
 
-      <tr class="odd">
+      <tr>
 
       <td><code>False</code></td>
 
@@ -151,7 +151,7 @@ properties_list:
 
       </tr>
 
-      <tr class="even">
+      <tr>
 
       <td><code>Fixnum</code></td>
 
@@ -159,7 +159,7 @@ properties_list:
 
       </tr>
 
-      <tr class="odd">
+      <tr>
 
       <td><code>Float</code></td>
 
@@ -167,7 +167,7 @@ properties_list:
 
       </tr>
 
-      <tr class="even">
+      <tr>
 
       <td><code>Hash</code></td>
 
@@ -175,7 +175,7 @@ properties_list:
 
       </tr>
 
-      <tr class="odd">
+      <tr>
 
       <td><code>True</code></td>
 
@@ -237,7 +237,7 @@ properties_list:
 
       <tbody>
 
-      <tr class="odd">
+      <tr>
 
       <td><code>:archive</code></td>
 
@@ -246,7 +246,7 @@ properties_list:
 
       </tr>
 
-      <tr class="even">
+      <tr>
 
       <td><code>:environment</code></td>
 
@@ -255,7 +255,7 @@ properties_list:
 
       </tr>
 
-      <tr class="odd">
+      <tr>
 
       <td><code>:file</code></td>
 
@@ -264,7 +264,7 @@ properties_list:
 
       </tr>
 
-      <tr class="even">
+      <tr>
 
       <td><code>:group</code></td>
 
@@ -273,7 +273,7 @@ properties_list:
 
       </tr>
 
-      <tr class="odd">
+      <tr>
 
       <td><code>:log</code></td>
 
@@ -282,7 +282,7 @@ properties_list:
 
       </tr>
 
-      <tr class="even">
+      <tr>
 
       <td><code>:package</code></td>
 
@@ -291,7 +291,7 @@ properties_list:
 
       </tr>
 
-      <tr class="odd">
+      <tr>
 
       <td><code>:registry</code></td>
 
@@ -300,7 +300,7 @@ properties_list:
 
       </tr>
 
-      <tr class="even">
+      <tr>
 
       <td><code>:script</code></td>
 
@@ -309,7 +309,7 @@ properties_list:
 
       </tr>
 
-      <tr class="odd">
+      <tr>
 
       <td><code>:service</code></td>
 
@@ -318,7 +318,7 @@ properties_list:
 
       </tr>
 
-      <tr class="even">
+      <tr>
 
       <td><code>:user</code></td>
 
@@ -327,7 +327,7 @@ properties_list:
 
       </tr>
 
-      <tr class="odd">
+      <tr>
 
       <td><code>:windowsfeature</code></td>
 
@@ -336,7 +336,7 @@ properties_list:
 
       </tr>
 
-      <tr class="even">
+      <tr>
 
       <td><code>:windowsoptionalfeature</code></td>
 
@@ -344,7 +344,7 @@ properties_list:
 
       </tr>
 
-      <tr class="odd">
+      <tr>
 
       <td><code>:windowsprocess</code></td>
 
@@ -419,4 +419,3 @@ examples: "
   \ :xCluster\n    module_name 'xFailOverCluster'\n    module_version '1.6.0.0'\n\
   \    property :name, 'TestCluster'\n    property :staticipaddress, '10.0.0.3'\n\
   \    property :domainadministratorcredential, ps_credential('abcd')\n  end\n  ```\n"
-

--- a/themes/docs-new/layouts/shortcodes/adopted_platforms_server.md
+++ b/themes/docs-new/layouts/shortcodes/adopted_platforms_server.md
@@ -14,27 +14,27 @@ The following table lists the commercially-supported platforms and versions for 
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>CentOS</td>
 <td><code>x86_64</code></td>
 <td><code>7.x</code>, <code>8.x</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Oracle Enterprise Linux</td>
 <td><code>x86_64</code></td>
 <td><code>7.x</code>, <code>8.x</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Red Hat Enterprise Linux</td>
 <td><code>x86_64</code></td>
 <td><code>7.x</code>, <code>8.x</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>SUSE Enterprise Linux Server</td>
 <td><code>x86_64</code></td>
 <td><code>12.x</code>, <code>15.x</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Ubuntu</td>
 <td><code>x86_64</code></td>
 <td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>

--- a/themes/docs-new/layouts/shortcodes/chef_client_bootstrap_stages.md
+++ b/themes/docs-new/layouts/shortcodes/chef_client_bootstrap_stages.md
@@ -18,28 +18,28 @@ During a `knife bootstrap` bootstrap operation, the following happens:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>knife bootstrap</strong></td>
 <td>Enter the <code>knife bootstrap</code> subcommand from a workstation. Include the hostname, IP address, or FQDN of the target node as part of this command. Knife will establish an SSH or WinRM connection with the target system and run a bootstrap script.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><strong>Get the install script from Chef</strong></p></td>
 <td><p>The shell script will make a request to the Chef website to get the most recent version of a the Chef Infra Client install script(<code>install.sh</code> or <code>install.ps1</code>).</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Get the Chef Infra Client package from Chef</strong></td>
 <td>The install script then gathers system-specific information and determines the correct package for Chef Infra Client, and then downloads the appropriate package from <code>omnitruck-direct.chef.io</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Install Chef Infra Client</strong></td>
 <td>Chef Infra Client is installed on the target node using a system native package (.rpm, .msi, etc).</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><strong>Start a Chef Infra Client run</strong></p></td>
 <td><p>On UNIX and Linux-based machines: The second shell script executes the <code>chef-client</code> binary with a set of initial settings stored within <code>first-boot.json</code> on the node. <code>first-boot.json</code> is generated from the workstation as part of the initial <code>knife bootstrap</code> subcommand.</p>
 <p>On Microsoft Windows machines: The batch file that is derived from the windows-chef-client-msi.erb bootstrap template executes the <code>chef-client</code> binary with a set of initial settings stored within <code>first-boot.json</code> on the node. <code>first-boot.json</code> is generated from the workstation as part of the initial <code>knife bootstrap</code> subcommand.</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><strong>Complete a Chef Infra Client run</strong></p></td>
 <td><p>a Chef Infra Client run proceeds, using HTTPS (port 443), and registers the node with the Chef Infra Server.</p>
 <p>The first Chef Infra Client run, by default, contains an empty run-list. A <a href="/workstation/knife_bootstrap/">run-list can be specified</a> as part of the initial bootstrap operation using the <code>--run-list</code> option as part of the <code>knife bootstrap</code> subcommand.</p></td>

--- a/themes/docs-new/layouts/shortcodes/chef_client_run.md
+++ b/themes/docs-new/layouts/shortcodes/chef_client_run.md
@@ -16,44 +16,44 @@ During every Chef Infra Client run, the following happens:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Get configuration data</strong></td>
 <td>Chef Infra Client gets process configuration data from the <a href="/config_rb_client/">client.rb</a> file on the <a href="/nodes/">node</a>, and then gets node configuration data from Ohai. One important piece of configuration data is the name of the node, which is found in the <code>node_name</code> attribute in the client.rb file or is provided by Ohai. If Ohai provides the name of a node, it is typically the FQDN for the node, which is always unique within an organization.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Authenticate to the Chef Infra Server</strong></td>
 <td>Chef Infra Client <a href="/server/auth/">authenticates</a> to the Chef Infra Server using an RSA private key and the Chef Infra Server API. The name of the node is required as part of the authentication process to the Chef Infra Server. If this is the first Chef Infra Client run for a node, the chef-validator will be used to generate the RSA private key.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Get, rebuild the node object</strong></td>
 <td>Chef Infra Client pulls down the node object from the Chef Infra Server and then rebuilds it. A node object is made up of the system attributes discovered by Ohai, the attributes set in Policyfiles or Cookbooks, and the run list of cookbooks. The first time Chef Infra Client runs on a node, it creates a node object from the the default run-list. A node that has not yet had a Chef Infra Client run will not have a node object or a Chef Infra Server entry for a node object. On any subsequent Chef Infra Client runs, the rebuilt node object will also contain the run-list from the previous Chef Infra Client run.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Expand the run-list</strong></td>
 <td>Chef Infra Client expands the <a href="/run_lists/">run-list</a> from the rebuilt node object and compiles a complete list of recipes in the exact order that they will be applied to the node.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Synchronize cookbooks</strong></td>
 <td>Chef Infra Client requests all off the <a href="/cookbooks/">cookbook files</a> (including recipes, templates, resources, providers, attributes, and libraries) that it needs for every action identified in the run-list from the Chef Infra Server. The Chef Infra Server responds to Chef Infra Client with the complete list of files. Chef Infra Client compares the list of files to the files that already exist on the node from previous runs, and then downloads a copy of every new or modified file from the Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Reset node attributes</strong></td>
 <td>All attributes in the rebuilt node object are reset. All attributes from attribute files, Policyfiles, and Ohai are loaded. Attributes that are defined in attribute files are first loaded according to cookbook order. For each cookbook, attributes in the <code>default.rb</code> file are loaded first, and then additional attribute files (if present) are loaded in lexical sort order. If attribute files are found within any cookbooks that are listed as dependencies in the <code>metadata.rb</code> file, these are loaded as well. All attributes in the rebuilt node object are updated with the attribute data according to attribute precedence. When all of the attributes are updated, the rebuilt node object is complete.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Compile the resource collection</strong></td>
 <td>Chef Infra Client identifies each resource in the node object and builds the resource collection. Libraries are loaded first to ensure that all language extensions and Ruby classes are available to all resources. Next, attributes are loaded, followed by custom resources. Finally, all recipes are loaded in the order specified by the expanded run-list. This is also referred to as the "compile phase".</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Converge the node</strong></td>
 <td>Chef Infra Client configures the system based on the information that has been collected. Each resource is executed in the order identified by the run-list, and then by the order in which each resource is listed in each recipe. Each resource defines an action to run, which configures a specific part of the system. This process is also referred to as convergence. This is also referred to as the "execution phase".</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><strong>Update the node object, process exception and report handlers</strong></p></td>
 <td><p>When all of the actions identified by resources in the resource collection have been done and Chef Infra Client finishes successfully, then Chef Infra Client updates the node object on the Chef Infra Server with the node object built during a Chef Infra Client run. (This node object will be pulled down by Chef Infra Client during the next Chef Infra Client run.) This makes the node object (and the data in the node object) available for search.</p>
 <p>Chef Infra Client always checks the resource collection for the presence of exception and report handlers. If any are present, each one is processed appropriately.</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Stop, wait for the next run</strong></td>
 <td>When everything is configured and the Chef Infra Client run is complete, Chef Infra Client stops and waits until the next time it is asked to run.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/chef_shell_modes.md
+++ b/themes/docs-new/layouts/shortcodes/chef_shell_modes.md
@@ -14,15 +14,15 @@ as interactive debugging features. chef-shell has three run modes:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Standalone</td>
 <td>Default. No cookbooks are loaded, and the run-list is empty.</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Solo</td>
 <td>chef-shell acts as a Chef Solo Client. It attempts to load the chef-solo configuration file at <code>~/.chef/config.rb</code> and any JSON attributes passed. If the JSON attributes set a run-list, it will be honored. Cookbooks will be loaded in the same way that chef-solo loads them. chef-solo mode is activated with the <code>-s</code> or <code>--solo</code> command line option, and JSON attributes are specified in the same way as for chef-solo, with <code>-j /path/to/chef-solo.json</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Client</td>
 <td>chef-shell acts as a Chef Infra Client. During startup, it reads the Chef Infra Client configuration file from <code>~/.chef/client.rb</code> and contacts the Chef Infra Server to get the node's run_list, attributes, and cookbooks. Chef Infra Client mode is activated with the <code>-z</code> or <code>--client</code> options. You can also specify the configuration file with <code>-c CONFIG</code> and the server URL with <code>-S SERVER_URL</code>.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/cookbooks_version_constraints_operators.md
+++ b/themes/docs-new/layouts/shortcodes/cookbooks_version_constraints_operators.md
@@ -12,27 +12,27 @@ The following operators may be used:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>=</code></td>
 <td>equal to</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>&gt;</code></td>
 <td>greater than</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>&lt;</code></td>
 <td>less than</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>&gt;=</code></td>
 <td>greater than or equal to; also known as "optimistically greater than", or "optimistic"</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>&lt;=</code></td>
 <td>less than or equal to</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>~&gt;</code></td>
 <td>approximately greater than; also known as "pessimistically greater than", or "pessimistic"</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/data_bag_encryption_knife_options.md
+++ b/themes/docs-new/layouts/shortcodes/data_bag_encryption_knife_options.md
@@ -14,11 +14,11 @@ arguments and the following options:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>--secret SECRET</code></td>
 <td>The encryption key that is used for values contained within a data bag item. If <code>secret</code> is not specified, Chef Infra Client looks for a secret at the path specified by the <code>encrypted_data_bag_secret</code> setting in the client.rb file.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>--secret-file FILE</code></td>
 <td>The path to the file that contains the encryption key.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/delivery_integration_ldap_attributes.md
+++ b/themes/docs-new/layouts/shortcodes/delivery_integration_ldap_attributes.md
@@ -13,43 +13,43 @@ Workflow:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>ldap_attr_fullname</code></td>
 <td>The full user name for an LDAP user. Default value: <code>nil</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ldap_attr_login</code></td>
 <td>The login user name for an LDAP user. Default value: <code>sAMAccountName</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ldap_attr_mail</code></td>
 <td>The email for an LDAP user. Default value: <code>mail</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ldap_base_dn</code></td>
 <td>Base dn to use when searching for users in LDAP, typically <code>OU=Users</code> and then the domain. Default value: <code>OU=Employees,OU=Domain users,DC=examplecorp,DC=com</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ldap_bind_dn</code></td>
 <td>The user Workflow will use to perform LDAP searches. This is often the administrator or manager user. This user needs to have read access to all LDAP users that require authentication. The Workflow server must do an LDAP search before any user can log in. Many LDAP systems do not allow an anonymous bind. If anonymous bind is allowed, leave the <code>bind_dn</code> and <code>bind_dn_password</code> settings blank. If anonymous bind is not allowed, a user with <code>READ</code> access to the directory is required. This user must be specified as an LDAP distinguished name (<code>dn</code>). Default value: <code>nil</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ldap_bind_dn_password</code></td>
 <td>The password for the user specified by <code>ldap['bind_dn']</code>. Leave this value and <code>ldap['bind_dn']</code> unset if anonymous bind is sufficient. Default value: <code>secret123</code>. We do not recommend using a backslash (<code>\</code>) in the password, but if the password needs to have a backslash, please contact support.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ldap_encryption</code></td>
 <td>The type of encryption used to communicate with Workflow. Default value: <code>start_tls</code>. If tls is not in use, set to <code>no_tls</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ldap_hosts</code></td>
 <td>An array of hostname(s) of the LDAP server. Be sure Workflow is able to resolve any host names. Default value: <code>[]</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ldap_port</code></td>
 <td>The default value is an appropriate value for most configurations. Default value: <code>3269</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ldap_timeout</code></td>
 <td>Timeout when Workflow connects to LDAP. Default value: <code>5000</code>.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_property_validation_parameter.md
+++ b/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_property_validation_parameter.md
@@ -13,7 +13,7 @@ parameters to a property.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>:callbacks</code></p></td>
 <td><p>Use to define a collection of unique keys and values (a ruby hash) for which the key is the error message and the value is a lambda to validate the parameter. For example:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb1-1"><a href="#cb1-1"></a><span class="st">callbacks: </span>{</span>
@@ -22,7 +22,7 @@ parameters to a property.
 <span id="cb1-4"><a href="#cb1-4"></a>             }</span>
 <span id="cb1-5"><a href="#cb1-5"></a>           }</span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>:default</code></p></td>
 <td><p>Use to specify the default value for a property. For example:</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb2-1"><a href="#cb2-1"></a><span class="st">default: &#39;a_string_value&#39;</span></span></code></pre></div>
@@ -31,23 +31,23 @@ parameters to a property.
 <div class="sourceCode" id="cb5"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb5-1"><a href="#cb5-1"></a><span class="st">default: </span>()</span></code></pre></div>
 <div class="sourceCode" id="cb6"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb6-1"><a href="#cb6-1"></a><span class="st">default: </span>{}</span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>:equal_to</code></p></td>
 <td><p>Use to match a value with <code>==</code>. Use an array of values to match any of those values with <code>==</code>. For example:</p>
 <div class="sourceCode" id="cb7"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb7-1"><a href="#cb7-1"></a><span class="st">equal_to: </span>[<span class="dv">true</span>, <span class="dv">false</span>]</span></code></pre></div>
 <div class="sourceCode" id="cb8"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb8-1"><a href="#cb8-1"></a><span class="st">equal_to: </span>[<span class="st">&#39;php&#39;</span>, <span class="st">&#39;perl&#39;</span>]</span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>:regex</code></p></td>
 <td><p>Use to match a value to a regular expression. For example:</p>
 <div class="sourceCode" id="cb9"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb9-1"><a href="#cb9-1"></a><span class="st">regex: </span>[ <span class="ot">/^([a-z]|[A-Z]|[0-9]|_|-)+$/</span>, <span class="ot">/^\d+$/</span> ]</span></code></pre></div></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p><code>:required</code></p></td>
 <td><p>Indicates that a property is required. For example:</p>
 <div class="sourceCode" id="cb10"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb10-1"><a href="#cb10-1"></a><span class="st">required: </span><span class="dv">true</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p><code>:respond_to</code></p></td>
 <td><p>Use to ensure that a value has a given method. This can be a single method name or an array of method names. For example:</p>
 <div class="sourceCode" id="cb11"><pre class="sourceCode ruby"><code class="sourceCode ruby"><span id="cb11-1"><a href="#cb11-1"></a><span class="st">respond_to: </span>valid_encoding?</span></code></pre></div></td>

--- a/themes/docs-new/layouts/shortcodes/dsl_handler_event_types.md
+++ b/themes/docs-new/layouts/shortcodes/dsl_handler_event_types.md
@@ -14,291 +14,291 @@ method block by declaring it as the event type.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>:run_start</code></td>
 <td>The start of a Chef Infra Client run.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:run_started</code></td>
 <td>The Chef Infra Client run has started.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:ohai_completed</code></td>
 <td>The Ohai run has completed.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:skipping_registration</code></td>
 <td>The Chef Infra Client is not registering with the Chef Infra Server because it already has a private key or because it does not need one.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:registration_start</code></td>
 <td>The Chef Infra Client is attempting to create a private key with which to register to the Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:registration_completed</code></td>
 <td>The Chef Infra Client created its private key successfully.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:registration_failed</code></td>
 <td>The Chef Infra Client encountered an error and was unable to register with the Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:node_load_start</code></td>
 <td>The Chef Infra Client is attempting to load node data from the Chef Infra Server.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:node_load_failed</code></td>
 <td>The Chef Infra Client encountered an error and was unable to load node data from the Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:run_list_expand_failed</code></td>
 <td>The Chef Infra Client failed to expand the run-list.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:node_load_completed</code></td>
 <td>The Chef Infra Client successfully loaded node data from the Chef Infra Server. Default and override attributes for roles have been computed, but are not yet applied.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:policyfile_loaded</code></td>
 <td>The policy file was loaded.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:cookbook_resolution_start</code></td>
 <td>The Chef Infra Client is attempting to pull down the cookbook collection from the Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:cookbook_resolution_failed</code></td>
 <td>The Chef Infra Client failed to pull down the cookbook collection from the Chef Infra Server.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:cookbook_resolution_complete</code></td>
 <td>The Chef Infra Client successfully pulled down the cookbook collection from the Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:cookbook_clean_start</code></td>
 <td>The Chef Infra Client is attempting to remove unneeded cookbooks.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:removed_cookbook_file</code></td>
 <td>The Chef Infra Client removed a file from a cookbook.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:cookbook_clean_complete</code></td>
 <td>The Chef Infra Client is done removing cookbooks and/or cookbook files.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:cookbook_sync_start</code></td>
 <td>The Chef Infra Client is attempting to synchronize cookbooks.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:synchronized_cookbook</code></td>
 <td>The Chef Infra Client is attempting to synchronize the named cookbook.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:updated_cookbook_file</code></td>
 <td>The Chef Infra Client updated the named file in the named cookbook.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:cookbook_sync_failed</code></td>
 <td>The Chef Infra Client was unable to synchronize cookbooks.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:cookbook_sync_complete</code></td>
 <td>The Chef Infra Client is finished synchronizing cookbooks.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:library_load_start</code></td>
 <td>The Chef Infra Client is loading library files.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:library_file_loaded</code></td>
 <td>The Chef Infra Client successfully loaded the named library file.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:library_file_load_failed</code></td>
 <td>The Chef Infra Client was unable to load the named library file.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:library_load_complete</code></td>
 <td>The Chef Infra Client is finished loading library files.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:lwrp_load_start</code></td>
 <td>The Chef Infra Client is loading custom resources.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:lwrp_file_loaded</code></td>
 <td>The Chef Infra Client successfully loaded the named custom resource.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:lwrp_file_load_failed</code></td>
 <td>The Chef Infra Client was unable to load the named custom resource.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:lwrp_load_complete</code></td>
 <td>The Chef Infra Client is finished loading custom resources.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:attribute_load_start</code></td>
 <td>The Chef Infra Client is loading attribute files.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:attribute_file_loaded</code></td>
 <td>The Chef Infra Client successfully loaded the named attribute file.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:attribute_file_load_failed</code></td>
 <td>The Chef Infra Client was unable to load the named attribute file.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:attribute_load_complete</code></td>
 <td>The Chef Infra Client is finished loading attribute files.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:definition_load_start</code></td>
 <td>The Chef Infra Client is loading definitions.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:definition_file_loaded</code></td>
 <td>The Chef Infra Client successfully loaded the named definition.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:definition_file_load_failed</code></td>
 <td>The Chef Infra Client was unable to load the named definition.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:definition_load_complete</code></td>
 <td>The Chef Infra Client is finished loading definitions.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:recipe_load_start</code></td>
 <td>The Chef Infra Client is loading recipes.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:recipe_file_loaded</code></td>
 <td>The Chef Infra Client successfully loaded the named recipe.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:recipe_file_load_failed</code></td>
 <td>The Chef Infra Client was unable to load the named recipe.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:recipe_not_found</code></td>
 <td>The Chef Infra Client was unable to find the named recipe.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:recipe_load_complete</code></td>
 <td>The Chef Infra Client is finished loading recipes.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:converge_start</code></td>
 <td>The Chef Infra Client run converge phase has started.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:converge_complete</code></td>
 <td>The Chef Infra Client run converge phase is complete.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:converge_failed</code></td>
 <td>The Chef Infra Client run converge phase has failed.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:control_group_started</code></td>
 <td>The named control group is being processed.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:control_example_success</code></td>
 <td>The named control group has been processed.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:control_example_failure</code></td>
 <td>The named control group's processing has failed.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:resource_action_start</code></td>
 <td>A resource action is starting.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:resource_skipped</code></td>
 <td>A resource action was skipped.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:resource_current_state_loaded</code></td>
 <td>A resource's current state was loaded.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:resource_current_state_load_bypassed</code></td>
 <td>A resource's current state was not loaded because the resource does not support why-run mode.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:resource_bypassed</code></td>
 <td>A resource action was skipped because the resource does not support why-run mode.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:resource_update_applied</code></td>
 <td>A change has been made to a resource. (This event occurs for each change made to a resource.)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:resource_failed_retriable</code></td>
 <td>A resource action has failed and will be retried.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:resource_failed</code></td>
 <td>A resource action has failed and will not be retried.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:resource_updated</code></td>
 <td>A resource requires modification.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:resource_up_to_date</code></td>
 <td>A resource is already correct.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:resource_completed</code></td>
 <td>All actions for the resource are complete.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:stream_opened</code></td>
 <td>A stream has opened.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:stream_closed</code></td>
 <td>A stream has closed.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:stream_output</code></td>
 <td>A chunk of data from a single named stream.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:handlers_start</code></td>
 <td>The handler processing phase of a Chef Infra Client run has started.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:handler_executed</code></td>
 <td>The named handler was processed.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:handlers_completed</code></td>
 <td>The handler processing phase of a Chef Infra Client run is complete.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:provider_requirement_failed</code></td>
 <td>An assertion declared by a provider has failed.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:whyrun_assumption</code></td>
 <td>An assertion declared by a provider has failed, but execution is allowed to continue because the Chef Infra Client is running in why-run mode.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:run_completed</code></td>
 <td>The Chef Infra Client run has completed.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:run_failed</code></td>
 <td>The Chef Infra Client run has failed.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:attribute_changed</code></td>
 <td>Prints out all the attribute changes in cookbooks or sets a policy that override attributes should never be used.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/handler_community_handlers.md
+++ b/themes/docs-new/layouts/shortcodes/handler_community_handlers.md
@@ -13,83 +13,83 @@ community:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/timops/ohai-plugins/blob/master/win32_svc.rb">Airbrake</a></td>
 <td>A handler that sends exceptions (only) to Airbrake, an application that collects data and aggregates it for review.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/rottenbytes/chef/tree/master/async_handler">Asynchronous Resources</a></td>
 <td>A handler that asynchronously pushes exception and report handler data to a STOMP queue, from which data can be processed into data storage.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/ampledata/chef-handler-campfire">Campfire</a></td>
 <td>A handler that collects exception and report handler data and reports it to Campfire, a web-based group chat tool.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/DataDog/chef-handler-datadog">Datadog</a></td>
 <td>A handler that collects Chef Infra Client stats and sends them into a Datadog newsfeed.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/mmarschall/chef-handler-flowdock">Flowdock</a></td>
 <td>A handler that collects exception and report handler data and sends it to users via the Flowdock API..</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/imeyer/chef-handler-graphite/wiki">Graphite</a></td>
 <td>A handler that collects exception and report handler data and reports it to Graphite, a graphic rendering application.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/jellybob/chef-gelf/">Graylog2 GELF</a></td>
 <td>A handler that provides exception and report handler status (including changes) to a Graylog2 server, so that the data can be viewed using Graylog Extended Log Format (GELF).</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://rubygems.org/gems/chef-handler-growl">Growl</a></td>
 <td>A handler that collects exception and report handler data and then sends it as a Growl notification.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/mojotech/hipchat/blob/master/lib/hipchat/chef.rb">HipChat</a></td>
 <td>A handler that collects exception handler data and sends it to HipChat, a hosted private chat service for companies and teams.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://rubygems.org/gems/chef-irc-snitch">IRC Snitch</a></td>
 <td>A handler that notifies administrators (via Internet Relay Chat (IRC)) when a Chef Infra Client run fails.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/marktheunissen/chef-handler-journald">Journald</a></td>
 <td>A handler that logs an entry to the systemd journal with the Chef Infra Client run status, exception details, configurable priority, and custom details.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/b1-systems/chef-handler-httpapi/">net/http</a></td>
 <td>A handler that reports the status of a Chef run to any API via net/HTTP.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://rubygems.org/gems/chef-handler-mail">Simple Email</a></td>
 <td>A handler that collects exception and report handler data and then uses pony to send email reports that are based on Erubis templates.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/sendgrid-ops/chef-sendgrid_mail_handler">SendGrid Mail Handler</a></td>
 <td>A chef handler that collects exception and report handler data and then uses SendGrid Ruby gem to send email reports that are based on Erubis templates.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="http://onddo.github.io/chef-handler-sns/">SNS</a></td>
 <td>A handler that notifies exception and report handler data and sends it to a SNS topic.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/rackspace-cookbooks/chef-slack_handler">Slack</a></td>
 <td>A handler to send Chef Infra Client run notifications to a Slack channel.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="http://ampledata.org/splunk_storm_chef_handler.html">Splunk Storm</a></td>
 <td>A handler that supports exceptions and reports for Splunk Storm.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/jblaine/syslog_handler">Syslog</a></td>
 <td>A handler that logs basic essential information, such as about the success or failure of a Chef Infra Client run.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://rubygems.org/gems/chef-handler-updated-resources">Updated Resources</a></td>
 <td>A handler that provides a simple way to display resources that were updated during a Chef Infra Client run.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="http://onddo.github.io/chef-handler-zookeeper/">ZooKeeper</a></td>
 <td>A Chef report handler to send Chef run notifications to ZooKeeper.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/handler_custom_object_run_status.md
+++ b/themes/docs-new/layouts/shortcodes/handler_custom_object_run_status.md
@@ -15,47 +15,47 @@ all) of the following properties:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>all_resources</code></td>
 <td>A list of all resources that are included in the <code>resource_collection</code> property for the current Chef Infra Client run.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>backtrace</code></td>
 <td>A backtrace associated with the uncaught exception data that caused a Chef Infra Client run to fail, if present; <code>nil</code> for a successful Chef Infra Client run.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>elapsed_time</code></td>
 <td>The amount of time between the start (<code>start_time</code>) and end (<code>end_time</code>) of a Chef Infra Client run.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>end_time</code></td>
 <td>The time at which a Chef Infra Client run ended.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>exception</code></td>
 <td>The uncaught exception data which caused a Chef Infra Client run to fail; <code>nil</code> for a successful Chef Infra Client run.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>failed?</code></td>
 <td>Show that a Chef Infra Client run has failed when uncaught exceptions were raised during a Chef Infra Client run. An exception handler runs when the <code>failed?</code> indicator is <code>true</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>node</code></td>
 <td>The node on which a Chef Infra Client run occurred.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>run_context</code></td>
 <td>An instance of the <code>Chef::RunContext</code> object; used by Chef Infra Client to track the context of the run; provides access to the <code>cookbook_collection</code>, <code>resource_collection</code>, and <code>definitions</code> properties.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>start_time</code></td>
 <td>The time at which a Chef Infra Client run started.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>success?</code></td>
 <td>Show that a Chef Infra Client run succeeded when uncaught exceptions were not raised during a Chef Infra Client run. A report handler runs when the <code>success?</code> indicator is <code>true</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>updated_resources</code></td>
 <td>A list of resources that were marked as updated as a result of a Chef Infra Client run.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/handler_types.md
+++ b/themes/docs-new/layouts/shortcodes/handler_types.md
@@ -12,15 +12,15 @@ There are three types of handlers:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>exception</td>
 <td>An exception handler is used to identify situations that have caused a Chef Infra Client run to fail. An exception handler can be loaded at the start of a Chef Infra Client run by adding a recipe that contains the <strong>chef_handler</strong> resource to a node's run-list. An exception handler runs when the <code>failed?</code> property for the <code>run_status</code> object returns <code>true</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td>report</td>
 <td>A report handler is used when a Chef Infra Client run succeeds and reports back on certain details about that Chef Infra Client run. A report handler can be loaded at the start of a Chef Infra Client run by adding a recipe that contains the <strong>chef_handler</strong> resource to a node's run-list. A report handler runs when the <code>success?</code> property for the <code>run_status</code> object returns <code>true</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>start</td>
 <td>A start handler is used to run events at the beginning of a Chef Infra Client run. A start handler can be loaded at the start of a Chef Infra Client run by adding the start handler to the <code>start_handlers</code> setting in the client.rb file or by installing the gem that contains the start handler by using the <strong>chef_gem</strong> resource in a recipe in the <strong>chef-client</strong> cookbook. (A start handler may not be loaded using the <code>chef_handler</code> resource.)</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/node_attribute_allowlist.md
+++ b/themes/docs-new/layouts/shortcodes/node_attribute_allowlist.md
@@ -21,19 +21,19 @@ Attributes are allowlisted by attribute type, with each attribute type being all
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>allowed_automatic_attributes</code></td>
 <td>A hash that allowlists <code>automatic</code> attributes, preventing non-allowlisted attributes from being saved. For example: <code>['network/interfaces/eth0']</code>. Default value: <code>nil</code>, all attributes are saved. If the hash is empty, no attributes are saved.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>allowed_default_attributes</code></td>
 <td>A hash that allowlists <code>default</code> attributes, preventing non-allowlisted attributes from being saved. For example: <code>['filesystem/dev/disk0s2/size']</code>. Default value: <code>nil</code>, all attributes are saved. If the hash is empty, no attributes are saved.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>allowed_normal_attributes</code></td>
 <td>A hash that allowlists <code>normal</code> attributes, preventing non-allowlisted attributes from being saved. For example: <code>['filesystem/dev/disk0s2/size']</code>. Default value: <code>nil</code>, all attributes are saved. If the hash is empty, no attributes are saved.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>allowed_override_attributes</code></td>
 <td>A hash that allowlists <code>override</code> attributes, preventing non-allowlisted attributes from being saved. For example: <code>['map - autohome/size']</code>. Default value: <code>nil</code>, all attributes are saved. If the hash is empty, no attributes are saved.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/node_attribute_blocklist.md
+++ b/themes/docs-new/layouts/shortcodes/node_attribute_blocklist.md
@@ -20,19 +20,19 @@ Attributes are blocklisted by attribute type, with each attribute type being blo
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>blocked_automatic_attributes</code></td>
 <td>A hash that blocklists <code>automatic</code> attributes, preventing blocklisted attributes from being saved. For example: <code>['network/interfaces/eth0']</code>. Default value: <code>nil</code>, all attributes are saved. If the array is empty, all attributes are saved.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>blocked_default_attributes</code></td>
 <td>A hash that blocklists <code>default</code> attributes, preventing blocklisted attributes from being saved. For example: <code>['filesystem/dev/disk0s2/size']</code>. Default value: <code>nil</code>, all attributes are saved. If the array is empty, all attributes are saved.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>blocked_normal_attributes</code></td>
 <td>A hash that blocklists <code>normal</code> attributes, preventing blocklisted attributes from being saved. For example: <code>['filesystem/dev/disk0s2/size']</code>. Default value: <code>nil</code>, all attributes are saved. If the array is empty, all attributes are saved.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>blocked_override_attributes</code></td>
 <td>A hash that blocklists <code>override</code> attributes, preventing blocklisted attributes from being saved. For example: <code>['map - autohome/size']</code>. Default value: <code>nil</code>, all attributes are saved. If the array is empty, all attributes are saved.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/node_attribute_precedence.md
+++ b/themes/docs-new/layouts/shortcodes/node_attribute_precedence.md
@@ -16,32 +16,32 @@ order:
   </tr>
 </thead>
 <tbody>
-  <tr class="odd">
+  <tr>
     <td>1</td>
     <td><code>`default`</code></td>
     <td>Cookbook attribute file<br>Recipe<br>Environment<br>Role</td>
   </tr>
-  <tr class="even">
+  <tr>
     <td>2</td>
     <td><code>`force_default`</code></td>
     <td>Cookbook attribute file<br>Recipe</td>
   </tr>
-  <tr class="odd">
+  <tr>
     <td>3</td>
     <td><code>`normal`</code></td>
     <td>JSON file passed with <code>`chef-client -j`</code><br>Cookbook attribute file<br>Recipe</td>
   </tr>
-  <tr class="even">
+  <tr>
     <td>4</td>
     <td><code>`override`</code></td>
     <td>Cookbook attribute file<br>Recipe<br>Role<br>Environment</td>
   </tr>
-  <tr class="odd">
+  <tr>
     <td>5</td>
     <td><code>`force_override`</code></td>
     <td>Cookbook attribute file<br>Recipe</td>
   </tr>
-  <tr class="even">
+  <tr>
     <td>6</td>
     <td><code>`automatic`</code></td>
     <td>Identified by Ohai at the start of a Chef Infra Client Run</td>

--- a/themes/docs-new/layouts/shortcodes/node_types.md
+++ b/themes/docs-new/layouts/shortcodes/node_types.md
@@ -13,23 +13,23 @@ limited to, the following:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_node_type_server.svg" class="align-center" width="100" alt="image" /></td>
 <td>A physical node is typically a server or a virtual machine, but it can be any active device attached to a network that is capable of sending, receiving, and forwarding information over a communications channel. In other words, a physical node is any active device attached to a network that can run a Chef Infra Client and also allow that Chef Infra Client to communicate with a Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_node_type_cloud_public.svg" class="align-center" width="100" alt="image" /></td>
 <td>A cloud-based node is hosted in an external cloud-based service, such as Amazon Web Services (AWS), OpenStack, Rackspace, Google Compute Engine, or Microsoft Azure. Plugins are available for knife that provide support for external cloud-based services. knife can use these plugins to create instances on cloud-based services. Once created, Chef Infra Client can be used to deploy, configure, and maintain those instances.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_node_virtual_machine.svg" class="align-center" width="100" alt="image" /></td>
 <td>A virtual node is a machine that runs only as a software implementation, but otherwise behaves much like a physical machine.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><img src="/images/icon_node_type_network_device.svg" class="align-center" width="100" alt="image" /></td>
 <td>A network node is any networking device---a switch, a router---that is being managed by a Chef Infra Client, such as networking devices by Juniper Networks, Arista, Cisco, and F5. Use Chef to automate common network configurations, such as physical and logical Ethernet link properties and VLANs, on these devices.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><img src="/images/icon_node_type_container.svg" class="align-center" width="100" alt="image" /></td>
 <td>Containers are an approach to virtualization that allows a single operating system to host many working configurations, where each working configuration---a container---is assigned a single responsibility that is isolated from all other responsibilities. Containers are popular as a way to manage distributed and scalable applications and services.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/ohai_automatic_attribute.md
+++ b/themes/docs-new/layouts/shortcodes/ohai_automatic_attribute.md
@@ -16,47 +16,47 @@ Infra Client run. The most commonly accessed automatic attributes are:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>node['platform']</code></td>
 <td>The platform on which a node is running. This attribute helps determine which providers will be used.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>node['platform_family']</code></td>
 <td>The platform family is a Chef Infra specific grouping of similar platforms where cookbook code can often be shared. For example, `rhel` includes Red Hat Linux, Oracle Linux, CentOS, and several other platforms that are nearly identical to Red Hat Linux.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>node['platform_version']</code></td>
 <td>The version of the platform. This attribute helps determine which providers will be used.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>node['ipaddress']</code></td>
 <td>The IP address for a node. If the node has a default route, this is the IPV4 address for the interface. If the node does not have a default route, the value for this attribute should be <code>nil</code>. The IP address for default route is the recommended default value.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>node['macaddress']</code></td>
 <td>The MAC address for a node, determined by the same interface that detects the <code>node['ipaddress']</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>node['fqdn']</code></td>
 <td>The fully qualified domain name for a node. This is used as the name of a node unless otherwise set.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>node['hostname']</code></td>
 <td>The host name for the node.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>node['domain']</code></td>
 <td>The domain for the node.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>node['recipes']</code></td>
 <td>A list of recipes associated with a node (and part of that node's run-list).</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>node['roles']</code></td>
 <td>A list of roles associated with a node (and part of that node's run-list).</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>node['ohai_time']</code></td>
 <td>The time at which Ohai was last run. This attribute is not commonly used in recipes, but it is saved to the Chef Infra Server and can be accessed using the <code>knife status</code> subcommand.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/plugin_knife_using_authenticated_requests.md
+++ b/themes/docs-new/layouts/shortcodes/plugin_knife_using_authenticated_requests.md
@@ -13,19 +13,19 @@ Chef Infra Server using the following methods:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>rest.delete_rest</code></td>
 <td>Use to delete an object from the Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>rest.get_rest</code></td>
 <td>Use to get the details of an object on the Chef Infra Server.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>rest.post_rest</code></td>
 <td>Use to add an object to the Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>rest.put_rest</code></td>
 <td>Use to update an object on the Chef Infra Server.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/resources_common_windows_security_acl.md
+++ b/themes/docs-new/layouts/shortcodes/resources_common_windows_security_acl.md
@@ -59,15 +59,15 @@ where
     </tr>
     </thead>
     <tbody>
-    <tr class="odd">
+    <tr>
     <td><code>:applies_to_children</code></td>
     <td>Specify how permissions are applied to children. Possible values: <code>true</code> to inherit both child directories and files; <code>false</code> to not inherit any child directories or files; <code>:containers_only</code> to inherit only child directories (and not files); <code>:objects_only</code> to recursively inherit files (and not child directories).</td>
     </tr>
-    <tr class="even">
+    <tr>
     <td><code>:applies_to_self</code></td>
     <td>Indicates whether a permission is applied to the parent directory. Possible values: <code>true</code> to apply to the parent directory or file and its children; <code>false</code> to not apply only to child directories and files.</td>
     </tr>
-    <tr class="odd">
+    <tr>
     <td><code>:one_level_deep</code></td>
     <td>Indicates the depth to which permissions will be applied. Possible values: <code>true</code> to apply only to the first level of children; <code>false</code> to apply to all children.</td>
     </tr>

--- a/themes/docs-new/layouts/shortcodes/ruby_style_basics_chef_log.md
+++ b/themes/docs-new/layouts/shortcodes/ruby_style_basics_chef_log.md
@@ -14,23 +14,23 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Fatal</td>
 <td><code>Chef::Log.fatal('string')</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Error</td>
 <td><code>Chef::Log.error('string')</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Warn</td>
 <td><code>Chef::Log.warn('string')</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Info</td>
 <td><code>Chef::Log.info('string')</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Debug</td>
 <td><code>Chef::Log.debug('string')</code></td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/search_boolean_operators.md
+++ b/themes/docs-new/layouts/shortcodes/search_boolean_operators.md
@@ -15,15 +15,15 @@ operators:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>AND</code></td>
 <td>Use to find a match when both terms exist.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>OR</code></td>
 <td>Use to find a match if either term exists.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>NOT</code></td>
 <td>Use to exclude the term after <code>NOT</code> from the search results.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/server_firewalls_and_ports_fe.md
+++ b/themes/docs-new/layouts/shortcodes/server_firewalls_and_ports_fe.md
@@ -16,7 +16,7 @@ firewalls that are in use:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p>80, 443, 9683</p></td>
 <td><p><strong>nginx</strong></p>
 <p>{{ readFile "themes/docs-new/layouts/shortcodes/server_services_nginx.md" | markdownify }}</p>
@@ -28,19 +28,19 @@ firewalls that are in use:
 </div></td>
 <td><p>yes</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p>9463</p></td>
 <td><p><strong>oc_bifrost</strong></p>
 <p>{{ readFile "themes/docs-new/layouts/shortcodes/server_services_bifrost.md" | markdownify }}</p></td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p>9090</p></td>
 <td><p><strong>oc-id</strong></p>
 <p>{{ readFile "themes/docs-new/layouts/shortcodes/server_services_oc_id.md" | markdownify }}</p></td>
 <td></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p>8000</p></td>
 <td><p><strong>opscode-erchef</strong></p>
 <p>{{ readFile "themes/docs-new/layouts/shortcodes/server_services_erchef.md" | markdownify }}</p></td>

--- a/themes/docs-new/layouts/shortcodes/server_firewalls_and_ports_tiered.md
+++ b/themes/docs-new/layouts/shortcodes/server_firewalls_and_ports_tiered.md
@@ -16,7 +16,7 @@ column) are open and accessible via any firewalls that are in use:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p>80, 443, 9683</p></td>
 <td><p><strong>nginx</strong></p>
 <p>{{ readFile "themes/docs-new/layouts/shortcodes/server_services_nginx.md" | markdownify }}</p>
@@ -28,37 +28,37 @@ column) are open and accessible via any firewalls that are in use:
 </div></td>
 <td><p>yes</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p>9463</p></td>
 <td><p><strong>oc_bifrost</strong></p>
 <p>{{ readFile "themes/docs-new/layouts/shortcodes/server_services_bifrost.md" | markdownify }}</p></td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p>9200</p></td>
 <td><p><strong>elasticsearch</strong></p>
 <p>{{ readFile "themes/docs-new/layouts/shortcodes/server_services_elasticsearch.md" | markdownify }}</p></td>
 <td></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p>5432</p></td>
 <td><p><strong>postgresql</strong></p>
 <p>{{ readFile "themes/docs-new/layouts/shortcodes/server_services_postgresql.md" | markdownify }}</p></td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p>16379</p></td>
 <td><p><strong>redis_lb</strong></p>
 <p>{{ readFile "themes/docs-new/layouts/shortcodes/server_services_redis.md" | markdownify }}</p></td>
 <td></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p>4321</p></td>
 <td><p><strong>bookshelf</strong></p>
 <p>{{ readFile "themes/docs-new/layouts/shortcodes/server_services_bookshelf.md" | markdownify }}</p></td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p>8000</p></td>
 <td><p><strong>opscode-erchef</strong></p>
 <p>{{ readFile "themes/docs-new/layouts/shortcodes/server_services_erchef.md" | markdownify }}</p></td>

--- a/themes/docs-new/layouts/shortcodes/server_rbac_permissions_object.md
+++ b/themes/docs-new/layouts/shortcodes/server_rbac_permissions_object.md
@@ -12,19 +12,19 @@ The Chef Infra Server includes the following object permissions:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Delete</strong></td>
 <td>Use the <strong>Delete</strong> permission to define which users and groups may delete an object. This permission is required for any user who uses the <code>knife [object] delete [object_name]</code> argument to interact with objects on the Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Grant</strong></td>
 <td>Use the <strong>Grant</strong> permission to define which users and groups may configure permissions on an object. This permission is required for any user who configures permissions using the <strong>Administration</strong> tab in the Chef management console.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Read</strong></td>
 <td>Use the <strong>Read</strong> permission to define which users and groups may view the details of an object. This permission is required for any user who uses the <code>knife [object] show [object_name]</code> argument to interact with objects on the Chef Infra Server.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Update</strong></td>
 <td>Use the <strong>Update</strong> permission to define which users and groups may edit the details of an object. This permission is required for any user who uses the <code>knife [object] edit [object_name]</code> argument to interact with objects on the Chef Infra Server and for any Chef Infra Client to save node data to the Chef Infra Server at the conclusion of a Chef Infra Client run.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/template_partials_render_method.md
+++ b/themes/docs-new/layouts/shortcodes/template_partials_render_method.md
@@ -20,19 +20,19 @@ where `partial_name` is the name of the partial template file and
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>:cookbook</code></td>
 <td>By default, a partial template file is assumed to be located in the cookbook that contains the top-level template. Use this option to specify the path to a different cookbook</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:local</code></td>
 <td>Indicates that the name of the partial template file should be interpreted as a path to a file in the local file system or looked up in a cookbook using the normal rules for template files. Set to <code>true</code> to interpret as a path to a file in the local file system and to <code>false</code> to use the normal rules for template files</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:source</code></td>
 <td>By default, a partial template file is identified by its file name. Use this option to specify a different name or a local path to use (instead of the name of the partial template file)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>:variables</code></td>
 <td>A hash of <code>variable_name =&gt; value</code> that will be made available to the partial template file. When this option is used, any variables that are defined in the top-level template that are required by the partial template file must have them defined explicitly using this option</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/test_kitchen_driver_vagrant_settings.md
+++ b/themes/docs-new/layouts/shortcodes/test_kitchen_driver_vagrant_settings.md
@@ -13,67 +13,67 @@ Chef:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>box</code></td>
 <td>Required. Use to specify the box on which Vagrant will run. Default value: computed from the platform name of the instance.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>box_check_update</code></td>
 <td>Use to check for box updates. Default value: <code>false</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>box_url</code></td>
 <td>Use to specify the URL at which the configured box is located. Default value: computed from the platform name of the instance, but only when the Vagrant provider is VirtualBox- or VMware-based.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>communicator</code></td>
 <td>Use to override the <code>config.vm.communicator</code> setting in Vagrant. For example, when a base box is a Microsoft Windows operating system that does not have SSH installed and enabled, Vagrant will not be able to boot without a custom Vagrant file. Default value: <code>nil</code> (assumes SSH is available).</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>customize</code></td>
 <td>A hash of key-value pairs that define customizations that should be made to the Vagrant virtual machine. For example: <code>customize: memory: 1024 cpuexecutioncap: 50</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>guest</code></td>
 <td>Use to specify the <code>config.vm.guest</code> setting in the default Vagrantfile.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>gui</code></td>
 <td>Use to enable the graphical user interface for the defined platform. This is passed to the <code>config.vm.provider</code> setting in Vagrant, but only when the Vagrant provider is VirtualBox- or VMware-based.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>network</code></td>
 <td>Use to specify an array of network customizations to be applied to the virtual machine. Default value: <code>[]</code>. For example: <code>network: - ["forwarded_port", {guest: 80, host: 8080}] - ["private_network", {ip: "192.168.33.33"}]</code>.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>pre_create_command</code></td>
 <td>Use to run a command immediately prior to <code>vagrant up --no-provisioner</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>provider</code></td>
 <td>Use to specify the Vagrant provider. This value must match a provider name in Vagrant.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>provision</code></td>
 <td>Use to provision Vagrant when the instance is created. This is useful if the operating system needs customization during provisioning. Default value: <code>false</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ssh_key</code></td>
 <td>Use to specify the private key file used for SSH authentication.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>synced_folders</code></td>
 <td>Use to specify a collection of synchronized folders on each Vagrant instance. Source paths are relative to the Kitchen root path. Default value: <code>[]</code>. For example: <code>synced_folders: - ["data/%{instance_name}", "/opt/instance_data"] - ["/host_path", "/vm_path", "create: true, type: :nfs"]</code>.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>vagrantfile_erb</code></td>
 <td>Use to specify an alternate Vagrant Embedded Ruby (ERB) template to be used by this driver.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>vagrantfiles</code></td>
 <td>An array of paths to one (or more) Vagrant files to be merged with the default Vagrant file. The paths may be absolute or relative to the kitchen.yml file.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>vm_hostname</code></td>
 <td>Use to specify the internal hostname for the instance. This is not required when connecting to a Vagrant virtual machine. Set this to <code>false</code> to prevent this value from being rendered in the default Vagrantfile. Default value: computed from the platform name of the instance.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/test_kitchen_drivers.md
+++ b/themes/docs-new/layouts/shortcodes/test_kitchen_drivers.md
@@ -35,47 +35,47 @@ Some popular drivers:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/test-kitchen/kitchen-azurerm">kitchen-azurerm</a></td>
 <td>A driver for Microsoft Azure.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/test-kitchen/kitchen-cloudstack">kitchen-cloudstack</a></td>
 <td>A driver for CloudStack.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/test-kitchen/kitchen-digitalocean">kitchen-digitalocean</a></td>
 <td>A driver for DigitalOcean. This driver ships in Chef Workstation.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/test-kitchen/kitchen-dokken">kitchen-dokken</a></td>
 <td>A driver for Docker. This driver ships in Chef Workstation.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/test-kitchen/kitchen-dsc">kitchen-dsc</a></td>
 <td>A driver for Windows PowerShell Desired State Configuration (DSC).</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/test-kitchen/kitchen-ec2">kitchen-ec2</a></td>
 <td>A driver for Amazon EC2. This driver ships in Chef Workstation.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/test-kitchen/kitchen-google">kitchen-google</a></td>
 <td>A driver for Google Compute Engine. This driver ships in Chef Workstation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/test-kitchen/kitchen-hyperv">kitchen-hyperv</a></td>
 <td>A driver for Microsoft Hyper-V Server. This driver ships in Chef Workstation.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/test-kitchen/kitchen-openstack">kitchen-openstack</a></td>
 <td>A driver for OpenStack. This driver ships in Chef Workstation.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/test-kitchen/kitchen-rackspace">kitchen-rackspace</a></td>
 <td>A driver for Rackspace.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/test-kitchen/kitchen-vagrant">kitchen-vagrant</a></td>
 <td>A driver for HashiCorp Vagrant. This driver ships in Chef Workstation.</td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/windows_msiexec_addlocal.md
+++ b/themes/docs-new/layouts/shortcodes/windows_msiexec_addlocal.md
@@ -13,15 +13,15 @@ Client. These options can be passed along with an Msiexec.exe command:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>ChefClientFeature</code></td>
 <td>Use to install Chef Infra Client.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>ChefSchTaskFeature</code></td>
 <td>Use to configure Chef Infra Client as a scheduled task in Microsoft Windows.</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>ChefPSModuleFeature</code></td>
 <td>Used to install the chef PowerShell module. This will enable chef command line utilities within PowerShell.</td>
 </tr>


### PR DESCRIPTION
This makes it a lot easier to update the tables if you don't worry about reordering the odd/even classes

Signed-off-by: Tim Smith <tsmith@chef.io>