### PR TITLE
Improve swiftype indexing in infra resources pages

### DIFF
--- a/themes/docs-new/layouts/_default/infra_resource.html
+++ b/themes/docs-new/layouts/_default/infra_resource.html
@@ -3,37 +3,56 @@
   <main id="main-content-col" tabindex="-1">
     <div class="col-content" data-swiftype-index='true'>
 
-    <h1 id="{{ anchorize ( .Title )}}">{{ .Title }}</h1>
+      <h1 id="{{ anchorize ( .Title )}}">{{ .Title }}</h1>
 
-    <button type="button" class="TOC-button hide-for-large" data-toggle="offCanvasRightTOC"
-      data-close="left-nav-off-canvas" data-swiftype-index='false'>
-      <i class="fas fa-bars"></i> Table of Contents
-    </button>
+      <button type="button" class="TOC-button hide-for-large" data-toggle="offCanvasRightTOC"
+        data-close="left-nav-off-canvas" data-swiftype-index='false'>
+        <i class="fas fa-bars"></i> Table of Contents
+      </button>
 
-    <div class="prose">
-      <p>
-        <button onclick="resource_note_function('resource_note')" class="note-btn note-block note-left-align">Edit this page in the Chef repository</button>
-        <div id="resource_note" class="note-container note-hide">
-          <p>
-            This page is generated from the <a href="https://github.com/chef/chef">Chef Infra Client source code</a>.</br>
-            To suggest a change, edit the <a href="https://github.com/chef/chef/blob/master/lib/chef/resource/{{ index .Params.data_path 2 }}.rb">{{ index .Params.data_path 2 }}.rb</a> file and submit a pull request to the <a href="https://github.com/chef/chef">Chef Infra Client repository</a>.</br>
-          </p>
-        </div>
-      </p>
-      <p><a href="/resources/">Resources Reference page</a></p>
-      <hr>
-      {{ $yaml_file := index $.Site.Data (.Params.data_path) }}
-      {{ with $yaml_file }}
-        {{ with "resource_description_list" }}
-          {{ range index $yaml_file . }}
-            {{ range $key, $value := . }}
-              {{ if eq $key "markdown" }}
-                <p>{{- $value | markdownify -}}</p>
-              {{ end }}
-              {{ if eq $key "note" }}
-                <div class="admonition-note">
-                  <p class="admonition-note-title">Note</p>
-                  <div class="admonition-note-text">
+      <div class="prose">
+        <p data-swiftype-index='false'>
+          <button onclick="resource_note_function('resource_note')" class="note-btn note-block note-left-align">Edit this page in the Chef repository</button>
+          <div id="resource_note" class="note-container note-hide">
+            <p>
+              This page is generated from the <a href="https://github.com/chef/chef">Chef Infra Client source code</a>.</br>
+              To suggest a change, edit the <a href="https://github.com/chef/chef/blob/master/lib/chef/resource/{{ index .Params.data_path 2 }}.rb">{{ index .Params.data_path 2 }}.rb</a> file and submit a pull request to the <a href="https://github.com/chef/chef">Chef Infra Client repository</a>.</br>
+            </p>
+          </div>
+        </p>
+        <p data-swiftype-index='false'><a href="/resources/">All Infra resources page</a></p>
+        <hr>
+        {{ $yaml_file := index $.Site.Data (.Params.data_path) }}
+        {{ with $yaml_file }}
+          {{ with "resource_description_list" }}
+            {{ range index $yaml_file . }}
+              {{ range $key, $value := . }}
+                {{ if eq $key "markdown" }}
+                  <p>{{- $value | markdownify -}}</p>
+                {{ end }}
+                {{ if eq $key "note" }}
+                  <div class="admonition-note">
+                    <p class="admonition-note-title">Note</p>
+                    <div class="admonition-note-text">
+                      {{ range $subkey, $subvalue := $value }}
+                        {{ if eq $subkey "markdown" }}
+                          <p>
+                            {{- $subvalue | markdownify -}}
+                          </p>
+                        {{ end }}
+                        {{ if eq $subkey "shortcode" }}
+                          <p>
+                            {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` $subvalue ) "") | markdownify }}
+                          </p>
+                        {{ end }}
+                      {{ end }}
+                    </div>
+                  </div>
+                {{ end }}
+                {{ if eq $key "warning" }}
+                <div class="admonition-warning">
+                  <p class="admonition-warning-title">Warning</p>
+                  <div class="admonition-warning-text">
                     {{ range $subkey, $subvalue := $value }}
                       {{ if eq $subkey "markdown" }}
                         <p>
@@ -48,730 +67,712 @@
                     {{ end }}
                   </div>
                 </div>
-              {{ end }}
-              {{ if eq $key "warning" }}
-              <div class="admonition-warning">
-                <p class="admonition-warning-title">Warning</p>
-                <div class="admonition-warning-text">
-                  {{ range $subkey, $subvalue := $value }}
-                    {{ if eq $subkey "markdown" }}
-                      <p>
-                        {{- $subvalue | markdownify -}}
-                      </p>
-                    {{ end }}
-                    {{ if eq $subkey "shortcode" }}
-                      <p>
-                        {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` $subvalue ) "") | markdownify }}
-                      </p>
-                    {{ end }}
-                  {{ end }}
-                </div>
-              </div>
-              {{ end }}
-              {{ if eq $key "shortcode" }}
-                <p>
-                  {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` $value ) "") | markdownify }}
-                </p>
-              {{ end }}
-              {{ if and (eq $key "notes_resource_based_on_package") (eq $value true)}}
-                <div class="admonition-note">
-                  <p class="admonition-note-title">Note</p>
-                  <div class="admonition-note-text">
-                    {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/notes_resource_based_on_package.md` ) "") | markdownify }}
-                  </div>
-                </div>
-              {{ end }}
-            {{ end }}
-          {{ end }}
-        {{ end }}
-      {{ end }}
-
-      {{ if and ( ne (index $yaml_file "resource_new_in") "" ) ( index $yaml_file "resource_new_in" )}}
-        <p><strong>New in Chef Infra Client {{ index $yaml_file "resource_new_in" }}.</strong></p>
-      {{ end }}
-
-      <!-------------- Handler Types ------------------->
-
-      {{ with index $yaml_file "handler_types" }}
-        <h2 id="handler_types">Handler Types</h2>
-        {{ readFile "themes/docs-new/layouts/shortcodes/handler_types.md" | markdownify }}
-
-        <h3 id="handler_type_exception_report">Exception / Report</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/handler_type_exception_report.md" | markdownify }}
-        {{ readFile "themes/docs-new/layouts/shortcodes/handler_type_exception_report_run_from_recipe.md" | markdownify }}
-
-
-        <h3 id="handler_type_start">Start</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/handler_type_start.md" | markdownify }}
-        {{ readFile "themes/docs-new/layouts/shortcodes/handler_type_start_run_from_recipe.md" | markdownify }}
-
-      {{ end }}
-
-
-      <!-------------- Syntax ------------------->
-
-
-      <h2 id = "syntax">Syntax</h2>
-      <hr>
-
-      <p>{{ index $yaml_file "syntax_description" | markdownify }}</p>
-
-      {{ with index $yaml_file "syntax_code_block" }}
-        <p>{{ highlight index $yaml_file . "ruby" "" }}</p>
-      {{ end }}
-
-      {{ with index $yaml_file "syntax_properties_list" }}
-        <p>where:</p>
-        <ul>
-          {{ range . }}
-          <li>{{ . | markdownify }}</li>
-          {{ end }}
-        </ul>
-      {{ end }}
-
-      {{ with index $yaml_file "syntax_full_code_block" }}
-        <p>The full syntax for all of the properties that are available to the <strong>{{ index $yaml_file "resource" }}</strong> resource is:</p>
-        <p>{{- highlight ( trim . "\n") "ruby" "" -}}</p>
-      {{ end }}
-
-      {{ with index $yaml_file "syntax_full_properties_list" }}
-        <p>where:</p>
-        <ul>
-          {{ range . }}
-          <li>{{ . | markdownify }}</li>
-          {{ end }}
-        </ul>
-      {{ end }}
-
-      {{ with index $yaml_file "syntax_shortcode" }}
-          {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` . ) "") | markdownify }}
-      {{ end }}
-
-      {{ with index $yaml_file "registry_key" }}
-        <h3 id="windows-registry-key-backslashes">Registry Key Path Separators</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/windows_registry_key_backslashes.md" | markdownify }}
-
-        <h3 id="dsl-recipe-method-windows-methods">Chef Infra Language Methods</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/infra_lang_method_windows_methods.md" | markdownify }}
-
-        <h4 id="dsl-recipe-method-registry-data-exists">registry_data_exists?</h4>
-        {{ $shortcode := "themes/docs-new/layouts/shortcodes/infra_lang_method_registry_data_exists.md" }}
-
-        {{ if in (readFile $shortcode) "readFile" }}
-          {{ $shortcode_text := newScratch }}
-          {{ $shortcode_text.Set "text" "" }}
-          {{ range split (readFile $shortcode) "\n"}}
-            {{ if in . "readFile" }}
-              {{ if ne $shortcode_text "" }}
-                {{ $shortcode_text.Get "text" | markdownify }}
-                {{ $shortcode_text.Set "text" "" }}
-              {{ end }}
-
-              <p>
-                {{ readFile (. | replaceRE `{{ readFile \"(themes\/docs-new\/layouts\/shortcodes\/\w+\.md)\" \| markdownify }}` "$1" ) | markdownify }}
-              </p>
-
-            {{ else }}
-              {{ $shortcode_text.Add "text" . }}
-              {{ $shortcode_text.Add "text" "\n" }}
-            {{ end }}
-          {{ end }}
-          {{ $shortcode_text.Get "text" | markdownify }}
-        {{ else }}
-          {{ readFile $shortcode | markdownify }}
-        {{ end }}
-
-        <h4 id="dsl-recipe-method-registry-get-subkeys">registry_get_subkeys</h4>
-        {{ $shortcode := "themes/docs-new/layouts/shortcodes/infra_lang_method_registry_get_subkeys.md" }}
-
-        {{ if in (readFile $shortcode) "readFile" }}
-          {{ $shortcode_text := newScratch }}
-          {{ $shortcode_text.Set "text" "" }}
-          {{ range split (readFile $shortcode) "\n"}}
-            {{ if in . "readFile" }}
-              {{ if ne $shortcode_text "" }}
-                {{ $shortcode_text.Get "text" | markdownify }}
-                {{ $shortcode_text.Set "text" "" }}
-              {{ end }}
-
-              <p>
-                {{ readFile (. | replaceRE `{{ readFile \"(themes\/docs-new\/layouts\/shortcodes\/\w+\.md)\" \| markdownify }}` "$1" ) | markdownify }}
-              </p>
-
-            {{ else }}
-              {{ $shortcode_text.Add "text" . }}
-              {{ $shortcode_text.Add "text" "\n" }}
-            {{ end }}
-          {{ end }}
-          {{ $shortcode_text.Get "text" | markdownify }}
-        {{ else }}
-          {{ readFile $shortcode | markdownify }}
-        {{ end }}
-
-        <h4 id="dsl-recipe-method-registry-get-values">registry_get_values</h4>
-        {{ $shortcode := "themes/docs-new/layouts/shortcodes/infra_lang_method_registry_get_values.md" }}
-
-        {{ if in (readFile $shortcode) "readFile" }}
-          {{ $shortcode_text := newScratch }}
-          {{ $shortcode_text.Set "text" "" }}
-          {{ range split (readFile $shortcode) "\n"}}
-            {{ if in . "readFile" }}
-              {{ if ne $shortcode_text "" }}
-                {{ $shortcode_text.Get "text" | markdownify }}
-                {{ $shortcode_text.Set "text" "" }}
-              {{ end }}
-
-              <p>
-                {{ readFile (. | replaceRE `{{ readFile \"(themes\/docs-new\/layouts\/shortcodes\/\w+\.md)\" \| markdownify }}` "$1" ) | markdownify }}
-              </p>
-
-            {{ else }}
-              {{ $shortcode_text.Add "text" . }}
-              {{ $shortcode_text.Add "text" "\n" }}
-            {{ end }}
-          {{ end }}
-          {{ $shortcode_text.Get "text" | markdownify }}
-        {{ else }}
-          {{ readFile $shortcode | markdownify }}
-        {{ end }}
-
-        <h4 id="dsl-recipe-method-registry-has-subkeys">registry_has_subkeys?</h4>
-        {{ $shortcode := "themes/docs-new/layouts/shortcodes/infra_lang_method_registry_has_subkeys.md" }}
-
-        {{ if in (readFile $shortcode) "readFile" }}
-          {{ $shortcode_text := newScratch }}
-          {{ $shortcode_text.Set "text" "" }}
-          {{ range split (readFile $shortcode) "\n"}}
-            {{ if in . "readFile" }}
-              {{ if ne $shortcode_text "" }}
-                {{ $shortcode_text.Get "text" | markdownify }}
-                {{ $shortcode_text.Set "text" "" }}
-              {{ end }}
-
-              <p>
-                {{ readFile (. | replaceRE `{{ readFile \"(themes\/docs-new\/layouts\/shortcodes\/\w+\.md)\" \| markdownify }}` "$1" ) | markdownify }}
-              </p>
-
-            {{ else }}
-              {{ $shortcode_text.Add "text" . }}
-              {{ $shortcode_text.Add "text" "\n" }}
-            {{ end }}
-          {{ end }}
-          {{ $shortcode_text.Get "text" | markdownify }}
-        {{ else }}
-          {{ readFile $shortcode | markdownify }}
-        {{ end }}
-
-        <h4 id="dsl-recipe-method-registry-key-exists">registry_key_exists?</h4>
-        {{ $shortcode := "themes/docs-new/layouts/shortcodes/infra_lang_method_registry_key_exists.md" }}
-
-        {{ if in (readFile $shortcode) "readFile" }}
-          {{ $shortcode_text := newScratch }}
-          {{ $shortcode_text.Set "text" "" }}
-          {{ range split (readFile $shortcode) "\n"}}
-            {{ if in . "readFile" }}
-              {{ if ne $shortcode_text "" }}
-                {{ $shortcode_text.Get "text" | markdownify }}
-                {{ $shortcode_text.Set "text" "" }}
-              {{ end }}
-
-              <p>
-                {{ readFile (. | replaceRE `{{ readFile \"(themes\/docs-new\/layouts\/shortcodes\/\w+\.md)\" \| markdownify }}` "$1" ) | markdownify }}
-              </p>
-
-            {{ else }}
-              {{ $shortcode_text.Add "text" . }}
-              {{ $shortcode_text.Add "text" "\n" }}
-            {{ end }}
-          {{ end }}
-          {{ $shortcode_text.Get "text" | markdownify }}
-        {{ else }}
-          {{ readFile $shortcode | markdownify }}
-        {{ end }}
-
-        <h4 id="dsl-recipe-method-registry-value-exists">registry_value_exists?</h4>
-        {{ $shortcode := "themes/docs-new/layouts/shortcodes/infra_lang_method_registry_value_exists.md" }}
-
-        {{ if in (readFile $shortcode) "readFile" }}
-          {{ $shortcode_text := newScratch }}
-          {{ $shortcode_text.Set "text" "" }}
-          {{ range split (readFile $shortcode) "\n"}}
-            {{ if in . "readFile" }}
-              {{ if ne $shortcode_text "" }}
-                {{ $shortcode_text.Get "text" | markdownify }}
-                {{ $shortcode_text.Set "text" "" }}
-              {{ end }}
-
-              <p>
-                {{ readFile (. | replaceRE `{{ readFile \"(themes\/docs-new\/layouts\/shortcodes\/\w+\.md)\" \| markdownify }}` "$1" ) | markdownify }}
-              </p>
-
-            {{ else }}
-              {{ $shortcode_text.Add "text" . }}
-              {{ $shortcode_text.Add "text" "\n" }}
-            {{ end }}
-          {{ end }}
-          {{ $shortcode_text.Get "text" | markdownify }}
-        {{ else }}
-          {{ readFile $shortcode | markdownify }}
-        {{ end }}
-
-      {{ end }}
-
-      <!-------------- Nameless ------------------->
-
-      {{ with index $yaml_file "nameless_apt_update" }}
-        <h2 id="nameless">Nameless</h2>
-        {{ readFile "themes/docs-new/layouts/shortcodes/nameless_apt_update.md" | markdownify }}
-      {{ end }}
-
-      {{ with index $yaml_file "nameless_build_essential" }}
-        <h2 id="nameless">Nameless</h2>
-        {{ readFile "themes/docs-new/layouts/shortcodes/nameless_build_essential.md" | markdownify }}
-      {{ end }}
-
-      <!-------------- Gem Package Options ------------------->
-
-      {{ with index $yaml_file "resource_package_options" }}
-        <h2 id="resource-package-options">Gem Package Options</h2>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_options.md" | markdownify }}
-
-        <h3 id="resource-package-options-hash">Specify with Hash</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_options_hash.md" | markdownify }}
-        <strong>Example</strong>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_install_gem_with_hash_options.md" | markdownify }}
-
-
-        <h3 id="resource-package-options-string">Specify with String</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_options_string.md" | markdownify }}
-        <strong>Example</strong>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_install_gem_with_options_string.md" | markdownify }}
-
-        <h3 id="resource-package-options-gemrc">Specify with .gemrc File</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_options_gemrc.md" | markdownify }}
-        {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_install_gem_with_gemrc.md" | markdownify }}
-      {{ end }}
-
-      <!-------------- Actions ------------------->
-
-      {{ with index $yaml_file "actions_list" }}
-        <h2 id = "actions">Actions</h2>
-        <hr>
-
-        <p>The <strong>{{ index $yaml_file "resource" }}</strong> resource has the following actions:</p>
-        <dl>
-          {{ range $key, $value := . }}
-            <dt><code>{{ $key | markdownify }}</code></dt>
-            {{ range $subkey, $subvalue := $value }}
-              {{ if eq $subkey "shortcode" }}
-                <dd>{{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` $subvalue ) "") | markdownify }}</dd>
-              {{ end }}
-              {{ if eq $subkey "markdown" }}
-                <dd>{{- $subvalue | markdownify -}}</dd>
-              {{ end }}
-            {{ end }}
-          {{ end }}
-        </dl>
-      {{ end }}
-
-      <!-------------- Properties ------------------->
-
-      <h2 id = "properties">Properties</h2>
-      <hr>
-      {{ if or (index $yaml_file "properties_shortcode") (index $yaml_file "properties_list") }}
-        {{ with index $yaml_file "properties_list" }}
-          <p>The <strong>{{ index $yaml_file "resource" }}</strong> resource has the following properties:</p>
-          {{ range . }}
-            <dl>
-              {{ if and (.property) (ne .property nil) }}
-                <dt>
-                  <code>{{ .property }}</code>
-                </dt>
-              {{ end }}
-
-              <dd>
-                {{ if ne .ruby_type nil }}
-                  <strong>Ruby Type:</strong> {{ .ruby_type }} {{ if .default_value }}| <strong>Default Value:</strong> <code>{{ .default_value }}</code>{{ end }} {{ if .required }}| <code>REQUIRED</code>{{ end }}
-                  {{ if .allowed_values }}</br><strong>Allowed Values:</strong> <code>{{ .allowed_values }}</code>{{ end }}
-                  </p>
                 {{ end }}
-
-                {{ range .description_list }}
-                  {{ range $key, $value :=  . }}
-                    {{ if eq $key "markdown" }}
-                      <p>{{- $value | markdownify -}}</p>
-                    {{ end }}
-
-                    {{ if eq $key "note" }}
-                      <div class="admonition-note">
-                        <p class="admonition-note-title">Note</p>
-                        <div class="admonition-note-text">
-                          {{ range $value }}
-                            {{ range $subkey, $subvalue := . }}
-                              {{ if eq $subkey "shortcode" }}
-                                <p>
-                                  {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` $subvalue ) "") | markdownify }}
-                                </p>
-                              {{ end }}
-                              {{ if eq $subkey "markdown" }}
-                                <p>{{- $subvalue | markdownify -}}</p>
-                              {{ end }}
-                            {{ end }}
-                          {{ end }}
-                        </div>
-                      </div>
-                    {{ end }}
-                    {{ if eq $key "warning" }}
-                      <div class="admonition-warning">
-                        <p class="admonition-warning-title">Warning</p>
-                        <div class="admonition-warning-text">
-                          {{ range $value }}
-                            {{ range $subkey, $subvalue := . }}
-                              {{ if eq $subkey "shortcode" }}
-                                <p>
-                                  {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` $subvalue ) "") | markdownify }}
-                                </p>
-                              {{ end }}
-                              {{ if eq $subkey "markdown" }}
-                                <p>
-                                  {{- $subvalue | markdownify -}}
-                                </p>
-                              {{ end }}
-                            {{ end }}
-                          {{ end }}
-                        </div>
-                      </div>
-                    {{ end }}
-                    {{ if eq $key "shortcode" }}
-                      <p>
-                        {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` $value ) "") | markdownify }}
-                      </p>
-                    {{ end }}
-                  {{ end }}
-                {{ end }}
-
-                {{ if and (.new_in) (ne .new_in nil) }}
+                {{ if eq $key "shortcode" }}
                   <p>
