### PR TITLE
Improve the platform support page

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -64,8 +64,8 @@ The following table lists the commercially-supported platforms and versions for 
 </tr>
 <tr>
 <td>Amazon Linux</td>
-<td><code>x86_64</code>, <code>aarch64</code> (2.x only)</td>
-<td>2013+ and 2.0</td>
+<td><code>x86_64</code>, <code>aarch64</code></td>
+<td>2.x</td>
 </tr>
 <tr>
 <td>CentOS</td>
@@ -270,7 +270,7 @@ versions for the Chef Workstation:
 <tr>
 <td>Amazon Linux</td>
 <td><code>x86_64</code></td>
-<td><code>2.0</code></td>
+<td><code>2.x</code></td>
 </tr>
 <tr>
 <td>macOS</td>
@@ -280,7 +280,7 @@ versions for the Chef Workstation:
 <tr>
 <td>Debian</td>
 <td><code>x86_64</code></td>
-<td><code>9</code>, <code>10</code></td>
+<td><code>9.x</code>, <code>10.x</code></td>
 </tr>
 <tr>
 <td>Red Hat Enterprise Linux</td>
@@ -322,8 +322,8 @@ The following table lists the commercially-supported platforms and versions for 
 <tbody>
 <tr>
 <td>Amazon Linux</td>
-<td><code>x86_64</code>, <code>aarch64</code> (2.x only)</td>
-<td><code>2013+ and 2.0</code></td>
+<td><code>x86_64</code>, <code>aarch64</code></td>
+<td><code>2.x</code></td>
 </tr>
 <tr>
 <td>Debian</td>

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -578,6 +578,11 @@ that platform and version.
 </thead>
 <tbody>
 <tr>
+<td>Amazon Linux 201X</td>
+<td>Dec 31st, 2020</td>
+<td>Dec 31st, 2020</td>
+</tr>
+<tr>
 <td>Apple macOS 10.13</td>
 <td>Nov 13th, 2020</td>
 <td>Nov 13th, 2020</td>

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -294,8 +294,7 @@ versions for the Chef Workstation:
 
 #### Commercial Support
 
-The following table lists the commercially-supported platforms and
-versions for Chef InSpec:
+The following table lists the commercially-supported platforms and versions for Chef InSpec:
 
 <table>
 <colgroup>
@@ -313,7 +312,7 @@ versions for Chef InSpec:
 <tbody>
 <tr>
 <td>Amazon Linux</td>
-<td><code>x86_64</code>, <code>aarch64</code></td>
+<td><code>x86_64</code>, <code>aarch64</code> (2.x only)</td>
 <td><code>2013+ and 2.0</code></td>
 </tr>
 <tr>
@@ -339,7 +338,7 @@ versions for Chef InSpec:
 <tr>
 <td>SUSE Enterprise Linux Server</td>
 <td><code>x86_64</code></td>
-<td><code>12</code>, <code>15</code></td>
+<td><code>12.x</code>, <code>15.x</code></td>
 </tr>
 <tr>
 <td>Ubuntu</td>

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -327,6 +327,11 @@ versions for Chef InSpec:
 <td><code>10.14</code>, <code>10.15</code>, <code>11.x</code></td>
 </tr>
 <tr>
+<td>Oracle Enterprise Linux</td>
+<td><code>x86_64</code><code>aarch64</code> (7.x / 8.x only)</td>
+<td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
+</tr>
+<tr>
 <td>Red Hat Enterprise Linux</td>
 <td><code>x86_64</code>, <code>aarch64</code> (7.x and 8.x only)</td>
 <td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -19,7 +19,7 @@ support, see the [Supported Versions](/versions/) page.
 
 ## Support
 
-We offer two levels of support for platforms (operating systems), [Commercial Support] and [Community Support].
+We offer two levels of support for platforms (operating systems), [Commercial Support]({{< relref "#commercial-support">}}) and [Community Support]({{< relref "#community-support" >}}).
 
 ### Commercial Support
 

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -31,7 +31,7 @@ Commercial support is limited to the platforms listed in the "Commercial Support
 
 Community support for platforms means that members of the the Chef community have contributed these platforms and Chef does not actively work to maintain this functionality. Chef does not explicitly test community supported platforms as part of the the development and release process.
 
