### PR TITLE
Add fontawesome shortcode

### DIFF
--- a/themes/docs-new/layouts/shortcodes/fontawesome.html
+++ b/themes/docs-new/layouts/shortcodes/fontawesome.html
@@ -1,6 +1,8 @@
-<i class="{{ .Get "icon" }}" style="
+<i class="{{ .Get "class" }}" style="
   font-size: {{ with .Get "font-size"}}{{.}}{{ else }}{{"2rem"}}{{ end }};
   border:{{ with .Get "border"}}{{.}}{{ else }}{{"2px solid"}}{{ end }}; 
   padding:{{ with .Get "padding"}}{{.}}{{ else }}{{"3px"}}{{ end }}; 
-  border-radius:{{ with .Get "border-radius" }}{{.}}{{ else }}{{"3px"}}{{ end }}"
+  border-radius:{{ with .Get "border-radius" }}{{.}}{{ else }}{{"3px"}}{{ end }};
+  {{ with .Get "color" }}color: {{ . | safeCSS }};{{end}}
+  {{ with .Get "background-color" }}background-color: {{ . | safeCSS }};{{end}}"
 ></i>

--- a/themes/docs-new/layouts/shortcodes/fontawesome.html
+++ b/themes/docs-new/layouts/shortcodes/fontawesome.html
@@ -1,0 +1,6 @@
+<i class="{{ .Get "icon" }}" style="
+  font-size: {{ with .Get "font-size"}}{{.}}{{ else }}{{"2rem"}}{{ end }};
+  border:{{ with .Get "border"}}{{.}}{{ else }}{{"2px solid"}}{{ end }}; 
+  padding:{{ with .Get "padding"}}{{.}}{{ else }}{{"3px"}}{{ end }}; 
+  border-radius:{{ with .Get "border-radius" }}{{.}}{{ else }}{{"3px"}}{{ end }}"
+></i>


### PR DESCRIPTION
Signed-off-by: IanMadd <Ian.Maddaus@progress.com>

### Description

Add a shortcode that we can use to add fontawesome icons (the free ones) to our docs.

It accepts the following parameters:

-class
-font-size
-border
-padding
-border-radius
-color
-background-color

All parameters have a default exception `class`.

Icons can be found on [Fontawesome's website](https://fontawesome.com/icons?d=gallery&p=2).

The `class` value is the class name, for example `fas fa-address-book` in https://fontawesome.com/icons/address-book?style=solid

This:
```
{{< fontawesome class="fas fa-ellipsis-h">}}

{{< fontawesome class="fas fa-anchor" font-size="5rem" border="2px dashed" padding="1px" border-radius="5px">}}

{{< fontawesome class="fas fa-archive" color="#cc814b">}}

{{< fontawesome class="far fa-address-book" background-color="white" color="rgb(76, 110, 245)">}}
```

will display this:

![Screen Shot 2021-04-06 at 11 31 59 AM](https://user-images.githubusercontent.com/8138169/113761349-31ec5a00-96cc-11eb-8c3c-e0611660660d.png)



### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
