### PR TITLE
[2673] Stop documenting using the chef_handler cookbook

### DIFF
--- a/content/debug.md
+++ b/content/debug.md
@@ -116,7 +116,7 @@ resources in recipes:
 Some more complex ways to debug issues with a Chef Infra Client run
 include:
 
--   Using the **chef_handler** cookbook
+-   Using the **chef_handler** resource
 -   Using the chef-shell and the **breakpoint** resource to add
     breakpoints to recipes, and to then step through the recipes using
     the breakpoints

--- a/content/handlers.md
+++ b/content/handlers.md
@@ -185,12 +185,12 @@ Client run.
 ### chef_handler
 
 Exception and report handlers can be distributed using the
-**chef_handler** cookbook. This cookbook is authored and maintained by
-Chef and exposes a custom resource that can be used to enable custom
-handlers from within recipes and to include product-specific handlers
-from cookbooks. The **chef_handler** cookbook can be accessed here:
-<https://github.com/chef-cookbooks/chef_handler>. See the `README.md`
-for additional information.
+**chef_handler** resource. This resource is included with Chef 14 and above.
+It can be used to enable custom handlers from within recipes and to
+include product-specific handlers from cookbooks.
+
+More information on the **chef_handler** resource can be accessed in the
+resource documentation [here](resources/chef_handler.md).
 
 ### Chef Infra Client
 

--- a/themes/docs-new/layouts/shortcodes/handler_custom.md
+++ b/themes/docs-new/layouts/shortcodes/handler_custom.md
@@ -1,0 +1,6 @@
+A custom handler can be created to support any situation. The easiest
+way to build a custom handler:
+
+1.  Write a recipe using the **chef_handler** resource
+2.  Add that recipe to a node's run-list, often as the first recipe in
+    that run-list

--- a/themes/docs-new/layouts/shortcodes/handler_custom_example_cookbook_versions.md
+++ b/themes/docs-new/layouts/shortcodes/handler_custom_example_cookbook_versions.md
@@ -1,0 +1,6 @@
+Community member `juliandunn` created a custom [report handler that logs
+all of the cookbooks and cookbook
+versions](https://github.com/juliandunn/cookbook_versions_handler) that
+were used during a Chef Infra Client run, and then reports after the run
+is complete. This handler requires the **chef_handler** resource (which
+is available from the **chef_handler** resource).

--- a/themes/docs-new/layouts/shortcodes/handler_custom_example_json_file.md
+++ b/themes/docs-new/layouts/shortcodes/handler_custom_example_json_file.md
@@ -1,0 +1,36 @@
+The
+[json_file](https://github.com/chef/chef/blob/master/lib/chef/handler/json_file.rb)
+handler is available from the **chef_handler** resource and can be used
+with exceptions and reports. It serializes run status data to a JSON
+file. This handler may be enabled in one of the following ways.
+
+By adding the following lines of Ruby code to either the client.rb file
+or the solo.rb file, depending on how Chef Infra Client is being run:
+
+```ruby
+require 'chef/handler/json_file'
+report_handlers << Chef::Handler::JsonFile.new(:path => '/var/chef/reports')
+exception_handlers << Chef::Handler::JsonFile.new(:path => '/var/chef/reports')
+```
+
+By using the **chef_handler** resource in a recipe, similar to the
+following:
+
+```ruby
+chef_handler 'Chef::Handler::JsonFile' do
+  source 'chef/handler/json_file'
+  arguments :path => '/var/chef/reports'
+  action :enable
+end
+```
+
+After it has run, the run status data can be loaded and inspected via
+Interactive Ruby (IRb):
+
+```ruby
+irb(main):002:0> require 'json' => true
+irb(main):003:0> require 'chef' => true
+irb(main):004:0> r = JSON.parse(IO.read('/var/chef/reports/chef-run-report-20110322060731.json')) => ... output truncated
+irb(main):005:0> r.keys => ['end_time', 'node', 'updated_resources', 'exception', 'all_resources', 'success', 'elapsed_time', 'start_time', 'backtrace']
+irb(main):006:0> r['elapsed_time'] => 0.00246
+```


### PR DESCRIPTION
## Description

The chef_handler cookbook has been deprecated for 3+ years and has been
included in chef infra client since 14.

## Issues Resolved

- Resolves #2673
- Resolves #2943

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