-Many of these platforms are forks, clones, or otherwise derivative of platforms that Chef commercially supports. Continued functionality for these platforms is likely, but not guaranteed. Unsupported platforms may have missing or non-operative functionality. As always, we welcome community contributions from anyone looking to expand communtiy support for platforms in Chef products.
+Many of these platforms are forks, clones, or otherwise derivative of platforms that Chef commercially supports. Continued functionality for these platforms is likely, but not guaranteed. Unsupported platforms may have missing or non-operative functionality. As always, we welcome community contributions from anyone looking to expand community support for platforms in Chef products.
 
 ## Platforms
 

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -13,38 +13,35 @@ product = ["automate", "client", "server", "habitat", "inspec", "workstation"]
     weight = 20
 +++
 
-Chef software is supported on the various operating systems (platforms)
+Chef software is supported on the operating systems (platforms)
 listed below. To see which versions of our software we currently
 support, see the [Supported Versions](/versions/) page.
 
+## Support
+
+We offer two levels of support for platforms (operating systems), [Commercial Support] and [Community Support].
+
+### Commercial Support
+
+Commercial support for platforms is part of paid maintenance contracts with Chef Software Inc. Support contracts allow you to open tickets and receive service level agreement (SLA) assistance from our support desk. Commercially supported platforms are extensively tested as part of Chef's development and release process. Commercial support generally follows the lifecycle of the underlying operating system vendor.
+
+Commercial support is limited to the platforms listed in the "Commercial Support" tables--platforms not listed in these tables are unsupported.
+
+### Community Support
+
+Community support for platforms means that members of the the Chef community have contributed these platforms and Chef does not actively work to maintain this functionality. Chef does not explicitly test community supported platforms as part of the the development and release process.
+
+Many of these platforms are forks, clones, or otherwise derivative of platforms that Chef commercially supports. Continued functionality for these platforms is likely, but not guaranteed. Unsupported platforms may have missing or non-operative functionality. As always, we welcome community contributions from anyone looking to expand communtiy support for platforms in Chef products.
+
 ## Platforms
 
-The sections below list the platforms that Chef Software Inc. supports.
-Support is divided into two levels:
-
--   **Commercial Support** consists of the platforms that are supported
-    as part of a paid commercial support contract with Chef Software
-    Inc.
--   **Community Support** is made up of platforms for which support is
-    only available through the Chef community
-
-Any platforms or versions not explicitly listed here are unsupported,
-both commercially and by the community.
-
-Commercial support generally follows Chef community support policies,
-which track the lifecycle policies of the underlying operating system
-vendor.
-
-In all cases (beyond community support), a maintenance contract with
-Chef Software Inc. is required in order to open support tickets and get
-SLA-based assistance from our support desk.
+The sections below list the platforms that Chef software
 
 ### Chef Infra Client
 
 #### Commercial Support
 
-The following table lists the commercially-supported platforms and
-versions for Chef Infra Client:
+The following table lists the commercially-supported platforms and versions for Chef Infra Client:
 
 <table>
 <colgroup>
@@ -60,62 +57,62 @@ versions for Chef Infra Client:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>AIX</td>
 <td><code>powerpc</code></td>
 <td><code>7.1</code> (TL5 SP2 or higher, recommended), <code>7.2</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Amazon Linux</td>
 <td><code>x86_64</code>, <code>aarch64</code> (2.x only)</td>
 <td>2013+ and 2.0</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>CentOS</td>
 <td><code>x86_64</code>, <code>ppc64le</code> (7.x only), <code>ppc64</code> (7.x only), <code>aarch64</code> (7.x / 8.x only)</td>
 <td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Debian</td>
 <td><code>x86_64</code><code>aarch64</code> (10.x only)</td>
 <td><code>9</code>, <code>10</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>FreeBSD</td>
 <td><code>amd64</code></td>
 <td><code>11.x</code>, <code>12.x</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>macOS</td>
 <td><code>x86_64</code></td>
