### PR TITLE
Make page links work in infra and desktop resource pages

### DIFF
--- a/themes/docs-new/layouts/_default/infra_resources_all.html
+++ b/themes/docs-new/layouts/_default/infra_resources_all.html
@@ -21,6 +21,7 @@
   {{ $remote_directory_recursive_directories_exampleID := 0 }}
   {{ $cookbook_file_specificityID := 0 }}
   {{ $ExamplesID := 0 }}
+  {{ $product := index .Params.data_path 0 }}
   <main id="main-content-col" tabindex="-1">
     <div id="col-content" data-swiftype-index='true'>
       <h1 id="{{ anchorize ( .Title )}}">{{ .Title }}</h1>
@@ -39,7 +40,11 @@
           {{ if index . "resource_reference" }}
 
             <h2 id="{{ anchorize (print ( index . "resource" ) "-resource")}}">{{ index . "resource" }} resource</h2>
-            <a href="/resources/{{ print (index . "resource" ) "/" }}">{{ index . "resource" }} resource page</a>
+            {{ if eq $product "infra" }}
+              <a href="/resources/{{ print (index . "resource" ) "/" }}">{{ index . "resource" }} resource page</a>
+            {{ else }}
+              <a href="/{{ $product }}/resources/{{ print (index . "resource" ) "/" }}">{{ index . "resource" }} resource page</a>
+            {{ end }}
 
             <hr>
 


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <Ian.Maddaus@progress.com>


## Description

The page that lists all resources has links to each individual resource page. This will make those links work regardless of whether the links are to infra, or desktop, or potentially some other future resource docs that would use this layout.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