-                    {{ if ge .new_in 15 }}
-                      New in Chef Infra Client {{ .new_in }}
-                    {{ else }}
-                      New in Chef Client {{ .new_in }}
-                    {{ end }}
+                    {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` $value ) "") | markdownify }}
                   </p>
                 {{ end }}
-                {{ if and (.note) (ne .note nil) }}
+                {{ if and (eq $key "notes_resource_based_on_package") (eq $value true)}}
                   <div class="admonition-note">
                     <p class="admonition-note-title">Note</p>
-                    <div class="admonition-note-text">{{- .note | markdownify -}}</div>
+                    <div class="admonition-note-text">
+                      {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/notes_resource_based_on_package.md` ) "") | markdownify }}
+                    </div>
                   </div>
                 {{ end }}
-              </dd>
-            </dl>
+              {{ end }}
+            {{ end }}
           {{ end }}
         {{ end }}
-        {{ with index $yaml_file "properties_shortcode" }}
-          {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` . ) "") | markdownify }}
+
+        {{ if and ( ne (index $yaml_file "resource_new_in") "" ) ( index $yaml_file "resource_new_in" )}}
+          <p><strong>New in Chef Infra Client {{ index $yaml_file "resource_new_in" }}.</strong></p>
         {{ end }}
-      {{ else }}
-        <p>This resource does not have any properties.</p>
-      {{ end }}
+
+        <!-------------- Handler Types ------------------->
+
+        {{ with index $yaml_file "handler_types" }}
+          <h2 id="handler_types">Handler Types</h2>
+          {{ readFile "themes/docs-new/layouts/shortcodes/handler_types.md" | markdownify }}
+
+          <h3 id="handler_type_exception_report">Exception / Report</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/handler_type_exception_report.md" | markdownify }}
+          {{ readFile "themes/docs-new/layouts/shortcodes/handler_type_exception_report_run_from_recipe.md" | markdownify }}
 
 
-      {{ with index $yaml_file "multi_package_resource" }}
-        <h3 id="multiple-packages-properties">Multiple Packages</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_multiple_packages.md" | markdownify }}
-      {{ end }}
+          <h3 id="handler_type_start">Start</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/handler_type_start.md" | markdownify }}
+          {{ readFile "themes/docs-new/layouts/shortcodes/handler_type_start_run_from_recipe.md" | markdownify }}
 
-      {{ with index $yaml_file "resource_directory_recursive_directories" }}
-        <h3 id="resource-directory-recursive-directories">Recursive Directories</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/remote_directory_recursive_directories.md" | markdownify }}
-      {{ end }}
-
-      {{ with index $yaml_file "resources_common_atomic_update" }}
-        <h3 id="resources-common-atomic-update">Atomic File Updates</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_atomic_update.md" | markdownify }}
-      {{ end }}
-
-      {{ with index $yaml_file "properties_resources_common_windows_security" }}
-        <h3 id="resources-common-windows-security">Windows File Security</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_windows_security.md" | markdownify }}
-        <strong>Access Control Lists (ACLs)</strong>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_windows_security_acl.md" | markdownify }}
-        <strong>Inheritance</strong>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_windows_security_inherits.md" | markdownify }}
-      {{ end }}
-
-      {{ with index $yaml_file "remote_file_prevent_re_downloads" }}
-        <h3 id="prevent-re-downloads">Prevent Re-downloads</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/remote_file_prevent_re_downloads.md" | markdownify }}
-      {{ end }}
-
-      {{ with index $yaml_file "remote_file_unc_path" }}
-        <h3 id="access-a-remote-unc-path-on-windows">Access a remote UNC path on Windows</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/remote_file_unc_path.md" | markdownify }}
-      {{ end }}
-
-      {{ with index $yaml_file "ps_credential_helper" }}
-        <h3 id="ps-credential-helper">ps_credential Helper</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/ps_credential_helper.md" | markdownify }}
-      {{ end }}
-
-      <!-------------- Chef::Log Entries ------------------->
-
-      {{ with index $yaml_file "ruby_style_basics_chef_log" }}
-        <h2 id="ruby-style-basics-chef-log">Log Entries</h2>
-        {{ readFile "themes/docs-new/layouts/shortcodes/ruby_style_basics_chef_log.md" | markdownify }}
-        {{ readFile "themes/docs-new/layouts/shortcodes/ruby_class_chef_log_fatal.md" | markdownify }}
-        {{ readFile "themes/docs-new/layouts/shortcodes/ruby_class_chef_log_multiple.md" | markdownify }}
-      {{ end }}
-
-      <!-------------- Debug Recipes with chef-shell ------------------->
-
-      {{ with index $yaml_file "debug_recipes_chef_shell" }}
-
-        <h2 id="debug-recipes-chef-shell">Debug Recipes with chef-shell</h2>
-        {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_summary.md" | markdownify }}
-
-        <h3 id="chef-shell-modes">Modes</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_modes.md" | markdownify }}
-
-        <h3 id="debug-recipes-config">Configure</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_config.md" | markdownify }}
-
-        <h4 id="chef-shell-config-rb">chef-shell.rb</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_config_rb.md" | markdownify }}
-
-        <h4 id="chef-shell-run-as-chef-client">Run as a Chef Infra Client</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_run_as_chef_client.md" | markdownify }}
-
-        <h3 id="chef-shell-manage">Manage</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_manage.md" | markdownify }}
-
-        <h3 id="chef-shell-breakpoints">Use Breakpoints</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_breakpoints.md" | markdownify }}
-
-        <h4 id="chef-shell-step-through-run-list">Step Through Run-list</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_step_through_run_list.md" | markdownify }}
-
-        <h4 id="chef-shell-debug-existing-recipe">Debug Existing Recipe</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_debug_existing_recipe.md" | markdownify }}
-
-        <h4 id="chef-shell-advanced-debug">Advanced Debugging</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_advanced_debug.md" | markdownify }}
-
-        <h3 id="chef-shell-debug-examples">Debug Examples</h3>
-
-        <p>The following examples show how to use chef-shell. </p>
-        <h4 id="chef-shell-debug-example-hello-world">"Hello World"</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_example_hello_world.md" | markdownify }}
-
-        <h4 id="chef-shell-debug-examples-specific-nodes">Get Specific Nodes</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_example_get_specific_nodes.md" | markdownify }}
-
-      {{ end }}
+        {{ end }}
 
 
-      <!-------------- Using Templates ------------------->
+        <!-------------- Syntax ------------------->
 
-      {{ with index $yaml_file "template_requirements" }}
-        <h2 id="template-requirements">Using Templates</h2>
-        {{ readFile "themes/docs-new/layouts/shortcodes/template_requirements.md" | markdownify}}
 
-        <h3 id="template-specificity">File Specificity</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/template_specificity.md" | markdownify}}
-        {{ readFile "themes/docs-new/layouts/shortcodes/template_specificity_pattern.md" | markdownify}}
-        {{ readFile "themes/docs-new/layouts/shortcodes/template_specificity_example.md" | markdownify}}
-
-        <h3 id="template-helpers">Helpers</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/template_helpers.md" | markdownify}}
-
-        <h4 id="resource-template-inline-method">Inline Methods</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resource_template_inline_method.md" | markdownify}}
-
-        <h4 id="resource-template-inline-module">Inline Modules</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resource_template_inline_module.md" | markdownify}}
-
-        <h4 id="resource-template-library-module">Library Modules</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/resource_template_library_module.md" | markdownify}}
-
-        <h3 id="template-host-notation">Host Notation</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/template_host_notation.md" | markdownify}}
-
-        <h3 id="template-partials">Partial Templates</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/template_partials.md" | markdownify}}
-
-        <h4 id="template-partials-render-method">render Method</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/template_partials_render_method.md" | markdownify}}
-
-        <h3 id="template-transfer-frequency">Transfer Frequency</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/template_transfer_frequency.md" | markdownify}}
-
-        <h3 id="template-variables">Variables</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/template_variables.md" | markdownify}}
-
-      {{ end }}
-
-      <!------------------ Unit File Verification ---------------------->
-
-      {{ with index $yaml_file "unit_file_verification" }}
-        <h2 id="unit-file-verification">Unit file verification</h2>
-        {{ readFile "themes/docs-new/layouts/shortcodes/unit_file_verification.md" | markdownify }}
-      {{ end }}
-
-      <!-------------- Common Resource Functionality ------------------->
-
-      {{ if or (index $yaml_file "resources_common_properties" ) ( index $yaml_file "resources_common_notification" ) ( index $yaml_file "resources_common_guards" ) ( index $yaml_file "multi_package_resource" ) ( index $yaml_file "resources_common_guard_interpreter" ) ( index $yaml_file "remote_directory_recursive_directories" ) ( index $yaml_file "common_resource_functionality_resources_common_windows_security" )}}
-        <br>
-        <h2 id = "functionality">Common Resource Functionality</h2>
+        <h2 id = "syntax">Syntax</h2>
         <hr>
 
-        <p>Chef resources include common properties, notifications, and resource guards.</p>
+        <p>{{ index $yaml_file "syntax_description" | markdownify }}</p>
 
-        {{ if index $yaml_file "resources_common_properties" }}
-          <h3 id="resources-common-properties">Common Properties</h3>
+        {{ with index $yaml_file "syntax_code_block" }}
+          <p>{{ highlight index $yaml_file . "ruby" "" }}</p>
+        {{ end }}
 
-          {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_properties.md" | markdownify }}
+        {{ with index $yaml_file "syntax_properties_list" }}
+          <p>where:</p>
+          <ul>
+            {{ range . }}
+            <li>{{ . | markdownify }}</li>
+            {{ end }}
+          </ul>
+        {{ end }}
+
+        {{ with index $yaml_file "syntax_full_code_block" }}
+          <p>The full syntax for all of the properties that are available to the <strong>{{ index $yaml_file "resource" }}</strong> resource is:</p>
+          <p>{{- highlight ( trim . "\n") "ruby" "" -}}</p>
+        {{ end }}
+
+        {{ with index $yaml_file "syntax_full_properties_list" }}
+          <p>where:</p>
+          <ul>
+            {{ range . }}
+            <li>{{ . | markdownify }}</li>
+            {{ end }}
+          </ul>
+        {{ end }}
+
+        {{ with index $yaml_file "syntax_shortcode" }}
+            {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` . ) "") | markdownify }}
+        {{ end }}
+
+        {{ with index $yaml_file "registry_key" }}
+          <h3 id="windows-registry-key-backslashes">Registry Key Path Separators</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/windows_registry_key_backslashes.md" | markdownify }}
+
+          <h3 id="dsl-recipe-method-windows-methods">Chef Infra Language Methods</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/infra_lang_method_windows_methods.md" | markdownify }}
+
+          <h4 id="dsl-recipe-method-registry-data-exists">registry_data_exists?</h4>
+          {{ $shortcode := "themes/docs-new/layouts/shortcodes/infra_lang_method_registry_data_exists.md" }}
+
+          {{ if in (readFile $shortcode) "readFile" }}
+            {{ $shortcode_text := newScratch }}
+            {{ $shortcode_text.Set "text" "" }}
+            {{ range split (readFile $shortcode) "\n"}}
+              {{ if in . "readFile" }}
+                {{ if ne $shortcode_text "" }}
+                  {{ $shortcode_text.Get "text" | markdownify }}
+                  {{ $shortcode_text.Set "text" "" }}
+                {{ end }}
+
+                <p>
+                  {{ readFile (. | replaceRE `{{ readFile \"(themes\/docs-new\/layouts\/shortcodes\/\w+\.md)\" \| markdownify }}` "$1" ) | markdownify }}
+                </p>
+
+              {{ else }}
+                {{ $shortcode_text.Add "text" . }}
+                {{ $shortcode_text.Add "text" "\n" }}
+              {{ end }}
+            {{ end }}
+            {{ $shortcode_text.Get "text" | markdownify }}
+          {{ else }}
+            {{ readFile $shortcode | markdownify }}
+          {{ end }}
+
+          <h4 id="dsl-recipe-method-registry-get-subkeys">registry_get_subkeys</h4>
+          {{ $shortcode := "themes/docs-new/layouts/shortcodes/infra_lang_method_registry_get_subkeys.md" }}
+
+          {{ if in (readFile $shortcode) "readFile" }}
+            {{ $shortcode_text := newScratch }}
+            {{ $shortcode_text.Set "text" "" }}
+            {{ range split (readFile $shortcode) "\n"}}
+              {{ if in . "readFile" }}
+                {{ if ne $shortcode_text "" }}
+                  {{ $shortcode_text.Get "text" | markdownify }}
+                  {{ $shortcode_text.Set "text" "" }}
+                {{ end }}
+
+                <p>
+                  {{ readFile (. | replaceRE `{{ readFile \"(themes\/docs-new\/layouts\/shortcodes\/\w+\.md)\" \| markdownify }}` "$1" ) | markdownify }}
+                </p>
+
+              {{ else }}
+                {{ $shortcode_text.Add "text" . }}
+                {{ $shortcode_text.Add "text" "\n" }}
+              {{ end }}
+            {{ end }}
+            {{ $shortcode_text.Get "text" | markdownify }}
+          {{ else }}
+            {{ readFile $shortcode | markdownify }}
+          {{ end }}
+
+          <h4 id="dsl-recipe-method-registry-get-values">registry_get_values</h4>
+          {{ $shortcode := "themes/docs-new/layouts/shortcodes/infra_lang_method_registry_get_values.md" }}
+
+          {{ if in (readFile $shortcode) "readFile" }}
+            {{ $shortcode_text := newScratch }}
+            {{ $shortcode_text.Set "text" "" }}
+            {{ range split (readFile $shortcode) "\n"}}
+              {{ if in . "readFile" }}
+                {{ if ne $shortcode_text "" }}
+                  {{ $shortcode_text.Get "text" | markdownify }}
+                  {{ $shortcode_text.Set "text" "" }}
+                {{ end }}
+
+                <p>
+                  {{ readFile (. | replaceRE `{{ readFile \"(themes\/docs-new\/layouts\/shortcodes\/\w+\.md)\" \| markdownify }}` "$1" ) | markdownify }}
+                </p>
+
+              {{ else }}
+                {{ $shortcode_text.Add "text" . }}
+                {{ $shortcode_text.Add "text" "\n" }}
+              {{ end }}
+            {{ end }}
+            {{ $shortcode_text.Get "text" | markdownify }}
+          {{ else }}
+            {{ readFile $shortcode | markdownify }}
+          {{ end }}
+
+          <h4 id="dsl-recipe-method-registry-has-subkeys">registry_has_subkeys?</h4>
+          {{ $shortcode := "themes/docs-new/layouts/shortcodes/infra_lang_method_registry_has_subkeys.md" }}
+
+          {{ if in (readFile $shortcode) "readFile" }}
+            {{ $shortcode_text := newScratch }}
+            {{ $shortcode_text.Set "text" "" }}
+            {{ range split (readFile $shortcode) "\n"}}
+              {{ if in . "readFile" }}
+                {{ if ne $shortcode_text "" }}
+                  {{ $shortcode_text.Get "text" | markdownify }}
+                  {{ $shortcode_text.Set "text" "" }}
+                {{ end }}
+
+                <p>
+                  {{ readFile (. | replaceRE `{{ readFile \"(themes\/docs-new\/layouts\/shortcodes\/\w+\.md)\" \| markdownify }}` "$1" ) | markdownify }}
+                </p>
+
+              {{ else }}
+                {{ $shortcode_text.Add "text" . }}
+                {{ $shortcode_text.Add "text" "\n" }}
+              {{ end }}
+            {{ end }}
+            {{ $shortcode_text.Get "text" | markdownify }}
+          {{ else }}
+            {{ readFile $shortcode | markdownify }}
+          {{ end }}
+
+          <h4 id="dsl-recipe-method-registry-key-exists">registry_key_exists?</h4>
+          {{ $shortcode := "themes/docs-new/layouts/shortcodes/infra_lang_method_registry_key_exists.md" }}
+
+          {{ if in (readFile $shortcode) "readFile" }}
+            {{ $shortcode_text := newScratch }}
+            {{ $shortcode_text.Set "text" "" }}
+            {{ range split (readFile $shortcode) "\n"}}
+              {{ if in . "readFile" }}
+                {{ if ne $shortcode_text "" }}
+                  {{ $shortcode_text.Get "text" | markdownify }}
+                  {{ $shortcode_text.Set "text" "" }}
+                {{ end }}
+
+                <p>
+                  {{ readFile (. | replaceRE `{{ readFile \"(themes\/docs-new\/layouts\/shortcodes\/\w+\.md)\" \| markdownify }}` "$1" ) | markdownify }}
+                </p>
+
+              {{ else }}
+                {{ $shortcode_text.Add "text" . }}
+                {{ $shortcode_text.Add "text" "\n" }}
+              {{ end }}
+            {{ end }}
+            {{ $shortcode_text.Get "text" | markdownify }}
+          {{ else }}
+            {{ readFile $shortcode | markdownify }}
+          {{ end }}
+
+          <h4 id="dsl-recipe-method-registry-value-exists">registry_value_exists?</h4>
+          {{ $shortcode := "themes/docs-new/layouts/shortcodes/infra_lang_method_registry_value_exists.md" }}
+
+          {{ if in (readFile $shortcode) "readFile" }}
+            {{ $shortcode_text := newScratch }}
+            {{ $shortcode_text.Set "text" "" }}
+            {{ range split (readFile $shortcode) "\n"}}
+              {{ if in . "readFile" }}
+                {{ if ne $shortcode_text "" }}
+                  {{ $shortcode_text.Get "text" | markdownify }}
+                  {{ $shortcode_text.Set "text" "" }}
+                {{ end }}
+
+                <p>
+                  {{ readFile (. | replaceRE `{{ readFile \"(themes\/docs-new\/layouts\/shortcodes\/\w+\.md)\" \| markdownify }}` "$1" ) | markdownify }}
+                </p>
+
+              {{ else }}
+                {{ $shortcode_text.Add "text" . }}
+                {{ $shortcode_text.Add "text" "\n" }}
+              {{ end }}
+            {{ end }}
+            {{ $shortcode_text.Get "text" | markdownify }}
+          {{ else }}
+            {{ readFile $shortcode | markdownify }}
+          {{ end }}
 
         {{ end }}
 