-<td><code>10.14</code>, <code>10.15</code>, <code>11.0</code></td>
+<td><code>10.14</code>, <code>10.15</code>, <code>11.x</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Oracle Enterprise Linux</td>
 <td><code>x86_64</code><code>aarch64</code> (7.x / 8.x only)</td>
 <td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Red Hat Enterprise Linux</td>
 <td><code>x86_64</code>, <code>ppc64le</code> (7.x only), <code>ppc64</code> (7.x only), <code>aarch64</code> (7.x / 8.x only)</td>
 <td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Solaris</td>
 <td><code>sparc</code>, <code>i86pc</code></td>
 <td><code>11.2</code>, <code>11.3</code>, <code>11.4</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>SUSE Enterprise Linux Server</td>
 <td><code>x86_64</code>, <code>aarch64</code> (15.x only)</td>
 <td><code>12</code>, <code>15</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Ubuntu (LTS releases)</td>
 <td><code>x86_64</code>,<code>aarch64</code> (18.04/20.04 only)</td>
 <td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Microsoft Windows</td>
 <td><code>x86</code>, <code>x64</code></td>
 <td><code>8.1</code>, <code>2012</code>, <code>2012 R2</code>, <code>2016</code>, <code>10 (all channels except "insider" builds)</code>, <code>2019 (Long-term servicing channel (LTSC), both Desktop Experience and Server Core)</code></td>
@@ -141,40 +138,100 @@ The following platforms are supported only via the community:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
+<td>Alma Linux</td>
+<td><code>x86_64</code></td>
+<td><code>8.x</code></td>
+</tr>
+<tr>
+<td>Alibaba Cloud Linux</td>
+<td><code>x86_64</code></td>
+<td>2.x</td>
+</tr>
+<tr>
 <td>Arch Linux</td>
 <td><code>x86_64</code></td>
 <td>current version</td>
 </tr>
-<tr class="even">
-<td>Fedora</td>
+<tr>
+<td>Arista EOS</td>
 <td><code>x86_64</code></td>
 <td>current non-EOL releases</td>
 </tr>
-<tr class="odd">
+<tr>
+<td>CentOS Stream</td>
+<td><code>x86_64</code>, <code>aarch64</code></td>
+<td>current non-EOL releases</td>
+</tr>
+<tr>
+<td>Clear Linux</td>
+<td><code>x86_64</code></td>
+<td>current non-EOL releases</td>
+</tr>
+<tr>
+<td>Cumulus Linux</td>
+<td><code>x86_64</code></td>
+<td>current non-EOL releases</td>
+</tr>
+<tr>
+<td>Fedora</td>
+<td><code>x86_64</code>, <code>aarch64</code></td>
+<td>current non-EOL releases</td>
+</tr>
+<tr>
 <td>Gentoo</td>
 <td><code>x86_64</code></td>
 <td>current version</td>
 </tr>
-<tr class="even">
-<td>openSUSE</td>
+<tr>
+<td>Kali Linux</td>
 <td><code>x86_64</code></td>
+<td>current non-EOL releases</td>
+</tr>
+<tr>
+<td>Linux Mint</td>
+<td><code>x86_64</code></td>
+<td>current non-EOL releases</td>
+</tr>
+<tr>
+<td>openSUSE</td>
+<td><code>x86_64</code>, <code>aarch64</code></td>
 <td><code>15.x</code></td>
 </tr>
-<tr class="odd">
-<td>Scientific Linux</td>
+<tr>
+<td>Pop!_OS</td>
 <td><code>x86_64</code></td>
-<td><code>6.x</code>, <code>7.x</code></td>
+<td>current non-EOL releases</td>
 </tr>
-<tr class="even">
+<tr>
+<td>Raspberry Pi OS</td>
+<td><code>aarch64</code></td>
+<td>current non-EOL releases</td>
+</tr>
+<tr>
+<td>SUSE Linux Enterprise Desktop</td>
+<td><code>x86_64</code>, <code>aarch64</code> (15.x only)</td>
+<td><code>12</code>, <code>15</code></td>
+</tr>
+<tr>
+<td>Raspberry Pi OS</td>
+<td><code>aarch64</code></td>
+<td>current non-EOL releases</td>
+</tr>
+<tr>
 <td>Ubuntu</td>
