### PR TITLE
Remove mention of the :community policyfile source

### DIFF
--- a/themes/docs-new/layouts/shortcodes/policyfile_rb_settings.md
+++ b/themes/docs-new/layouts/shortcodes/policyfile_rb_settings.md
@@ -13,9 +13,9 @@ A `Policyfile.rb` file may contain the following settings:
 `default_source :SOURCE_TYPE, *args`
 
 :   The location in which any cookbooks not specified by `cookbook` are
-    located. Possible values: `chef_repo`, `chef_server`, `:community`,
-    `:supermarket`, and `:artifactory`. Use more than one
-    `default_source` to specify more than one location for cookbooks.
+    located. Possible values: `chef_repo`, `chef_server`, `:supermarket`,
+    and `:artifactory`. Use more than one `default_source` to specify more
+    than one location for cookbooks.
 
     `default_source :supermarket` pulls cookbooks from the public Chef
     Supermarket.
@@ -25,8 +25,6 @@ A `Policyfile.rb` file may contain the following settings:
 
     `default_source :chef_server, "https://chef-server.example/organizations/example"`
     pulls cookbooks from the Chef Infra Server.
-
-    `default_source :community` is an alias for `:supermarket`.
 
     `default_source :chef_repo, "path/to/repo"` pulls cookbooks from a
     monolithic cookbook repository. This may be a path to the top-level


### PR DESCRIPTION
I'm introducing a cookstyle rule to nuke any of these that are still
around. It's pretty unlikely anyone has this.

Signed-off-by: Tim Smith <tsmith@chef.io>