### PR TITLE
Use new_resource for load_current_value blocks

### DIFF
--- a/content/release_notes_client.md
+++ b/content/release_notes_client.md
@@ -9785,8 +9785,8 @@ example:
 ```ruby
 resource_name :file
 
-load_current_value do |desired|
-  puts "The user typed content = #{desired.content} in the resource"
+load_current_value do |new_resource|
+  puts "The user typed content = #{new_resource.content} in the resource"
 end
 ```
 

--- a/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_converge_if_changed_multiple.md
+++ b/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_converge_if_changed_multiple.md
@@ -8,10 +8,10 @@ property :path, String
 property :content, String
 property :mode, String
 
-load_current_value do |desired|
-  if ::File.exist?(desired.path)
-    content IO.read(desired.path)
-    mode ::File.stat(desired.path).mode
+load_current_value do |new_resource|
+  if ::File.exist?(new_resource.path)
+    content IO.read(new_resource.path)
+    mode ::File.stat(new_resource.path).mode
   end
 end
 

--- a/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_property_block_argument.md
+++ b/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_property_block_argument.md
@@ -9,9 +9,9 @@ argument will have the values of the requested resource. For example:
 property :action, String, name_property: true
 property :content, String
 
-load_current_value do |desired|
+load_current_value do |new_resource|
   puts "The user requested action = #{action} in the resource"
-  puts "The user typed content = #{desired.content} in the resource"
+  puts "The user typed content = #{new_resource.content} in the resource"
 end
 ```
 
@@ -20,8 +20,8 @@ end
 property :action, String
 property :content, String
 
-load_current_value do |desired|
-  puts "The user requested action = #{desired.action} in the resource"
-  puts "The user typed content = #{desired.content} in the resource"
+load_current_value do |new_resource|
+  puts "The user requested action = #{new_resource.action} in the resource"
+  puts "The user typed content = #{new_resource.content} in the resource"
 end
 ```


### PR DESCRIPTION
### Description

Resolves a lack of continuity of the use of the `#load_current_value` API. The [caller](https://github.com/chef/chef/blob/4d3b847aee1b917bb139862c623e9633d180fb31/lib/chef/resource/action_class.rb#L49) of `#load_current_value`  refers to `new_resource` (not `desired`).

### Issues Resolved

N/A

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
