### PR TITLE
Add missing CHEF-26 to deprecations page

### DIFF
--- a/content/chef_deprecations_client.md
+++ b/content/chef_deprecations_client.md
@@ -244,8 +244,14 @@ of Chef comes out.
 </tr>
 <tr>
 <td><a href="/deprecations_map_collision/">CHEF-25</a></td>
-<td>Resource(s) in a cookbook collide with the same resource(s) now included in Chef.</td>
+<td>Resource(s) in a cookbook collide with the same resource(s) now included in Chef Infra Client.</td>
 <td>XX.X</td>
+<td>15.0</td>
+</tr>
+<tr>
+<td><a href="/deprecations_shell_out/">CHEF-26</a></td>
+<td>Deprecation of legacy shell_out APIs.</td>
+<td>14.3</td>
 <td>15.0</td>
 </tr>
 <tr>

--- a/content/deprecations_shell_out.md
+++ b/content/deprecations_shell_out.md
@@ -1,5 +1,5 @@
 +++
-title = "Deprecation: Deprecation of old shell_out APIs (CHEF-26)"
+title = "Deprecation: Deprecation of legacy shell_out APIs (CHEF-26)"
 draft = false
 
 gh_repo = "chef-web-docs"
@@ -9,9 +9,9 @@ robots = "noindex"
 aliases = "/deprecations_shell_out.html"
 +++
 
-The functionality of multiple old <span
+The functionality of multiple legacy <span
 class="title-ref">shell_out</span> APIs has been collapsed into the
-<span class="title-ref">shell_out</span> API itself, and the old
+<span class="title-ref">shell_out</span> API itself, and the legacy
 methods have been deprecated.
 
 The <span class="title-ref">shell_out_compact</span> API has been


### PR DESCRIPTION
This was missed on the page

Signed-off-by: Tim Smith <tsmith@chef.io>