### PR TITLE
confirmation of default interval and splay when using -d

### DIFF
--- a/content/ctl_chef_client.md
+++ b/content/ctl_chef_client.md
@@ -79,7 +79,7 @@ This command has the following options:
     of seconds to wait before the first daemonized Chef Infra Client
     run. `SECONDS` is set to `0` by default.
     
-    If not otherwise set, this will also make use of the default `--interval` 
+    Left unset, the daemon uses the default `--interval` and `--splay` values.
 
     This option is only available on machines that run in UNIX or Linux
     environments. For machines that are running Microsoft Windows that

--- a/content/ctl_chef_client.md
+++ b/content/ctl_chef_client.md
@@ -80,7 +80,6 @@ This command has the following options:
     run. `SECONDS` is set to `0` by default.
     
     If not otherwise set, this will also make use of the default `--interval` 
-    and `--splay` values.
 
     This option is only available on machines that run in UNIX or Linux
     environments. For machines that are running Microsoft Windows that

--- a/content/ctl_chef_client.md
+++ b/content/ctl_chef_client.md
@@ -78,6 +78,9 @@ This command has the following options:
 :   Run the executable as a daemon. Use `SECONDS` to specify the number
     of seconds to wait before the first daemonized Chef Infra Client
     run. `SECONDS` is set to `0` by default.
+    
+    If not otherwise set, this will also make use of the default `--interval` 
+    and `--splay` values.
 
     This option is only available on machines that run in UNIX or Linux
     environments. For machines that are running Microsoft Windows that


### PR DESCRIPTION
confirmation of default interval and splay when using -d    - change prompted by customer support ticket.

### Description

adds further information about the use of daemonized chef-client 

### Definition of Done

n/a

### Issues Resolved

this was prompted by customer support ticket 27499

### Check List

- [x] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass

Signed-off-by: James McCormick <James.McCormick@progress.com>