### PR TITLE
Style changes for responsive images

### DIFF
--- a/_vendor/github.com/chef/automate/components/docs-chef-io/content/automate/chef_infra_server.md
+++ b/_vendor/github.com/chef/automate/components/docs-chef-io/content/automate/chef_infra_server.md
@@ -39,11 +39,11 @@ The _Chef Infra Server_ panel starts out with an empty list of servers.
 
 To add existing Chef Infra Servers to the Chef Automate infrastructure, select **Add Chef Server** which will request the name, FQDN, and IP address of your Chef Infra Server:
 
-{{< figure src="/images/automate/add-chef-server-popup-menu.png" width="500" alt="Add Chef Server Form">}}
+{{< figure src="/images/automate/add-chef-server-popup-menu.png" width="60%" alt="Add Chef Server Form">}}
 
 Chef Automate will warn you if you enter an invalid FQDN or IP address:
 
-{{< figure src="/images/automate/add-chef-server-popup-menu-with-error.png" width="500" alt="Add Chef Server Form">}}
+{{< figure src="/images/automate/add-chef-server-popup-menu-with-error.png" width="60%" alt="Add Chef Server Form">}}
 
 Once you are finished, select **Add Chef Server** and you will see your server in the list of Chef Infra Servers.
 

--- a/themes/docs-new/assets/sass/partials/_grid.scss
+++ b/themes/docs-new/assets/sass/partials/_grid.scss
@@ -27,12 +27,9 @@
     p img {
       display: block;
       margin: rem-calc(32) auto;
-      -webkit-box-shadow: $box-shadow;
-      -moz-box-shadow: $box-shadow;
-      box-shadow: $box-shadow;
-      border: 1px solid transparent;
+      border: 1px solid lightgray;
       padding: 1rem;
-      max-width: 75%;
+      max-width: 80%;
     }
 
     figure {
@@ -41,19 +38,17 @@
       font-style: italic;
       font-size: smaller;
       text-indent: 0;
-      border: 1px solid transparent;
-      -webkit-box-shadow: $box-shadow;
-      -moz-box-shadow: $box-shadow;
-      box-shadow: $box-shadow;
-      padding: 0.5rem;
+      padding: 0;
       margin: rem-calc(32) auto;
       position: relative;
       left: 50%;
       transform: translateX(-50%);
-      max-width: 75%;
+      max-width: 90%;
 
       img {
-        padding: 1rem;
+        padding: 0;
+        max-width: 100%;
+        border: 1px solid lightgray;
       }
     }
 


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>


## Description

The use of `box-shadow` in our styling meant that we had to size figures specifically, (width="500") and we couldn't use percentages without the entire area seeming to jump off the page. Removing the shadows & adding a lightgrey around the image in a figure fixes this.

This PR also removes the padding and margin that was constraining the images to even smaller sizes.

The problem: 

`{{< figure src="/images/automate/add-chef-organization-popup-menu.png" width="500" alt="Add Chef Organization Form" width="60%">}}`

<img width="1042" alt="Screen Shot 2021-06-25 at 4 46 45 PM" src="https://user-images.githubusercontent.com/4400151/123494522-fed3ab80-d5d4-11eb-997a-4c62e2a639d8.png">

This solution:

`{{< figure src="/images/automate/add-chef-organization-popup-menu.png" alt="Add Chef Organization Form" width="60%">}}`

<img width="1254" alt="Screen Shot 2021-06-25 at 5 01 29 PM" src="https://user-images.githubusercontent.com/4400151/123495073-0d22c700-d5d7-11eb-84a7-a14b94eff0ab.png">


## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