-<td><code>x86_64</code></td>
+<td><code>x86_64</code>, <code>aarch64</code></td>
 <td>Current non-LTS releases</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Windows</td>
 <td><code>x64</code></td>
 <td><code>Windows Server, Semi-annual channel (SAC) (Server Core only)</code></td>
+</tr>
+<tr>
+<td>XCP-ng</td>
+<td><code>x86_64</code></td>
+<td>8.x</td>
 </tr>
 </tbody>
 </table>
@@ -200,32 +257,32 @@ versions for the Chef Workstation:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Amazon Linux</td>
 <td><code>x86_64</code></td>
 <td><code>2.0</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>macOS</td>
 <td><code>x86_64</code></td>
-<td><code>10.14</code>, <code>10.15</code>, <code>11.0</code></td>
+<td><code>10.14</code>, <code>10.15</code>, <code>11.x</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Debian</td>
 <td><code>x86_64</code></td>
 <td><code>9</code>, <code>10</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Red Hat Enterprise Linux</td>
 <td><code>x86_64</code></td>
 <td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Ubuntu</td>
 <td><code>x86_64</code></td>
 <td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Microsoft Windows</td>
 <td><code>x64</code></td>
 <td><code>8.1</code>, <code>2012</code>, <code>2012 R2</code>, <code>2016</code>, <code>10 (all channels except "insider" builds)</code>, <code>2019 (Long-term servicing channel (LTSC), Desktop Experience only)</code></td>
@@ -254,37 +311,37 @@ versions for Chef InSpec:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Amazon Linux</td>
 <td><code>x86_64</code>, <code>aarch64</code></td>
 <td><code>2013+ and 2.0</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Debian</td>
 <td><code>x86_64</code><code>aarch64</code> (10.x only)</td>
 <td><code>9.x</code>, <code>10.x</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>macOS</td>
 <td><code>x86_64</code></td>
-<td><code>10.14</code>, <code>10.15</code>, <code>11.0</code></td>
+<td><code>10.14</code>, <code>10.15</code>, <code>11.x</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Red Hat Enterprise Linux</td>
 <td><code>x86_64</code>, <code>aarch64</code> (7.x and 8.x only)</td>
 <td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>SUSE Enterprise Linux Server</td>
 <td><code>x86_64</code></td>
 <td><code>12</code>, <code>15</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Ubuntu</td>
 <td><code>x86_64</code></td>
 <td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Microsoft Windows</td>
 <td><code>x86_64</code></td>
 <td><code>8.1</code>, <code>2012</code>, <code>2012 R2</code>, <code>2016</code>, <code>10 (all channels except "insider" builds)</code>, <code>2019</code></td>
@@ -337,7 +394,7 @@ following platforms:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>macOS</td>
 <td><code>x86_64</code></td>
 <td><code>10.12</code></td>
@@ -366,17 +423,17 @@ Backend, the high-availability solution for Chef Infra Server:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>CentOS</td>
 <td><code>x86_64</code></td>
 <td><code>6.x</code>, <code>7.x</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Red Hat Enterprise Linux</td>
 <td><code>x86_64</code></td>
 <td><code>6.x</code>, <code>7.x</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Ubuntu (LTS releases)</td>
 <td><code>x86_64</code></td>
 <td><code>16.04</code>, <code>18.04</code></td>
@@ -405,17 +462,17 @@ Manage:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>CentOS</td>
 <td><code>x86_64</code></td>
 <td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Red Hat Enterprise Linux</td>
 <td><code>x86_64</code></td>
 <td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Ubuntu (LTS releases)</td>
 <td><code>x86_64</code></td>
 <td><code>16.04</code>, <code>18.04</code></td>
@@ -443,43 +500,43 @@ according to those vendors' terms:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Apple macOS</td>
-<td>Apple generally supports the last three macOS releases, for example: 10.14, 10.15, and 11.0. Apple does not officially publish EOL dates.</td>
+<td>Apple generally supports the last three macOS releases, for example: 10.14, 10.15, and 11.x. Apple does not officially publish EOL dates.</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Debian</td>
 <td>End of maintenance updates</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Enterprise Linux (covers Red Hat Enterprise Linux, CentOS)</td>
 <td>End of Production 3</td>
 </tr>
