### PR TITLE
Improve site layout

### DIFF
--- a/themes/docs-new/assets/sass/_homepage.scss
+++ b/themes/docs-new/assets/sass/_homepage.scss
@@ -3,7 +3,6 @@
 
   &-col {
     padding-right: rem-calc(12px);
-    max-width: 1000px;
     min-height: 100vh;
     margin-bottom: 30px;
     &:focus {

--- a/themes/docs-new/assets/sass/_variables.scss
+++ b/themes/docs-new/assets/sass/_variables.scss
@@ -94,3 +94,7 @@ $header-styles: (
     'h6': ('font-size': 16),
   )
 );
+
+$offcanvas-sizes: (
+  small: 250px,
+);

--- a/themes/docs-new/assets/sass/partials/_grid.scss
+++ b/themes/docs-new/assets/sass/partials/_grid.scss
@@ -18,21 +18,6 @@
     }
   }
 
-  .col-sidebar {
-    margin-top: rem-calc(24);
-    padding: rem-calc(8 0);
-    background-color: $sidebargray;
-    overflow-y: hidden;
-
-    @include breakpoint(medium) {
-      margin-top: 0;
-    }
-
-    .sticky.is-stuck {
-      z-index: 1;
-    }
-  }
-
   .col-content {
     padding-top: rem-calc(14);
     background-color: $white;
@@ -87,6 +72,16 @@
       }
     }
   }
+}
+
+#left-nav-on-canvas {
+  margin-top: rem-calc(24);
+  padding: rem-calc(8 0);
+  z-index: 50;
+}
+
+#left-nav-off-canvas{
+  border-bottom: 1px solid $border;
 }
 
 .has-sidebar {

--- a/themes/docs-new/assets/sass/partials/_sidebar.scss
+++ b/themes/docs-new/assets/sass/partials/_sidebar.scss
@@ -20,11 +20,6 @@
 
 > .nav {
   margin-bottom: 30px;
-  overflow-y: scroll;
-
-  @include breakpoint(medium) {
-    overflow-y: scroll;
-  };
 
   > .accordion-menu {
     font-size: rem-calc(14px);

--- a/themes/docs-new/assets/sass/partials/_sidebar.scss
+++ b/themes/docs-new/assets/sass/partials/_sidebar.scss
@@ -5,14 +5,11 @@
   width: 260px;
 }
 
-#left-nav-off-canvas{
-  border-bottom: 1px solid $border;
-}
-
 #sidebar-nav{
   height: 100%;
   z-index: 25;
   overflow-y: scroll;
+  overflow-x: hidden;
 
   &.offCanvas{
     width: inherit;
@@ -30,13 +27,17 @@
       > a {
         font-weight: 700;
         color: $charcoal;
+      }
 
-        @include breakpoint(medium) {
-          border-radius: $border-radius-base 0 0 $border-radius-base;
-        };
+      a {
+        text-overflow: ellipsis;
+        overflow: hidden;
+        &:focus {
+          outline: none;
+        }
       }
     }
-    
+
     .nested.is-active li.active a {
       font-weight: normal;
       background: none;
@@ -63,15 +64,5 @@
     text-align: center;
     margin: 12px 12px;
     object-fit: contain;
-  }
-}
-
-#header-logo {
-
-  img {
-    @include transition();
-    padding: 8px 0;
-    width: 90px;
-    margin: 2px 18px;
   }
 }

--- a/themes/docs-new/assets/sass/partials/_sidebar.scss
+++ b/themes/docs-new/assets/sass/partials/_sidebar.scss
@@ -12,7 +12,6 @@
 #sidebar-nav{
   height: 100%;
   z-index: 25;
