### PR TITLE
EOL 2022 Backend & Manage

### DIFF
--- a/content/versions.md
+++ b/content/versions.md
@@ -262,13 +262,7 @@ confused with the modern [Chef Compliance offering](/compliance/).
 </tr>
 <tr>
 <td>ChefDK</td>
-<td>3 and under</td>
-<td>EOL</td>
-<td>April 30, 2020</td>
-</tr>
-<tr>
-<td>ChefDK</td>
-<td>4.x</td>
+<td>ALL</td>
 <td>EOL</td>
 <td>December 31, 2020</td>
 </tr>

--- a/content/versions.md
+++ b/content/versions.md
@@ -120,7 +120,7 @@ announcement](https://blog.chef.io/2019/04/02/chef-software-announces-the-enterp
 <td>Chef Backend</td>
 <td>3.x</td>
 <td>Releasing 2021</td>
-<td>n/a</td>
+<td>2022</td>
 </tr>
 </tbody>
 </table>
@@ -188,7 +188,7 @@ newer versions or products.
 <td>Chef Backend</td>
 <td>2.x</td>
 <td>Deprecated</td>
-<td>December 31, 2021</td>
+<td>December 31, 2022</td>
 </tr>
 <tr>
 <td>Chef Infra Client</td>
@@ -206,7 +206,7 @@ newer versions or products.
 <td>Chef Manage</td>
 <td>2.5.x+</td>
 <td>Deprecated</td>
-<td>December 31, 2021</td>
+<td>December 31, 2022</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
### Description

Changes EOL dates for Chef Backend and Chef Manage to 2022.
Also simplified the EOL entry for ChefDK

### Definition of Done

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
