### PR TITLE
Default figure width

### DIFF
--- a/themes/docs-new/assets/sass/partials/_grid.scss
+++ b/themes/docs-new/assets/sass/partials/_grid.scss
@@ -49,6 +49,7 @@
       position: relative;
       left: 50%;
       transform: translateX(-50%);
+      max-width: 75%;
 
       img {
         padding: 1rem;

--- a/themes/docs-new/assets/sass/partials/_grid.scss
+++ b/themes/docs-new/assets/sass/partials/_grid.scss
@@ -32,6 +32,7 @@
       box-shadow: $box-shadow;
       border: 1px solid transparent;
       padding: 1rem;
+      max-width: 75%;
     }
 
     figure {


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>


## Description

Sets 75% default width for figures. Figures on the same page should be the same size.

This doesn't address the problem for images. We need to use classes & breakpoints there.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