-<tr class="even">
+<tr>
 <td>FreeBSD</td>
 <td>End of Life</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>IBM AIX</td>
 <td>IBM End of Support Date</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Microsoft Windows</td>
 <td>End of Extended Support</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Oracle Enterprise Linux</td>
 <td>Premier Support Ends</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Oracle Solaris</td>
 <td>Premier Support Ends</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>SUSE Linux Enterprise Server</td>
 <td>General Support Ends</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Ubuntu Linux</td>
 <td>End of maintenance updates</td>
 </tr>
@@ -506,102 +563,102 @@ that platform and version.
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Apple macOS 10.13</td>
 <td>Nov 13th, 2020</td>
 <td>Nov 13th, 2020</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Debian 7 (Wheezy)</td>
 <td>May 31st, 2018</td>
 <td>May 31st, 2018</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Debian 8 (Jessie)</td>
 <td>June 6th, 2020</td>
 <td>June 6th, 2020</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Enterprise Linux 5 (covers Red Hat Enterprise Linux, CentOS)</td>
 <td>April 30, 2017</td>
 <td>December 31, 2017</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Enterprise Linux 6 (covers Red Hat Enterprise Linux, CentOS)</td>
 <td>November 30, 2020</td>
 <td>November 30, 2020</td>
 </tr>
-<tr class="even">
+<tr>
 <td>FreeBSD 10-STABLE</td>
 <td>October 31, 2018</td>
 <td>October 31, 2018</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>FreeBSD 11-STABLE</td>
 <td>September 30, 2021</td>
 <td>September 30, 2021</td>
 </tr>
-<tr class="even">
+<tr>
 <td>IBM AIX 6.1</td>
 <td>April 30, 2017</td>
 <td>December 31, 2017</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Microsoft Windows Server 2008 (SP2)/R2 (SP1)</td>
 <td>January 13, 2015</td>
 <td>January 14, 2020</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Microsoft Windows Server 2012/2012 R2</td>
 <td>October 10, 2023</td>
 <td>October 10, 2023</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Microsoft Windows Server 2016</td>
 <td>November 11, 2027</td>
 <td>November 11, 2027</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Microsoft Windows Server 2019</td>
 <td>October 10, 2028</td>
 <td>October 10, 2028</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Oracle Enterprise Linux 5</td>
 <td>June 30, 2017</td>
 <td>December 31, 2017</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Oracle Enterprise Linux 6</td>
 <td>March 31, 2021</td>
 <td>March 31, 2021</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Oracle Solaris 10</td>
 <td>January 30, 2018</td>
 <td>January 30, 2018</td>
 </tr>
-<tr class="even">
+<tr>
 <td>SUSE Linux Enterprise Server 11</td>
 <td>March 31, 2019</td>
 <td>March 31, 2019</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>SUSE Linux Enterprise Server 12</td>
 <td>October 31, 2024</td>
 <td>October 31, 2024</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Ubuntu Linux 12.04 LTS</td>
 <td>April 30, 2017</td>
 <td>April 30, 2017</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Ubuntu Linux 14.04 LTS</td>
 <td>April 30, 2019</td>
 <td>April 30, 2019</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Ubuntu Linux 16.04 LTS</td>
 <td>April 30, 2021</td>
 <td>April 30, 2021</td>

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -35,7 +35,7 @@ Many of these platforms are forks, clones, or otherwise derivative of platforms 
 
 ## Platforms
 
-The sections below list the platforms that Chef software
+The sections below list the platforms that Chef Software Inc. supports.
 
 ### Chef Infra Client
 

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -279,7 +279,7 @@ versions for the Chef Workstation:
 </tr>
 <tr>
 <td>Ubuntu</td>
-<td><code>x86_64</code></td>
+<td><code>x86_64</code>,<code>aarch64</code> (18.04/20.04 only)</td>
 <td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>
 </tr>
 <tr>
@@ -337,7 +337,7 @@ The following table lists the commercially-supported platforms and versions for 
 </tr>
 <tr>
 <td>SUSE Enterprise Linux Server</td>
