### PR TITLE
added always_update_cookbooks to provisioner section of kitchen.

### DIFF
--- a/_vendor/github.com/chef/chef-workstation/docs-chef-io/content/workstation/config_yml_kitchen.md
+++ b/_vendor/github.com/chef/chef-workstation/docs-chef-io/content/workstation/config_yml_kitchen.md
@@ -280,7 +280,7 @@ kitchen.yml file when the provisioner is chef-zero or chef-solo.
 </tr>
 <tr class="even">
 <td><code>always_update_cookbooks</code></td>
-<td>Updates the policyfile.lock.json when changes are made to the cookbook</td>
+<td>Updates the policyfile.lock.json when changes are made to the cookbook. Supports <code>true</code> or <code>false</code> </td>
 <td>&lt;auto detected&gt;</td>
 <td></td>
 </tr>

--- a/_vendor/github.com/chef/chef-workstation/docs-chef-io/content/workstation/config_yml_kitchen.md
+++ b/_vendor/github.com/chef/chef-workstation/docs-chef-io/content/workstation/config_yml_kitchen.md
@@ -278,6 +278,12 @@ kitchen.yml file when the provisioner is chef-zero or chef-solo.
 <td>&lt;auto detected&gt;</td>
 <td></td>
 </tr>
+<tr class="even">
+<td><code>always_update_cookbooks</code></td>
+<td>Updates the policyfile.lock.json when changes are made to the cookbook</td>
+<td>&lt;auto detected&gt;</td>
+<td></td>
+</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
Signed-off-by: Jeff Brimager <jbrimager@chef.io>

## Description

Adds a description for `always_update_cookbooks` provisioner option in test kitchen. This flag has existed for around 4 years and seems to be unknown to the public. It has been requested that we add it. 

## Definition of Done


## Issues Resolved
#3236

## Related PRs

## Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
