### PR TITLE
Deprecation Note for Chef Backend 

### DIFF
--- a/themes/docs-new/layouts/shortcodes/EOL_backend.md
+++ b/themes/docs-new/layouts/shortcodes/EOL_backend.md
@@ -1,0 +1,7 @@
+{{% EOL_manage %}}
+
+Chef Backend is [deprecated](/versions/#deprecated-products-and-versions) and no longer under active development. Contact your Chef account representative for information about upgrading your system.
+
+This document is no longer maintained.
+
+{{% /EOL_manage %}}

--- a/themes/docs-new/layouts/shortcodes/EOL_backend.md
+++ b/themes/docs-new/layouts/shortcodes/EOL_backend.md
@@ -1,7 +1,7 @@
-{{% EOL_manage %}}
+<div class="admonition-warning"><p class="admonition-warning-title">Warning</p><div class="admonition-warning-text">
 
 Chef Backend is [deprecated](/versions/#deprecated-products-and-versions) and no longer under active development. Contact your Chef account representative for information about upgrading your system.
 
 This document is no longer maintained.
 
-{{% /EOL_manage %}}
+</div></div>


### PR DESCRIPTION
Deprecation note added for Chef Backend

**Reference PR:** https://github.com/chef/chef-web-docs/issues/3063

**Link to page and section that will be updated:**
https://docs.chef.io/server/upgrade_server_ha_v2/

Reported by @sirajrauff
https://chefio.slack.com/archives/C07JP2HN1/p1618507246041300