### PR TITLE
Update our current Solaris support

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -100,7 +100,7 @@ The following table lists the commercially-supported platforms and versions for 
 <tr>
 <td>Solaris</td>
 <td><code>sparc</code>, <code>i86pc</code></td>
-<td><code>11.2</code>, <code>11.3</code>, <code>11.4</code></td>
+<td><code>11.4</code></td>
 </tr>
 <tr>
 <td>SUSE Enterprise Linux Server</td>
@@ -643,6 +643,11 @@ that platform and version.
 <td>Oracle Solaris 10</td>
 <td>January 30, 2018</td>
 <td>January 30, 2018</td>
+</tr>
+<tr>
+<td>Oracle Solaris 11.3</td>
+<td>January 30, 2021</td>
+<td>January 30, 2021</td>
 </tr>
 <tr>
 <td>SUSE Linux Enterprise Server 11</td>


### PR DESCRIPTION
11.3 left premier support so we don't support that. Also remove 11.2, but I can't find the date that Oracle nuked that so don't call it out.

Signed-off-by: Tim Smith <tsmith@chef.io>