-  width: 260px;
   overflow-y: scroll;
 
   &.offCanvas{

--- a/themes/docs-new/layouts/_default/baseof.html
+++ b/themes/docs-new/layouts/_default/baseof.html
@@ -15,11 +15,11 @@
     <div class="grid-container fluid">
       <div class="grid-x">
 
-        <div class="cell position-left off-canvas-absolute reveal-for-medium col-sidebar" id="left-nav-on-canvas" data-off-canvas data-transition="overlap" >
+        <div id="left-nav-on-canvas" class="cell position-left off-canvas-absolute reveal-for-medium col-sidebar" data-off-canvas data-transition="overlap" >
           {{ partial "sidebar-on-canvas" . }}
         </div>
 
-        <div id="main-content" class="cell off-canvas-content cell auto" data-off-canvas-content>
+        <div id="main-content" class="cell off-canvas-content auto" data-off-canvas-content>
           {{ block "main" . }}
           {{ end }}
         </div>
@@ -27,13 +27,13 @@
         {{ $headers := findRE "<h[12].*?>(.|\n])+?</h[12]>" .Content }}
         {{ if or (and (ge (len $headers) 1) (ne .Params.toc false )) (isset .Params "release_notes") (.Params.version_docs_product) (.Params.toc_layout)}}
           {{ if .Params.toc_layout }}
-            <div class="cell off-canvas position-right toc off-canvas-absolute reveal-for-large" id="onCanvasRightTOC" data-off-canvas >
+            <div id="onCanvasRightTOC" class="cell off-canvas position-right toc off-canvas-absolute reveal-for-large" data-off-canvas >
               {{ partial .Params.toc_layout . }}
             </div>
           {{ else if (.Params.version_docs_product)}}
             {{ partial "versioned-docs-toc" . }}
           {{ else }}
-            <div class="cell off-canvas position-right toc off-canvas-absolute reveal-for-large" id="onCanvasRightTOC" data-off-canvas >
+            <div id="onCanvasRightTOC" class="cell off-canvas position-right toc off-canvas-absolute reveal-for-large" data-off-canvas >
               {{ partial "table-of-contents" . }}
             </div>
           {{ end }}
@@ -44,8 +44,7 @@
 
   {{ if or (and (ge (len $headers) 1) (ne .Params.toc false )) (isset .Params "release_notes") (.Params.version_docs_product) (.Params.toc_layout)}}
 
-    <div class="off-canvas position-right toc hide-for-large hide-for-print" id="offCanvasRightTOC" data-off-canvas
-      data-transition="overlap">
+    <div id="offCanvasRightTOC" class="off-canvas position-right toc hide-for-large hide-for-print" data-off-canvas data-transition="overlap">
       {{ if .Params.toc_layout }}
         {{ partial .Params.toc_layout . }}
       {{ else }}

--- a/themes/docs-new/layouts/_default/baseof.html
+++ b/themes/docs-new/layouts/_default/baseof.html
@@ -12,7 +12,7 @@
   </div>
 
   <div class="off-canvas-wrapper">
-    <div class="grid-container">
+    <div class="grid-container fluid">
       <div class="grid-x">
 
         <div class="cell position-left off-canvas-absolute reveal-for-medium col-sidebar" id="left-nav-on-canvas" data-off-canvas data-transition="overlap" >
@@ -44,7 +44,7 @@
 
   {{ if or (and (ge (len $headers) 1) (ne .Params.toc false )) (isset .Params "release_notes") (.Params.version_docs_product) (.Params.toc_layout)}}
 
-    <div class="off-canvas position-right toc off-canvas-absolute hide-for-large hide-for-print" id="offCanvasRightTOC" data-off-canvas
+    <div class="off-canvas position-right toc hide-for-large hide-for-print" id="offCanvasRightTOC" data-off-canvas
       data-transition="overlap">
       {{ if .Params.toc_layout }}
         {{ partial .Params.toc_layout . }}

--- a/themes/docs-new/layouts/partials/javascript.html
+++ b/themes/docs-new/layouts/partials/javascript.html
@@ -14,12 +14,13 @@
 {{- $resourceNote := resources.Get "js/resource-note.js" -}}
 {{- $versionDocs := resources.Get "js/version-docs.js" -}}
 {{- $feedback := resources.Get "js/feedback.js" -}}
+{{- $customJs := slice $segment $omnitruck $copycodebutton $chefHugo $resourceNote $versionDocs $feedback -}}
 
 {{ if hugo.Environment | eq "development" }}
-  {{- $customJs := slice $segment $omnitruck $copycodebutton $chefHugo $resourceNote $versionDocs $feedback | resources.Concat "js/custom-bundle.js" -}}
+  {{- $customJs := $customJs | resources.Concat "js/custom-bundle.js" -}}
   <script src="{{ $customJs.Permalink }}" type="text/javascript"></script>
 {{ else }}
-  {{- $customJs := slice $segment $omnitruck $copycodebutton $chefHugo $resourceNote $versionDocs $feedback | resources.Concat "js/custom-bundle.js" | minify | fingerprint -}}
+  {{- $customJs := $customJs | resources.Concat "js/custom-bundle.js" | minify | fingerprint -}}
   <script src="{{ $customJs.Permalink }}" type="text/javascript"></script>
 {{ end }}
 

--- a/themes/docs-new/layouts/partials/versioned-docs-toc.html
+++ b/themes/docs-new/layouts/partials/versioned-docs-toc.html
@@ -50,7 +50,7 @@
 </div>
 
 
-<div class="off-canvas position-right toc off-canvas-absolute hide-for-large" id="offCanvasRightTOC" data-off-canvas
+<div class="off-canvas position-right toc hide-for-large" id="offCanvasRightTOC" data-off-canvas
 data-transition="overlap">
   <strong>
     <h4 class="mini-toc-header">Table Of Contents</h4>


### PR DESCRIPTION
### Description

Fixes a few things:

- removes that pesky issue where the page content would scroll left when the right TOC disappeared
- removes `max-width` and adds `fluid` so the page looks better on larger screens
- removes left-nav width because it's not really doing anything
- touch up the javascript resources concatenation in Hugo a little

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