-<td><code>x86_64</code></td>
+<td><code>x86_64</code>, <code>aarch64</code> (15.x only)</td>
 <td><code>12.x</code>, <code>15.x</code></td>
 </tr>
 <tr>

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -29,7 +29,7 @@ Commercial support is limited to the platforms listed in the "Commercial Support
 
 ### Community Support
 
-Community support for platforms means that members of the the Chef community have contributed these platforms and Chef does not actively work to maintain this functionality. Chef does not explicitly test community supported platforms as part of the the development and release process.
+Community support for platforms means that members of the Chef community have contributed to these platforms and Chef does not actively work to maintain this functionality. Chef does not explicitly test community supported platforms as part of the development and release process.
 
 Many of these platforms are forks, clones, or otherwise derivative of platforms that Chef commercially supports. Continued functionality for these platforms is likely, but not guaranteed. Unsupported platforms may have missing or non-operative functionality. As always, we welcome community contributions from anyone looking to expand community support for platforms in Chef products.
 

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -194,6 +194,16 @@ The following platforms are supported only via the community:
 <td>current non-EOL releases</td>
 </tr>
 <tr>
+<td>OmniOS Community Edition</td>
+<td><code>x86_64</code></td>
+<td>current non-EOL releases</td>
+</tr>
+<tr>
+<td>OpenIndiana Hipster</td>
+<td><code>x86_64</code></td>
+<td>current non-EOL releases</td>
+</tr>
+<tr>
 <td>openSUSE</td>
 <td><code>x86_64</code>, <code>aarch64</code></td>
 <td><code>15.x</code></td>
@@ -209,14 +219,14 @@ The following platforms are supported only via the community:
 <td>current non-EOL releases</td>
 </tr>
 <tr>
+<td>SmartOS</td>
+<td><code>x86_64</code></td>
+<td>current non-EOL releases</td>
+</tr>
+<tr>
 <td>SUSE Linux Enterprise Desktop</td>
 <td><code>x86_64</code>, <code>aarch64</code> (15.x only)</td>
 <td><code>12</code>, <code>15</code></td>
-</tr>
-<tr>
-<td>Raspberry Pi OS</td>
-<td><code>aarch64</code></td>
-<td>current non-EOL releases</td>
 </tr>
 <tr>
 <td>Ubuntu</td>

--- a/themes/docs-new/layouts/shortcodes/adopted_platforms_server.md
+++ b/themes/docs-new/layouts/shortcodes/adopted_platforms_server.md
@@ -1,5 +1,4 @@
-The following table lists the commercially-supported platforms and
-versions for the Chef Infra Server:
+The following table lists the commercially-supported platforms and versions for the Chef Infra Server:
 
 <table>
 <colgroup>
@@ -18,22 +17,22 @@ versions for the Chef Infra Server:
 <tr class="odd">
 <td>CentOS</td>
 <td><code>x86_64</code></td>
-<td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
+<td><code>7.x</code>, <code>8.x</code></td>
 </tr>
 <tr class="even">
 <td>Oracle Enterprise Linux</td>
 <td><code>x86_64</code></td>
-<td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
+<td><code>7.x</code>, <code>8.x</code></td>
 </tr>
 <tr class="odd">
 <td>Red Hat Enterprise Linux</td>
 <td><code>x86_64</code></td>
-<td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
+<td><code>7.x</code>, <code>8.x</code></td>
 </tr>
 <tr class="even">
 <td>SUSE Enterprise Linux Server</td>
 <td><code>x86_64</code></td>
-<td><code>12</code>, <code>15</code></td>
+<td><code>12.x</code>, <code>15.x</code></td>
 </tr>
 <tr class="odd">
 <td>Ubuntu</td>


### PR DESCRIPTION
- Expand on the differences between community and commercially supported platforms. 
- Expand the list of community supported platforms. 
- Make sure to call out derivative/clone platforms and what that means for support.
- Remove RHEL 6 support from Infra Server
- Mark Amazon Linux 201X as EOL per their policy
- Add Oracle Linux as a supported platform in InSpec
- Add the arm platforms we support on InSpec