### PR TITLE
Update the requirements for Supermarket + airgap

### DIFF
--- a/content/install_chef_air_gap.md
+++ b/content/install_chef_air_gap.md
@@ -213,15 +213,11 @@ with your Chef Infra Server URL:
 
 ```ruby
 current_dir = File.dirname(__FILE__)
-log_level                :info
-log_location             STDOUT
 node_name                'USER'
 client_key               "#{current_dir}/USER.pem"
 validation_client_name   'ORGANIZATION-validator'
 validation_key           "#{current_dir}/ORGANIZATION.pem"
 chef_server_url          'https://chef-server.example.com/organizations/ORGANIZATION'
-cache_type               'BasicFile'
-cache_options( :path => "#{ENV['HOME']}/.chef/checksums" )
 cookbook_path            ["#{current_dir}/../cookbooks"]
 knife[:bootstrap_template] = "#{current_dir}/bootstrap/airgap.erb"
 ```

--- a/content/install_chef_air_gap.md
+++ b/content/install_chef_air_gap.md
@@ -266,16 +266,12 @@ installed before you will be able to use the Supermarket cookbook
 wrapper. In addition the necessary cookbooks, a private Chef Supermarket
 has the following requirements:
 
--   An operational Chef Infra Server (version 12.0 or higher) to act as
-    the OAuth 2.0 provider
+-   An operational Chef Infra Server to act as the OAuth 2.0 provider
 -   A user account on the Chef Infra Server with `admins` privileges
 -   A key for the user account on the Chef server
--   An x86_64 compatible Linux host with at least 1 GB memory
--   System clocks synchronized on the Chef Infra Server and Supermarket
-    hosts
--   Sufficient disk space to meet project cookbook storage capacity or
-    credentials to store cookbooks in an Amazon Simple Storage Service
-    (S3) bucket
+-   An x86_64 Ubuntu, RHEL, or Amazon Linux host with at least 1 GB memory
+-   System clocks synchronized on the Chef Infra Server and Supermarket hosts
+-   Sufficient disk space to meet project cookbook storage capacity or credentials to store cookbooks in an Amazon Simple Storage Service (S3) bucket
 
 ### Configure credentials
 


### PR DESCRIPTION
- List the actual distros we support
- Remove the mention of Chef Server 12+. That bar is so low it doesn't
  need to be mentioned
- Remove some default knife config from the airgap page

Signed-off-by: Tim Smith <tsmith@chef.io>