### PR TITLE
Add Expeditor config for Cookstyle repo

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -36,3 +36,8 @@ subscriptions:
     - bash:.expeditor/update_hugo_modules_pull_request_merged.sh:
         only_if_modified:
           - docs-chef-io/*
+  - workload: chef/cookstyle:master_completed:project_promoted:chef/cookstyle:master:*
+    actions:
+    - bash:.expeditor/update_hugo_modules_cookstyle.sh:
+        only_if_modified:
+          - docs-chef-io/*

--- a/.expeditor/update_hugo_modules_cookstyle.sh
+++ b/.expeditor/update_hugo_modules_cookstyle.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eoux pipefail
+
+# Create a new branch and checkout that branch.
+
+branch="expeditor/update_docs_cookstyle"
+git checkout -b "$branch"
+
+# Update the go.mod and go.sum for chef/cookstyle
+
+hugo mod get "github.com/chef/cookstyle"
+hugo mod get "github.com/chef/cookstyle/docs-chef-io"
+hugo mod tidy
+
+# Update the vendored files in chef-web-docs.
+# See https://gohugo.io/hugo-modules/use-modules/#vendor-your-modules
+
+hugo mod vendor
+
+# Submit pull request to chef/chef-web-docs.
+
+git add .
+
+# Give a friendly message for the commit and make sure it's noted for any future
+# audit of our codebase that no DCO sign-off is needed for this sort of PR since
+# it contains no intellectual property
+
+dco_safe_git_commit "Bump Hugo module ${EXPEDITOR_PROJECT} to latest {$EXPEDITOR_TARGET_CHANNEL}."
+
+open_pull_request
+
+# Get back to master and cleanup the leftovers - any changed files left over at
+# the end of this script will get committed to master.
+git checkout -
+git branch -D "$branch"


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Add Expeditor config for updating content from chef/cookstyle repo.

As far as I can tell there's no way to get the git sha of the promoted commit for chef/cookstyle, so that's why I created a new script instead of using the existing `update_hugo_modules_project_promoted.sh` script. 

### Definition of Done

### Issues Resolved

#2987 

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
