### PR TITLE
More updates to the Chef Infra Server release notes

### DIFF
--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -112,8 +112,7 @@ Upgrading to Chef Infra Server 14 will require a reindexing operation for most u
 
 #### Updated Components
 
-- openresty (1.15.8.1 -> 1.17.8.2)
-- server-open-jre (11.0.4+1 -> 11.0.7+1)
+- server-open-jre (11.0.4+11 -> 11.0.7+10)
 
 #### Removed Components
 
@@ -127,6 +126,10 @@ Upgrading to Chef Infra Server 14 will require a reindexing operation for most u
 #### OpenSSL
 
 OpenSSL was updated from 1.0.2u to 1.0.2w which includes a fix for [CVE-2020-1968](https://nvd.nist.gov/vuln/detail/2020-1968) and multiple security hardening fixes not related to particular CVEs.
+
+#### OpenResty
+
+OpenResty was upgraded from 1.15.8.1 to 1.17.8.2 to resolve [CVE-2020-11724](https://nvd.nist.gov/vuln/detail/CVE-2020-11724).
 
 #### PCRE
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -177,37 +177,18 @@ PCRE has been updated from 8.38 to 8.44 to resolve the following CVEs:
 ### Updates
 
 - Erlang in the Habitat package: 18 -> 20
-- Haproxy 1.6.4 -> 1.6.15
-- Redis 3.0.7 -> 5.0.7
 - libxml2 2.9.9 -> 2.9.10
 - libxslt 1.1.30 -> 1.1.34
 
 ### Security
 
-#### Rack
+#### haproxy
 
-The `rack` gem in the `oc-id` Chef Infra Server component has been updated from 1.6.11 to 1.6.12 to resolve [CVE-2019-16782](https://nvd.nist.gov/vuln/detail/CVE-2019-16782)
-
-#### Ruby
-
-Ruby has been updated from 2.6.3 to 2.6.5 to resolve the following CVEs:
-
-- [CVE-2019-16255](https://nvd.nist.gov/vuln/detail/CVE-2019-16255): A code injection vulnerability of Shell#[] and Shell#test
-- [CVE-2019-16254](https://nvd.nist.gov/vuln/detail/CVE-2019-16254): HTTP response splitting in WEBrick (Additional fix)
-- [CVE-2019-15845](https://nvd.nist.gov/vuln/detail/CVE-2019-15845): A NUL injection vulnerability of File.fnmatch and File.fnmatch?
-- [CVE-2019-16201](https://nvd.nist.gov/vuln/detail/CVE-2019-16201): Regular Expression Denial of Service vulnerability of WEBrick's Digest access authentication
-- [CVE-2012-6708](https://nvd.nist.gov/vuln/detail/CVE-2012-6708): Cross-site Scripting vulnerability in RDoc
-- [CVE-2015-16892](https://nvd.nist.gov/vuln/detail/CVE-2015-9251): Cross-site Scripting vulnerability in RDoc
-
-#### rubyzip
-
-The release of rubyzip in the `oc-id` Chef Infra Server component has been updated from 1.2.3 to 1.3.0 to resolve [CVE-2019-16892](https://nvd.nist.gov/vuln/detail/CVE-2019-16892)
-
-#### OpenSSL
-
-OpenSSL has been updated from 1.0.2t to 1.0.2u to resolve the following CVEs:
-
-- [CVE-2019-1551](https://nvd.nist.gov/vuln/detail/CVE-2019-1551)
+- [CVE-2018-10184](https://nvd.nist.gov/vuln/detail/CVE-2018-10184)
+- [CVE-2018-14645](https://nvd.nist.gov/vuln/detail/CVE-2018-14645)
+- [CVE-2018-20103](https://nvd.nist.gov/vuln/detail/CVE-2018-20103)
+- [CVE-2018-20102](https://nvd.nist.gov/vuln/detail/CVE-2018-20102)
+- [CVE-2019-11323](https://nvd.nist.gov/vuln/detail/CVE-2019-11323)
 
 #### Java JRE
 
@@ -225,6 +206,40 @@ The Java JRE has been updated from 8u162 to 8u202 to resolve the following CVEs:
 - [CVE-2018-2800](https://nvd.nist.gov/vuln/detail/CVE-2018-2800)
 - [CVE-2018-2811](https://nvd.nist.gov/vuln/detail/CVE-2018-2811)
 - [CVE-2018-2815](https://nvd.nist.gov/vuln/detail/CVE-2018-2815)
+
+#### OpenSSL
+
+OpenSSL has been updated from 1.0.2t to 1.0.2u to resolve the following CVEs:
+
+- [CVE-2019-1551](https://nvd.nist.gov/vuln/detail/CVE-2019-1551)
+
+#### Rack
+
+The `rack` gem in the `oc-id` Chef Infra Server component has been updated from 1.6.11 to 1.6.12 to resolve [CVE-2019-16782](https://nvd.nist.gov/vuln/detail/CVE-2019-16782)
+
+#### Redis
+
+Redis has been updated from 3.0.7 to 5.0.7 to resolve the following CVEs:
+
+- [CVE-2019-10193](https://nvd.nist.gov/vuln/detail/CVE-2019-10193)
+- [CVE-2019-10192](https://nvd.nist.gov/vuln/detail/CVE-2019-10192)
+- [CVE-2019-11218](https://nvd.nist.gov/vuln/detail/CVE-2019-11218)
+- [CVE-2019-11219](https://nvd.nist.gov/vuln/detail/CVE-2019-11219)
+
+#### Ruby
+
+Ruby has been updated from 2.6.3 to 2.6.5 to resolve the following CVEs:
+
+- [CVE-2019-16255](https://nvd.nist.gov/vuln/detail/CVE-2019-16255): A code injection vulnerability of Shell#[] and Shell#test
+- [CVE-2019-16254](https://nvd.nist.gov/vuln/detail/CVE-2019-16254): HTTP response splitting in WEBrick (Additional fix)
+- [CVE-2019-15845](https://nvd.nist.gov/vuln/detail/CVE-2019-15845): A NUL injection vulnerability of File.fnmatch and File.fnmatch?
+- [CVE-2019-16201](https://nvd.nist.gov/vuln/detail/CVE-2019-16201): Regular Expression Denial of Service vulnerability of WEBrick's Digest access authentication
+- [CVE-2012-6708](https://nvd.nist.gov/vuln/detail/CVE-2012-6708): Cross-site Scripting vulnerability in RDoc
+- [CVE-2015-16892](https://nvd.nist.gov/vuln/detail/CVE-2015-9251): Cross-site Scripting vulnerability in RDoc
+
+#### rubyzip
+
+The release of rubyzip in the `oc-id` Chef Infra Server component has been updated from 1.2.3 to 1.3.0 to resolve [CVE-2019-16892](https://nvd.nist.gov/vuln/detail/CVE-2019-16892)
 
 ## What's New in 13.1.13
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -253,11 +253,7 @@ See our [Frequently Asked Questions document](https://www.chef.io/subscription-m
 
 -   Updated Ruby version to 2.5.5
 -   Updated Chef Infra Client to 14.11.21
--   Updated runit cookbook to 5.1.1
--   Migrated unit tests from Travis to Buildkite. Reorganized them for
-    improved speed, stability and portability.
--   Added some Habitat packaging improvements with parameterized
-    search_server.
+-   Added some Habitat packaging improvements with parameterized search_server.
 -   Erchef request size increased from 1,000,000 to 2,000,000 bytes to
     better support inspec scanning via the audit cookbook.
 -   Nginx error logs no longer log 404s. In the Chef API, 404s are

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -290,27 +290,18 @@ Omnibus release was done to keep in sync with the Habitat release.
 
 ## What's New in 12.19.26
 
-This release contains some minor improvements and updates to include
-software:
+This release contains some minor improvements and updates to include software:
 
--   Added request id to nginx log to easily track the Chef request
-    through the logs.
--   Bundler pinned to 1.17 to avoid taking the 2.0 upgrade.
+-   Added request id to nginx log to easily track the Chef request through the logs.
 -   Ruby updated to 2.5.3.
 -   Chef Client updated to 14.5.
--   Erchef and Bookshelf can optionally use mTLS protocol for their
-    internal communications.
--   Added configuration for pedant SSL-signed requests to include mTLS
-    support.
+-   Erchef and Bookshelf can optionally use mTLS protocol for their internal communications.
 -   Habitat package improvements:
     -   Increased `authn:keygen_timeout` amount for `oc_erchef` hab pkg.
     -   Removed `do_end` function from `chef-server-ctl` hab plan.
-    -   Enhanced `chef-server-ctl` to function in more habitat
-        environments.
-    -   `chef-server-ctl` commands pass relevant TLS options during
-        bifrost API calls.
--   Used standard ruby-cleanup definition, which shrinks install size by
-    \~5% on disk.
+    -   Enhanced `chef-server-ctl` to function in more habitat environments.
+    -   `chef-server-ctl` commands pass relevant TLS options during bifrost API calls.
+-   Used standard ruby-cleanup definition, which shrinks install size by \~5% on disk.
 -   Removed unused couchdb configurables.
 
 ### Security
@@ -335,21 +326,16 @@ This release:
 -   Optional disabling of welcome page
 -   chef-server-ctl now has version subcommand.
 -   chef-server-ctl appbundled to better control gem loading.
--   Support for SSL auth between internal Chef Server Services. This
-    includes connections to bifrost and the internal Postgresql server.
+-   Support for SSL auth between internal Chef Server Services. This includes connections to bifrost and the internal Postgresql server.
 -   All datestamps in logs are now in UTC. SOLR GC log now datestamped.
 -   Nginx logs now include the request id.
--   Fixie is now shipped with chef server.
--   Security issue with old doorkeeper fixed by upgrading.
-    CVE-2018-1000211
+-   Fixie is now shipped with Chef Server.
+-   Security issue with old doorkeeper fixed by upgrading. CVE-2018-1000211
 -   Fixed issue migrating rabbitmq passwords (migration 031).
--   Chef indexing queue times now reported in stats in log messages and
-    status endpoint.
+-   Chef indexing queue times now reported in stats in log messages and status endpoint.
 -   Ruby updated to 2.5.1
--   Update gems
 -   Chef Client updated to 14.3.
--   Postgresql updated to 9.6.10 and 9.2.24 (latter only for upgrades
-    from older Chef Servers).
+-   Postgresql updated to 9.6.10 and 9.2.24 (latter only for upgrades from older Chef Servers).
 -   Fix for SUSE SLES-11 sysvinit install
 -   Removed nodejs (a build dependency that was shipped).
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -177,6 +177,10 @@ PCRE has been updated from 8.38 to 8.44 to resolve the following CVEs:
 ### Updates
 
 - Erlang in the Habitat package: 18 -> 20
+- Haproxy 1.6.4 -> 1.6.15
+- Redis 3.0.7 -> 5.0.7
+- libxml2 2.9.9 -> 2.9.10
+- libxslt 1.1.30 -> 1.1.34
 
 ### Security
 
@@ -225,6 +229,10 @@ The release of rubyzip in the `oc-id` Chef Infra Server component has been updat
 
 ### Security
 
+#### Loofah
+
+Loofah has been updated from 2.2.3 to 2.3.1 to resolve [CVE-2019-15587](https://nvd.nist.gov/vuln/detail/CVE-2019-15587)
+
 #### OpenSSL
 
 OpenSSL has been updated from 1.0.2s to 1.0.2t to resolve the following CVEs:
@@ -232,10 +240,6 @@ OpenSSL has been updated from 1.0.2s to 1.0.2t to resolve the following CVEs:
 - [CVE-2019-1547](https://nvd.nist.gov/vuln/detail/CVE-2019-1547)
 - [CVE-2019-1563](https://nvd.nist.gov/vuln/detail/CVE-2019-1563)
 - [CVE-2019-1552](https://nvd.nist.gov/vuln/detail/CVE-2019-1552)
-
-#### Loofah
-
-Loofah has been updated from 2.2.3 to 2.3.1 to resolve [CVE-2019-15587](https://nvd.nist.gov/vuln/detail/CVE-2019-15587)
 
 #### Postgresql
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -251,10 +251,6 @@ See our [Frequently Asked Questions document](https://www.chef.io/subscription-m
 
 ### Updates and Improvements
 
--   Updated OpenResty to 1.13.6.2
-    -   This fixes two CVEs: CVE-2018-9230 and CVE-2017-7529.
-    -   This version cannot be built on PowerPC and s390x because those
-        platforms are not supported in mainline luajit.
 -   Updated Ruby version to 2.5.5
 -   Updated Chef Infra Client to 14.11.21
 -   Updated runit cookbook to 5.1.1
@@ -272,6 +268,15 @@ See our [Frequently Asked Questions document](https://www.chef.io/subscription-m
     root_url is configured. If the data_collector token secret is not
     set, a 401 response code and an error message will be seen instead
     of 404.
+
+### Security
+
+#### OpenResty
+
+OpenResty was updated to 1.13.6.2 to resolve the following CVEs:
+
+- [CVE-2018-9230](https://nvd.nist.gov/vuln/detail/CVE-2018-9230)
+- [CVE-2017-7529](https://nvd.nist.gov/vuln/detail/CVE-2017-7529)
 
 ## What's New in 12.19.31
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -91,6 +91,7 @@ Upgrading to Chef Infra Server 14 will require a reindexing operation for most u
 - Improved Indexing Metrics: The `/_stats` API endpoint now returns metrics about search indexing. These new metrics should allow us to more easily investigate problems that users report with search indexing.
 - Integration Testing: In Chef Infra Server 13.2, we added a new integration testing pipeline. We've further improved this pipeline, expanding the testing scenarios and improving the fidelity of the existing scenarios.
 - New Command: `chef-server-ctl` now features the `check-config` command, which runs only the configuration portion of the reconfigure cookbooks and preflight checks.
+- New smaller installation and package size. Up to 22% reduction in overall size.
 
 ### Bug Fixes
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -51,10 +51,10 @@ The AdoptOpenJDK package has been updated from 11.0.7+10 to 11.0.10+9 to resolve
 
 The OpenSSL library has been updated to 1.0.2y to resolve the following CVEs:
 
-- [CVE-2021-23841](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23841)
-- [CVE-2021-23839](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23839)
-- [CVE-2021-23840](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23840)
-- [CVE-2020-1971](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1971)
+- [CVE-2021-23841](https://nvd.nist.gov/vuln/detail/CVE-2021-23841)
+- [CVE-2021-23839](https://nvd.nist.gov/vuln/detail/CVE-2021-23839)
+- [CVE-2021-23840](https://nvd.nist.gov/vuln/detail/CVE-2021-23840)
+- [CVE-2020-1971](https://nvd.nist.gov/vuln/detail/CVE-2020-1971)
 
 ### Platform Support
 
@@ -76,7 +76,7 @@ Please keep in mind that upgrading from releases before 14.0 will run an automat
 
 #### Elasticsearch
 
-Elasticsearch has been upgraded from 6.8.1 to 6.8.12 to resolve [CVE-2020-7019](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7019)
+Elasticsearch has been upgraded from 6.8.1 to 6.8.12 to resolve [CVE-2020-7019](https://nvd.nist.gov/vuln/detail/CVE-2020-7019)
 
 ## What's New in 14.0.58
 
@@ -125,7 +125,7 @@ Upgrading to Chef Infra Server 14 will require a reindexing operation for most u
 
 #### OpenSSL
 
-OpenSSL was updated from 1.0.2u to 1.0.2w which includes a fix for [CVE-2020-1968](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-1968) and multiple security hardening fixes not related to particular CVEs.
+OpenSSL was updated from 1.0.2u to 1.0.2w which includes a fix for [CVE-2020-1968](https://nvd.nist.gov/vuln/detail/2020-1968) and multiple security hardening fixes not related to particular CVEs.
 
 ## What's New in 13.2
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -209,6 +209,23 @@ OpenSSL has been updated from 1.0.2t to 1.0.2u to resolve the following CVEs:
 
 - [CVE-2019-1551](https://nvd.nist.gov/vuln/detail/CVE-2019-1551)
 
+#### Java JRE
+
+The Java JRE has been updated from 8u162 to 8u202 to resolve the following CVEs:
+
+- [CVE-2018-3214](https://nvd.nist.gov/vuln/detail/CVE-2018-3214)
+- [CVE-2018-14048](https://nvd.nist.gov/vuln/detail/CVE-2018-14048)
+- [CVE-2018-3209](https://nvd.nist.gov/vuln/detail/CVE-2018-3209)
+- [CVE-2018-3211](https://nvd.nist.gov/vuln/detail/CVE-2018-3211)
+- [CVE-2018-2941](https://nvd.nist.gov/vuln/detail/CVE-2018-2941)
+- [CVE-2018-2942](https://nvd.nist.gov/vuln/detail/CVE-2018-2942)
+- [CVE-2018-2964](https://nvd.nist.gov/vuln/detail/CVE-2018-2964)
+- [CVE-2018-2798](https://nvd.nist.gov/vuln/detail/CVE-2018-2798)
+- [CVE-2018-2799](https://nvd.nist.gov/vuln/detail/CVE-2018-2799)
+- [CVE-2018-2800](https://nvd.nist.gov/vuln/detail/CVE-2018-2800)
+- [CVE-2018-2811](https://nvd.nist.gov/vuln/detail/CVE-2018-2811)
+- [CVE-2018-2815](https://nvd.nist.gov/vuln/detail/CVE-2018-2815)
+
 ## What's New in 13.1.13
 
 ### Improvements/Bug Fixes

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -354,18 +354,26 @@ Ruby has been updated from 2.5.3 to 2.5.4 to resolve the following CVEs:
 
 #### OpenResty
 
-OpenResty was updated to 1.13.6.2 to resolve the following CVEs:
+OpenResty was updated from 1.11.2.1 to 1.13.6.2 to resolve the following CVEs:
 
 - [CVE-2018-9230](https://nvd.nist.gov/vuln/detail/CVE-2018-9230)
 - [CVE-2017-7529](https://nvd.nist.gov/vuln/detail/CVE-2017-7529)
 
 ## What's New in 12.19.31
 
-This release was triggered by the update to Habitat base plans.
-(<https://blog.chef.io/2019/01/28/base-plans-refresh-is-coming-to-habitat-core-plans/>)
-Omnibus release was done to keep in sync with the Habitat release.
+### Security
 
-- `chef-server-ctl` leverages HAB_LISTEN_CTL envvar if available.
+#### OpenSSL
+
+OpenSSL has been updated from 1.0.2q to 1.0.2r to resolve [CVE-2019-1559](https://nvd.nist.gov/vuln/detail/CVE-2019-1559)
+
+#### libxml2
+
+libxml2 has been updated from 2.9.8 to 2.9.9 to resolve the following CVEs:
+
+- [CVE-2018-9251](https://nvd.nist.gov/vuln/detail/CVE-2018-9251)
+- [CVE-2018-14567](https://nvd.nist.gov/vuln/detail/CVE-2018-14567)
+- [CVE-2018-14404](https://nvd.nist.gov/vuln/detail/CVE-2018-14404)
 
 ## What's New in 12.19.26
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -220,11 +220,18 @@ The release of rubyzip in the `oc-id` Chef Infra Server component has been updat
 - Nokogiri 1.8.5 -\> 1.10.4
 - Rebar3 -\> 3.12.0
 - Updated erlang deps to be the latest
-- Loofah 2.2.3 -\> 2.3.1
 - Erlang 18.3.4.9 -\> 20.3.8.9
 - Ruby 2.5.5 -\> 2.6.3
 
 ### Security
+
+#### OpenSSL
+
+OpenSSL has been updated from 1.0.2s to 1.0.2t to resolve the following CVEs:
+
+- [CVE-2019-1547](https://nvd.nist.gov/vuln/detail/CVE-2019-1547)
+- [CVE-2019-1563](https://nvd.nist.gov/vuln/detail/CVE-2019-1563)
+- [CVE-2019-1552](https://nvd.nist.gov/vuln/detail/CVE-2019-1552)
 
 #### Loofah
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -269,6 +269,13 @@ The release of rubyzip in the `oc-id` Chef Infra Server component has been updat
 
 ### Security
 
+#### bzip2
+
+bzip has been updated from 1.0.6 to 1.0.8 to resolve the following CVEs
+
+- [CVE-2019-12900](https://nvd.nist.gov/vuln/detail/CVE-2019-12900)
+- [CVE-2016-3189](https://nvd.nist.gov/vuln/detail/CVE-2016-3189)
+
 #### Loofah
 
 Loofah has been updated from 2.2.3 to 2.3.1 to resolve [CVE-2019-15587](https://nvd.nist.gov/vuln/detail/CVE-2019-15587)

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -294,11 +294,6 @@ software:
 -   Added request id to nginx log to easily track the Chef request
     through the logs.
 -   Bundler pinned to 1.17 to avoid taking the 2.0 upgrade.
--   Erlang updated to 18.3.4.9
-    -   Fixed two CVEs CVE-2017-1000385 and CVE-2016-10253. SSL headers
-        got stricter which unfortunately broke LDAP. (Issue \#1642)
-    -   Removed `et`, `debugger`, `gs`, and `observer` as they depend on
-        `wx`, which is not available on all platforms.
 -   Ruby updated to 2.5.3.
 -   Chef Client updated to 14.5.
 -   Erchef and Bookshelf can optionally use mTLS protocol for their
@@ -315,6 +310,15 @@ software:
 -   Used standard ruby-cleanup definition, which shrinks install size by
     \~5% on disk.
 -   Removed unused couchdb configurables.
+
+### Security
+
+#### Erlang
+
+Erlang has been updated to 18.3.4.9 to resolve the following CVEs:
+
+- [CVE-2017-1000385](https://nvd.nist.gov/vuln/detail/CVE-2017-1000385)
+- [CVE-2016-10253](https://nvd.nist.gov/vuln/detail/CVE-2016-10253)
 
 ## What's New in 12.18.14
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -49,7 +49,7 @@ The AdoptOpenJDK package has been updated from 11.0.7+10 to 11.0.10+9 to resolve
 
 #### OpenSSL
 
-The OpenSSL library has been updated to 1.0.2y to resolve the following CVEs:
+The OpenSSL library has been updated from 1.0.2w to 1.0.2y to resolve the following CVEs:
 
 - [CVE-2021-23841](https://nvd.nist.gov/vuln/detail/CVE-2021-23841)
 - [CVE-2021-23839](https://nvd.nist.gov/vuln/detail/CVE-2021-23839)
@@ -126,6 +126,14 @@ Upgrading to Chef Infra Server 14 will require a reindexing operation for most u
 #### OpenSSL
 
 OpenSSL was updated from 1.0.2u to 1.0.2w which includes a fix for [CVE-2020-1968](https://nvd.nist.gov/vuln/detail/2020-1968) and multiple security hardening fixes not related to particular CVEs.
+
+#### PCRE
+
+PCRE has been updated from 8.38 to 8.44 to resolve the following CVEs:
+
+- [CVE-2016-3191](https://nvd.nist.gov/vuln/detail/CVE-2016-3191)
+- [CVE-2017-6004](https://nvd.nist.gov/vuln/detail/CVE-2017-6004)
+- [CVE-2016-1283](https://nvd.nist.gov/vuln/detail/CVE-2016-1283)
 
 ## What's New in 13.2
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -203,6 +203,12 @@ Ruby has been updated from 2.6.3 to 2.6.5 to resolve the following CVEs:
 
 The release of rubyzip in the `oc-id` Chef Infra Server component has been updated from 1.2.3 to 1.3.0 to resolve [CVE-2019-16892](https://nvd.nist.gov/vuln/detail/CVE-2019-16892)
 
+#### OpenSSL
+
+OpenSSL has been updated from 1.0.2t to 1.0.2u to resolve the following CVEs:
+
+- [CVE-2019-1551](https://nvd.nist.gov/vuln/detail/CVE-2019-1551)
+
 ## What's New in 13.1.13
 
 ### Improvements/Bug Fixes

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -164,7 +164,6 @@ OpenSSL was updated from 1.0.2u to 1.0.2w which includes a fix for [CVE-2020-196
 
 ### Updates
 
-- Chef Infra Client: 15.5.17 -> 15.8.23
 - Erlang in the Habitat package: 18 -> 20
 
 ### Security
@@ -205,7 +204,6 @@ The release of rubyzip in the `oc-id` Chef Infra Server component has been updat
 
 ### Updates and Improvements
 
-- Chef Infra Client v15.3.14 -\> v15.4.45
 - OpenResty 1.13.6.2 -\> 1.15.8.1
 - Nokogiri 1.8.5 -\> 1.10.4
 - Rebar3 -\> 3.12.0
@@ -294,7 +292,6 @@ This release contains some minor improvements and updates to include software:
 
 -   Added request id to nginx log to easily track the Chef request through the logs.
 -   Ruby updated to 2.5.3.
--   Chef Client updated to 14.5.
 -   Erchef and Bookshelf can optionally use mTLS protocol for their internal communications.
 -   Habitat package improvements:
     -   Increased `authn:keygen_timeout` amount for `oc_erchef` hab pkg.
@@ -334,7 +331,6 @@ This release:
 -   Fixed issue migrating rabbitmq passwords (migration 031).
 -   Chef indexing queue times now reported in stats in log messages and status endpoint.
 -   Ruby updated to 2.5.1
--   Chef Client updated to 14.3.
 -   Postgresql updated to 9.6.10 and 9.2.24 (latter only for upgrades from older Chef Servers).
 -   Fix for SUSE SLES-11 sysvinit install
 -   Removed nodejs (a build dependency that was shipped).

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -228,36 +228,26 @@ Postgresql has been updated from 9.6.14 to 9.6.15 to resolve [CVE-2019-10208](ht
 
 ### Chef Server is now Chef Infra Server
 
-Chef Server has a new name, but don't worry, it's the same Chef Server
-you've grown used to. You'll notice new branding throughout the
-application and documentation but the command <span
-class="title-ref">chef-server-ctl</span> remains the same.
+Chef Server has a new name, but don't worry, it's the same Chef Server you've grown used to. You'll notice new branding throughout the application and documentation but the command <span class="title-ref">chef-server-ctl</span> remains the same.
 
 ### Chef EULA
 
-Chef Infra Server requires an EULA to be accepted by users before it can
-be installed. Users can accept the EULA in a variety of ways:
+Chef Infra Server requires an EULA to be accepted by users before it can be installed. Users can accept the EULA in a variety of ways:
 
 - `chef-server-ctl reconfigure --chef-license accept`
 - `chef-server-ctl reconfigure --chef-license accept-no-persist`
 - `CHEF_LICENSE="accept" chef-server-ctl reconfigure`
 - `CHEF_LICENSE="accept-no-persist" chef-server-ctl reconfigure`
 
-Finally, if users run `chef-server-ctl reconfigure` without any of these
-options, they will receive an interactive prompt asking for license
-acceptance. If the license is accepted, a marker file will be written to
-the filesystem unless `accept-no-persist` is specified. Once this marker
-file is persisted, users no longer need to set any of these flags.
+Finally, if users run `chef-server-ctl reconfigure` without any of these options, they will receive an interactive prompt asking for license acceptance. If the license is accepted, a marker file will be written to the filesystem unless `accept-no-persist` is specified. Once this marker file is persisted, users no longer need to set any of these flags.
 
-See our [Frequently Asked Questions
-document](https://www.chef.io/bmc-faq/) for more information on the EULA
-and license acceptance.
+See our [Frequently Asked Questions document](https://www.chef.io/subscription-model-faq) for more information on the EULA and license acceptance.
 
 ### Deprecation notice
 
 - [Deprecated PowerPC and s390x platforms](https://blog.chef.io/2018/11/01/end-of-life-announcement-for-chef-server-for-linux-on-ibm-z-and-linux-on-ibm-power-systems/)
 - [Deprecated Keepalived/DRBD-based HA](https://blog.chef.io/2018/10/02/end-of-life-announcement-for-drbd-based-ha-support-in-chef-server/)
-- Deprecated Ubuntu 14.04 support. (Ubuntu 14 was EoL'd at the end of April 2019)
+- Deprecated Ubuntu 14.04 support. (Ubuntu 14.04 was EoL'd at the end of April 2019)
 
 ### Updates and Improvements
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -255,21 +255,23 @@ See our [Frequently Asked Questions document](https://www.chef.io/subscription-m
 
 ### Updates and Improvements
 
--   Updated Ruby version to 2.5.5
--   Updated Chef Infra Client to 14.11.21
--   Added some Habitat packaging improvements with parameterized search_server.
--   Erchef request size increased from 1,000,000 to 2,000,000 bytes to
-    better support inspec scanning via the audit cookbook.
--   Nginx error logs no longer log 404s. In the Chef API, 404s are
-    typically not errors as they are often the expected response about
-    an object that doesn't exist. The logs will continue to show 404s in
-    the request logs.
--   Profiles and data-collector upstreams now render correctly if their
-    root_url is configured. If the data_collector token secret is not
-    set, a 401 response code and an error message will be seen instead
-    of 404.
+- Added some Habitat packaging improvements with parameterized search_server.
+- Erchef request size increased from 1,000,000 to 2,000,000 bytes to better support InSpec scanning via the audit cookbook.
+- Nginx error logs no longer log 404s. In the Chef API, 404s are typically not errors as they are often the expected response about an object that doesn't exist. The logs will continue to show 404s in the request logs.
+- Profiles and data-collector upstreams now render correctly if their root_url is configured. If the data_collector token secret is not set, a 401 response code and an error message will be seen instead of 404.
 
 ### Security
+
+#### Ruby
+
+Ruby has been updated from 2.5.3 to 2.5.4 to resolve the following CVEs:
+
+- [CVE-2019-8320](https://nvd.nist.gov/vuln/detail/CVE-2019-8320)
+- [CVE-2019-8321](https://nvd.nist.gov/vuln/detail/CVE-2019-8321)
+- [CVE-2019-8322](https://nvd.nist.gov/vuln/detail/CVE-2019-8322)
+- [CVE-2019-8323](https://nvd.nist.gov/vuln/detail/CVE-2019-8323)
+- [CVE-2019-8324](https://nvd.nist.gov/vuln/detail/CVE-2019-8324)
+- [CVE-2019-8325](https://nvd.nist.gov/vuln/detail/CVE-2019-8325)
 
 #### OpenResty
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -224,7 +224,11 @@ Loofah has been updated from 2.2.3 to 2.3.1 to resolve [CVE-2019-15587](https://
 
 Postgresql has been updated from 9.6.14 to 9.6.15 to resolve [CVE-2019-10208](https://nvd.nist.gov/vuln/detail/CVE-2019-10208)
 
-## What's New in 13.0.11
+## What's New in 13.0.17
+
+This is an identical release to 13.0.16 that was performed for product packaging reasons.
+
+## What's New in 13.0.16
 
 ### Chef Server is now Chef Infra Server
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -234,6 +234,14 @@ Loofah has been updated from 2.2.3 to 2.3.1 to resolve [CVE-2019-15587](https://
 
 Postgresql has been updated from 9.6.14 to 9.6.15 to resolve [CVE-2019-10208](https://nvd.nist.gov/vuln/detail/CVE-2019-10208)
 
+#### RabbitMQ
+
+RabbitMQ has been updated from 3.6.6 to 3.6.15 to resolve the following CVEs:
+
+- [CVE-2017-4967](https://nvd.nist.gov/vuln/detail/CVE-2017-4967)
+- [CVE-2017-4966](https://nvd.nist.gov/vuln/detail/CVE-2017-4966)
+- [CVE-2017-4965](https://nvd.nist.gov/vuln/detail/CVE-2017-4965)
+
 ## What's New in 13.0.17
 
 This is an identical release to 13.0.16 that was performed for product packaging reasons.

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -460,7 +460,7 @@ OpenSSL has been updated from 1.0.2n to 1.0.2p to resolve the following CVEs:
 
 #### Postgresql
 
-Postgresql has been updated from 9.6.4 9.6.10 to resolve the following CVEs:
+Postgresql has been updated from 9.6.4 to 9.6.10 to resolve the following CVEs:
 
 - [CVE-2017-15099](https://nvd.nist.gov/vuln/detail/CVE-2017-15099)
 - [CVE-2017-15098](https://nvd.nist.gov/vuln/detail/CVE-2017-15098)

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -380,7 +380,6 @@ libxml2 has been updated from 2.9.8 to 2.9.9 to resolve the following CVEs:
 This release contains some minor improvements and updates to include software:
 
 -   Added request id to nginx log to easily track the Chef request through the logs.
--   Ruby updated to 2.5.3.
 -   Erchef and Bookshelf can optionally use mTLS protocol for their internal communications.
 -   Habitat package improvements:
     -   Increased `authn:keygen_timeout` amount for `oc_erchef` hab pkg.
@@ -398,6 +397,20 @@ Erlang has been updated to 18.3.4.9 to resolve the following CVEs:
 
 - [CVE-2017-1000385](https://nvd.nist.gov/vuln/detail/CVE-2017-1000385)
 - [CVE-2016-10253](https://nvd.nist.gov/vuln/detail/CVE-2016-10253)
+
+#### OpenSSL
+
+OpenSSL has been updated from 1.0.2p to 1.0.2q to resolve the following CVEs:
+
+- [CVE-2018-0734](https://nvd.nist.gov/vuln/detail/CVE-2018-0734)
+- [CVE-2018-5407](https://nvd.nist.gov/vuln/detail/CVE-2018-5407)
+
+#### Ruby
+
+Ruby has been updated from 2.5.1 to 2.5.3 to resolve the following CVEs:
+
+- [CVE-2018-16396](https://nvd.nist.gov/vuln/detail/CVE-2018-16396)
+- [CVE-2018-16395](https://nvd.nist.gov/vuln/detail/CVE-2018-16395)
 
 ## What's New in 12.18.14
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -416,26 +416,21 @@ Ruby has been updated from 2.5.1 to 2.5.3 to resolve the following CVEs:
 
 This release:
 
--   Segment free cookbooks are implemented.
-    (<https://github.com/chef/chef-rfc/blob/master/rfc067-cookbook-segment-deprecation.md>)
-    This bumps the API version.
--   ACLs for cookbook artifacts
--   /nodes/NODENAME endpoint has HEAD operation.
--   Security headers for HTTP
--   Optional disabling of welcome page
--   chef-server-ctl now has version subcommand.
--   chef-server-ctl appbundled to better control gem loading.
--   Support for SSL auth between internal Chef Server Services. This includes connections to bifrost and the internal Postgresql server.
--   All datestamps in logs are now in UTC. SOLR GC log now datestamped.
--   Nginx logs now include the request id.
--   Fixie is now shipped with Chef Server.
--   Security issue with old doorkeeper fixed by upgrading. CVE-2018-1000211
--   Fixed issue migrating rabbitmq passwords (migration 031).
--   Chef indexing queue times now reported in stats in log messages and status endpoint.
--   Ruby updated to 2.5.1
--   Postgresql updated to 9.6.10 and 9.2.24 (latter only for upgrades from older Chef Servers).
--   Fix for SUSE SLES-11 sysvinit install
--   Removed nodejs (a build dependency that was shipped).
+- Segment free cookbooks are implemented. (<https://github.com/chef/chef-rfc/blob/master/rfc067-cookbook-segment-deprecation.md>) This bumps the API version.
+- ACLs for cookbook artifacts
+- /nodes/NODENAME endpoint has HEAD operation.
+- Security headers for HTTP
+- Optional disabling of welcome page
+- chef-server-ctl now has version subcommand.
+- chef-server-ctl appbundled to better control gem loading.
+- Support for SSL auth between internal Chef Server Services. This includes connections to bifrost and the internal Postgresql server.
+- All datestamps in logs are now in UTC. SOLR GC log now datestamped.
+- Nginx logs now include the request id.
+- Fixie is now shipped with Chef Server.
+- Fixed issue migrating rabbitmq passwords (migration 031).
+- Chef indexing queue times now reported in stats in log messages and status endpoint.
+- Fix for SUSE SLES-11 sysvinit install
+- Removed nodejs (a build dependency that was shipped).
 
 {{< note >}}
 
@@ -448,6 +443,45 @@ containing `status=400` and `req_api_version=1` in the log line for the
 corresponding cookbook upload API request.
 
 {{< /note >}}
+
+### Security
+
+#### doorkeeper
+
+Doorkeeper has been updated to resolve [CVE-2018-1000211](https://nvd.nist.gov/vuln/detail/CVE-2018-1000211)
+
+#### OpenSSL
+
+OpenSSL has been updated from 1.0.2n to 1.0.2p to resolve the following CVEs:
+
+- [CVE-2018-0732](https://nvd.nist.gov/vuln/detail/CVE-2018-0732)
+- [CVE-2018-0737](https://nvd.nist.gov/vuln/detail/CVE-2018-0737)
+- [CVE-2018-0739](https://nvd.nist.gov/vuln/detail/CVE-2018-0739)
+
+#### Postgresql
+
+Postgresql has been updated from 9.6.4 9.6.10 to resolve the following CVEs:
+
+- [CVE-2017-15099](https://nvd.nist.gov/vuln/detail/CVE-2017-15099)
+- [CVE-2017-15098](https://nvd.nist.gov/vuln/detail/CVE-2017-15098)
+- [CVE-2017-12172](https://nvd.nist.gov/vuln/detail/CVE-2017-12172)
+- [CVE-2018-1053](https://nvd.nist.gov/vuln/detail/CVE-2018-1053)
+- [CVE-2018-1058](https://nvd.nist.gov/vuln/detail/CVE-2018-1058)
+- [CVE-2018-1115](https://nvd.nist.gov/vuln/detail/CVE-2018-1115)
+- [CVE-2018-10915](https://nvd.nist.gov/vuln/detail/CVE-2018-10915)
+- [CVE-2018-10925](https://nvd.nist.gov/vuln/detail/CVE-2018-10925)
+
+#### Ruby
+
+Ruby has been updated from 2.4.3 to 2.5.1 to resolve the following CVEs:
+
+- [CVE-2017-17742](https://nvd.nist.gov/vuln/detail/CVE-2017-17742)
+- [CVE-2018-6914](https://nvd.nist.gov/vuln/detail/CVE-2018-6914)
+- [CVE-2018-8777](https://nvd.nist.gov/vuln/detail/CVE-2018-8777)
+- [CVE-2018-8778](https://nvd.nist.gov/vuln/detail/CVE-2018-8778)
+- [CVE-2018-8779](https://nvd.nist.gov/vuln/detail/CVE-2018-8779)
+- [CVE-2018-8780](https://nvd.nist.gov/vuln/detail/CVE-2018-8780)
+- Multiple vulnerabilities in RubyGems
 
 ## What's New in 12.17.33
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -184,6 +184,8 @@ PCRE has been updated from 8.38 to 8.44 to resolve the following CVEs:
 
 #### haproxy
 
+haproxy has been updated from 1.6.4 to 1.6.15 to resolve the following CVEs:
+
 - [CVE-2018-10184](https://nvd.nist.gov/vuln/detail/CVE-2018-10184)
 - [CVE-2018-14645](https://nvd.nist.gov/vuln/detail/CVE-2018-14645)
 - [CVE-2018-20103](https://nvd.nist.gov/vuln/detail/CVE-2018-20103)
@@ -281,7 +283,10 @@ OpenSSL has been updated from 1.0.2s to 1.0.2t to resolve the following CVEs:
 
 #### Postgresql
 
-Postgresql has been updated from 9.6.14 to 9.6.15 to resolve [CVE-2019-10208](https://nvd.nist.gov/vuln/detail/CVE-2019-10208)
+Postgresql has been updated from 9.6.10 to 9.6.15 to resolve the following CVEs:
+
+- [CVE-2019-10208](https://nvd.nist.gov/vuln/detail/CVE-2019-10208)
+- [CVE-2019-10130](https://nvd.nist.gov/vuln/detail/CVE-2019-10130)
 
 #### RabbitMQ
 


### PR DESCRIPTION
Update these to better describe what's new in each release. Remove things that don't matter to end users, fix incorrect version numbers, clearly call out CVE fixes