### PR TITLE
Fix table width on environments page

### DIFF
--- a/content/environments.md
+++ b/content/environments.md
@@ -87,8 +87,8 @@ domain-specific attributes:
 
 <table>
 <colgroup>
-<col style="width: 40%" />
-<col style="width: 60%" />
+<col style="width: 20%" />
+<col style="width: 80%" />
 </colgroup>
 <thead>
 <tr class="header">


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <Ian.Maddaus@progress.com>


## Description

The table looks a bit ridiculous as is because the left column has almost no content but has 40% of the table width.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