-        {{ if index $yaml_file "resources_common_notification" }}
-          <h3 id="resources-common-notifications">Notifications</h3>
+        <!-------------- Nameless ------------------->
 
-          <dl>
-            <dt>
-              <code>notifies</code>
-            </dt>
-            <dd>
-              <p><strong>Ruby Type:</strong> Symbol, 'Chef::Resource[String]'</p>
-              {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_notification_notifies.md" | markdownify }}
-            </dd>
-          </dl>
-
-          {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_notification_timers.md" | markdownify  }}
-          {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_notification_notifies_syntax.md" | markdownify }}
-
-          <dl>
-            <dt>
-              <code>subscribes</code>
-            </dt>
-            <dd>
-              <p><strong>Ruby Type:</strong>  Symbol, 'Chef::Resource[String]'</p>
-            </dd>
-          </dl>
-          {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_notification_subscribes.md" | markdownify }}
-          {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_notification_timers.md" | markdownify }}
-          {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_notification_subscribes_syntax.md" | markdownify }}
-
+        {{ with index $yaml_file "nameless_apt_update" }}
+          <h2 id="nameless">Nameless</h2>
+          {{ readFile "themes/docs-new/layouts/shortcodes/nameless_apt_update.md" | markdownify }}
         {{ end }}
 
-        {{ if index $yaml_file "resources_common_guards" }}
-          <h3 id = "guards">Guards</h3>
-
-          {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_guards.md" | markdownify }}
-          <strong>Properties</strong>
-          {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_guards_properties.md" | markdownify }}
-
+        {{ with index $yaml_file "nameless_build_essential" }}
+          <h2 id="nameless">Nameless</h2>
+          {{ readFile "themes/docs-new/layouts/shortcodes/nameless_build_essential.md" | markdownify }}
         {{ end }}
 
-        {{ if index $yaml_file "multi_package_resource" }}
-          <h3 id="multiple-packages-common">Multiple Packages</h3>
+        <!-------------- Gem Package Options ------------------->
 
-          {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_multiple_packages.md" | markdownify }}
+        {{ with index $yaml_file "resource_package_options" }}
+          <h2 id="resource-package-options">Gem Package Options</h2>
+          {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_options.md" | markdownify }}
 
-        {{ end }}
-
-        {{ if index $yaml_file "resources_common_guard_interpreter" }}
-          <h3 id="guard-interpreter">Guard Interpreter</h3>
-
-          <p>
-            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_guard_interpreter.md" | markdownify }}
-          </p>
-          <strong>Attributes</strong>
-          <p>
-            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_guard_interpreter_attributes.md" | markdownify }}
-          </p>
-
-          <strong>Inheritance</strong>
-          <p>
-            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_guard_interpreter_attributes_inherit.md" | markdownify }}
-          </p>
-
+          <h3 id="resource-package-options-hash">Specify with Hash</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_options_hash.md" | markdownify }}
           <strong>Example</strong>
-          <p>
-            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_guard_interpreter_example_default.md" | markdownify }}
-          </p>
+          {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_install_gem_with_hash_options.md" | markdownify }}
 
+
+          <h3 id="resource-package-options-string">Specify with String</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_options_string.md" | markdownify }}
+          <strong>Example</strong>
+          {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_install_gem_with_options_string.md" | markdownify }}
+
+          <h3 id="resource-package-options-gemrc">Specify with .gemrc File</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_options_gemrc.md" | markdownify }}
+          {{ readFile "themes/docs-new/layouts/shortcodes/resource_package_install_gem_with_gemrc.md" | markdownify }}
         {{ end }}
 
-        {{ if index $yaml_file "remote_directory_recursive_directories" }}
+        <!-------------- Actions ------------------->
 
-          <h3 id="recursive-directories">Recursive Directories</h3>
+        {{ with index $yaml_file "actions_list" }}
+          <h2 id = "actions">Actions</h2>
+          <hr>
+
+          <p>The <strong>{{ index $yaml_file "resource" }}</strong> resource has the following actions:</p>
+          <dl>
+            {{ range $key, $value := . }}
+              <dt><code>{{ $key | markdownify }}</code></dt>
+              {{ range $subkey, $subvalue := $value }}
+                {{ if eq $subkey "shortcode" }}
+                  <dd>{{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` $subvalue ) "") | markdownify }}</dd>
+                {{ end }}
+                {{ if eq $subkey "markdown" }}
+                  <dd>{{- $subvalue | markdownify -}}</dd>
+                {{ end }}
+              {{ end }}
+            {{ end }}
+          </dl>
+        {{ end }}
+
+        <!-------------- Properties ------------------->
+
+        <h2 id = "properties">Properties</h2>
+        <hr>
+        {{ if or (index $yaml_file "properties_shortcode") (index $yaml_file "properties_list") }}
+          {{ with index $yaml_file "properties_list" }}
+            <p>The <strong>{{ index $yaml_file "resource" }}</strong> resource has the following properties:</p>
+            {{ range . }}
+              <dl>
+                {{ if and (.property) (ne .property nil) }}
+                  <dt>
+                    <code>{{ .property }}</code>
+                  </dt>
+                {{ end }}
+
+                <dd>
+                  {{ if ne .ruby_type nil }}
+                    <strong>Ruby Type:</strong> {{ .ruby_type }} {{ if .default_value }}| <strong>Default Value:</strong> <code>{{ .default_value }}</code>{{ end }} {{ if .required }}| <code>REQUIRED</code>{{ end }}
+                    {{ if .allowed_values }}</br><strong>Allowed Values:</strong> <code>{{ .allowed_values }}</code>{{ end }}
+                    </p>
+                  {{ end }}
+
+                  {{ range .description_list }}
+                    {{ range $key, $value :=  . }}
+                      {{ if eq $key "markdown" }}
+                        <p>{{- $value | markdownify -}}</p>
+                      {{ end }}
+
+                      {{ if eq $key "note" }}
+                        <div class="admonition-note">
+                          <p class="admonition-note-title">Note</p>
+                          <div class="admonition-note-text">
+                            {{ range $value }}
+                              {{ range $subkey, $subvalue := . }}
+                                {{ if eq $subkey "shortcode" }}
+                                  <p>
+                                    {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` $subvalue ) "") | markdownify }}
+                                  </p>
+                                {{ end }}
+                                {{ if eq $subkey "markdown" }}
+                                  <p>{{- $subvalue | markdownify -}}</p>
+                                {{ end }}
+                              {{ end }}
+                            {{ end }}
+                          </div>
+                        </div>
+                      {{ end }}
+                      {{ if eq $key "warning" }}
+                        <div class="admonition-warning">
+                          <p class="admonition-warning-title">Warning</p>
+                          <div class="admonition-warning-text">
+                            {{ range $value }}
+                              {{ range $subkey, $subvalue := . }}
+                                {{ if eq $subkey "shortcode" }}
+                                  <p>
+                                    {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` $subvalue ) "") | markdownify }}
+                                  </p>
+                                {{ end }}
+                                {{ if eq $subkey "markdown" }}
+                                  <p>
+                                    {{- $subvalue | markdownify -}}
+                                  </p>
+                                {{ end }}
+                              {{ end }}
+                            {{ end }}
+                          </div>
+                        </div>
+                      {{ end }}
+                      {{ if eq $key "shortcode" }}
+                        <p>
+                          {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` $value ) "") | markdownify }}
+                        </p>
+                      {{ end }}
+                    {{ end }}
+                  {{ end }}
+
+                  {{ if and (.new_in) (ne .new_in nil) }}
+                    <p>
+                      {{ if ge .new_in 15 }}
+                        New in Chef Infra Client {{ .new_in }}
+                      {{ else }}
+                        New in Chef Client {{ .new_in }}
+                      {{ end }}
+                    </p>
+                  {{ end }}
+                  {{ if and (.note) (ne .note nil) }}
+                    <div class="admonition-note">
+                      <p class="admonition-note-title">Note</p>
+                      <div class="admonition-note-text">{{- .note | markdownify -}}</div>
+                    </div>
+                  {{ end }}
+                </dd>
+              </dl>
+            {{ end }}
+          {{ end }}
+          {{ with index $yaml_file "properties_shortcode" }}
+            {{ readFile (delimit (slice `themes/docs-new/layouts/shortcodes/` . ) "") | markdownify }}
+          {{ end }}
+        {{ else }}
+          <p>This resource does not have any properties.</p>
+        {{ end }}
+
+
+        {{ with index $yaml_file "multi_package_resource" }}
+          <h3 id="multiple-packages-properties">Multiple Packages</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_multiple_packages.md" | markdownify }}
+        {{ end }}
+
+        {{ with index $yaml_file "resource_directory_recursive_directories" }}
+          <h3 id="resource-directory-recursive-directories">Recursive Directories</h3>
           {{ readFile "themes/docs-new/layouts/shortcodes/remote_directory_recursive_directories.md" | markdownify }}
-          <h4 id="recursive-directories-example">Example</h4>
-          {{ readFile "themes/docs-new/layouts/shortcodes/remote_directory_recursive_directories_example.md" | markdownify }}
-
         {{ end }}
 
-        {{ if index $yaml_file "common_resource_functionality_resources_common_windows_security" }}
+        {{ with index $yaml_file "resources_common_atomic_update" }}
+          <h3 id="resources-common-atomic-update">Atomic File Updates</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_atomic_update.md" | markdownify }}
+        {{ end }}
 
+        {{ with index $yaml_file "properties_resources_common_windows_security" }}
           <h3 id="resources-common-windows-security">Windows File Security</h3>
-
           {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_windows_security.md" | markdownify }}
           <strong>Access Control Lists (ACLs)</strong>
           {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_windows_security_acl.md" | markdownify }}
           <strong>Inheritance</strong>
           {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_windows_security_inherits.md" | markdownify }}
+        {{ end }}
+
+        {{ with index $yaml_file "remote_file_prevent_re_downloads" }}
+          <h3 id="prevent-re-downloads">Prevent Re-downloads</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/remote_file_prevent_re_downloads.md" | markdownify }}
+        {{ end }}
+
+        {{ with index $yaml_file "remote_file_unc_path" }}
+          <h3 id="access-a-remote-unc-path-on-windows">Access a remote UNC path on Windows</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/remote_file_unc_path.md" | markdownify }}
+        {{ end }}
+
+        {{ with index $yaml_file "ps_credential_helper" }}
+          <h3 id="ps-credential-helper">ps_credential Helper</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/ps_credential_helper.md" | markdownify }}
+        {{ end }}
+
+        <!-------------- Chef::Log Entries ------------------->
+
+        {{ with index $yaml_file "ruby_style_basics_chef_log" }}
+          <h2 id="ruby-style-basics-chef-log">Log Entries</h2>
+          {{ readFile "themes/docs-new/layouts/shortcodes/ruby_style_basics_chef_log.md" | markdownify }}
+          {{ readFile "themes/docs-new/layouts/shortcodes/ruby_class_chef_log_fatal.md" | markdownify }}
+          {{ readFile "themes/docs-new/layouts/shortcodes/ruby_class_chef_log_multiple.md" | markdownify }}
+        {{ end }}
+
+        <!-------------- Debug Recipes with chef-shell ------------------->
+
+        {{ with index $yaml_file "debug_recipes_chef_shell" }}
+
+          <h2 id="debug-recipes-chef-shell">Debug Recipes with chef-shell</h2>
+          {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_summary.md" | markdownify }}
+
+          <h3 id="chef-shell-modes">Modes</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_modes.md" | markdownify }}
+
+          <h3 id="debug-recipes-config">Configure</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_config.md" | markdownify }}
+
+          <h4 id="chef-shell-config-rb">chef-shell.rb</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_config_rb.md" | markdownify }}
+
+          <h4 id="chef-shell-run-as-chef-client">Run as a Chef Infra Client</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_run_as_chef_client.md" | markdownify }}
+
+          <h3 id="chef-shell-manage">Manage</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_manage.md" | markdownify }}
+
+          <h3 id="chef-shell-breakpoints">Use Breakpoints</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_breakpoints.md" | markdownify }}
+
+          <h4 id="chef-shell-step-through-run-list">Step Through Run-list</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_step_through_run_list.md" | markdownify }}
+
+          <h4 id="chef-shell-debug-existing-recipe">Debug Existing Recipe</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_debug_existing_recipe.md" | markdownify }}
+
+          <h4 id="chef-shell-advanced-debug">Advanced Debugging</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_advanced_debug.md" | markdownify }}
+
+          <h3 id="chef-shell-debug-examples">Debug Examples</h3>
+
+          <p>The following examples show how to use chef-shell. </p>
+          <h4 id="chef-shell-debug-example-hello-world">"Hello World"</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_example_hello_world.md" | markdownify }}
+
+          <h4 id="chef-shell-debug-examples-specific-nodes">Get Specific Nodes</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/chef_shell_example_get_specific_nodes.md" | markdownify }}
 
         {{ end }}
-      {{ end }}
-
-      <!-------------- Custom Handlers ------------------->
-
-      {{ if index $yaml_file "handler_custom" }}
-        <h2 id="handler-custom">Custom Handlers</h2>
-        {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom.md" | markdownify }}
-
-        <h3 id="handler-custom-syntax">Syntax</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_syntax.md" | markdownify }}
-
-        <h3 id="handler-custom-interface-report">report Interface</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_interface_report.md" | markdownify }}
-
-        <h3 id="handler-custom-optional-interfaces">Optional Interfaces</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_optional_interfaces.md" | markdownify }}
-
-        <h4 id="handler-custom-interface-data">data</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_interface_data.md" | markdownify }}
-
-        <h4 id="handler-custom-interface-run-report-safely">run_report_safely</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_interface_run_report_safely.md" | markdownify }}
-
-        <h4 id="handler-custom-interface-run-report-unsafe">run_report_unsafe</h4>
-        {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_interface_run_report_unsafe.md" | markdownify }}
-
-        <h3 id="handler-custom-object-run-status">run_status Object</h3>
-        {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_object_run_status.md" | markdownify }}
-
-      {{ end }}
-
-      <!-------------- File Specificity ------------------->
-
-      {{ if index $yaml_file "cookbook_file_specificity" }}
-        <h2 id="cookbook-file-specificity">File Specificity</h2>
-        {{ readFile "themes/docs-new/layouts/shortcodes/cookbook_file_specificity.md" | markdownify }}
-      {{ end }}
 
 
-      <!-------------- Examples ------------------->
+        <!-------------- Using Templates ------------------->
 
-      <h2 id = "examples">Examples</h2>
-      <hr>
-      {{ with index $yaml_file "examples" }}
-        <p>The following examples demonstrate various approaches for using the <strong>{{ index $yaml_file "resource" }}</strong> resource in recipes:</p>
-        {{ . | markdownify }}
-      {{ else }}
-        <p>This resource does not have any examples.</p>
-      {{ end }}
+        {{ with index $yaml_file "template_requirements" }}
+          <h2 id="template-requirements">Using Templates</h2>
+          {{ readFile "themes/docs-new/layouts/shortcodes/template_requirements.md" | markdownify}}
+
+          <h3 id="template-specificity">File Specificity</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/template_specificity.md" | markdownify}}
+          {{ readFile "themes/docs-new/layouts/shortcodes/template_specificity_pattern.md" | markdownify}}
+          {{ readFile "themes/docs-new/layouts/shortcodes/template_specificity_example.md" | markdownify}}
+
+          <h3 id="template-helpers">Helpers</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/template_helpers.md" | markdownify}}
+
+          <h4 id="resource-template-inline-method">Inline Methods</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/resource_template_inline_method.md" | markdownify}}
+
+          <h4 id="resource-template-inline-module">Inline Modules</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/resource_template_inline_module.md" | markdownify}}
+
+          <h4 id="resource-template-library-module">Library Modules</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/resource_template_library_module.md" | markdownify}}
+
+          <h3 id="template-host-notation">Host Notation</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/template_host_notation.md" | markdownify}}
+
+          <h3 id="template-partials">Partial Templates</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/template_partials.md" | markdownify}}
+
+          <h4 id="template-partials-render-method">render Method</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/template_partials_render_method.md" | markdownify}}
+
+          <h3 id="template-transfer-frequency">Transfer Frequency</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/template_transfer_frequency.md" | markdownify}}
+
+          <h3 id="template-variables">Variables</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/template_variables.md" | markdownify}}
+
+        {{ end }}
+
+        <!------------------ Unit File Verification ---------------------->
+
+        {{ with index $yaml_file "unit_file_verification" }}
+          <h2 id="unit-file-verification">Unit file verification</h2>
+          {{ readFile "themes/docs-new/layouts/shortcodes/unit_file_verification.md" | markdownify }}
+        {{ end }}
+
+        <!-------------- Common Resource Functionality ------------------->
+
+        {{ if or (index $yaml_file "resources_common_properties" ) ( index $yaml_file "resources_common_notification" ) ( index $yaml_file "resources_common_guards" ) ( index $yaml_file "multi_package_resource" ) ( index $yaml_file "resources_common_guard_interpreter" ) ( index $yaml_file "remote_directory_recursive_directories" ) ( index $yaml_file "common_resource_functionality_resources_common_windows_security" )}}
+          <br>
+          <h2 id = "functionality">Common Resource Functionality</h2>
+          <hr>
+
+          <p>Chef resources include common properties, notifications, and resource guards.</p>
+
+          {{ if index $yaml_file "resources_common_properties" }}
+            <h3 id="resources-common-properties">Common Properties</h3>
+
+            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_properties.md" | markdownify }}
+
+          {{ end }}
+
+          {{ if index $yaml_file "resources_common_notification" }}
+            <h3 id="resources-common-notifications">Notifications</h3>
+
+            <dl>
+              <dt>
+                <code>notifies</code>
+              </dt>
+              <dd>
+                <p><strong>Ruby Type:</strong> Symbol, 'Chef::Resource[String]'</p>
+                {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_notification_notifies.md" | markdownify }}
+              </dd>
+            </dl>
+
+            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_notification_timers.md" | markdownify  }}
+            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_notification_notifies_syntax.md" | markdownify }}
+
+            <dl>
+              <dt>
+                <code>subscribes</code>
+              </dt>
+              <dd>
+                <p><strong>Ruby Type:</strong>  Symbol, 'Chef::Resource[String]'</p>
+              </dd>
+            </dl>
+            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_notification_subscribes.md" | markdownify }}
+            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_notification_timers.md" | markdownify }}
+            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_notification_subscribes_syntax.md" | markdownify }}
+
+          {{ end }}
+
+          {{ if index $yaml_file "resources_common_guards" }}
+            <h3 id = "guards">Guards</h3>
+
+            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_guards.md" | markdownify }}
+            <strong>Properties</strong>
+            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_guards_properties.md" | markdownify }}
+
+          {{ end }}
+
+          {{ if index $yaml_file "multi_package_resource" }}
+            <h3 id="multiple-packages-common">Multiple Packages</h3>
+
+            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_multiple_packages.md" | markdownify }}
+
+          {{ end }}
+
+          {{ if index $yaml_file "resources_common_guard_interpreter" }}
+            <h3 id="guard-interpreter">Guard Interpreter</h3>
+
+            <p>
+              {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_guard_interpreter.md" | markdownify }}
+            </p>
+            <strong>Attributes</strong>
+            <p>
+              {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_guard_interpreter_attributes.md" | markdownify }}
+            </p>
+
+            <strong>Inheritance</strong>
+            <p>
+              {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_guard_interpreter_attributes_inherit.md" | markdownify }}
+            </p>
+
+            <strong>Example</strong>
+            <p>
+              {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_guard_interpreter_example_default.md" | markdownify }}
+            </p>
+
+          {{ end }}
+
+          {{ if index $yaml_file "remote_directory_recursive_directories" }}
+
+            <h3 id="recursive-directories">Recursive Directories</h3>
+            {{ readFile "themes/docs-new/layouts/shortcodes/remote_directory_recursive_directories.md" | markdownify }}
+            <h4 id="recursive-directories-example">Example</h4>
+            {{ readFile "themes/docs-new/layouts/shortcodes/remote_directory_recursive_directories_example.md" | markdownify }}
+
+          {{ end }}
+
+          {{ if index $yaml_file "common_resource_functionality_resources_common_windows_security" }}
+
+            <h3 id="resources-common-windows-security">Windows File Security</h3>
+
+            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_windows_security.md" | markdownify }}
+            <strong>Access Control Lists (ACLs)</strong>
+            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_windows_security_acl.md" | markdownify }}
+            <strong>Inheritance</strong>
+            {{ readFile "themes/docs-new/layouts/shortcodes/resources_common_windows_security_inherits.md" | markdownify }}
+
+          {{ end }}
+        {{ end }}
+
+        <!-------------- Custom Handlers ------------------->
+
+        {{ if index $yaml_file "handler_custom" }}
+          <h2 id="handler-custom">Custom Handlers</h2>
+          {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom.md" | markdownify }}
+
+          <h3 id="handler-custom-syntax">Syntax</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_syntax.md" | markdownify }}
+
+          <h3 id="handler-custom-interface-report">report Interface</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_interface_report.md" | markdownify }}
+
+          <h3 id="handler-custom-optional-interfaces">Optional Interfaces</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_optional_interfaces.md" | markdownify }}
+
+          <h4 id="handler-custom-interface-data">data</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_interface_data.md" | markdownify }}
+
+          <h4 id="handler-custom-interface-run-report-safely">run_report_safely</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_interface_run_report_safely.md" | markdownify }}
+
+          <h4 id="handler-custom-interface-run-report-unsafe">run_report_unsafe</h4>
+          {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_interface_run_report_unsafe.md" | markdownify }}
+
+          <h3 id="handler-custom-object-run-status">run_status Object</h3>
+          {{ readFile "themes/docs-new/layouts/shortcodes/handler_custom_object_run_status.md" | markdownify }}
+
+        {{ end }}
+
+        <!-------------- File Specificity ------------------->
+
+        {{ if index $yaml_file "cookbook_file_specificity" }}
+          <h2 id="cookbook-file-specificity">File Specificity</h2>
+          {{ readFile "themes/docs-new/layouts/shortcodes/cookbook_file_specificity.md" | markdownify }}
+        {{ end }}
+
+
+        <!-------------- Examples ------------------->
+
+        <h2 id = "examples">Examples</h2>
+        <hr>
+        {{ with index $yaml_file "examples" }}
+          <p>The following examples demonstrate various approaches for using the <strong>{{ index $yaml_file "resource" }}</strong> resource in recipes:</p>
+          {{ . | markdownify }}
+        {{ else }}
+          <p>This resource does not have any examples.</p>
+        {{ end }}
+      </div>
     </div>
     {{ partialCached "feedback" . }}
   </main>


### PR DESCRIPTION
Signed-off-by: IanMadd <Ian.Maddaus@progress.com>

### Description

Swiftype is indexing some content in the resources pages that shouldn't be included. This removes the link text at the top of the page to the chef resources in the chef/chef repo and the link to the resources reference page. It also indents things more better.

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
