### PR TITLE
Use one space in unordered lists

### DIFF
--- a/content/attribute_precedence.md
+++ b/content/attribute_precedence.md
@@ -125,9 +125,9 @@ override!['attribute'] = "The '!' means I win!"
 
 Attribute precedence levels may be:
 
--   Removed for a specific, named attribute precedence level.
--   Removed for all attribute precedence levels.
--   Fully assigned attributes.
+- Removed for a specific, named attribute precedence level.
+- Removed for all attribute precedence levels.
+- Fully assigned attributes.
 
 ### Remove Precedence Level
 
@@ -136,15 +136,15 @@ attributes may be removed by using one of the following syntax patterns.
 
 For default attributes:
 
--   `node.rm_default('foo', 'bar')`
+- `node.rm_default('foo', 'bar')`
 
 For normal attributes:
 
--   `node.rm_normal('foo', 'bar')`
+- `node.rm_normal('foo', 'bar')`
 
 For override attributes:
 
--   `node.rm_override('foo', 'bar')`
+- `node.rm_override('foo', 'bar')`
 
 These patterns return the computed value of the key being deleted for
 the specified precedence level.
@@ -295,7 +295,7 @@ node.rm_default("no", "such", "thing") #=> nil
 All attribute precedence levels may be removed by using the following
 syntax pattern:
 
--   `node.rm('foo', 'bar')`
+- `node.rm('foo', 'bar')`
 
 {{< note >}}
 
@@ -355,11 +355,11 @@ Use `!` to clear out the key for the named attribute precedence level,
 and then complete the write by using one of the following syntax
 patterns:
 
--   `node.default!['foo']['bar'] = {...}`
--   `node.force_default!['foo']['bar'] = {...}`
--   `node.normal!['foo']['bar'] = {...}`
--   `node.override!['foo']['bar'] = {...}`
--   `node.force_override!['foo']['bar'] = {...}`
+- `node.default!['foo']['bar'] = {...}`
+- `node.force_default!['foo']['bar'] = {...}`
+- `node.normal!['foo']['bar'] = {...}`
+- `node.override!['foo']['bar'] = {...}`
+- `node.force_override!['foo']['bar'] = {...}`
 
 #### Examples
 

--- a/content/attribute_sources.md
+++ b/content/attribute_sources.md
@@ -16,34 +16,34 @@ cookbook dependencies.
 Attributes are provided to Chef Infra Client from the following
 locations:
 
--   JSON files passed via the `chef-client -j`
--   Nodes (collected by Ohai at the start of each Chef Infra Client run)
--   Attribute files (in cookbooks)
--   Recipes (in cookbooks)
--   Environments
--   Roles
--   Policyfiles
+- JSON files passed via the `chef-client -j`
+- Nodes (collected by Ohai at the start of each Chef Infra Client run)
+- Attribute files (in cookbooks)
+- Recipes (in cookbooks)
+- Environments
+- Roles
+- Policyfiles
 
 Notes:
 
--   Many attributes are maintained in the chef-repo for Policyfiles,
+- Many attributes are maintained in the chef-repo for Policyfiles,
     environments, roles, and cookbooks (attribute files and recipes)
--   Many attributes are collected by Ohai on each individual node at the
+- Many attributes are collected by Ohai on each individual node at the
     start of every Chef Infra Client run
--   The attributes that are maintained in the chef-repo are uploaded to
+- The attributes that are maintained in the chef-repo are uploaded to
     the Chef Infra Server from the workstation, periodically
--   Chef Infra Client will pull down the node object from the Chef Infra
+- Chef Infra Client will pull down the node object from the Chef Infra
     Server and then reset all the attributes except `normal`. The node
     object will contain the attribute data from the previous Chef Infra
     Client run including attributes set with JSON files via `-j`.
--   Chef Infra Client will update the cookbooks on the node (if
+- Chef Infra Client will update the cookbooks on the node (if
     required), which updates the attributes contained in attribute files
     and recipes
--   Chef Infra Client will update the role and environment data (if
+- Chef Infra Client will update the role and environment data (if
     required)
--   Chef Infra Client will rebuild the attribute list and apply
+- Chef Infra Client will rebuild the attribute list and apply
     attribute precedence while configuring the node
--   Chef Infra Client pushes the node object to the Chef Infra Server at
+- Chef Infra Client pushes the node object to the Chef Infra Server at
     the end of a Chef Infra Client run; the updated node object on the
     Chef Infra Server is then indexed for search and is stored until the
     next Chef Infra Client run

--- a/content/chef_overview.md
+++ b/content/chef_overview.md
@@ -15,16 +15,16 @@ product = ["client", "server", "workstation"]
 
 {{% chef %}}
 
--   **Chef Workstation** is the location where users interact with Chef
+- **Chef Workstation** is the location where users interact with Chef
     Infra. With Chef Workstation, users can author and test
     [cookbooks](/cookbooks/) using tools such as [Test
     Kitchen](/workstation/kitchen/) and interact with the Chef Infra Server
     using the [knife](/workstation/knife/) and [chef](/ctl_chef/) command
     line tools.
--   **Chef Infra Client nodes** are the machines that are managed by
+- **Chef Infra Client nodes** are the machines that are managed by
     Chef Infra. The Chef Infra Client is installed on each node and is
     used to configure the node to its desired state.
--   **Chef Infra Server** acts as [a hub for configuration
+- **Chef Infra Server** acts as [a hub for configuration
     data](/server/). Chef Infra Server stores cookbooks,
     the policies that are applied to nodes, and metadata that describes
     each registered node that is being managed by Chef. Nodes use the

--- a/content/chef_repo.md
+++ b/content/chef_repo.md
@@ -87,9 +87,9 @@ version control data, build output data, and so on. The chefignore file
 uses the `File.fnmatch` Ruby syntax to define the ignore patterns using
 `*`, `**`, and `?` wildcards.
 
--   A pattern is relative to the cookbook root
--   A pattern may contain relative directory names
--   A pattern may match all files in a directory
+- A pattern is relative to the cookbook root
+- A pattern may contain relative directory names
+- A pattern may match all files in a directory
 
 The chefignore file can be located in any subdirectory of a chef-repo:
 `/`, `/cookbooks`, `/cookbooks/COOKBOOK_NAME/`, etc. It should contain

--- a/content/chef_solo.md
+++ b/content/chef_solo.md
@@ -18,8 +18,8 @@ aliases = ["/chef_solo.html"]
 
 chef-solo supports two locations from which cookbooks can be run:
 
--   A local directory.
--   A URL at which a tar.gz archive is located.
+- A local directory.
+- A URL at which a tar.gz archive is located.
 
 Using a tar.gz archive is the more common approach, but requires that
 cookbooks be added to an archive. For example:

--- a/content/chef_system_requirements.md
+++ b/content/chef_system_requirements.md
@@ -15,11 +15,11 @@ product = ["client", "server", "workstation"]
 
 Before installing Chef Infra:
 
--   Ensure that each system you will be managing is running a [supported
+- Ensure that each system you will be managing is running a [supported
     platform](/platforms/)
--   Ensure that the machine that will run the Chef Infra Server is
+- Ensure that the machine that will run the Chef Infra Server is
     sufficiently powerful
--   Ensure that any network and firewall settings are configured
+- Ensure that any network and firewall settings are configured
     correctly
 
 Install and configure the Chef Infra Server, then install and configure
@@ -35,9 +35,9 @@ Infra Server.
 
 The hosted Chef Infra Server has the following requirements:
 
--   **Browser** --- Firefox, Google Chrome, Safari, or Internet Explorer
+- **Browser** --- Firefox, Google Chrome, Safari, or Internet Explorer
     (versions 9 or better)
--   Every node that will be configured by Chef Infra Client and every
+- Every node that will be configured by Chef Infra Client and every
     workstation that will upload data to the Chef Infra Server must be
     able to communicate with the hosted Chef server
 
@@ -47,16 +47,16 @@ The hosted Chef Infra Server has the following requirements:
 
 ## Chef Infra Client
 
--   The recommended amount of RAM available to Chef Infra Client during
+- The recommended amount of RAM available to Chef Infra Client during
     a Chef Infra Client run is 512MB
--   The Chef Infra Client binaries are stored in the `/opt/chef`
+- The Chef Infra Client binaries are stored in the `/opt/chef`
     directory, which requires a minimum of 200MB of disk space. On
     Windows, the Chef Infra Client binaries can be found in
     `C:\opscode\`, and they require a minimum of 600MB of disk space.
--   The processor must be [supported](/platforms/). We recommend
+- The processor must be [supported](/platforms/). We recommend
     a 1 gigahertz (GHz) or faster processor, but the processor speed
     should be based on the other system loads.
--   Chef Infra Client caches to `/var/chef/cache` during a Chef Infra
+- Chef Infra Client caches to `/var/chef/cache` during a Chef Infra
     Client run. This is the location in which downloaded cookbooks,
     packages required by those cookbooks, and other large files are
     stored. This directory requires enough space to save all of this
@@ -68,6 +68,6 @@ The hosted Chef Infra Server has the following requirements:
 
 ## Chef Workstation
 
--   64-bit architecture
--   4 GB of RAM or more
--   2 GB of free disk space
+- 64-bit architecture
+- 4 GB of RAM or more
+- 2 GB of free disk space

--- a/content/community.md
+++ b/content/community.md
@@ -24,61 +24,61 @@ community.
 
 ## Meet
 
--   [Chef events](https://events.chef.io/)
--   [Chef meetups](https://www.meetup.com/topics/opscode/)
--   [Continuous delivery meetups](https://www.meetup.com/topics/continuous-delivery/)
--   [DevOps meetups](https://www.meetup.com/topics/devops/)
+- [Chef events](https://events.chef.io/)
+- [Chef meetups](https://www.meetup.com/topics/opscode/)
+- [Continuous delivery meetups](https://www.meetup.com/topics/continuous-delivery/)
+- [DevOps meetups](https://www.meetup.com/topics/devops/)
 
 ## Learn
 
--   [Chef training](https://www.chef.io/training)
--   [Self-guided learning](https://learn.chef.io/)
+- [Chef training](https://www.chef.io/training)
+- [Self-guided learning](https://learn.chef.io/)
 
 ## Interact
 
--   [Community Guidelines](/community_guidelines/)
--   [@chef](https://twitter.com/chef)
--   [@chef-docs](https://twitter.com/chefdocs)
--   [@opscode_status](https://twitter.com/opscode_status)
--   [Facebook](https://www.facebook.com/getchefdotcom)
--   [Chef Community Slack](https://community-slack.chef.io/)
--   Join the "Chef Software Users Group" on LinkedIn
--   [Chef Software Mailing List](https://discourse.chef.io/) (for
+- [Community Guidelines](/community_guidelines/)
+- [@chef](https://twitter.com/chef)
+- [@chef-docs](https://twitter.com/chefdocs)
+- [@opscode_status](https://twitter.com/opscode_status)
+- [Facebook](https://www.facebook.com/getchefdotcom)
+- [Chef Community Slack](https://community-slack.chef.io/)
+- Join the "Chef Software Users Group" on LinkedIn
+- [Chef Software Mailing List](https://discourse.chef.io/) (for
     discussion among users, developers, and other interested parties)
 
 ## Read
 
--   [Effective DevOps (Building a Culture of Collaboration, Affinity,
+- [Effective DevOps (Building a Culture of Collaboration, Affinity,
     and Tooling at
     Scale)](http://shop.oreilly.com/product/0636920039846.do)
--   [Customizing Chef (Getting the Most Out of Your Infrastructure
+- [Customizing Chef (Getting the Most Out of Your Infrastructure
     Automation)](http://shop.oreilly.com/product/0636920032984.do)
--   [Chef: Powerful Infrastructure Automation \[Packt
+- [Chef: Powerful Infrastructure Automation \[Packt
     Publishing\]](https://www.packtpub.com/virtualization-and-cloud/chef-powerful-infrastructure-automation)
--   [Chef Cookbook - Third Edition \[Packt
+- [Chef Cookbook - Third Edition \[Packt
     Publishing\]](https://www.packtpub.com/networking-and-servers/chef-cookbook-third-edition)
--   [Learning Chef \[Packt
+- [Learning Chef \[Packt
     Publishing\]](https://www.packtpub.com/networking-and-servers/learning-chef)
--   [Chef Infrastructure Automation Cookbook - Second Edition \[Packt
+- [Chef Infrastructure Automation Cookbook - Second Edition \[Packt
     Publishing\]](https://www.packtpub.com/networking-and-servers/chef-infrastructure-automation-cookbook-second-edition/)
--   [Mastering Chef \[Packt
+- [Mastering Chef \[Packt
     Publishing\]](https://www.packtpub.com/networking-and-servers/mastering-chef/)
 
 ## Contribute
 
--   [Chef on GitHub](https://github.com/chef)
--   [Community cookbooks](https://supermarket.chef.io)
--   [Documentation](https://github.com/chef/chef-web-docs)
--   [Share your Chef product ideas](https://www.chef.io/feedback/)
+- [Chef on GitHub](https://github.com/chef)
+- [Community cookbooks](https://supermarket.chef.io)
+- [Documentation](https://github.com/chef/chef-web-docs)
+- [Share your Chef product ideas](https://www.chef.io/feedback/)
 
 ## Supermarket
 
--   [About Supermarket](/supermarket/)
--   [Visit Supermarket](https://supermarket.chef.io)
--   [Cookbooks available on Supermarket](https://supermarket.chef.io/cookbooks-directory)
+- [About Supermarket](/supermarket/)
+- [Visit Supermarket](https://supermarket.chef.io)
+- [Cookbooks available on Supermarket](https://supermarket.chef.io/cookbooks-directory)
 
 ## Subscribe
 
--   [Blog](https://blog.chef.io/)
--   [Videos](https://www.youtube.com/user/getchef)
--   [Mailing List](https://discourse.chef.io/)
+- [Blog](https://blog.chef.io/)
+- [Videos](https://www.youtube.com/user/getchef)
+- [Mailing List](https://discourse.chef.io/)

--- a/content/community_contributions.md
+++ b/content/community_contributions.md
@@ -125,38 +125,38 @@ Chef uses the Apache License Version 2 because it provides the same
 level of freedom for our users that we desire for ourselves. Based upon
 the Apache Licensing FAQ, it allows you to:
 
--   freely download and use Chef software, in whole or in part, for
+- freely download and use Chef software, in whole or in part, for
     personal, company internal, or commercial purposes;
--   use Chef software in packages or distributions that you create.
+- use Chef software in packages or distributions that you create.
 
 It forbids you to:
 
--   redistribute any piece of Chef-originated software without proper
+- redistribute any piece of Chef-originated software without proper
     attribution;
--   use any marks owned by Chef in any way that might state or imply
+- use any marks owned by Chef in any way that might state or imply
     that Chef endorses your distribution;
--   use any marks owned by Chef in any way that might state or imply
+- use any marks owned by Chef in any way that might state or imply
     that you created the Chef software in question.
 
 It requires you to:
 
--   include a copy of the license in any redistribution you may make
+- include a copy of the license in any redistribution you may make
     that includes Chef software;
--   provide clear attribution to Chef for any distributions that include
+- provide clear attribution to Chef for any distributions that include
     Chef software; attribution can be done in the NOTICE file for an
     application, by adding yourself as an author/copyright holder to the
     HEADER for an individual file, and by placing text in a header file
     saying that new work is based on previous work
--   reuse work as long as the licensing terms of the reused work remains
+- reuse work as long as the licensing terms of the reused work remains
     unchanged (i.e. The Apache License Version 2 also applies to the
     reused work)
 
 It does not require you to:
 
--   include the source of the Chef software itself, or of any
+- include the source of the Chef software itself, or of any
     modifications you may have made to it, in any redistribution you may
     assemble that includes it;
--   submit changes that you make to the software back to Chef (though
+- submit changes that you make to the software back to Chef (though
     such feedback is encouraged).
 
 It is our goal to run a successful, truly open source business. To that
@@ -208,10 +208,10 @@ Chef does not merge any pull requests made against a Chef-managed open
 source repository until each commit has been signed for the DCO, with
 three exceptions:
 
--   "Obvious Fixes" (as described below)
--   Pull requests made against the docs.chef.io documentation repository
+- "Obvious Fixes" (as described below)
+- Pull requests made against the docs.chef.io documentation repository
     (<https://github.com/chef/chef-web-docs>)
--   Pull requests that contain only documentation updates made against
+- Pull requests that contain only documentation updates made against
     projects where the documentation is embedded in the project's
     repository (i.e. the `docs` directory in the `chef/inspec`
     repository)
@@ -266,33 +266,33 @@ As a rule of thumb, changes are obvious fixes if they do not introduce
 any new functionality or creative thinking. As long as the change does
 not affect functionality, some likely examples include the following:
 
--   Spelling/grammar fixes;
--   Correcting typos;
--   Cleaning up comments in the code;
--   Changes to white space or formatting;
--   Bug fixes that change default return values or error codes stored in
+- Spelling/grammar fixes;
+- Correcting typos;
+- Cleaning up comments in the code;
+- Changes to white space or formatting;
+- Bug fixes that change default return values or error codes stored in
     constants, literals, or simple variable types;
--   Adding logging messages or debugging output;
--   Changes to 'metadata' files like Gemfile, rebar.config, Makefile,
+- Adding logging messages or debugging output;
+- Changes to 'metadata' files like Gemfile, rebar.config, Makefile,
     app.config, sys.config, .gitignore, example configuration files,
     build scripts, etc.;
--   Changes that reflect outside facts, like renaming a build directory
+- Changes that reflect outside facts, like renaming a build directory
     or changing a constant;
--   Changes in build or installation scripts;
--   Re-ordering of objects or subroutines within a source file (such as
+- Changes in build or installation scripts;
+- Re-ordering of objects or subroutines within a source file (such as
     alphabetizing routines);
--   Moving source files from one directory or package to another, with
+- Moving source files from one directory or package to another, with
     no changes in code;
--   Breaking a source file into multiple source files, or consolidating
+- Breaking a source file into multiple source files, or consolidating
     multiple source files into one source file, with no change in code
     behavior;
--   Changes to words or phrases isolated from their context;
--   Changes to typeface.
+- Changes to words or phrases isolated from their context;
+- Changes to typeface.
 
 Things that would still require a DCO sign-off before submitting would
 likely include stuff like the following:
 
--   Any of the above actions that result in a change in functionality;
--   A new feature;
--   A translation;
--   Extensive or creative comments.
+- Any of the above actions that result in a change in functionality;
+- A new feature;
+- A translation;
+- Extensive or creative comments.

--- a/content/community_guidelines.md
+++ b/content/community_guidelines.md
@@ -53,12 +53,12 @@ help and guidance.
 The following list isn't exhaustive, but these few examples can help all
 of us communicate well, so that the community can work better together:
 
--   Use welcoming and inclusive language
--   Exercise patience and friendliness
--   Be respectful of differing viewpoints and experiences
--   Gracefully accept constructive criticism
--   Focus on what is best for the community
--   Show empathy towards other community members
+- Use welcoming and inclusive language
+- Exercise patience and friendliness
+- Be respectful of differing viewpoints and experiences
+- Gracefully accept constructive criticism
+- Focus on what is best for the community
+- Show empathy towards other community members
 
 The previous list applies to all forms of communication: Slack (or any
 web chat), Discourse, the issue tracker, and any other forum that is
@@ -66,46 +66,46 @@ used by the community.
 
 Please keep in mind that:
 
--   Your work will be used by other people, and you, in turn, will
+- Your work will be used by other people, and you, in turn, will
     depend on the work of others.
--   Decisions that you make often will affect others in the community.
--   Disagreements happen, but should not be an excuse for poor behavior
+- Decisions that you make often will affect others in the community.
+- Disagreements happen, but should not be an excuse for poor behavior
     and bad manners. When disagreements do happen, let's work together
     to solve them effectively and in a way that ensures that everyone
     understands what the disagreements were.
--   Our community spans languages, cultures, perspectives (and
+- Our community spans languages, cultures, perspectives (and
     continents!), and as such people may not understand jokes, sarcasm,
     and oblique references in the same way that you do. Remember that
     and be kind to the other members of the community.
--   Be cautious about making assumptions about what someone does or does
+- Be cautious about making assumptions about what someone does or does
     not know about something - assuming that someone does not understand
     an issue and over explaining can be condescending (even when not
     intended to be so).
--   Sexist, racist, ableist, ageist, and other prejudicial or
+- Sexist, racist, ableist, ageist, and other prejudicial or
     exclusionary comments are not welcome in the community.
 
 ## Unacceptable Behavior
 
 Harassment comes in many forms, including but not limited to:
 
--   Offensive comments related to gender, sexual orientation, age,
+- Offensive comments related to gender, sexual orientation, age,
     disability, physical appearance, body size, race, veteran status, or
     religion.
--   Posting/Exposing sexually explicit or violent images.
--   Deliberate (or implied) intimidation.
--   Trolling, insulting/derogatory comments, and personal or political
+- Posting/Exposing sexually explicit or violent images.
+- Deliberate (or implied) intimidation.
+- Trolling, insulting/derogatory comments, and personal or political
     attacks particularly those related to gender, sexual orientation,
     age, race, religion or disability.
--   Publishing others' private information, such as a physical or
+- Publishing others' private information, such as a physical or
     electronic address, without explicit permission ("doxing").
 
 As a community that meets in physical public spaces, harassment also
 includes:
 
--   Stalking or persistent following.
--   Intrusive or otherwise unwanted photography or recording.
--   Sustained disruption of talks or other events.
--   Inappropriate physical contact or unwelcome sexual attention.
+- Stalking or persistent following.
+- Intrusive or otherwise unwanted photography or recording.
+- Sustained disruption of talks or other events.
+- Inappropriate physical contact or unwelcome sexual attention.
 
 **NOTE**: If you are in a physical space -- e.g. Chef Conf, Meetup, etc.
 -- please see the [Physical Spaces Code of
@@ -138,18 +138,18 @@ by other members of the project's leadership.
 The following are the various roles of our **Community Organizers** and
 the person(s) assigned to each role:
 
--   The **Deciders** have final say on community guidelines and final
+- The **Deciders** have final say on community guidelines and final
     authority on correct actions and appeals.
--   The **Community Advocates** may be assigned for each area where the
+- The **Community Advocates** may be assigned for each area where the
     community convenes online (Slack, email list, GitHub, etc.).
     Community Advocates are volunteers who have the best interests of
     our community in mind. They act in good faith to help enforce our
     community guidelines and respond to incidents when they occur.
--   The **Project Maintainers** are expected to conduct their behavior
+- The **Project Maintainers** are expected to conduct their behavior
     in line with the Code of Conduct and are individually responsible
     for both escalating to a **Community Advocate** in case of
     witnessing an incident, and helping to foster the community.
--   A **Community Member** is anyone who participates with the community
+- A **Community Member** is anyone who participates with the community
     whether in-person or via online channels. Community members are
     responsible for following the community guidelines, suggesting
     updates to the guidelines when warranted, and helping enforce
@@ -232,25 +232,25 @@ behaving in a way that is outside of our guidelines (a violator), the
 Community Advocate should make every reasonable attempt to help curtail
 that behavior. The Community Advocate may:
 
--   Remind the violator about our Community Code of Conduct and provide
+- Remind the violator about our Community Code of Conduct and provide
     a link to this document.
--   Ask the violator to stop the unacceptable behavior.
--   Raise the issue with a maintainer, the community manager, or any
+- Ask the violator to stop the unacceptable behavior.
+- Raise the issue with a maintainer, the community manager, or any
     member of the core project team.
--   Allow time for the violator to correct the behavior.
+- Allow time for the violator to correct the behavior.
 
 The Community Advocate should take the following steps if the behavior
 is not brought in-line with our guidelines or the incident is not
 resolved:
 
--   Consult with another Community Organizer to make a judgment call
+- Consult with another Community Organizer to make a judgment call
     about what reasonable corrective actions are warranted.
--   In the case that no conclusion can be made, escalate to include the
+- In the case that no conclusion can be made, escalate to include the
     next level of Community Organizers.
--   If still no conclusion can be made, report the incident to the
+- If still no conclusion can be made, report the incident to the
     **Deciders** listed above.
--   Apply the corrective action.
--   Document the incident as described below.
+- Apply the corrective action.
+- Document the incident as described below.
 
 #### Documenting Incidents
 
@@ -265,14 +265,14 @@ terminate any local copies of the repository.
 
 The important information to report consists of:
 
--   Identifying information (name, email address, Slack username, etc.)
+- Identifying information (name, email address, Slack username, etc.)
     of the person doing the harassing.
--   The behavior that was in violation.
--   The approximate time and date of the behavior.
--   The circumstances surrounding the incident.
--   Where applicable, contextual information/proof (email body, chat
+- The behavior that was in violation.
+- The approximate time and date of the behavior.
+- The circumstances surrounding the incident.
+- Where applicable, contextual information/proof (email body, chat
     log, GitHub Issue, etc.).
--   Contact information for witnesses to the incident.
+- Contact information for witnesses to the incident.
 
 If you feel your safety is in jeopardy, please do not hesitate to
 contact local law enforcement.
@@ -309,9 +309,9 @@ project maintainers and community organizers.
 
 This Code of Conduct is adapted from the following:
 
--   [Contributor Covenant](https://www.contributor-covenant.org/),
+- [Contributor Covenant](https://www.contributor-covenant.org/),
     version 1.4, available
     [here](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
--   [Rust Code of
+- [Rust Code of
     Conduct](https://www.rust-lang.org/policies/code-of-conduct)
--   [Citizen Code of Conduct](http://citizencodeofconduct.org/)
+- [Citizen Code of Conduct](http://citizencodeofconduct.org/)

--- a/content/config_rb_client.md
+++ b/content/config_rb_client.md
@@ -384,8 +384,8 @@ This configuration file has the following settings:
 `ssl_verify_mode`
 : Set the verify mode for HTTPS requests.
 
-    -   Use `:verify_none` for no validation of SSL certificates.
-    -   Use `:verify_peer` for validation of all SSL certificates, including the Chef Infra Server connections, S3 connections, and any HTTPS **remote_file** resource URLs used in Chef Infra Client runs. This is the recommended setting.
+    - Use `:verify_none` for no validation of SSL certificates.
+    - Use `:verify_peer` for validation of all SSL certificates, including the Chef Infra Server connections, S3 connections, and any HTTPS **remote_file** resource URLs used in Chef Infra Client runs. This is the recommended setting.
 
     Depending on how OpenSSL is configured, the `ssl_ca_path` may nee to be specified. Default value: `:verify_peer`.
 

--- a/content/config_rb_metadata.md
+++ b/content/config_rb_metadata.md
@@ -18,13 +18,13 @@ aliases = ["/config_rb_metadata.html"]
 
 A metadata.rb file is:
 
--   Located at the top level of a cookbook's directory structure.
--   Compiled whenever a cookbook is uploaded to the Chef Infra Server or
+- Located at the top level of a cookbook's directory structure.
+- Compiled whenever a cookbook is uploaded to the Chef Infra Server or
     when the `knife cookbook metadata` subcommand is run, and then
     stored as JSON data.
--   Created automatically by knife whenever the `knife cookbook create`
+- Created automatically by knife whenever the `knife cookbook create`
     subcommand is run.
--   Edited using a text editor, and then re-uploaded to the Chef Infra
+- Edited using a text editor, and then re-uploaded to the Chef Infra
     Server as part of a cookbook upload.
 
 ## Error Messages

--- a/content/config_rb_solo.md
+++ b/content/config_rb_solo.md
@@ -17,12 +17,12 @@ aliases = ["/config_rb_solo.html"]
 A solo.rb file is used to specify the configuration details for
 chef-solo.
 
--   This file is loaded every time this executable is run
--   The default location in which chef-solo expects to find this file is
+- This file is loaded every time this executable is run
+- The default location in which chef-solo expects to find this file is
     `/etc/chef/solo.rb`; use the `--config` option from the command line
     to change this location
--   This file is not created by default
--   When a `solo.rb` file is present in this directory, the settings
+- This file is not created by default
+- When a `solo.rb` file is present in this directory, the settings
     contained within that file will override the default configuration
     settings
 

--- a/content/cookbook_repo.md
+++ b/content/cookbook_repo.md
@@ -48,17 +48,17 @@ where `COOKBOOK_NAME` is the name of a cookbook on [Chef
 Supermarket](https://supermarket.chef.io/). This will start a process
 that:
 
--   downloads the cookbook from [Chef
+- downloads the cookbook from [Chef
     Supermarket](https://supermarket.chef.io/) as a tar.gz archive
--   ensures that its using the git master branch, and then checks out
+- ensures that its using the git master branch, and then checks out
     the cookbook from a vendor branch (creating a new vendor branch, if
     required)
--   removes the old (existing) version
--   expands the tar.gz archive and adds the expanded files to the git
+- removes the old (existing) version
+- expands the tar.gz archive and adds the expanded files to the git
     index and commits
--   creates a tag for the version that was downloaded
--   checks out the master branch
--   merges the cookbook into the master (to ensure that any local
+- creates a tag for the version that was downloaded
+- checks out the master branch
+- merges the cookbook into the master (to ensure that any local
     changes or modifications are preserved)
 
 ### Download

--- a/content/cookbook_versioning.md
+++ b/content/cookbook_versioning.md
@@ -202,9 +202,9 @@ Version 0.0.0 of cookbook redis is frozen. Use --force to override
 There are two strategies to consider when using version control as part
 of the cookbook management process:
 
--   Use maximum version control when it is important to keep every bit
+- Use maximum version control when it is important to keep every bit
     of data within version control
--   Use branch tracking when cookbooks are being managed in separate
+- Use branch tracking when cookbooks are being managed in separate
     environments using git branches and the versioning policy
     information is already stored in a cookbook's metadata.
 

--- a/content/ctl_chef_client.md
+++ b/content/ctl_chef_client.md
@@ -322,12 +322,12 @@ This command has the following options:
     help identify, and then resolve performance bottlenecks in a Chef
     Infra Client run. This option:
 
-    -   Generates a large amount of data about a Chef Infra Client run.
-    -   Has a dependency on the `ruby-prof` gem, which is packaged as
+    - Generates a large amount of data about a Chef Infra Client run.
+    - Has a dependency on the `ruby-prof` gem, which is packaged as
         part of Chef and Chef Workstation.
-    -   Increases the amount of time required to complete a Chef Infra
+    - Increases the amount of time required to complete a Chef Infra
         Client run.
-    -   Should not be used in a production environment.
+    - Should not be used in a production environment.
 
 `-r RUN_LIST_ITEM`, `--runlist RUN_LIST_ITEM`
 
@@ -404,10 +404,10 @@ Infra Client run. A new Chef Infra Client run looks for the presence of
 a lock file and, if present, will wait for that lock file to be deleted.
 The location of the lock file can vary by platform.
 
--   Use the `lockfile` setting in the client.rb file to specify
+- Use the `lockfile` setting in the client.rb file to specify
     non-default locations for the lock file. (The default location is
     typically platform-dependent and is recommended.)
--   Use the `run_lock_timeout` setting in the client.rb file to specify
+- Use the `run_lock_timeout` setting in the client.rb file to specify
     the amount of time (in seconds) to wait for the lock file associated
     with an in-progress Chef Infra Client run to be deleted.
 
@@ -465,17 +465,17 @@ providers to test more thoroughly.
 When Chef Infra Client is run in why-run mode, certain assumptions are
 made:
 
--   If the **service** resource cannot find the appropriate command to
+- If the **service** resource cannot find the appropriate command to
     verify the status of a service, why-run mode will assume that the
     command would have been installed by a previous resource and that
     the service would not be running.
--   For `not_if` and `only_if` properties, why-run mode will assume
+- For `not_if` and `only_if` properties, why-run mode will assume
     these are commands or blocks that are safe to run. These conditions
     are not designed to be used to change the state of the system, but
     rather to help facilitate idempotency for the resource itself. That
     said, it may be possible that these attributes are being used in a
     way that modifies the system state
--   The closer the current state of the system is to the desired state,
+- The closer the current state of the system is to the desired state,
     the more useful why-run mode will be. For example, if a full
     run-list is run against a fresh system, that run-list may not be
     completely correct on the first try, but also that run-list will
@@ -590,9 +590,9 @@ chef-client
 This can be resolved by running the command as root. There are a few
 ways this can be done:
 
--   Log in as root and then run the Chef Infra Client
+- Log in as root and then run the Chef Infra Client
 
--   Use `su` to become the root user, and then run the Chef Infra
+- Use `su` to become the root user, and then run the Chef Infra
     Client. For example:
 
     ```bash
@@ -605,13 +605,13 @@ ways this can be done:
     chef-client
     ```
 
--   Use the sudo utility
+- Use the sudo utility
 
     ```bash
     sudo chef-client
     ```
 
--   Give a user access to read `/etc/chef` and also the files accessed
+- Give a user access to read `/etc/chef` and also the files accessed
     by the Chef Infra Client. This requires super user privileges and,
     as such, is not a recommended approach
 
@@ -706,10 +706,10 @@ The Chef Infra Client has the [same system
 requirements](/chef_system_requirements/#chef-infra-client) on the
 AIX platform as any other platform, with the following notes:
 
--   Expand the file system on the AIX platform using `chfs` or by
+- Expand the file system on the AIX platform using `chfs` or by
     passing the `-X` flag to `installp` to automatically expand the
     logical partition (LPAR)
--   The EN_US (UTF-8) character set should be installed on the logical
+- The EN_US (UTF-8) character set should be installed on the logical
     partition prior to installing the Chef Infra Client
 
 **Install the Chef Infra Client on the AIX platform**

--- a/content/ctl_supermarket.md
+++ b/content/ctl_supermarket.md
@@ -366,11 +366,11 @@ run: service_name: (pid 12345) 12345s; run: log: (pid 1234) 67890s
 
 where
 
--   `run:` is the state of the service (`run:` or `down:`)
--   `service_name:` is the name of the service for which status is
+- `run:` is the state of the service (`run:` or `down:`)
+- `service_name:` is the name of the service for which status is
     returned
--   `(pid 12345)` is the process identifier
--   `12345s` is the uptime of the service, in seconds
+- `(pid 12345)` is the process identifier
+- `12345s` is the uptime of the service, in seconds
 
 For example:
 
@@ -403,13 +403,13 @@ run: name_of_service: (pid 1486) 7819s; run: log: (pid 1485) 7819s
 
 where:
 
--   `run` describes the state in which the supervisor attempts to keep
+- `run` describes the state in which the supervisor attempts to keep
     processes. This state is either `run` or `down`. If a service is in
     a `down` state, it should be stopped
--   `name_of_service` is the service name
--   `(pid 1486) 7819s;` is the process identifier followed by the amount
+- `name_of_service` is the service name
+- `(pid 1486) 7819s;` is the process identifier followed by the amount
     of time (in seconds) the service has been running
--   `run: log: (pid 1485) 7819s` is the log process. It is typical for a
+- `run: log: (pid 1485) 7819s` is the log process. It is typical for a
     log process to have a longer run time than a service; this is
     because the supervisor does not need to restart the log process in
     order to connect the supervised process
@@ -423,8 +423,8 @@ down: actions: 3s, normally up; run: log: (pid 1485) 8526s
 
 where
 
--   `down` indicates that the service is in a down state
--   `3s, normally up;` indicates that the service is normally in a run
+- `down` indicates that the service is in a down state
+- `3s, normally up;` indicates that the service is normally in a run
     state and that the supervisor would attempt to restart this service
     after a reboot
 

--- a/content/custom_resources.md
+++ b/content/custom_resources.md
@@ -16,11 +16,11 @@ aliases = ["/custom_resources.html"]
 
 A custom resource:
 
--   Is a simple extension of Chef Infra Client that adds your own resources
--   Is implemented and shipped as part of a cookbook
--   Follows easy, repeatable syntax patterns
--   Effectively leverages resources that are built into Chef Infra Client and/or custom Ruby code
--   Is reusable in the same way as resources that are built into Chef Infra Client
+- Is a simple extension of Chef Infra Client that adds your own resources
+- Is implemented and shipped as part of a cookbook
+- Follows easy, repeatable syntax patterns
+- Effectively leverages resources that are built into Chef Infra Client and/or custom Ruby code
+- Is reusable in the same way as resources that are built into Chef Infra Client
 
 For example, Chef Infra Client includes built-in resources to manage
 files, packages, templates, and services, but it does not include a
@@ -31,9 +31,9 @@ resource that manages websites.
 A custom resource is defined as a Ruby file and is located in a
 cookbook's `/resources` directory. This file:
 
--   Declares the properties of the custom resource
--   Loads current state of properties, if the resource already exists
--   Defines each action the custom resource may take
+- Declares the properties of the custom resource
+- Loads current state of properties, if the resource already exists
+- Defines each action the custom resource may take
 
 The syntax for a custom resource is. For example:
 
@@ -91,13 +91,13 @@ end
 
 where
 
--   `homepage` is a property that sets the default HTML for the
+- `homepage` is a property that sets the default HTML for the
     `index.html` file with a default value of `'<h1>Hello world!</h1>'`
--   the `action` block uses the built-in collection of resources to tell
+- the `action` block uses the built-in collection of resources to tell
     Chef Infra Client how to install Apache, start the service, and then
     create the contents of the file located at
     `/var/www/html/index.html`
--   `action :create` is the default resource, because it is listed
+- `action :create` is the default resource, because it is listed
     first; `action :delete` must be called specifically (because it is
     not the default action)
 
@@ -161,10 +161,10 @@ Define a custom resource!
 
 A custom resource typically contains:
 
--   A list of defined custom properties (property values are specified
+- A list of defined custom properties (property values are specified
     in recipes)
--   At least one action (actions tell Chef Infra Client what to do)
--   For each action, use a collection of resources that are built into
+- At least one action (actions tell Chef Infra Client what to do)
+- For each action, use a collection of resources that are built into
     Chef Infra Client to define the steps required to complete the
     action
 
@@ -172,9 +172,9 @@ A custom resource typically contains:
 
 This custom resource requires:
 
--   Two template files
--   Two properties
--   An action that defines all of the steps necessary to create the
+- Two template files
+- Two properties
+- An action that defines all of the steps necessary to create the
     website
 
 ### Define Properties
@@ -182,8 +182,8 @@ This custom resource requires:
 Custom properties are defined in the resource. This custom resource
 needs two:
 
--   `instance_name`
--   `port`
+- `instance_name`
+- `port`
 
 These properties are defined as variables in the `httpd.conf.erb` file.
 A **template** block in recipes will tell Chef Infra Client how to apply
@@ -198,9 +198,9 @@ property :port, Integer, required: true
 
 where
 
--   `String` and `Integer` are Ruby types (all custom properties must
+- `String` and `Integer` are Ruby types (all custom properties must
     have an assigned Ruby type)
--   `name_property: true` allows the value for this property to be equal
+- `name_property: true` allows the value for this property to be equal
     to the `'name'` of the resource block
 
 The `instance_name` property is then used within the custom resource in
@@ -264,8 +264,8 @@ end
 
 where
 
--   `source` gets the `httpd.service.erb` template from this cookbook
--   `variables` assigns the `instance_name` property to a variable in
+- `source` gets the `httpd.service.erb` template from this cookbook
+- `variables` assigns the `instance_name` property to a variable in
     the template
 
 #### template, httpd.conf
@@ -286,8 +286,8 @@ end
 
 where
 
--   `source` gets the `httpd.conf.erb` template from this cookbook
--   `variables` assigns the `instance_name` and `port` properties to
+- `source` gets the `httpd.conf.erb` template from this cookbook
+- `variables` assigns the `instance_name` and `port` properties to
     variables in the template
 
 {{< note >}}
@@ -327,8 +327,8 @@ end
 
 The `/templates` directory must contain two templates:
 
--   `httpd.conf.erb` to configure Apache httpd
--   `httpd.service.erb` to tell systemd how to start and stop the
+- `httpd.conf.erb` to configure Apache httpd
+- `httpd.service.erb` to tell systemd how to start and stop the
     website
 
 #### httpd.conf.erb
@@ -359,17 +359,17 @@ Copy it as shown, add it under `/templates`, and then name the file
 
 The `httpd.conf.erb` template has two variables:
 
--   `<%= @instance_name %>`
--   `<%= @port %>`
+- `<%= @instance_name %>`
+- `<%= @port %>`
 
 They are:
 
--   Declared as properties of the custom resource
--   Defined as variables in a **template** resource block within the
+- Declared as properties of the custom resource
+- Defined as variables in a **template** resource block within the
     custom resource
--   Tunable from a recipe when using `port` and `instance_name` as
+- Tunable from a recipe when using `port` and `instance_name` as
     properties in that recipe
--   `instance_name` defaults to the `'name'` of the custom resource if
+- `instance_name` defaults to the `'name'` of the custom resource if
     not specified as a property
 
 #### httpd.service.erb
@@ -472,11 +472,11 @@ end
 
 which does the following:
 
--   Installs Apache httpd
--   Assigns an instance name of `httpd_site` that uses port 81
--   Configures httpd and systemd from a template
--   Creates the virtual host for the website
--   Starts the website using systemd
+- Installs Apache httpd
+- Assigns an instance name of `httpd_site` that uses port 81
+- Configures httpd and systemd from a template
+- Creates the virtual host for the website
+- Starts the website using systemd
 
 ## Custom Resource DSL
 

--- a/content/debug.md
+++ b/content/debug.md
@@ -15,9 +15,9 @@ aliases = ["/debug.html"]
 Elements of good approaches to building cookbooks and recipes that are
 reliable include:
 
--   A consistent syntax pattern when constructing recipes
--   Using the same patterns in Ruby
--   Using resources included in Chef Infra Client or community cookbooks
+- A consistent syntax pattern when constructing recipes
+- Using the same patterns in Ruby
+- Using resources included in Chef Infra Client or community cookbooks
     before creating custom ones
 
 Ideally, the best way to debug a recipe is to not have to debug it in
@@ -29,10 +29,10 @@ approaches to debugging recipes and failed Chef Infra Client runs.
 Some simple ways to quickly identify common issues that can trigger
 recipe and/or Chef Infra Client run failures include:
 
--   Using an empty run-list
--   Using verbose logging with knife
--   Using logging with Chef Infra Client
--   Using the **log** resource in a recipe to define custom logging
+- Using an empty run-list
+- Using verbose logging with knife
+- Using logging with Chef Infra Client
+- Using the **log** resource in a recipe to define custom logging
 
 ### Empty Run-lists
 
@@ -116,16 +116,16 @@ resources in recipes:
 Some more complex ways to debug issues with a Chef Infra Client run
 include:
 
--   Using the **chef_handler** resource
--   Using the chef-shell and the **breakpoint** resource to add
+- Using the **chef_handler** resource
+- Using the chef-shell and the **breakpoint** resource to add
     breakpoints to recipes, and to then step through the recipes using
     the breakpoints
--   Using the `debug_value` method from chef-shell to identify the
+- Using the `debug_value` method from chef-shell to identify the
     location(s) from which attribute values are being set
--   Using the `ignore_failure` method in a recipe to force Chef Infra
+- Using the `ignore_failure` method in a recipe to force Chef Infra
     Client to move past an error to see what else is going on in the
     recipe, outside of a known failure
--   Using chef-solo to run targeted Chef Infra Client runs for specific
+- Using chef-solo to run targeted Chef Infra Client runs for specific
     scenarios
 
 ### chef_handler
@@ -255,12 +255,12 @@ without a value:
 
 where
 
--   `set_unless_enabled` indicates if the attribute collection is in
+- `set_unless_enabled` indicates if the attribute collection is in
     `set_unless` mode; this typically returns `false`
--   Each attribute type is listed in order of precedence
--   Each attribute value shown is the value that is set for that
+- Each attribute type is listed in order of precedence
+- Each attribute value shown is the value that is set for that
     precedence level
--   `:not_present` is shown for any attribute precedence level that has
+- `:not_present` is shown for any attribute precedence level that has
     no attributes
 
 ### ignore_failure Method

--- a/content/definitions.md
+++ b/content/definitions.md
@@ -33,29 +33,29 @@ Though a definition looks like a resource, and at first glance seems
 like it could be used interchangeably, some important differences exist.
 Definitions:
 
--   Are not true resources
--   Are processed when resource collection is compiled, not when a node
+- Are not true resources
+- Are processed when resource collection is compiled, not when a node
     is converged
--   Don't support common resource properties, such as `notifies`,
+- Don't support common resource properties, such as `notifies`,
     `subscribes`, `only_if`, `not_if`, and `sensitive`
--   Don't support input validation in passed arguments, unlike a
+- Don't support input validation in passed arguments, unlike a
     resource which supports validation with properties
--   Don't support `why-run` mode
--   Can't report to Chef Automate
--   Cannot be tested with ChefSpec
--   There are known issues with the definition parameters hash where certain names, `timeout` for example,
+- Don't support `why-run` mode
+- Can't report to Chef Automate
+- Cannot be tested with ChefSpec
+- There are known issues with the definition parameters hash where certain names, `timeout` for example,
     will not work. These issues will not be fixed.
 
 ## Syntax
 
 A definition had four components:
 
--   A resource name
--   Zero or more arguments that define parameters their default values;
+- A resource name
+- Zero or more arguments that define parameters their default values;
     if a default value was not specified, it was assumed to be `nil`
--   A hash that could have been used within a definition's body to
+- A hash that could have been used within a definition's body to
     provide access to parameters and their values
--   The body of the definition
+- The body of the definition
 
 The basic syntax of a definition was:
 

--- a/content/deprecations_legacy_hwrp_mixins.md
+++ b/content/deprecations_legacy_hwrp_mixins.md
@@ -18,8 +18,8 @@ The [Cookstyle](/workstation/cookstyle/) cop
 [ChefDeprecations/UsesDeprecatedMixins](https://github.com/chef/cookstyle/blob/master/docs/cops_chefdeprecations.md#chefdeprecationsusesdeprecatedmixins)
 has been introduced to detect these mixins:
 
--   `Chef::Mixin::LanguageIncludeAttribute`
--   `Chef::Mixin::RecipeDefinitionDSLCore`
--   `Chef::Mixin::LanguageIncludeRecipe`
--   `Chef::Mixin::Language`
--   `Chef::DSL::Recipe::FullDSL`
+- `Chef::Mixin::LanguageIncludeAttribute`
+- `Chef::Mixin::RecipeDefinitionDSLCore`
+- `Chef::Mixin::LanguageIncludeRecipe`
+- `Chef::Mixin::Language`
+- `Chef::DSL::Recipe::FullDSL`

--- a/content/dsl_custom_resource.md
+++ b/content/dsl_custom_resource.md
@@ -14,9 +14,9 @@ aliases = ["/dsl_custom_resource.html"]
 
 Use the Custom Resource DSL to define behaviors within custom resources, such as:
 
--   Loading the value of a specific property
--   Comparing the current property value against a desired property value
--   Telling Chef Infra Client when and how to make changes
+- Loading the value of a specific property
+- Comparing the current property value against a desired property value
+- Telling Chef Infra Client when and how to make changes
 
 ## action_class
 

--- a/content/environments.md
+++ b/content/environments.md
@@ -75,9 +75,9 @@ pinning syntax.
 Environments may be stored on disk (any in source control) in two
 formats:
 
--   As Ruby (i.e. a file that ends with `.rb`); this format is not
+- As Ruby (i.e. a file that ends with `.rb`); this format is not
     available when running Chef Infra Client in local mode
--   As JSON (i.e. a file that ends with `.json`)
+- As JSON (i.e. a file that ends with `.json`)
 
 ### Chef Language
 
@@ -268,12 +268,12 @@ The JSON format has two additional settings:
 
 An environment can be created in four different ways:
 
--   Creating a Ruby file in the environments sub-directory of the
+- Creating a Ruby file in the environments sub-directory of the
     chef-repo and then pushing it to the Chef server
--   Creating a JSON file directly in the chef-repo and then pushing it
+- Creating a JSON file directly in the chef-repo and then pushing it
     to the Chef server
--   Using knife
--   Using the Chef Infra Server REST API
+- Using knife
+- Using the Chef Infra Server REST API
 
 Once an environment exists on the Chef Infra Server, a node can be
 associated with that environment using the `chef_environment` method.
@@ -282,9 +282,9 @@ associated with that environment using the `chef_environment` method.
 
 Once created, an environment can be managed in several ways:
 
--   By using knife and passing the `-E ENVIRONMENT_NAME` option with
+- By using knife and passing the `-E ENVIRONMENT_NAME` option with
     `knife cookbook upload`
--   By using Ruby or JSON files that are stored in a version source
+- By using Ruby or JSON files that are stored in a version source
     control system. These files are pushed to the Chef Infra Server
     using the `knife environment` subcommand and the `from file`
     argument. This approach allows environment data to be dynamically
@@ -378,9 +378,9 @@ cannot be set with normal or override attributes (i.e. in a role)
 because it is actually a method. An environment may be set explicitly
 using the following methods:
 
--   By using the `knife edit` and `knife exec` subcommands
+- By using the `knife edit` and `knife exec` subcommands
 
--   By editing the `environment` configuration details in the client.rb
+- By editing the `environment` configuration details in the client.rb
     file, and then using `knife bootstrap -e environment_name` to
     bootstrap the changes to the specified environment
 
@@ -392,7 +392,7 @@ using the following methods:
 
     {{< /note >}}
 
--   By setting the `environment` configuration entry in the client.rb
+- By setting the `environment` configuration entry in the client.rb
     file ; when Chef Infra Client runs, it will pick up the value and
     then set the `chef_environment` attribute of the node
 

--- a/content/errors.md
+++ b/content/errors.md
@@ -70,10 +70,10 @@ Response:  Failed to authenticate as USERNAME. Ensure that your node_name and cl
 
 **Troubleshooting Steps**
 
--   Verify you have the correct values in your config.rb file,
+- Verify you have the correct values in your config.rb file,
     especially for the `node_name` and `client_key` settings.
 
--   Check if the file referenced in the `client_key` setting (usually
+- Check if the file referenced in the `client_key` setting (usually
     USER.pem) exists. Some common locations include:
 
         - ~/.chef
@@ -82,7 +82,7 @@ Response:  Failed to authenticate as USERNAME. Ensure that your node_name and cl
 
     If one is present, verify that it has the correct read permissions.
 
--   If there's no client.rb file, regenerate it and ensure the values
+- If there's no client.rb file, regenerate it and ensure the values
     for the `node_name` and `client_key` settings are correct.
 
 ### Organization not found
@@ -241,8 +241,8 @@ HTTP 500 is a non-specific error message. The full error message for the
 error Chef Infra Client is receiving can be found in one of the
 following log files:
 
--   `/var/log/opscode/opscode-account/current`
--   `/var/log/opscode/opscode-erchef/current`
+- `/var/log/opscode/opscode-account/current`
+- `/var/log/opscode/opscode-erchef/current`
 
 The error will likely found in a stacktrace from the application error.
 In some cases the error message will clearly indicate a problem with
@@ -391,7 +391,7 @@ The value of `postgresql['external']` has been changed.
 
 **Possible Causes**
 
--   This setting must be set before running
+- This setting must be set before running
     `chef-server-ctl reconfigure`, and may not be changed after
 
 {{< warning >}}
@@ -402,9 +402,9 @@ Upgrading is not supported at this time.
 
 **Resolution**
 
--   Back up the data using `knife ec backup`, create a new backend
+- Back up the data using `knife ec backup`, create a new backend
     instance, and then restore the data
--   Re-point front end machines at the new backend instance **or**
+- Re-point front end machines at the new backend instance **or**
     assign the new backend instance the name/VIP of the old backend
     instance (including certificates, keys, and so on)
 
@@ -416,11 +416,11 @@ Cannot connect to PostgreSQL on the remote server.
 
 **Possible Causes**
 
--   PostgreSQL is not running on the remote server
--   The port used by PostgreSQL is blocked by a firewall on the remote
+- PostgreSQL is not running on the remote server
+- The port used by PostgreSQL is blocked by a firewall on the remote
     server
--   Network routing configuration is preventing access to the host
--   When using Amazon Web Services (AWS), rules for security groups are
+- Network routing configuration is preventing access to the host
+- When using Amazon Web Services (AWS), rules for security groups are
     preventing the Chef Infra Server from communicating with PostgreSQL
 
 ### CSPG011 (cannot authenticate)
@@ -431,8 +431,8 @@ Cannot authenticate to PostgreSQL on the remote server.
 
 **Possible Causes**
 
--   Incorrect password specified for `db_superuser_password`
--   Incorrect user name specified for `db_superuser`
+- Incorrect password specified for `db_superuser_password`
+- Incorrect user name specified for `db_superuser`
 
 ### CSPG012 (incorrect rules)
 
@@ -443,14 +443,14 @@ Cannot connect to PostgreSQL on the remote server because rules in
 
 **Possible Causes**
 
--   There is no `pg_hba.conf` rule for the `db_superuser` in PostgreSQL
--   A rule exists for the `db_superuser` in `pg_hba.conf`, but it does
+- There is no `pg_hba.conf` rule for the `db_superuser` in PostgreSQL
+- A rule exists for the `db_superuser` in `pg_hba.conf`, but it does
     not specify `md5` access
--   A rule in `pg_hba.conf` specifies an incorrect originating address
+- A rule in `pg_hba.conf` specifies an incorrect originating address
 
 **Resolution**
 
--   Entries in the `pg_hba.conf` file should allow all user names that
+- Entries in the `pg_hba.conf` file should allow all user names that
     originate from any Chef Infra Server instance using `md5`
     authentication. For example, a `pg_hba.conf` entry for a valid
     username and password from the 192.0.2.0 subnet:
@@ -511,7 +511,7 @@ Cannot connect to PostgreSQL on the remote server because rules in
     SELECT pg_reload_conf();
     ```
 
--   Rules in the `pg_hba.conf` file should allow only specific
+- Rules in the `pg_hba.conf` file should allow only specific
     application names: `$db_superuser` (the configured superuser name in
     the chef-server.rb file), `oc_id`, `oc_id_ro`, `opscode_chef`,
     `opscode_chef_ro`, `bifrost`, and `bifrost_ro`
@@ -524,9 +524,9 @@ The `db_superuser` account has incorrect permissions.
 
 **Possible Causes**
 
--   The `db_superuser` account has not been granted `SUPERUSER` access
+- The `db_superuser` account has not been granted `SUPERUSER` access
 
--   The `db_superuser` account has not been granted `CREATE DATABASE`
+- The `db_superuser` account has not been granted `CREATE DATABASE`
     and `CREATE ROLE` privileges
 
     ```bash
@@ -547,7 +547,7 @@ Bad version of PostgreSQL.
 
 **Possible Causes**
 
--   The remote server is not running PostgreSQL version 9.2.x
+- The remote server is not running PostgreSQL version 9.2.x
 
 ### CSPG015 (missing database)
 
@@ -557,12 +557,12 @@ The database template `template1` does not exist.
 
 **Possible Causes**
 
--   The `template1` database template has been removed from the remote
+- The `template1` database template has been removed from the remote
     server
 
 **Resolution**
 
--   Run the following command (as a superuser):
+- Run the following command (as a superuser):
 
     ```bash
     CREATE DATABASE template1 TEMPLATE template0
@@ -582,16 +582,16 @@ One (or more) of the PostgreSQL databases already exists.
 
 **Possible Causes**
 
--   The `opscode_chef`, `oc_id`, and/or `bifrost` databases already
+- The `opscode_chef`, `oc_id`, and/or `bifrost` databases already
     exist on the remote machine
--   The PostgreSQL database exists for another application
+- The PostgreSQL database exists for another application
 
 **Resolution**
 
--   Verify that the `opscode_chef`, `oc_id`, and/or `bifrost` databases
+- Verify that the `opscode_chef`, `oc_id`, and/or `bifrost` databases
     exist, and then verify that they are not being used by another
     internal application
--   Back up the PostgreSQL data, remove the existing databases, and
+- Back up the PostgreSQL data, remove the existing databases, and
     reconfigure the Chef server
 
 ### CSPG017 (user exists)
@@ -602,18 +602,18 @@ One (or more) of the PostgreSQL predefined users already exists.
 
 **Possible Causes**
 
--   The `opscode_chef`, `ospcode_chef_ro`, `bifrost`, `bifrost_ro`,
+- The `opscode_chef`, `ospcode_chef_ro`, `bifrost`, `bifrost_ro`,
     `oc_id`, or `oc_id_ro` users already exist on the remote machine
--   The `postgresql['vip']` setting is configured to a remote host, but
+- The `postgresql['vip']` setting is configured to a remote host, but
     `postgresql['external']` is not set to `true`, which causes the
     `opscode_chef` and `ospcode_chef_ro` users to be created before the
     machine is reconfigured, which will return a permissions error
--   Existing, valid naming conflicts are present, where the users were
+- Existing, valid naming conflicts are present, where the users were
     created independently of the Chef server
 
 **Resolution**
 
--   Run the following, if it is safe to do so, to update the user name
+- Run the following, if it is safe to do so, to update the user name
     that is specified in the error message:
 
     ```bash

--- a/content/feedback.md
+++ b/content/feedback.md
@@ -19,17 +19,17 @@ feedback. There are several ways to get feedback to chef-docs. For
 members of the Chef community, customers, or people who just want to
 send feedback, choose any of the following four options:
 
--   Email --- Send an email to <docs@chef.io> for documentation bugs,
+- Email --- Send an email to <docs@chef.io> for documentation bugs,
     ideas, thoughts, and suggestions. Typos and little errors and quick
     fixes will be fixed quickly and without fuss. This email address is
     not a support email address, however. If you need support for Chef,
     contact Chef support.
--   GitHub issues --- Use the
+- GitHub issues --- Use the
     <https://github.com/chef/chef-web-docs/issues> in the chef-docs repo
     on GitHub. If you believe the issue may be a product bug within Chef
     itself, consider using <https://github.com/chef/chef/issues> to
     raise the issue.
--   GitHub pull request -- The documentation repository is on GitHub:
+- GitHub pull request -- The documentation repository is on GitHub:
     <https://github.com/chef/chef-web-docs>. We require a DCO sign-off
     to submit pull requests to this repo except for obvious fixes. See
     our [Contributing
@@ -37,7 +37,7 @@ send feedback, choose any of the following four options:
     for more information about our DCO policy. If you have questions
     about the chef-docs repo, send an email to <docs@chef.io> and we're
     happy to assist.
--   <https://discourse.chef.io> --- chef-docs follows the discussions at
+- <https://discourse.chef.io> --- chef-docs follows the discussions at
     <https://discourse.chef.io>. Improvements to the documentation are
     made because of conversations that happen on this mailing list. That
     said, relying solely on the mailing list is the least effective way

--- a/content/install_chef_air_gap.md
+++ b/content/install_chef_air_gap.md
@@ -24,18 +24,18 @@ Since a variety of different practices are used to create an air-gapped
 network, this guide focuses solely on the implementation of Chef
 software - as such, it makes the following assumptions:
 
--   You have a way to get packages to your air-gapped machines
--   Machines on your air-gapped network are able to resolve each other
+- You have a way to get packages to your air-gapped machines
+- Machines on your air-gapped network are able to resolve each other
     via DNS
--   A server's Fully Qualified Domain Name (FQDN) is the name that will
+- A server's Fully Qualified Domain Name (FQDN) is the name that will
     be used by other servers to access it
--   You have a private Ruby gem mirror to supply gems as needed
--   You have an artifact store for file downloads. At a minimum, it
+- You have a private Ruby gem mirror to supply gems as needed
+- You have an artifact store for file downloads. At a minimum, it
     should have the following packages available:
-    -   Chef Workstation
-    -   Chef Infra Client
-    -   Chef Supermarket
-    -   An [install
+    - Chef Workstation
+    - Chef Infra Client
+    - Chef Supermarket
+    - An [install
         script](/install_chef_air_gap/#create-an-install-script) for
         Chef Infra Client
 
@@ -47,19 +47,19 @@ of the cookbooks required to complete the entire guide:
 
 For Chef Supermarket:
 
--   [supermarket-omnibus-cookbook](https://supermarket.chef.io/cookbooks/supermarket-omnibus-cookbook)
--   [chef-ingredient](https://supermarket.chef.io/cookbooks/chef-ingredient)
--   [hostsfile](https://supermarket.chef.io/cookbooks/hostsfile)
+- [supermarket-omnibus-cookbook](https://supermarket.chef.io/cookbooks/supermarket-omnibus-cookbook)
+- [chef-ingredient](https://supermarket.chef.io/cookbooks/chef-ingredient)
+- [hostsfile](https://supermarket.chef.io/cookbooks/hostsfile)
 
 ### Required Gems
 
 The following Ruby gems are required to install private Supermarket via
 the supermarket-omnibus-cookbook:
 
--   mixlib-install
--   mixlib-shellout
--   mixlib-versioning
--   artifactory
+- mixlib-install
+- mixlib-shellout
+- mixlib-versioning
+- artifactory
 
 These should be accessible from your Gem mirror.
 
@@ -247,27 +247,27 @@ In this section, you will use a wrapper around the
 to install private Supermarket. The Supermarket cookbook depends upon
 the following cookbooks:
 
--   [chef-ingredient](https://supermarket.chef.io/cookbooks/chef-ingredient)
--   [hostsfile](https://supermarket.chef.io/cookbooks/hostsfile)
+- [chef-ingredient](https://supermarket.chef.io/cookbooks/chef-ingredient)
+- [hostsfile](https://supermarket.chef.io/cookbooks/hostsfile)
 
 The following Gems must be accessible via your Gem mirror:
 
--   mixlib-install
--   mixlib-shellout
--   mixlib-versioning
--   artifactory
+- mixlib-install
+- mixlib-shellout
+- mixlib-versioning
+- artifactory
 
 Your `cookbooks` directory must have all three of these cookbooks
 installed before you will be able to use the Supermarket cookbook
 wrapper. In addition the necessary cookbooks, a private Chef Supermarket
 has the following requirements:
 
--   An operational Chef Infra Server to act as the OAuth 2.0 provider
--   A user account on the Chef Infra Server with `admins` privileges
--   A key for the user account on the Chef server
--   An x86_64 Ubuntu, RHEL, or Amazon Linux host with at least 1 GB memory
--   System clocks synchronized on the Chef Infra Server and Supermarket hosts
--   Sufficient disk space to meet project cookbook storage capacity or credentials to store cookbooks in an Amazon Simple Storage Service (S3) bucket
+- An operational Chef Infra Server to act as the OAuth 2.0 provider
+- A user account on the Chef Infra Server with `admins` privileges
+- A key for the user account on the Chef server
+- An x86_64 Ubuntu, RHEL, or Amazon Linux host with at least 1 GB memory
+- System clocks synchronized on the Chef Infra Server and Supermarket hosts
+- Sufficient disk space to meet project cookbook storage capacity or credentials to store cookbooks in an Amazon Simple Storage Service (S3) bucket
 
 ### Configure credentials
 
@@ -351,12 +351,12 @@ and then reference them from the recipe. For example, the data bag could
 be named `apps` and then a data bag item within the data bag could be
 named `supermarket`. The following attributes are required:
 
--   `chef_server_url`: the url for your chef server.
--   `chef_oauth2_app_id`: the Chef Identity uid from
+- `chef_server_url`: the url for your chef server.
+- `chef_oauth2_app_id`: the Chef Identity uid from
     `/etc/opscode/oc-id-applications/supermarket.json`
--   `chef_oauth2_secret`: The Chef Identity secret from
+- `chef_oauth2_secret`: The Chef Identity secret from
     `/etc/opscode/oc-id-applications/supermarket.json`
--   `package_url`: The location of the Supermarket package on your
+- `package_url`: The location of the Supermarket package on your
     artifact store
 
 To define these attributes, do the following:
@@ -426,10 +426,10 @@ knife bootstrap ip_address -N supermarket-node -x ubuntu --sudo
 
 where:
 
--   `-N` defines the name of the Chef Supermarket node:
+- `-N` defines the name of the Chef Supermarket node:
     `supermarket-node`
--   `-x` defines the (ssh) user name: `ubuntu`
--   `--sudo` ensures that sudo is used while running commands on the
+- `-x` defines the (ssh) user name: `ubuntu`
+- `--sudo` ensures that sudo is used while running commands on the
     node during the bootstrap operation
 
 When the bootstrap operation is finished, do the following:

--- a/content/install_supermarket.md
+++ b/content/install_supermarket.md
@@ -19,31 +19,31 @@ product = ["client", "server", "workstation"]
 
 A private Chef Supermarket has the following requirements:
 
--   An operational Chef Infra Server (Chef Server version 12.0 or
+- An operational Chef Infra Server (Chef Server version 12.0 or
     higher) to act as the OAuth 2.0 provider
--   A user account on the Chef Infra Server with `admins` privileges
--   A key for the user account on the Chef server
--   An x86_64 compatible Linux host with at least 1 GB memory
--   System clocks synchronized on the Chef Infra Server and Supermarket
+- A user account on the Chef Infra Server with `admins` privileges
+- A key for the user account on the Chef server
+- An x86_64 compatible Linux host with at least 1 GB memory
+- System clocks synchronized on the Chef Infra Server and Supermarket
     hosts
--   Sufficient disk space on host to meet project cookbook storage
+- Sufficient disk space on host to meet project cookbook storage
     capacity **or** credentials to store cookbooks in an Amazon Simple
     Storage Service (S3) bucket
 
 **Considerations with regard to storage capacity:**
 
--   PostgreSQL database size will grow linearly based on the number of
+- PostgreSQL database size will grow linearly based on the number of
     cookbooks and the number of cookbook versions published
--   Redis database size is negligible as it is used only for background
+- Redis database size is negligible as it is used only for background
     job queuing, and to cache a small number of API responses
--   Cookbook storage growth is entirely dependent on the size of the
+- Cookbook storage growth is entirely dependent on the size of the
     cookbooks published. Cookbooks that include binaries or other large
     files will consume more space than code-only cookbooks
--   Opting to run a private Supermarket with off-host PostgreSQL, Redis,
+- Opting to run a private Supermarket with off-host PostgreSQL, Redis,
     and cookbook store is less a decision about storage sizing; it is
     about data service uptime, backup, and restore procedure for your
     organization
--   As a point of reference: as of May 2021 after six years of
+- As a point of reference: as of May 2021 after six years of
     operation, the public Supermarket has approx 83,000 users, 4,000
     cookbooks with a total of 27,000 versions published. The PostgreSQL
     database weighs in at 435 MB, and the S3 bucket containing all of
@@ -131,15 +131,15 @@ To install a private Chef Supermarket use the
 public](https://supermarket.chef.io/cookbooks/supermarket-omnibus-cookbook)
 Chef Supermarket.
 
--   The `supermarket-omnibus-cookbook` cookbook is attribute-driven; use
+- The `supermarket-omnibus-cookbook` cookbook is attribute-driven; use
     a custom cookbook to specify your organization's unique
     `node[supermarket_omnibus]` attribute values.
--   The custom cookbook is a wrapper around
+- The custom cookbook is a wrapper around
     `supermarket-omnibus-cookbook`, which performs the actual
     installation of the Chef Supermarket packages, and then writes the
     custom `node[supermarket_omnibus]` values to
     `/etc/supermarket/supermarket.json`.
--   The Chef Supermarket package itself contains an internal cookbook
+- The Chef Supermarket package itself contains an internal cookbook
     which configures the already-installed package using the attributes
     defined in `/etc/supermarket/supermarket.json`.
 
@@ -227,9 +227,9 @@ and then a data bag item within the data bag could be named
 
 The following attribute values must be defined:
 
--   `chef_server_url`
--   `chef_oauth2_app_id`
--   `chef_oauth2_secret`
+- `chef_server_url`
+- `chef_oauth2_app_id`
+- `chef_oauth2_secret`
 
 Once configured, you can get the `chef_oauth2_app_id` and
 `chef_oauth2_secret` values from your Chef Infra Server within
@@ -339,10 +339,10 @@ knife bootstrap ip_address -N supermarket-node -x ubuntu --sudo
 
 where
 
--   `-N` defines the name of the Chef Supermarket node:
+- `-N` defines the name of the Chef Supermarket node:
     `supermarket-node`
--   `-x` defines the (ssh) user name: `ubuntu`
--   `--sudo` ensures that sudo is used while running commands on the
+- `-x` defines the (ssh) user name: `ubuntu`
+- `--sudo` ensures that sudo is used while running commands on the
     node during the bootstrap operation
 
 When the bootstrap operation is finished, do the following:
@@ -396,13 +396,13 @@ guide.
 2.  Install Supermarket using the appropriate package manager for your
     distribution:
 
-    -   For Ubuntu:
+    - For Ubuntu:
 
         ```bash
         dpkg -i /path/to/package/supermarket*.deb
         ```
 
-    -   For RHEL / CentOS:
+    - For RHEL / CentOS:
 
         ```bash
         rpm -Uvh /path/to/package/supermarket*.rpm
@@ -432,18 +432,18 @@ guide.
 
     Where:
 
-    -   `"chef_server_url"` should contain the FQDN of your Chef Infra
+    - `"chef_server_url"` should contain the FQDN of your Chef Infra
         Server. Note that if you're using a non-standard SSL port, this
         much be appended to the URL. For example:
         `https://chefserver.mycompany.com:65400`
-    -   `"chef_oauth2_app_id"` should contain the `"uid"` value from
+    - `"chef_oauth2_app_id"` should contain the `"uid"` value from
         your OAuth credentials
-    -   `"chef_oauth2_secret"` should contain the `"secret"` value from
+    - `"chef_oauth2_secret"` should contain the `"secret"` value from
         your OAuth credentials
-    -   `chef_oauth2_verify_ssl` is set to false, which is necessary
+    - `chef_oauth2_verify_ssl` is set to false, which is necessary
         when using a self-signed certificate without a properly
         configured certificate authority
-    -   `fqdn` should contain the desired URL that will be used to
+    - `fqdn` should contain the desired URL that will be used to
         access your private Supermarket. If not specified, this default
         to the FQDN of the machine
 
@@ -552,13 +552,13 @@ Encrypted S3 buckets are currently not supported.
 1. Download the [Chef Supermarket](https://downloads.chef.io/) package.
 1. Upgrade your system with the new package using the appropriate package manager for your distribution:
 
-    -   For Ubuntu:
+    - For Ubuntu:
 
         ```bash
         dpkg -i /path/to/package/supermarket*.deb
         ```
 
-    -   For RHEL / CentOS:
+    - For RHEL / CentOS:
 
         ```bash
         rpm -Uvh /path/to/package/supermarket*.rpm

--- a/content/libraries.md
+++ b/content/libraries.md
@@ -16,10 +16,10 @@ aliases = ["/libraries.html"]
 
 Use a library to:
 
--   Connect to a database
--   Fetch secrets from a cloud provider
--   Talk to an LDAP provider
--   Do anything that can be done with Ruby
+- Connect to a database
+- Fetch secrets from a cloud provider
+- Talk to an LDAP provider
+- Do anything that can be done with Ruby
 
 ## Syntax
 

--- a/content/ohai_custom.md
+++ b/content/ohai_custom.md
@@ -58,36 +58,36 @@ end
 
 where
 
--   Required. `(:Name)` is used to identify the plugin; when two plugins
+- Required. `(:Name)` is used to identify the plugin; when two plugins
     have the same `(:Name)`, those plugins are joined together and run
     as if they were a single plugin. This value must be a valid Ruby
     class name, starting with a capital letter and containing only
     alphanumeric characters
--   Required. `provides` is a comma-separated list of one (or more)
+- Required. `provides` is a comma-separated list of one (or more)
     attributes that are defined by this plugin. This attribute will
     become an automatic attribute (i.e. `node['attribute']`) after it is
     collected by Ohai at the start of a Chef Infra Client run. An
     attribute can also be defined using an `attribute/subattribute`
     pattern
--   `depends` is a comma-separated list of one (or more) attributes that
+- `depends` is a comma-separated list of one (or more) attributes that
     are collected by another plugin; as long as the value is collected
     by another Ohai plugin, it can be used by any plugin
--   `shared_method` defines code that can be shared among one (or more)
+- `shared_method` defines code that can be shared among one (or more)
     `collect_data` blocks; for example, instead of defining a mash for
     each `collect_data` block, the code can be defined as a shared
     method, and then called from any `collect_data` block
--   `collect_data` is a block of Ruby code that is called by Ohai when
+- `collect_data` is a block of Ruby code that is called by Ohai when
     it runs; one (or more) `collect_data` blocks can be defined in a
     plugin, but only a single `collect_data` block is ever run.
--   `collect_data(:default)` is the code block that runs when a node's
+- `collect_data(:default)` is the code block that runs when a node's
     platform is not defined by a platform-specific `collect_data` block
--   `collect_data(:platform)` is a platform-specific code block that is
+- `collect_data(:platform)` is a platform-specific code block that is
     run when a match exists between the node's platform and this
     `collect_data` block; only one `collect_data` block may exist for
     each platform; possible values: `:aix`, `:darwin`, `:freebsd`,
     `:linux`, `:openbsd`, `:netbsd`, `:solaris2`, `:windows`, or any
     other value from `RbConfig::CONFIG['host_os']`
--   `my_data` is string (`a string value`) or an empty mash
+- `my_data` is string (`a string value`) or an empty mash
     (`{ :setting_a => 'value_a', :setting_b => 'value_b' }`). This is
     used to define the data that should be collected by the plugin
 
@@ -149,10 +149,10 @@ Ohai.plugin(:Cloud) do
 
 where
 
--   `provides` defines the `cloud` attribute, which is then turned into
+- `provides` defines the `cloud` attribute, which is then turned into
     an object using the `create_objects` shared method, which then
     generates a hash based on public or private IP addresses
--   if the cloud provider is Google Compute Engine, then based on the IP
+- if the cloud provider is Google Compute Engine, then based on the IP
     address for the node, the `cloud` attribute data is populated into a
     hash
 
@@ -177,10 +177,10 @@ plugin, but only a single `collect_data` block is ever run. The
 the node is running, which is then matched up against the available
 `collect_data` blocks in the plugin.
 
--   A `collect_data(:default)` block is used when Ohai is not able to
+- A `collect_data(:default)` block is used when Ohai is not able to
     match the platform of the node with a `collect_data(:platform)`
     block in the plugin
--   A `collect_data(:platform)` block is required for each platform that
+- A `collect_data(:platform)` block is required for each platform that
     requires non-default behavior
 
 When Ohai runs, if there isn't a matching `collect_data` block for a
@@ -203,8 +203,8 @@ end
 
 where:
 
--   `:default` is the name of the default `collect_data` block
--   `:platform` is the name of a platform, such as `:aix` for AIX or
+- `:default` is the name of the default `collect_data` block
+- `:platform` is the name of a platform, such as `:aix` for AIX or
     `:windows` for Microsoft Windows
 
 #### Use a Mash
@@ -469,8 +469,8 @@ Ohai::Log.log_type('message')
 
 where
 
--   `log_type` can be `.debug`, `.info`, `.warn`, `.error`, or `.fatal`
--   `'message'` is the message that is logged.
+- `log_type` can be `.debug`, `.info`, `.warn`, `.error`, or `.fatal`
+- `'message'` is the message that is logged.
 
 For example:
 

--- a/content/packages.md
+++ b/content/packages.md
@@ -48,8 +48,8 @@ products on production systems.
 The `stable` and `current` release channels support the following
 package repositories:
 
--   Apt (Debian and Ubuntu platforms)
--   Yum (Enterprise Linux platforms)
+- Apt (Debian and Ubuntu platforms)
+- Yum (Enterprise Linux platforms)
 
 Chef Software Inc. GPG public key can be downloaded
 [here](https://packages.chef.io/chef.asc).
@@ -80,10 +80,10 @@ To set up an Apt package repository for Debian and Ubuntu platforms:
 
     Replace `<DISTRIBUTION>` with the appropriate distribution name:
 
-    -   For Debian 9: `stretch`
-    -   For Debian 10: `buster`
-    -   For Ubuntu 18.04: `bionic`
-    -   For Ubuntu 20.04: `focal`
+    - For Debian 9: `stretch`
+    - For Debian 10: `buster`
+    - For Ubuntu 18.04: `bionic`
+    - For Ubuntu 20.04: `focal`
 
 4.  Update the package repository list:
 

--- a/content/plugin_knife.md
+++ b/content/plugin_knife.md
@@ -15,9 +15,9 @@ product = ["client", "server", "workstation"]
 
 {{% plugin_knife_summary %}}
 
--   The same [common options](/workstation/knife_options/) used by knife
+- The same [common options](/workstation/knife_options/) used by knife
     subcommands can also be used by knife plug-ins
--   A knife plugin can make authenticated API requests to the Chef
+- A knife plugin can make authenticated API requests to the Chef
     server
 
 The following knife plug-ins are maintained by Chef:

--- a/content/plugin_knife_custom.md
+++ b/content/plugin_knife_custom.md
@@ -18,9 +18,9 @@ product = ["client", "server", "workstation"]
 The Chef Infra Client will load knife plugins from the following
 locations:
 
--   The home directory: `~/.chef/plugins/knife/`
--   A `.chef/plugins/knife` directory in the cookbook repository
--   A plugin installed from RubyGems. (For more information about
+- The home directory: `~/.chef/plugins/knife/`
+- A `.chef/plugins/knife` directory in the cookbook repository
+- A plugin installed from RubyGems. (For more information about
     releasing a plugin on RubyGems, see:
     <http://guides.rubygems.org/make-your-own-gem/>.)
 
@@ -64,34 +64,34 @@ end
 
 where:
 
--   `require` identifies any other knife subcommands and/or knife
+- `require` identifies any other knife subcommands and/or knife
     plugins required by this plugin
--   `module ModuleName` declares the knife plugin as its own namespace
--   `class SubclassName < Chef::Knife` declares the plugin as a subclass
+- `module ModuleName` declares the knife plugin as its own namespace
+- `class SubclassName < Chef::Knife` declares the plugin as a subclass
     of `Knife`, which is in the `Chef` namespace. The capitalization of
     this name is important. For example, `SubclassName` would have a
     knife command of `knife subclass name`, whereas `Subclassname` would
     have a knife command of `knife subclassname`
--   `deps do` is a list of dependencies
--   `banner "knife subcommand argument VALUE (options)"` is displayed
+- `deps do` is a list of dependencies
+- `banner "knife subcommand argument VALUE (options)"` is displayed
     when a user enters `knife subclassName --help`
--   `option :name_of_option` defines each of the command-line options
+- `option :name_of_option` defines each of the command-line options
     that are available for this plugin. For example,
     `knife subclass -l VALUE` or
     `knife subclass --long-option-name VALUE`
--   `def run` is the Ruby code that is executed when the command is run
+- `def run` is the Ruby code that is executed when the command is run
 
 and where for each command-line option:
 
--   `:short` defines the short option name
--   `:long` defines the long option name
--   `:description` defines a description that is displayed when a user
+- `:short` defines the short option name
+- `:long` defines the long option name
+- `:description` defines a description that is displayed when a user
     enters `knife subclassName --help`
--   `:boolean` defines whether the option is `true` or `false`; if the
+- `:boolean` defines whether the option is `true` or `false`; if the
     `:short` and `:long` names define a `VALUE`, then this attribute
     must not be used
--   `:proc` defines code that determines the value for this option
--   `:default` defines a default value
+- `:proc` defines code that determines the value for this option
+- `:default` defines a default value
 
 The following example shows part of a knife plugin named
 `knife windows`:
@@ -426,12 +426,12 @@ end
 
 where
 
--   `unless name_args.size == 1` is used to check the number of
+- `unless name_args.size == 1` is used to check the number of
     arguments given; the command should fail if the input does not make
     sense
--   `who = name_args.first` is used to access arguments using
+- `who = name_args.first` is used to access arguments using
     `name_args`
--   `show_usage` is used to display the correct usage before exiting (if
+- `show_usage` is used to display the correct usage before exiting (if
     the command fails)
 
 For example, the following command:
@@ -476,9 +476,9 @@ OMG HELLO CHEFS!!!1!!11
 Certain settings defined by a knife plugin can be configured so that
 they can be set using the config.rb file. This can be done in two ways:
 
--   By using the `:proc` attribute of the `option` method and code that
+- By using the `:proc` attribute of the `option` method and code that
     references `Chef::Config[:knife][:setting_name]`
--   By specifying the configuration setting directly within the `def`
+- By specifying the configuration setting directly within the `def`
     Ruby blocks using either `Chef::Config[:knife][:setting_name]` or
     `config[:setting_name]`
 
@@ -533,13 +533,13 @@ end
 
 where
 
--   `ssh = Chef::Knife::Ssh.new` creates a new instance of the `Ssh`
+- `ssh = Chef::Knife::Ssh.new` creates a new instance of the `Ssh`
     subclass named `ssh`
--   A series of settings in `knife ssh` are associated with
+- A series of settings in `knife ssh` are associated with
     `knife bootstrap` using the `ssh.config[:setting_name]` syntax
--   `Chef::Config[:knife][:setting_name]` tells knife to check the
+- `Chef::Config[:knife][:setting_name]` tells knife to check the
     config.rb file for various settings
--   Raises an exception if any aspect of the SSH operation fails
+- Raises an exception if any aspect of the SSH operation fails
 
 ### Search
 
@@ -787,8 +787,8 @@ program.
 
 To install a knife plugin from a file, do one of the following:
 
--   Copy the file to the `~/.chef/plugins/knife` directory; the file's
+- Copy the file to the `~/.chef/plugins/knife` directory; the file's
     extension must be `.rb`
--   Add the file to the chef-repo at the
+- Add the file to the chef-repo at the
     `CHEF_REPO/.chef/plugins/knife`; the file's extension must be `.rb`
--   Install the plugin from RubyGems
+- Install the plugin from RubyGems

--- a/content/proxies.md
+++ b/content/proxies.md
@@ -181,12 +181,12 @@ to be specified explicitly (i.e. "without wildcards").
 Consider the following for situations where environment variables are
 used to set the proxy:
 
--   Proxy settings may not be honored by all applications. For example,
+- Proxy settings may not be honored by all applications. For example,
     proxy settings may be ignored by the underlying application when
     specifying a `ftp` source with a `remote_file` resource. Consider a
     workaround. For example, in this situation try doing a `wget` with
     an `ftp` URL instead.
--   Proxy settings may be honored inconsistently by applications. For
+- Proxy settings may be honored inconsistently by applications. For
     example, the behavior of the `no_proxy` setting may not work with
     certain applications when wildcards are specified. Consider
     specifying the hostnames without using wildcards.

--- a/content/quick_start.md
+++ b/content/quick_start.md
@@ -47,19 +47,19 @@ This will create a file named `test.txt` at the home path on your
 machine. Open that file and it will say
 `This file was created by Chef Infra!`.
 
--   Delete the file, run Chef Infra Client again, and Chef Infra will
+- Delete the file, run Chef Infra Client again, and Chef Infra will
     put the file back.
--   Change the string in the file, run Chef Infra Client again, and Chef
+- Change the string in the file, run Chef Infra Client again, and Chef
     Infra will make the string in the file the same as the string in the
     recipe.
--   Change the string in the recipe, run Chef Infra Client again, and
+- Change the string in the recipe, run Chef Infra Client again, and
     Chef Infra will update that string to be the same as the one in the
     recipe.
 
 There's a lot more that Chef Infra can do, obviously, but that was super
 easy!
 
--   See <https://learn.chef.io/> for more detailed setup scenarios.
--   Keep reading for more information about setting up a workstation,
+- See <https://learn.chef.io/> for more detailed setup scenarios.
+- Keep reading for more information about setting up a workstation,
     configuring Test Kitchen to run virtual environments, setting up a
     more detailed cookbook, resources, and more.

--- a/content/recipes.md
+++ b/content/recipes.md
@@ -352,12 +352,12 @@ Sometimes it may be necessary to stop processing a recipe and/or stop
 processing the entire Chef Infra Client run. There are a few ways to do
 this:
 
--   Use the `return` keyword to stop processing a recipe based on a
+- Use the `return` keyword to stop processing a recipe based on a
     condition, but continue processing a Chef Infra Client run
--   Use the `raise` keyword to stop a Chef Infra Client run by
+- Use the `raise` keyword to stop a Chef Infra Client run by
     triggering an unhandled exception
--   Use a `rescue` block in Ruby code
--   Use an [exception handler](/handlers/)
+- Use a `rescue` block in Ruby code
+- Use an [exception handler](/handlers/)
 
 The following sections show various approaches to ending a Chef Infra
 Client run.
@@ -507,14 +507,14 @@ end
 
 where:
 
--   The **ruby_block** resource declares a `block` of Ruby code that is
+- The **ruby_block** resource declares a `block` of Ruby code that is
     run during the execution phase of a Chef Infra Client run
--   The `if` statement randomly chooses PHP or Perl, saving the choice
+- The `if` statement randomly chooses PHP or Perl, saving the choice
     to `node.run_state['scripting_language']`
--   When the **package** resource has to install the package for the
+- When the **package** resource has to install the package for the
     scripting language, it looks up the scripting language and uses the
     one defined in `node.run_state['scripting_language']`
--   `lazy {}` ensures that the **package** resource evaluates this
+- `lazy {}` ensures that the **package** resource evaluates this
     during the execution phase of a Chef Infra Client run (as opposed to
     during the compile phase)
 

--- a/content/release_notes_chefdk.md
+++ b/content/release_notes_chefdk.md
@@ -727,22 +727,22 @@ Chef InSpec has been updated from 4.17.17 to 4.18.38. This release
 includes a large number of bug fixes in addition to some great resource
 enhancements:
 
--   Inputs can now be used within a `describe.one` block
--   The `service` resource now includes a `startname` property for
+- Inputs can now be used within a `describe.one` block
+- The `service` resource now includes a `startname` property for
     Windows and systemd services
--   The `interface` resource now includes a `name` property
--   The `user` resource now better supports Windows with the addition of
+- The `interface` resource now includes a `name` property
+- The `user` resource now better supports Windows with the addition of
     `passwordage`, `maxbadpasswords`, and `badpasswordattempts`
     properties
--   The nginx resource now includes parsing support for wildcard, dot
+- The nginx resource now includes parsing support for wildcard, dot
     prefix, and regex
--   The `iis_app_pool` resource now handles empty app pools
--   The `filesystem` resource now supports devices with very long names
--   The `apt` resource better handles URIs and supports repos with an
+- The `iis_app_pool` resource now handles empty app pools
+- The `filesystem` resource now supports devices with very long names
+- The `apt` resource better handles URIs and supports repos with an
     arch
--   The `oracledb_session` resource has received multiple fixes to make
+- The `oracledb_session` resource has received multiple fixes to make
     it work better
--   The `npm` resource now works under sudo on Unix and on Windows with
+- The `npm` resource now works under sudo on Unix and on Windows with
     a custom PATH
 
 #### Test Kitchen
@@ -785,9 +785,9 @@ releases.
 libxlst was updated from 1.1.30 to 1.1.34 to resolve these
 vulnerabilities:
 
-> -   [CVE-2019-11068](https://www.cvedetails.com/cve/CVE-2019-11068/)
-> -   [CVE-2019-13117](https://www.cvedetails.com/cve/CVE-2019-13117/)
-> -   [CVE-2019-13118](https://www.cvedetails.com/cve/CVE-2019-13118/)
+> - [CVE-2019-11068](https://www.cvedetails.com/cve/CVE-2019-11068/)
+> - [CVE-2019-13117](https://www.cvedetails.com/cve/CVE-2019-13117/)
+> - [CVE-2019-13118](https://www.cvedetails.com/cve/CVE-2019-13118/)
 
 ## What's New in 4.5
 
@@ -814,12 +814,12 @@ changes:
 
 **New Features**
 
--   We have released our beta Chef InSpec plug-in for HashiCorp Vault.
+- We have released our beta Chef InSpec plug-in for HashiCorp Vault.
     Check it out in our [inspec-vault GitHub
     repo](https://github.com/inspec/inspec-vault) and let us know what
     you think -- or better yet, start jumping in and contributing with
     us on it.
--   Waivers, our new beta feature, was added to InSpec! Waivers allows
+- Waivers, our new beta feature, was added to InSpec! Waivers allows
     you to better manage compliance failures. We would love to hear your
     feedback on this! See the [InSpec Waivers
     documentation](/inspec/waivers/) for
@@ -827,17 +827,17 @@ changes:
 
 **Improvements**
 
--   The `interface` resource now has a name property.
--   Expanded `user` resource to include the passwordage,
+- The `interface` resource now has a name property.
+- Expanded `user` resource to include the passwordage,
     maxbadpasswords, and badpasswordattempts properties with Windows.
--   The `sys_info` resource now supports ip_address, fqdn, domain, and
+- The `sys_info` resource now supports ip_address, fqdn, domain, and
     short options when giving a version of the hostname.
--   Sped up initial load/response time for all commands by removing
+- Sped up initial load/response time for all commands by removing
     pre-leading of resources on invocation of inspec.
--   If an error occurs when using the `json` resource with a command
+- If an error occurs when using the `json` resource with a command
     source, you will now get the error message from STDERR returned in
     the report.
--   We improved the formatting of the usage help, so what you see when
+- We improved the formatting of the usage help, so what you see when
     you type `inspec exec --help` should look better!
 
 #### Cookstyle
@@ -865,13 +865,13 @@ determining the state of instances.
 Ruby has been updated from 2.6.4 to 2.6.5 in order to resolve the
 following CVEs:
 
--   [CVE-2019-16255](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16255):
+- [CVE-2019-16255](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16255):
     A code injection vulnerability of Shell\#\[\] and Shell\#test
--   [CVE-2019-16254](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16254):
+- [CVE-2019-16254](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16254):
     HTTP response splitting in WEBrick (Additional fix)
--   [CVE-2019-15845](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15845):
+- [CVE-2019-15845](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15845):
     A NUL injection vulnerability of File.fnmatch and File.fnmatch?
--   [CVE-2019-16201](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16201):
+- [CVE-2019-16201](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16201):
     Regular Expression Denial of Service vulnerability of WEBrick's
     Digest access authentication
 
@@ -892,14 +892,14 @@ for a complete list of the new and improved functionality.
 Chef InSpec has been updated from 4.10.4 to 4.16.0 with the following
 changes:
 
--   A new `postfix_conf` has been added for inspecting Postfix
+- A new `postfix_conf` has been added for inspecting Postfix
     configuration files.
--   A new `plugins` section has been added to the InSpec configuration
+- A new `plugins` section has been added to the InSpec configuration
     file which can be used to pass secrets or other configurations
     into Chef InSpec plugins.
--   The `service` resource now includes a new `startname` property for
+- The `service` resource now includes a new `startname` property for
     determining which user is starting the Windows services.
--   The `groups` resource now properly gathers membership information
+- The `groups` resource now properly gathers membership information
     on macOS hosts.
 
 See the [Chef InSpec 4.16.0 Release
@@ -914,15 +914,15 @@ departments. The new departments make it easier to search for specific
 cops, and to enable and disable groups of cops. Instead of just "Chef",
 we now have the following departments:
 
--   `ChefDeprecations`: Cops that detect, and in many cases correct,
+- `ChefDeprecations`: Cops that detect, and in many cases correct,
     deprecations that will prevent cookbooks from running on modern
     versions of Chef Infra Client.
--   `ChefStyle`: Cops that will help you improve the format and
+- `ChefStyle`: Cops that will help you improve the format and
     readability of your cookbooks.
--   `ChefModernize`: Cops that will help you modernize your cookbooks
+- `ChefModernize`: Cops that will help you modernize your cookbooks
     by including features introduced in new releases of Chef Infra
     Client.
--   `ChefEffortless`: Cops that will help you migrate your cookbooks
+- `ChefEffortless`: Cops that will help you migrate your cookbooks
     to the Effortless pattern. These are disabled by default.
 
 You can run cookstyle with just a single department:
@@ -973,16 +973,16 @@ match InSpec 4. The old names are still supported, but issue a warning.
 `knife-ec2` has been updated from 1.0.12 to 1.0.16. This resolves the
 following issues:
 
--   Fix argument error for --platform option
+- Fix argument error for --platform option
     [\#609](https://github.com/chef/knife-ec2/pull/609)
     ([dheerajd-msys](https://github.com/dheerajd-msys))
--   Fix for Generate temporary keypair when none is supplied
+- Fix for Generate temporary keypair when none is supplied
     [\#608](https://github.com/chef/knife-ec2/pull/608)
     ([kapilchouhan99](https://github.com/kapilchouhan99))
--   Color code fixes in json format output of knife ec2 server list
+- Color code fixes in json format output of knife ec2 server list
     [\#606](https://github.com/chef/knife-ec2/pull/606)
     ([dheerajd-msys](https://github.com/dheerajd-msys))
--   Allow instances to be provisioned with source/dest checks disabled
+- Allow instances to be provisioned with source/dest checks disabled
     [\#605](https://github.com/chef/knife-ec2/pull/605)
     ([kapilchouhan99](https://github.com/kapilchouhan99))
 
@@ -991,9 +991,9 @@ following issues:
 Test Kitchen has been updated from 2.2.5 to 2.3.2 with the following
 changes:
 
--   Add `keepalive_maxcount` setting for better control of ssh
+- Add `keepalive_maxcount` setting for better control of ssh
     connection timeouts.
--   Add `lifecycle_hooks` information to `kitchen diagnose` output.
+- Add `lifecycle_hooks` information to `kitchen diagnose` output.
 
 #### knife-google
 
@@ -1024,9 +1024,9 @@ Git has been updated from 2.20.0 to 2.23.0 on Windows and from 2.14.1 to
 2.23.0 on non-Windows systems. This brings the latest git workflows to
 our users who do not have it installed another way and fixes two CVEs:
 
--   non-Windows systems:
+- non-Windows systems:
     [CVE-2017-14867](https://www.cvedetails.com/cve/CVE-2017-14867/)
--   Windows systems:
+- Windows systems:
     [CVE-2019-1211](https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2019-1211)
 
 #### Nokogiri
@@ -1070,12 +1070,12 @@ for a complete list of new and improved functionality.
 Chef InSpec has been updated from 4.7.3 to 4.10.4 with the following
 changes:
 
--   Fixed handling multiple triggers in the `windows_task` resource
--   Fixed exceptions when resources are used with incompatible
+- Fixed handling multiple triggers in the `windows_task` resource
+- Fixed exceptions when resources are used with incompatible
     transports
--   Un-deprecated the `be_running` matcher on the `service` resource
--   Added `sys_info.manufacturer` and `sys_info.model` resources
--   Added `ip6tables` resource
+- Un-deprecated the `be_running` matcher on the `service` resource
+- Added `sys_info.manufacturer` and `sys_info.model` resources
+- Added `ip6tables` resource
 
 #### Cookstyle
 
@@ -1103,12 +1103,12 @@ for more information on this new feature.
 kitchen-ec2 has been updated from 3.0.1 to 3.1.0 with several new
 features:
 
--   Added support for SSH through Session Manager. Thanks
+- Added support for SSH through Session Manager. Thanks
     [@awiddersheim](https://github.com/awiddersheim)
--   Adds support for searching for multiple security groups, as well as
+- Adds support for searching for multiple security groups, as well as
     searching by group name. Thanks
     [@bdwyertech](https://github.com/bdwyertech)
--   Allows asking for multiple instance types and subnets for spot
+- Allows asking for multiple instance types and subnets for spot
     pricing. Thanks
     [@vmiszczak-teads](https://github.com/vmiszczak-teads)
 
@@ -1147,10 +1147,10 @@ for more information on when Chef ends support for an OS release.
 
 ### Bug Fixes
 
--   Rubygems has been rolled back to 3.0.3 to resolve duplicate bundler
+- Rubygems has been rolled back to 3.0.3 to resolve duplicate bundler
     gems that shipped in ChefDK 4.1.7. This resulted in warning messages
     when running commands as well as performance degradations.
--   Fixed 'chef install foo.lock.json' errors when loading cookbooks
+- Fixed 'chef install foo.lock.json' errors when loading cookbooks
     from Artifactory.
 
 ### Updated Components
@@ -1171,12 +1171,12 @@ occurred when running some commands.
 Fauxhai has been updated to 7.4.0, which adds additional platforms for
 use with ChefSpec testing.
 
--   Updated <span class="title-ref">suse</span> 15 from 15.0 to 15.1
--   Added a new <span class="title-ref">redhat</span> 8 definition to
+- Updated <span class="title-ref">suse</span> 15 from 15.0 to 15.1
+- Added a new <span class="title-ref">redhat</span> 8 definition to
     replace the 8.0 definition, which is now deprecated
--   Updated all <span class="title-ref">amazon</span> and <span
+- Updated all <span class="title-ref">amazon</span> and <span
     class="title-ref">ubuntu</span> releases to Chef 15.1
--   Added <span class="title-ref">debian</span> 10 and 9.9
+- Added <span class="title-ref">debian</span> 10 and 9.9
 
 #### Chef InSpec 4.7.3
 
@@ -1202,16 +1202,16 @@ for a complete list of new and improved functionality.
 Chef InSpec has been updated from 4.3.2 to 4.6.9 with the following
 changes:
 
--   InSpec `Attributes` have now been renamed to `Inputs` to avoid
+- InSpec `Attributes` have now been renamed to `Inputs` to avoid
     confusion with Chef Infra attributes.
--   A new InSpec plugin type of `Input` has been added for defining new
+- A new InSpec plugin type of `Input` has been added for defining new
     input types. See the [InSpec Plugins
     documentation](https://github.com/inspec/inspec/blob/master/docs/dev/plugins.md#implementing-input-plugins)
     for more information on writing these plugins.
--   InSpec no longer prints errors to the stdout when passing
+- InSpec no longer prints errors to the stdout when passing
     `--format json`.
--   When fetching profiles from GitHub, the URL can now include periods.
--   The performance of InSpec startup has been improved.
+- When fetching profiles from GitHub, the URL can now include periods.
+- The performance of InSpec startup has been improved.
 
 #### Cookstyle 5.0.0
 
@@ -1238,13 +1238,13 @@ Foodcritic 16.1.1
 Foodcritic has been updated from 16.0.0 to 16.1.1 with new rules and
 support for the latest Chef:
 
--   Updated Chef Infra Client metadata for 15.1 to include the new
+- Updated Chef Infra Client metadata for 15.1 to include the new
     `chocolatey_feature` resources, as well as new properties in the
     `launchd` and `chocolatey_source` resources
--   Added new rule to detect large files shipped in a cookbook:
+- Added new rule to detect large files shipped in a cookbook:
     `FC123: Content of a cookbook file is larger than 1MB`. Thanks
     [@mattray](http://github.com/mattray)
--   Allowed configuring the size of the AST cache with a new
+- Allowed configuring the size of the AST cache with a new
     `--ast-cache-size` command line option. Thanks
     [@Babar](http://github.com/Babar)
 
@@ -1362,12 +1362,12 @@ highly recommend upgrading your host to Ubuntu 16.04 or 18.04.
 
 #### curl 7.65.1
 
--   CVE-2019-5435: Integer overflows in curl_url_set
--   CVE-2019-5436: tftp: use the current blksize for recvfrom()
--   CVE-2018-16890: NTLM type-2 out-of-bounds buffer read
--   CVE-2019-3822: NTLMv2 type-3 header stack buffer overflow
--   CVE-2019-3823: SMTP end-of-response out-of-bounds read
--   CVE-2019-5443: Windows OpenSSL engine code injection
+- CVE-2019-5435: Integer overflows in curl_url_set
+- CVE-2019-5436: tftp: use the current blksize for recvfrom()
+- CVE-2018-16890: NTLM type-2 out-of-bounds buffer read
+- CVE-2019-3822: NTLMv2 type-3 header stack buffer overflow
+- CVE-2019-3823: SMTP end-of-response out-of-bounds read
+- CVE-2019-5443: Windows OpenSSL engine code injection
 
 #### cacerts 5-11-2019
 
@@ -1409,9 +1409,9 @@ bootstrap library.
 
 Affected gems:
 
--   `knife-ec2`
--   `knife-google`
--   `knife-vsphere`
+- `knife-ec2`
+- `knife-google`
+- `knife-vsphere`
 
 If you leverage this functionality, please wait to update ChefDK until
 4.1 is released with fixes for these gems.
@@ -1421,33 +1421,33 @@ If you leverage this functionality, please wait to update ChefDK until
 The `chef generate` command has been updated to produce cookbooks and
 repositories that match Chef's best practices.
 
--   `chef generate repo` now generates a Chef repository with
+- `chef generate repo` now generates a Chef repository with
     Policyfiles by default. You can revert to the previous roles /
     environment behavior with the `--roles` flag.
--   `chef generate cookbook` now generates a cookbook with a
+- `chef generate cookbook` now generates a cookbook with a
     Policyfile and no Berksfile by default. You can revert to the
     previous behavior with the `--berks` flag.
--   `chef generate cookbook` now includes ChefSpecs that utilize the
+- `chef generate cookbook` now includes ChefSpecs that utilize the
     ChefSpec 7.3+ format. This is a much simpler syntax that requires
     less updating of specs as older platforms are deprecated.
--   `chef generate cookbook` no longer creates cookbook files with the
+- `chef generate cookbook` no longer creates cookbook files with the
     unnecessary `frozen_string_literal: true` comments.
--   `chef generate cookbook` no longer generates a full Workflow
+- `chef generate cookbook` no longer generates a full Workflow
     (Delivery) build cookbook by default. A new `--workflow` flag has
     been added to allow generating the build cookbook. This flag
     replaces the previously unused `--delivery` flag.
--   `chef generate cookbook` now generates cookbooks with metadata
+- `chef generate cookbook` now generates cookbooks with metadata
     requiring Chef 14 or later.
--   `chef generate cookbook --kitchen dokken` now generates a fully
+- `chef generate cookbook --kitchen dokken` now generates a fully
     working kitchen-dokken config.
--   `chef generate cookbook` now generates Test Kitchen configs with
+- `chef generate cookbook` now generates Test Kitchen configs with
     the `product_name`/`product_version` method of specifying Chef
     Infra Client releases as `require_chef_omnibus` will be removed in
     the next major Test Kitchen release.
--   `chef generate cookbook_file` no longer places the specified file
+- `chef generate cookbook_file` no longer places the specified file
     in a "default" folder as these aren't needed in Chef Infra Client
     12 and later.
--   `chef generate repo` no longer outputs the full Chef Infra Client
+- `chef generate repo` no longer outputs the full Chef Infra Client
     run information while generating the repository. Similar to the
     <spancommand class="title-ref">cookbook</spancommand you can view this
     verbose output with the `--verbose` flag.
@@ -1479,11 +1479,11 @@ platforms](https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md).
 This release also adds the following new platform releases for testing
 in ChefSpec:
 
--   RHEL 6.10 and 8.0
--   openSUSE 15.0
--   CentOS 6.10
--   Debian 9.8 / 9.9
--   Oracle Linux 6.10, 7.5, and 7.6
+- RHEL 6.10 and 8.0
+- openSUSE 15.0
+- CentOS 6.10
+- Debian 9.8 / 9.9
+- Oracle Linux 6.10, 7.5, and 7.6
 
 #### Test Kitchen 2.2
 
@@ -1538,13 +1538,13 @@ update existing keys to sparse-mode by running
 kitchen-azurerm has been updated from 0.14.9 to 0.15.1 with the
 following improvements:
 
--   Enable the WinRM HTTP listener by default. Thanks
+- Enable the WinRM HTTP listener by default. Thanks
     [@sean-nixon](https//github.com/sean-nixon)
--   Allow overriding of the `subscription_id` by setting the
+- Allow overriding of the `subscription_id` by setting the
     `AZURE_SUBSCRIPTION_ID` ENV variable.
--   Add a new `nic_name` config. Thanks
+- Add a new `nic_name` config. Thanks
     [@libertymutual](https//github.com/libertymutual)
--   Support for creating VM with Azure KeyVault certificate. Thanks
+- Support for creating VM with Azure KeyVault certificate. Thanks
     [@javgallegos](https//github.com/javgallegos)
 
 #### kitchen-dokken
@@ -1593,15 +1593,15 @@ OpenSSL has been updated to 1.0.2u to resolve
 The embedded git client has been updated to 2.24.1 to resolve the
 following CVEs:
 
--   [CVE-2019-1348](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1348)
--   [CVE-2019-1349](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1349)
--   [CVE-2019-1350](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1350)
--   [CVE-2019-1351](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1351)
--   [CVE-2019-1352](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1352)
--   [CVE-2019-1353](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1353)
--   [CVE-2019-1354](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1354)
--   [CVE-2019-1387](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1387)
--   [CVE-2019-19604](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19604)
+- [CVE-2019-1348](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1348)
+- [CVE-2019-1349](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1349)
+- [CVE-2019-1350](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1350)
+- [CVE-2019-1351](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1351)
+- [CVE-2019-1352](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1352)
+- [CVE-2019-1353](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1353)
+- [CVE-2019-1354](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1354)
+- [CVE-2019-1387](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1387)
+- [CVE-2019-19604](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19604)
 
 ## What's New in 3.12.10
 
@@ -1612,10 +1612,10 @@ following CVEs:
 Chef Infra Client has been updated to 14.14.29 with the following bug
 fixes:
 
--   Fixed an error with the `service` and `systemd_unit` resources which
+- Fixed an error with the `service` and `systemd_unit` resources which
     would try to re-enable services with an indirect status.
--   The `systemd_unit` resource now logs at the info level.
--   Fixed knife config when it returned a
+- The `systemd_unit` resource now logs at the info level.
+- Fixed knife config when it returned a
     `TypeError: no implicit conversion of nil into String` error.
 
 #### kitchen-digitalocean 0.10.4
@@ -1642,13 +1642,13 @@ libxslt has been updated to 1.1.34 to resolve
 Ruby has been updated from 2.5.6 to 2.5.7 in order to resolve the
 following CVEs:
 
--   [CVE-2019-16255](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16255):
+- [CVE-2019-16255](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16255):
     A code injection vulnerability of Shell\#\[\] and Shell\#test
--   [CVE-2019-16254](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16254):
+- [CVE-2019-16254](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16254):
     HTTP response splitting in WEBrick (Additional fix)
--   [CVE-2019-15845](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15845):
+- [CVE-2019-15845](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15845):
     A NUL injection vulnerability of File.fnmatch and File.fnmatch?
--   [CVE-2019-16201](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16201):
+- [CVE-2019-16201](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16201):
     Regular Expression Denial of Service vulnerability of WEBrick's
     Digest access authentication
 
@@ -1659,25 +1659,25 @@ following CVEs:
 Many of the non-breaking updates to the `chef generate` command that
 shipped in ChefDK 4 have been backported to ChefDK 3.
 
--   `chef generate cookbook` now includes ChefSpecs that utilize the
+- `chef generate cookbook` now includes ChefSpecs that utilize the
     ChefSpec 7.3+ format. This is a much simpler syntax that requires
     less updating of specs as older platforms are deprecated.
--   `chef generate cookbook` now generates Test Kitchen configs with
+- `chef generate cookbook` now generates Test Kitchen configs with
     Ubuntu 18.04
--   `chef generate cookbook` now generates non-hidden Test Kitchen
+- `chef generate cookbook` now generates non-hidden Test Kitchen
     configs (kitchen.yml instead of .kitchen.yml)
--   `chef generate cookbook --kitchen dokken` now generates a fully
+- `chef generate cookbook --kitchen dokken` now generates a fully
     working kitchen-dokken config.
--   `chef generate cookbook` no longer creates cookbook files with the
+- `chef generate cookbook` no longer creates cookbook files with the
     unnecessary `frozen_string_literal: true` comments.
--   `chef generate cookbook` now generates Test Kitchen configs with the
+- `chef generate cookbook` now generates Test Kitchen configs with the
     `product_name`/`product_version` method of specifying Chef Infra
     Client releases as `require_chef_omnibus` will be removed in the
     next major Test Kitchen release.
--   `chef generate cookbook_file` no longer places the specified file in
+- `chef generate cookbook_file` no longer places the specified file in
     a `default` folder as these aren't needed in Chef Infra Client 12
     and later.
--   `chef generate cookbook` now generates cookbooks with updated
+- `chef generate cookbook` now generates cookbooks with updated
     `.gitignore` and `chefignore` files
 
 ### Updated Components
@@ -1778,13 +1778,13 @@ for more information on when Chef ends support for an OS release.
 Ruby has been updated from 2.5.5 to 2.5.6 in order to resolve the
 following CVEs:
 
--   [CVE-2019-16255](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16255):
+- [CVE-2019-16255](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16255):
     A code injection vulnerability of Shell\#\[\] and Shell\#test
--   [CVE-2019-16254](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16254):
+- [CVE-2019-16254](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16254):
     HTTP response splitting in WEBrick (Additional fix)
--   [CVE-2019-15845](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15845):
+- [CVE-2019-15845](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15845):
     A NUL injection vulnerability of File.fnmatch and File.fnmatch?
--   [CVE-2019-16201](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16201):
+- [CVE-2019-16201](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16201):
     Regular Expression Denial of Service vulnerability of WEBrick's
     Digest access authentication
 
@@ -1793,9 +1793,9 @@ following CVEs:
 OpenSSL has been updated from 1.0.2r to 1.0.2t to resolve the following
 CVEs:
 
--   [CVE-2019-1563](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1563)
--   [CVE-2019-1547](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547)
--   [CVE-2019-1552](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1552)
+- [CVE-2019-1563](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1563)
+- [CVE-2019-1547](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547)
+- [CVE-2019-1552](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1552)
 
 #### Nokogiri
 
@@ -1818,32 +1818,32 @@ for a detailed list of changes.
 Test Kitchen has been updated to 1.25 with backports of many
 non-breaking Test Kitchen 2.0 features:
 
--   Support for accepting the Chef 15 license in Test Kitchen runs. See
+- Support for accepting the Chef 15 license in Test Kitchen runs. See
     [Accepting the Chef
     License](/chef_license_accept/) for usage
     details.
--   A new `--fail-fast` command line flag for use with the <span
+- A new `--fail-fast` command line flag for use with the <span
     class="title-ref">concurrency</span> flag. With this flag set, Test
     Kitchen will immediately fail when any converge fails instead of
     continuing to test additional instances.
--   The `policyfile_path` config option now accepts relative paths.
--   A new `berksfile_path` config option allows specifying Berkshelf
+- The `policyfile_path` config option now accepts relative paths.
+- A new `berksfile_path` config option allows specifying Berkshelf
     files in non-standard locations.
--   Retries are now honored when using SSH proxies
+- Retries are now honored when using SSH proxies
 
 #### kitchen-dokken 2.7.0
 
--   The Chef Docker image is now pulled by default so that locally
+- The Chef Docker image is now pulled by default so that locally
     cached <span class="title-ref">latest</span> or <span
     class="title-ref">current</span> container versions will be compared
     to those available on DockerHub. See the
     [readme](https://github.com/someara/kitchen-dokken#disable-pulling-chef-docker-images)
     for instructions on reverting to the previous behavior.
--   User namespace mode can be disabled when running privileged
+- User namespace mode can be disabled when running privileged
     containers with a new `userns_host` config option. See the
     [readme](https://github.com/someara/kitchen-dokken#running-with-user-namespaces-enabled)
     for details.
--   You can now disable pulling the platform Docker images for local
+- You can now disable pulling the platform Docker images for local
     platform image testing or air gapped testing. See the
     [readme](https://github.com/someara/kitchen-dokken#disable-pulling-platform-docker-images)
     for details.
@@ -1852,11 +1852,11 @@ non-breaking Test Kitchen 2.0 features:
 
 #### curl 7.65.0
 
--   CVE-2019-5435: Integer overflows in curl_url_set
--   CVE-2019-5436: tftp: use the current blksize for recvfrom()
--   CVE-2018-16890: NTLM type-2 out-of-bounds buffer read
--   CVE-2019-3822: NTLMv2 type-3 header stack buffer overflow
--   CVE-2019-3823: SMTP end-of-response out-of-bounds read
+- CVE-2019-5435: Integer overflows in curl_url_set
+- CVE-2019-5436: tftp: use the current blksize for recvfrom()
+- CVE-2018-16890: NTLM type-2 out-of-bounds buffer read
+- CVE-2019-3822: NTLMv2 type-3 header stack buffer overflow
+- CVE-2019-3823: SMTP end-of-response out-of-bounds read
 
 ## What's New in 3.10
 
@@ -1870,9 +1870,9 @@ if the included policy file includes cookbooks with paths. Thanks
 
 ### Updated Components
 
--   `kitchen-vagrant`: 1.5.1 -\> 1.5.2
--   `mixlib-install`: 3.11.12 -\> 3.11.18
--   `ohai`: 14.8.11 -\> 14.8.12
+- `kitchen-vagrant`: 1.5.1 -\> 1.5.2
+- `mixlib-install`: 3.11.12 -\> 3.11.18
+- `ohai`: 14.8.11 -\> 14.8.12
 
 ## What's New in 3.9
 
@@ -1920,14 +1920,14 @@ knife-vsphere has been updated to 2.1.3, which adds support for knife's
 Rubygems has been updated from 2.7.8 to 2.7.9 to resolves the following
 CVEs:
 
--   CVE-2019-8320: Delete directory using symlink when decompressing tar
--   CVE-2019-8321: Escape sequence injection vulnerability in verbose
--   CVE-2019-8322: Escape sequence injection vulnerability in gem owner
--   CVE-2019-8323: Escape sequence injection vulnerability in API
+- CVE-2019-8320: Delete directory using symlink when decompressing tar
+- CVE-2019-8321: Escape sequence injection vulnerability in verbose
+- CVE-2019-8322: Escape sequence injection vulnerability in gem owner
+- CVE-2019-8323: Escape sequence injection vulnerability in API
     response handling
--   CVE-2019-8324: Installing a malicious gem may lead to arbitrary code
+- CVE-2019-8324: Installing a malicious gem may lead to arbitrary code
     execution
--   CVE-2019-8325: Escape sequence injection vulnerability in errors
+- CVE-2019-8325: Escape sequence injection vulnerability in errors
 
 ## What's New in 3.8
 
@@ -1941,19 +1941,19 @@ information on what's new.
 
 #### Fauxhai 6.11.0
 
--   Added Windows 2019 Server, Red Hat Linux 7.6, Debian 9.6, and CentOS
+- Added Windows 2019 Server, Red Hat Linux 7.6, Debian 9.6, and CentOS
     7.6.1804.
--   Updated Windows7, 8.1, and 10, 2008 R2, 2012, 2012 R2, and 2016 to
+- Updated Windows7, 8.1, and 10, 2008 R2, 2012, 2012 R2, and 2016 to
     Chef 14.10.
--   Updated Oracle Linux 6.8/7.2/7.3/7.4 to Ohai 14.8 in EC2.
--   Updated the fetcher logic to be compatible with ChefSpec 7.3+.
+- Updated Oracle Linux 6.8/7.2/7.3/7.4 to Ohai 14.8 in EC2.
+- Updated the fetcher logic to be compatible with ChefSpec 7.3+.
     Thanks [oscar123mendoza](https://github.com/oscar123mendoza)!
--   Removed duplicate json data in gentoo 4.9.6.
+- Removed duplicate json data in gentoo 4.9.6.
 
 #### Other Component Updates
 
--   \`kitchen-digitalocean\`: 0.10.1 -\> 0.10.2
--   \`mixlib-install\`: 3.11.5 -\> 3.11.11
+- \`kitchen-digitalocean\`: 0.10.1 -\> 0.10.2
+- \`mixlib-install\`: 3.11.5 -\> 3.11.11
 
 ## What's New in 3.7
 
@@ -1967,27 +1967,27 @@ what's new.
 
 #### InSpec 3.4.1
 
--   New aws_billing_report / aws_billing_reports resources
--   Many under the hood improvements
+- New aws_billing_report / aws_billing_reports resources
+- Many under the hood improvements
 
 #### kitchen-inspec 1.0.1
 
--   Support for bastion configuration in transport options.
+- Support for bastion configuration in transport options.
 
 #### kitchen-vagrant 1.4.0
 
--   This fixes audio for VirtualBox users by disabling audio in
+- This fixes audio for VirtualBox users by disabling audio in
     VirtualBox by default to prevent interrupting host Bluetooth audio.
 
 #### kitchen-azurerm 0.14.8
 
--   Support Azure Managed Identities and apply vm_tags to all resources
+- Support Azure Managed Identities and apply vm_tags to all resources
     in resource group.
 
 #### Other Updated Components
 
-> -   \`chef-apply\`: 0.2.4 -\> 0.2.7
-> -   \`knife-tidy\`: 1.2.0 -\> 2.0.0
+> - \`chef-apply\`: 0.2.4 -\> 0.2.7
+> - \`knife-tidy\`: 1.2.0 -\> 2.0.0
 
 ### Deprecations
 
@@ -2013,75 +2013,75 @@ what's new.
 
 #### InSpec 3.2.6
 
--   Added new <span class="title-ref">aws_sqs_queue</span> resource.
+- Added new <span class="title-ref">aws_sqs_queue</span> resource.
     Thanks [amitsaha](https://github.com/amitsaha)
--   Exposed additional WinRM options for transport, basic auth, and
+- Exposed additional WinRM options for transport, basic auth, and
     SSPI. Thanks [frezbo](https://github.com/frezbo)
--   Improved UI experience throughout including new CLI flags
+- Improved UI experience throughout including new CLI flags
     --color/--no-color and --interactive/--no-interactive
 
 #### Berkshelf 7.0.7
 
--   Added <span class="title-ref">berks outdated --all</span> command to
+- Added <span class="title-ref">berks outdated --all</span> command to
     get a list of outdated dependencies, including those that wouldn't
     satisfy the version constraints set in Berksfile. Thanks
     [jeroenj](https://github.com/jeroenj)
 
 #### Fauxhai 6.10.0
 
--   Added Fedora 29 Ohai data for use in ChefSpec
+- Added Fedora 29 Ohai data for use in ChefSpec
 
 #### chef-sugar 5.0
 
--   Added a new parallels? helper. Thanks
+- Added a new parallels? helper. Thanks
     [ehanlon](https://github.com/ehanlon)
--   Added support for the Raspberry Pi 1 and Zero to armhf? helper
--   Added a centos_final? helper. Thanks
+- Added support for the Raspberry Pi 1 and Zero to armhf? helper
+- Added a centos_final? helper. Thanks
     [kareiva](https://github.com/kareiva)
 
 #### Foodcritic 15.1
 
--   Updated the Chef metadata to Chef versions 13.12 / 14.8 and removed
+- Updated the Chef metadata to Chef versions 13.12 / 14.8 and removed
     all other Chef metadata
 
 #### kitchen-azurerm 0.14.7
 
--   Resolved failures in the plugin by updating the azure API gems
+- Resolved failures in the plugin by updating the azure API gems
 
 #### kitchen-ec2 2.4.0
 
--   Added support for arm64 architecture instances
--   Support Windows Server 1709 and 1803 image searching. Thanks
+- Added support for arm64 architecture instances
+- Support Windows Server 1709 and 1803 image searching. Thanks
     [xtimon](https://github.com/xtimon)
--   Support Amazon Linux 2.0 image searching. Use the platform
+- Support Amazon Linux 2.0 image searching. Use the platform
     'amazon2'. Thanks [pschaumburg](https://github.com/pschaumburg)
 
 #### knife-ec2 0.19.16
 
--   Allow passing the <span
+- Allow passing the <span
     class="title-ref">--bootstrap-template</span> option during node
     bootstrapping
 
 #### knife-google 3.3.7
 
--   Allow running knife google zone list, region list, region quotas,
+- Allow running knife google zone list, region list, region quotas,
     project quotas to run without specifying the <span
     class="title-ref">gce_zone</span> option
 
 #### stove 7.0.1
 
--   The yank command has been removed as this command causes large
+- The yank command has been removed as this command causes large
     downstream impact to other users and should not be part of the
     tooling
--   The metadata.rb file will now be included in uploads to match the
+- The metadata.rb file will now be included in uploads to match the
     behavior of berkshelf 7+
 
 #### test-kitchen 1.24
 
--   Added support for the Chef 13+ root aliases. With this chance you
+- Added support for the Chef 13+ root aliases. With this chance you
     can now test a cookbook with a simple recipe.rb and attributes.rb
     file.
--   Improve WinRM support with retries and graceful connection cleanup.
+- Improve WinRM support with retries and graceful connection cleanup.
     Thanks [bdwyertech](https://github.com/bdwyertech) and
     [dwoz](https://github.com/dwoz)
 
@@ -2089,11 +2089,11 @@ what's new.
 
 #### OpenSSL updated to 1.0.2q
 
--   Microarchitecture timing vulnerability in ECC scalar multiplication
+- Microarchitecture timing vulnerability in ECC scalar multiplication
     [CVE-2018-5407](https://nvd.nist.gov/vuln/detail/CVE-2018-5407)
--   Timing vulnerability in DSA signature generation
+- Timing vulnerability in DSA signature generation
     [CVE-2018-0734](https://nvd.nist.gov/vuln/detail/CVE-2018-0734)
--   **New Chef Command Functionality**
+- **New Chef Command Functionality**
 
 ## What's New in 3.5
 
@@ -2124,59 +2124,59 @@ what's new.
 
 #### Fauxhai 6.9.1
 
--   Updated mock Ohai run data for use with ChefSpec for multiple
+- Updated mock Ohai run data for use with ChefSpec for multiple
     platforms
--   Added Linux Mint 19, macOS 10.14, Solaris 5.11 (11.4 release), and
+- Added Linux Mint 19, macOS 10.14, Solaris 5.11 (11.4 release), and
     SLES 15.
--   Deprecated the following platforms for removal April 2018: Linux
+- Deprecated the following platforms for removal April 2018: Linux
     Mint 18.2, Gentoo 4.9.6, All versions of ios_xr, All versions of
     omnios, All versions of nexus, macOS 10.10, and Solaris 5.10.
--   See [Fauxhai Supported
+- See [Fauxhai Supported
     Platforms](https://github.com/chefspec/fauxhai/tree/master/lib/fauxhai/platforms)
     for a complete list of supported platform data for use with
     ChefSpec.
 
 #### Foodcritic 14.3
 
--   Updated the metadata that ships with Foodcritic to provide the
+- Updated the metadata that ships with Foodcritic to provide the
     latest Chef 13.11 and 14.5 metadata
--   Removed metadata from older Chef releases. This update also
--   Removed the FC121 rule, which was causing confusion with community
+- Removed metadata from older Chef releases. This update also
+- Removed the FC121 rule, which was causing confusion with community
     cookbook authors. This rule will be added back when Chef 13 goes EOL
     in April 2019.
 
 #### InSpec 3.0.12
 
--   Added a new plugin system for inspec and the train transport system
--   Added a new global attributes system
--   Enhanced skip messages
--   Many more enhancements
+- Added a new plugin system for inspec and the train transport system
+- Added a new global attributes system
+- Enhanced skip messages
+- Many more enhancements
 
 #### Kitchen AzureRM
 
--   Added support for the Shared Image Gallery.
+- Added support for the Shared Image Gallery.
 
 #### Kitchen DigitalOcean
 
--   Added support for FreeBSD 10.4 and 11.2
+- Added support for FreeBSD 10.4 and 11.2
 
 #### Kitchen EC2
 
--   Improved Windows system support. The auto-generated security group
+- Improved Windows system support. The auto-generated security group
     will now include support for RDP and the log directory will alway be
     created.
 
 #### Kitchen Google
 
--   Added support for adding labels to instances with a new <span
+- Added support for adding labels to instances with a new <span
     class="title-ref">labels</span> config that accepts labels as a
     hash.
 
 #### Knife Windows
 
--   Improved Windows detection support to identify Windows 2012r2, 2016,
+- Improved Windows detection support to identify Windows 2012r2, 2016,
     and 10.
--   Added support for using the client.d directories when bootstrapping
+- Added support for using the client.d directories when bootstrapping
     nodes.
 
 ### Smaller Package Size
@@ -2186,8 +2186,8 @@ gems were updated to remove extraneous files that do not need to be
 included. The download size of packages has decreased accordingly (all
 measurements in megabytes):
 
--   .deb: 108 -\> 84 (22%)
--   .rpm: 112 -\> 86 (24%)
+- .deb: 108 -\> 84 (22%)
+- .rpm: 112 -\> 86 (24%)
 
 ### Platform Support Updates
 
@@ -2198,9 +2198,9 @@ downloads.chef.io.
 
 Ruby has been updated to 2.5.3 to resolve the following vulnerabilities:
 
--   \`CVE-2018-16396\`: Tainted flags are not propagated in Array\#pack
+- \`CVE-2018-16396\`: Tainted flags are not propagated in Array\#pack
     and String\#unpack with some directives
--   \`CVE-2018-16395\`: OpenSSL::X509::Name equality check does not work
+- \`CVE-2018-16395\`: OpenSSL::X509::Name equality check does not work
     correctly
 
 ## What's New in 3.3
@@ -2224,12 +2224,12 @@ for examples of the new syntax.
 
 #### Other Updated Components
 
--   `chef-provisioning-aws`: 3.0.4 -\> 3.0.6
--   `chef-vault`: 3.3.0 -\> 3.4.2
--   `foodcritic`: 14.0.0 -\> 14.1.0
--   `inspec`: 2.2.70 -\> 2.2.112
--   `kitchen-inspec`: 0.23.1 -\> 0.24.0
--   `kitchen-vagrant`: 1.3.3 -\> 1.3.4
+- `chef-provisioning-aws`: 3.0.4 -\> 3.0.6
+- `chef-vault`: 3.3.0 -\> 3.4.2
+- `foodcritic`: 14.0.0 -\> 14.1.0
+- `inspec`: 2.2.70 -\> 2.2.112
+- `kitchen-inspec`: 0.23.1 -\> 0.24.0
+- `kitchen-vagrant`: 1.3.3 -\> 1.3.4
 
 ### New Chef CLI Functionality
 
@@ -2239,29 +2239,29 @@ cookbook(s) given on the command line.
 
 ### Deprecations
 
--   `chef generate app` - Application repos were a pattern that didn't
+- `chef generate app` - Application repos were a pattern that didn't
     take off.
--   `chef generate lwrp` - Use <span class="title-ref">chef generate
+- `chef generate lwrp` - Use <span class="title-ref">chef generate
     resource</span>. Every supported release of Chef supports custom
     resources. Custom resources are awesome. No one should be writing
     new LWRPs any more. LWRPS are not awesome.
 
 ## What's New in 3.2
 
--   **Chef 14.4.56**
+- **Chef 14.4.56**
 
     ChefDK now ships with Chef 14.4.56. See [Chef 14.4 release
     notes](/release_notes/#whats-new-in-14-4) for more information
     on what's new.
 
--   **New Functionality**
+- **New Functionality**
 
-    -   New <span class="title-ref">chef describe-cookbook</span>
+    - New <span class="title-ref">chef describe-cookbook</span>
         command to display the cookbook checksum.
-    -   Change policyfile generator to use `policyfiles` directory
+    - Change policyfile generator to use `policyfiles` directory
         instead of `policies` directory
 
--   **New Tooling**
+- **New Tooling**
 
     **Kitchen AzureRM**
 
@@ -2271,116 +2271,116 @@ cookbook(s) given on the command line.
         testing. This driver uses the new Microsoft Azure Resource
         Management REST API via the azure-sdk-for-ruby.
 
--   **Updated Tooling**
+- **Updated Tooling**
 
     **Test Kitchen**
 
     Test Kitchen 1.23 now includes support for [lifecycle
     hooks](https://github.com/test-kitchen/test-kitchen/blob/master/RELEASE_NOTES.md#life-cycle-hooks).
 
--   **Updated Components**
+- **Updated Components**
 
-    -   `berkshelf`: 7.0.4 -\> 7.0.6
-    -   `chef-provisioning`: 2.7.1 -\> 2.7.2
-    -   `chef-provisioning-aws`: 3.0.2 -\> 3.0.4
-    -   `chef-sugar`: 4.0.0 -\> 4.1.0
-    -   `fauxhai`: 6.4.0 -\> 6.6.0
-    -   `inspec`: 2.1.72 -\>2.2.70
-    -   `kitchen-google`: 1.4.0 -\> 1.5.0
+    - `berkshelf`: 7.0.4 -\> 7.0.6
+    - `chef-provisioning`: 2.7.1 -\> 2.7.2
+    - `chef-provisioning-aws`: 3.0.2 -\> 3.0.4
+    - `chef-sugar`: 4.0.0 -\> 4.1.0
+    - `fauxhai`: 6.4.0 -\> 6.6.0
+    - `inspec`: 2.1.72 -\>2.2.70
+    - `kitchen-google`: 1.4.0 -\> 1.5.0
 
--   **Security Updates**
+- **Security Updates**
 
     **OpenSSL**
 
     OpenSSL updated to 1.0.2p to resolve:
 
-    -   Client DoS due to large DH parameter
+    - Client DoS due to large DH parameter
         [CVE-2018-0732](https://nvd.nist.gov/vuln/detail/CVE-2018-0732)
-    -   Cache timing vulnerability in RSA Key Generation
+    - Cache timing vulnerability in RSA Key Generation
         [CVE-2018-0737](https://nvd.nist.gov/vuln/detail/CVE-2018-0737)
 
 ## What's New in 3.1
 
--   **Chef 14.2.0**
+- **Chef 14.2.0**
 
     ChefDK now ships with Chef 14.2.0. See [Chef 14.2 release
     notes](/release_notes/#whats-new-in-14-2-0) for more information
     on what's new.
 
--   **Habitat Packages**
+- **Habitat Packages**
 
     ChefDK is now released as a habitat package under the identifier
     `chef/chef-dk`. All successful builds are available in the unstable
     channel and all promoted builds are available in the stable channel.
 
--   **Updated Homebrew Cask Tap**
+- **Updated Homebrew Cask Tap**
 
     You can install ChefDK on macOS using
     `brew cask install chef/chef/chefdk`. The tap name is new, but not
     the behavior.
 
--   **Updated Tooling**
+- **Updated Tooling**
 
     **Fauxhai 6.4**
 
-    -   Added for 3 new platforms - CentOS 7.5, Debian 8.11, and FreeBSD
+    - Added for 3 new platforms - CentOS 7.5, Debian 8.11, and FreeBSD
         11.2.
-    -   Updated platform data for Amazon Linux, Red Hat, SLES, and
+    - Updated platform data for Amazon Linux, Red Hat, SLES, and
         Ubuntu to match Chef 14.2 output.
-    -   Deprecated the FreeBSD 10.3 platform data.
+    - Deprecated the FreeBSD 10.3 platform data.
 
     **Foodcritic 14.0**
 
-    -   Added support for Chef 14.2 metadata
-    -   Removes older Chef 13 metadata.
-    -   Updated rules for clarity and removes an unnecessary rule.
-    -   Added a new rule saying when cookbooks have unnecessary
+    - Added support for Chef 14.2 metadata
+    - Removes older Chef 13 metadata.
+    - Updated rules for clarity and removes an unnecessary rule.
+    - Added a new rule saying when cookbooks have unnecessary
         dependencies now that resources moved into core Chef.
 
     **knife-acl**
 
-    -   `knife-acl` is now included with ChefDK. This knife plugin
+    - `knife-acl` is now included with ChefDK. This knife plugin
         allows admin users to modify Chef Server ACLs from their command
         line.
 
     **knife-tidy**
 
-    -   `knife-tidy` is now included with ChefDK. This knife plugin
+    - `knife-tidy` is now included with ChefDK. This knife plugin
         generates reports about stale nodes and helps clean them up.
 
     **Test Kitchen 1.22**
 
-    -   Added a new `ssh_gateway_port` config.
-    -   Fixed a bug on Unix systems where scripts are not created as
+    - Added a new `ssh_gateway_port` config.
+    - Fixed a bug on Unix systems where scripts are not created as
         executable.
 
--   **Other Updated Components and Tools**
+- **Other Updated Components and Tools**
 
-    -   `kitchen-digitalocean: 0.9.8 -> 0.10.0`
-    -   `knife-opc: 0.3.2 -> 0.4.0`
+    - `kitchen-digitalocean: 0.9.8 -> 0.10.0`
+    - `knife-opc: 0.3.2 -> 0.4.0`
 
--   **Security Updates**
+- **Security Updates**
 
-    -   **ffi**
+    - **ffi**
 
         CVE-2018-1000201: DLL loading issue which can be hijacked on
         Windows OS
 
 ## What's New in 3.0
 
--   **Chef 14.1.1**
+- **Chef 14.1.1**
 
     ChefDK now ships with Chef 14.1.1. See the [Chef 14.1 release
     notes](/release_notes/#what-s-new-in-14-1-1) for more
     information on what's new.
 
--   **Updated Operating System support**
+- **Updated Operating System support**
 
     ChefDK now ships packages for Ubuntu 18.04 and Debian 9. In
     accordance with Chef's platform End Of Life policy, ChefDK is no
     longer shipped on macOS 10.10.
 
--   **Enhanced cookbook archive handling**
+- **Enhanced cookbook archive handling**
 
     ChefDK now uses an embedded copy of `libarchive` to support
     Policyfile and Berkshelf. This improves overall performance and
@@ -2388,7 +2388,7 @@ cookbook(s) given on the command line.
     also resolves the long standing "not an octal string" problem users
     face when depending on certain cookbooks in the supermarket.
 
--   **Policyfiles: updated include_policy support**
+- **Policyfiles: updated include_policy support**
 
     Policyfiles now support git targets for included policies.
 
@@ -2399,9 +2399,9 @@ cookbook(s) given on the command line.
                   path: 'policies/base/Policyfile.lock.json'
     ```
 
--   **Updated Tooling**
+- **Updated Tooling**
 
-    -   *Test Kitchen*
+    - *Test Kitchen*
 
         Test Kitchen has been updated from 1.20.0 to 1.21.2. This
         release allows you to use a `kitchen.yml` config file instead of
@@ -2412,7 +2412,7 @@ cookbook(s) given on the command line.
         [CHANGELOG](https://github.com/chef/chef-dk/blob/master/CHANGELOG.md)
         for a complete list of changes.
 
-    -   **InSpec**
+    - **InSpec**
 
         InSpec has been updated from 1.51.21 to 2.1.68. InSpec 2.0
         brings compliance automation to the cloud, with new resource
@@ -2421,7 +2421,7 @@ cookbook(s) given on the command line.
         updates. Please visit [InSpec](/inspec/) for more
         information.
 
-    -   **ChefSpec**
+    - **ChefSpec**
 
         ChefSpec has been updated to 7.2.1 with Fauxhai 6.2.0. This
         release removes all platforms that were previously marked as
@@ -2432,7 +2432,7 @@ cookbook(s) given on the command line.
         ChefSpec see
         <https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md>.
 
-    -   **Foodcritic**
+    - **Foodcritic**
 
         Foodcritic has been updated to from 12.3.0 to 13.1.1. This
         updates Foodcritic for Chef 13 or later by removing Chef 12
@@ -2442,7 +2442,7 @@ cookbook(s) given on the command line.
         Chef 13 and 14, resolves several long standing file detection
         bugs, and improves performance.
 
-    -   **Cookstyle**
+    - **Cookstyle**
 
         Cookstyle has been updated to 3.0, which updates the underlying
         RuboCop engine to 0.55 with a long list of bug fixes and
@@ -2451,7 +2451,7 @@ cookbook(s) given on the command line.
         [CHANGELOG](https://github.com/chef/chef-dk/blob/master/CHANGELOG.md)
         for a complete list of newly enabled rules.
 
-    -   **Berkshelf**
+    - **Berkshelf**
 
         Berkshelf has been updated to 7.0.2. Berkshelf 7 moves to using
         the same libraries as the Chef Client, ensuring consistent
@@ -2460,98 +2460,98 @@ cookbook(s) given on the command line.
         "Actor crashed" failures of celluloid will no longer be produced
         by Berkshelf.
 
-    -   **VMware vSphere support**
+    - **VMware vSphere support**
 
         The `knife-vsphere` plugin for managing VMware vSphere is now
         bundled with ChefDK.
 
-    -   **Cookbook generator creates a CHANGELOG.md**
+    - **Cookbook generator creates a CHANGELOG.md**
 
         `chef cookbook generate [cookbook_name]` now creates a
         CHANGELOG.md file.
 
--   **Updated Components and Tools**
+- **Updated Components and Tools**
 
-    -   `chef-provisioning 2.7.0 -> 2.7.1`
-    -   `knife-ec2 0.17.0 -> 0.18.0`
-    -   `opscode-pushy-client 2.3.0 -> 2.4.11`
+    - `chef-provisioning 2.7.0 -> 2.7.1`
+    - `knife-ec2 0.17.0 -> 0.18.0`
+    - `opscode-pushy-client 2.3.0 -> 2.4.11`
 
--   **Security Updates**
+- **Security Updates**
 
-    -   **Ruby**
+    - **Ruby**
 
         Ruby has been updated to 2.5.1 to resolve the following
         vulnerabilities:
 
-        -   [CVE-2017-17742](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17742)
-        -   [CVE-2018-6914](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6914)
-        -   [CVE-2018-8777](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8777)
-        -   [CVE-2018-8778](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8778)
-        -   [CVE-2018-8779](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8779)
-        -   [CVE-2018-8780](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-69148780)
-        -   Multiple vulnerabilities in RubyGems
+        - [CVE-2017-17742](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17742)
+        - [CVE-2018-6914](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6914)
+        - [CVE-2018-8777](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8777)
+        - [CVE-2018-8778](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8778)
+        - [CVE-2018-8779](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8779)
+        - [CVE-2018-8780](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-69148780)
+        - Multiple vulnerabilities in RubyGems
 
-    -   **OpenSSL**
+    - **OpenSSL**
 
         OpenSSL has been updated to 1.0.2o to resolve CVE-2018-0739.
 
 ## What's New in 2.5.3
 
--   **Rename smoke tests to integration tests**
+- **Rename smoke tests to integration tests**
 
     The cookbook, recipe, and app generators now name the test directory
     `integration` instead of `smoke`. This will not impact existing
     cookbooks generated with older releases of ChefDK, but it does
     simplify the `.kitchen.yml` configuration for all new cookbooks.
 
--   **Chef 13.8.5**
+- **Chef 13.8.5**
 
     ChefDK now ships with Chef 13.8.5. See the [Chef 13.8 release
     notes](/release_notes/#what-s-new-in-13-8-5) for more
     information.
 
--   **Updated chef_version in cookbook generator**
+- **Updated chef_version in cookbook generator**
 
     When running `chef generate cookbook` the generated cookbook will
     now specify a minimum Chef release of 12.14 not 12.1.
 
--   **Security Updates**
+- **Security Updates**
 
-    -   Ruby has been updated to 2.4.3 to resolve
+    - Ruby has been updated to 2.4.3 to resolve
         [CVE-2017-17405](https://nvd.nist.gov/vuln/detail/CVE-2017-17405)
-    -   OpenSSL has been updated to 1.0.2n to resolve
+    - OpenSSL has been updated to 1.0.2n to resolve
         [CVE-2017-3738](https://nvd.nist.gov/vuln/detail/CVE-2017-3738),
         [CVE-2017-3737](https://nvd.nist.gov/vuln/detail/CVE-2017-3737),
         [CVE-2017-3736](https://nvd.nist.gov/vuln/detail/CVE-2017-3736),
         and
         [CVE-2017-3735](https://nvd.nist.gov/vuln/detail/CVE-2017-3735)
-    -   LibXML2 has been updated to 2.9.7 to fix
+    - LibXML2 has been updated to 2.9.7 to fix
         [CVE-2017-15412](https://access.redhat.com/security/cve/cve-2017-15412)
-    -   minitar has been updated to 0.6.1 to resolve
+    - minitar has been updated to 0.6.1 to resolve
         [CVE-2016-10173](https://nvd.nist.gov/vuln/detail/CVE-2016-10173)
 
--   **Updated Components**
+- **Updated Components**
 
-    -   chefspec 7.1.1 -\> 7.1.2
-    -   chef-api 0.7.1 -\> 0.8.0
-    -   chef-provisioning 2.6.0 -\> 2.7.0
-    -   chef-provisioning-aws 3.0.0 -\> 3.0.2
-    -   chef-sugar 3.6.0 -\> 4.0.0
-    -   foodcritic 12.2.1 -\> 12.3.0
-    -   inspec 1.45.13 -\> 1.51.21
-    -   kitchen-dokken 2.6.5 -\> 2.6.7
-    -   kitchen-ec2 1.3.2 -\> 2.2.1
-    -   kitchen-inspec 0.20.0 -\> 0.23.1
-    -   kitchen-vagrant 1.2.1 -\> 1.3.1
-    -   knife-ec2 0.16.0 -\> 0.17.0
-    -   knife-windows 1.9.0 -\> 1.9.1
-    -   test-kitchen 1.19.2 -\> 1.20.0
-    -   chef-provisioning-azure has been removed as it used deprecated
+    - chefspec 7.1.1 -\> 7.1.2
+    - chef-api 0.7.1 -\> 0.8.0
+    - chef-provisioning 2.6.0 -\> 2.7.0
+    - chef-provisioning-aws 3.0.0 -\> 3.0.2
+    - chef-sugar 3.6.0 -\> 4.0.0
+    - foodcritic 12.2.1 -\> 12.3.0
+    - inspec 1.45.13 -\> 1.51.21
+    - kitchen-dokken 2.6.5 -\> 2.6.7
+    - kitchen-ec2 1.3.2 -\> 2.2.1
+    - kitchen-inspec 0.20.0 -\> 0.23.1
+    - kitchen-vagrant 1.2.1 -\> 1.3.1
+    - knife-ec2 0.16.0 -\> 0.17.0
+    - knife-windows 1.9.0 -\> 1.9.1
+    - test-kitchen 1.19.2 -\> 1.20.0
+    - chef-provisioning-azure has been removed as it used deprecated
         Azure APIs
 
 ## What's New in 2.4.17
 
--   **Improved performance downloading cookbooks from a Chef server**
+- **Improved performance downloading cookbooks from a Chef server**
 
     Policyfile users who use a Chef server as a cookbook source will
     experience faster cookbook downloads when running `chef install`.
@@ -2560,7 +2560,7 @@ cookbook(s) given on the command line.
     Additionally, HTTP keepalives are enabled to reduce connection
     overhead.
 
--   **Cookbook artifact source for policyfiles**
+- **Cookbook artifact source for policyfiles**
 
     Policyfile users may now source cookbooks from the Chef server's
     cookbook artifact store. This is mainly intended to support the
@@ -2577,7 +2577,7 @@ cookbook(s) given on the command line.
       identifier: '09d43fad354b3efcc5b5836fef5137131f60f974'
     ```
 
--   **Added include_policy directive**
+- **Added include_policy directive**
 
     Policyfile can use the `include_policy` directive as described in
     [RFC097](https://github.com/chef/chef-rfc/blob/master/rfc097-policyfile-includes.md).
@@ -2651,14 +2651,14 @@ cookbook(s) given on the command line.
     [RFC097](https://github.com/chef/chef-rfc/blob/master/rfc097-policyfile-includes.md)
     and the [Policyfile documentation](/policyfile/).
 
--   **New tools bundled**
+- **New tools bundled**
 
     We are now shipping these tools as part of ChefDK:
 
-    -   [kitchen-digitalocean](https://github.com/test-kitchen/kitchen-digitalocean)
-    -   [kitchen-google](https://github.com/test-kitchen/kitchen-google)
-    -   [knife-ec2](https://github.com/chef/knife-ec2)
-    -   [knife-google](https://github.com/chef/knife-google)
+    - [kitchen-digitalocean](https://github.com/test-kitchen/kitchen-digitalocean)
+    - [kitchen-google](https://github.com/test-kitchen/kitchen-google)
+    - [knife-ec2](https://github.com/chef/knife-ec2)
+    - [knife-google](https://github.com/chef/knife-google)
 
 See the detailed [change
 log](https://github.com/chef/chef-dk/blob/master/CHANGELOG.md#v2417-2017-11-29)
@@ -2681,20 +2681,20 @@ for more information.
 
 This release includes Ruby 2.4.2 to fix the following CVEs:
 
--   [CVE-2017-0898](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0898)
--   [CVE-2017-10784](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-10784)
--   CVE-2017-14033
--   [CVE-2017-14064](https://nvd.nist.gov/vuln/detail/CVE-2017-14064)
+- [CVE-2017-0898](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0898)
+- [CVE-2017-10784](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-10784)
+- CVE-2017-14033
+- [CVE-2017-14064](https://nvd.nist.gov/vuln/detail/CVE-2017-14064)
 
 ChefDK 2.3 includes:
 
--   Chef 13.4.19
--   InSpec 1.36.1
--   Berkshelf 6.3.1
--   Chef Vault 3.3.0
--   Foodcritic 11.4.0
--   Test Kitchen 1.17.0
--   Stove 6.0
+- Chef 13.4.19
+- InSpec 1.36.1
+- Berkshelf 6.3.1
+- Chef Vault 3.3.0
+- Foodcritic 11.4.0
+- Test Kitchen 1.17.0
+- Stove 6.0
 
 Additionally, the cookbook generator now adds a `LICENSE` file when
 creating a new cookbook.
@@ -2715,19 +2715,19 @@ soon as possible.
 
 This release includes RubyGems 2.6.13 to address the following CVEs:
 
--   [CVE-2017-0899](https://nvd.nist.gov/vuln/detail/CVE-2017-0899)
--   [CVE-2017-0900](https://nvd.nist.gov/vuln/detail/CVE-2017-0900)
--   [CVE-2017-0901](https://nvd.nist.gov/vuln/detail/CVE-2017-0901)
--   [CVE-2017-0902](https://nvd.nist.gov/vuln/detail/CVE-2017-0902)
+- [CVE-2017-0899](https://nvd.nist.gov/vuln/detail/CVE-2017-0899)
+- [CVE-2017-0900](https://nvd.nist.gov/vuln/detail/CVE-2017-0900)
+- [CVE-2017-0901](https://nvd.nist.gov/vuln/detail/CVE-2017-0901)
+- [CVE-2017-0902](https://nvd.nist.gov/vuln/detail/CVE-2017-0902)
 
 ChefDK 2.2.1 includes:
 
--   Chef 13.3.42
--   InSpec 1.35.1
--   Berkshelf 6.3.1
--   Chef Vault 3.3.0
--   Foodcritic 11.3.1
--   Test Kitchen 1.17.0
+- Chef 13.3.42
+- InSpec 1.35.1
+- Berkshelf 6.3.1
+- Chef Vault 3.3.0
+- Foodcritic 11.3.1
+- Test Kitchen 1.17.0
 
 ## What's New in 2.1.11
 
@@ -2737,18 +2737,18 @@ address
 
 ### Notable Updated Gems
 
--   berkshelf 6.2.0 -\> 6.3.0
--   chef-provisioning 2.4.0 -\> 2.5.0
--   chef-zero 13.0.0 -\> 13.1.0
--   fauxhai 5.2.0 -\> 5.3.0
--   fog 1.40 -\> 1.41
--   inspec 1.31.1 -\> 1.33.1
--   kitchen-dokken 2.5.1 -\> 2.6.1
--   kitchen-vagrant 1.1.0 -\> 1.2.0
--   knife-push 1.0.2 -\> 1.0.3
--   ohai 13.2.0 -\> 13.3.0
--   serverspec 2.39.1 -\> 2.40.0
--   test-kitchen 1.16 -\> 1.17
+- berkshelf 6.2.0 -\> 6.3.0
+- chef-provisioning 2.4.0 -\> 2.5.0
+- chef-zero 13.0.0 -\> 13.1.0
+- fauxhai 5.2.0 -\> 5.3.0
+- fog 1.40 -\> 1.41
+- inspec 1.31.1 -\> 1.33.1
+- kitchen-dokken 2.5.1 -\> 2.6.1
+- kitchen-vagrant 1.1.0 -\> 1.2.0
+- knife-push 1.0.2 -\> 1.0.3
+- ohai 13.2.0 -\> 13.3.0
+- serverspec 2.39.1 -\> 2.40.0
+- test-kitchen 1.16 -\> 1.17
 
 See the detailed [change
 log](https://github.com/chef/chef-dk/blob/master/CHANGELOG.md#v2111-2017-08-11)
@@ -2791,9 +2791,9 @@ in libraries.
 
 Berkshelf adds support for two new sources:
 
--   Artifactory: source artifactory:
+- Artifactory: source artifactory:
     '<https://myserver/api/chef/chef-virtual>'
--   Chef Repo: source chef_repo: '.'
+- Chef Repo: source chef_repo: '.'
 
 ### Chef Vault 3.1
 
@@ -2848,13 +2848,13 @@ of rule names.
 This release contains only dependency updates, including several
 security fixes:
 
--   Ruby has been upgraded to 2.3.5 to address the following CVEs:
-    -   [CVE-2017-0898](https://www.ruby-lang.org/en/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
-    -   [CVE-2017-10784](https://www.ruby-lang.org/en/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
-    -   [CVE-2017-14033](https://www.ruby-lang.org/en/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
-    -   [CVE-2017-14064](https://www.ruby-lang.org/en/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
--   Chef Client has been upgraded to 12.21.26
--   Push Jobs Client has been upgraded to 2.4.5
+- Ruby has been upgraded to 2.3.5 to address the following CVEs:
+    - [CVE-2017-0898](https://www.ruby-lang.org/en/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
+    - [CVE-2017-10784](https://www.ruby-lang.org/en/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
+    - [CVE-2017-14033](https://www.ruby-lang.org/en/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
+    - [CVE-2017-14064](https://www.ruby-lang.org/en/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
+- Chef Client has been upgraded to 12.21.26
+- Push Jobs Client has been upgraded to 2.4.5
 
 ## What's New in 1.5
 
@@ -2862,10 +2862,10 @@ security fixes:
 
 Chef has been updated to the 12.21 release, fixing a number of bugs:
 
--   Debian-based systems will now correctly prefer Systemd to Upstart
--   Better handling of the `supports` pseudo-property
--   Fixes crashes that occurred when downgrading from Chef 13 to Chef 12
--   Provides better system information when Chef crashes
+- Debian-based systems will now correctly prefer Systemd to Upstart
+- Better handling of the `supports` pseudo-property
+- Fixes crashes that occurred when downgrading from Chef 13 to Chef 12
+- Provides better system information when Chef crashes
 
 See the full [release
 notes](https://github.com/chef/chef/blob/chef-12/RELEASE_NOTES.md#chef-client-release-notes-1221)
@@ -2873,29 +2873,29 @@ for more details.
 
 Chef Client 12.21 also contains a new version of zlib, fixing 4 CVEs:
 
--   [CVE-2016-98402](https://www.cvedetails.com/cve/CVE-2016-9840/)
--   [CVE-2016-9841](https://www.cvedetails.com/cve/CVE-2016-9841/)
--   [CVE-2016-9842](https://www.cvedetails.com/cve/CVE-2016-9842/)
--   [CVE-2016-9843](https://www.cvedetails.com/cve/CVE-2016-9843/)
+- [CVE-2016-98402](https://www.cvedetails.com/cve/CVE-2016-9840/)
+- [CVE-2016-9841](https://www.cvedetails.com/cve/CVE-2016-9841/)
+- [CVE-2016-9842](https://www.cvedetails.com/cve/CVE-2016-9842/)
+- [CVE-2016-9843](https://www.cvedetails.com/cve/CVE-2016-9843/)
 
 ### Notable Updated Gems
 
--   cookstyle 1.3.1 -\> 1.4.0
+- cookstyle 1.3.1 -\> 1.4.0
 
 ## What's New in 1.4
 
 ### InSpec 1.25.1
 
--   Consistent hashing for InSpec profiles
--   Add platform info to json formatter
--   Allow mysql_session to test databases on different hosts
--   Add an oracledb_session resource
--   Support new Chef Automate compliance backend
--   Add command-line completions for fish shell
+- Consistent hashing for InSpec profiles
+- Add platform info to json formatter
+- Allow mysql_session to test databases on different hosts
+- Add an oracledb_session resource
+- Support new Chef Automate compliance backend
+- Add command-line completions for fish shell
 
 ### Cookstyle 1.3.1
 
--   Disabled Style/DoubleNegation rule, which can be necessary in
+- Disabled Style/DoubleNegation rule, which can be necessary in
     not_if / only_if blocks
 
 ## What's New in 1.3
@@ -2953,26 +2953,26 @@ for a list of all supported platforms for use in ChefSpec.
 
 InSpec has been updated to 1.19.1 with the following new functionality:
 
--   Better filter support for the [processes
+- Better filter support for the [processes
     resource](/inspec/resources/processes/).
--   New `packages`, `crontab`, `x509_certificate`, and
+- New `packages`, `crontab`, `x509_certificate`, and
     `x509_private_key` resources
--   New `inspec habitat profile create` command to create a Habitat
+- New `inspec habitat profile create` command to create a Habitat
     artifact for a given InSpec profile.
--   Functional JUnit reporting
--   A new command for generating profiles has been added
+- Functional JUnit reporting
+- A new command for generating profiles has been added
 
 ### Foodcritic
 
 Foodcritic has been updated to 10.2.2. This release includes the
 following new functionality
 
--   FC003, which required gating certain code when running on Chef Solo
+- FC003, which required gating certain code when running on Chef Solo
     has been removed
--   FC023, which preferred conditional (only_if / not_if) code within
+- FC023, which preferred conditional (only_if / not_if) code within
     resources has been removed as many disagreed with this coding style
--   False positives in FC007 and FC016 have been resolved
--   New rules have been added requiring the license (FC068), supports
+- False positives in FC007 and FC016 have been resolved
+- New rules have been added requiring the license (FC068), supports
     (FC067), and chef_version (FC066) metadata properties in cookbooks
 
 ### Kitchen EC2 Driver
@@ -2989,46 +2989,46 @@ standard license strings.
 
 ### Notable Updated Gems
 
--   berkshelf 5.6.0 -\> 5.6.4
--   chef-provisioning 2.1.0 -\> 2.2.1
--   chef-provisioning-aws 2.1.0 -\> 2.2.0
--   chef-zero 5.2.0 -\> 5.3.1
--   chef 12.18.31 -\> 12.19.36
--   cheffish 4.1.0 -\> 5.0.1
--   chefspec 5.3.0 -\> 6.2.0
--   cookstyle 1.2.0 -\> 1.3.0
--   fauxhai 3.10.0 -\> 4.1.0
--   foodcritic 9.0.0 -\> 10.2.2
--   inspec 1.11.0 -\> 1.19.1
--   kitchen-dokken 1.1.0 -\> 2.1.2
--   kitchen-ec2 1.2.0 -\> 1.3.2
--   kitchen-vagrant 1.0.0 -\> 1.0.2
--   mixlib-install 2.1.11 -\> 2.1.12
--   opscode-pushy-client 2.1.2 -\> 2.2.0
--   specinfra 2.66.7 -\> 2.67.7
--   test-kitchen 1.15.0 -\> 1.16.0
--   train 0.22.1 -\> 0.23.0
+- berkshelf 5.6.0 -\> 5.6.4
+- chef-provisioning 2.1.0 -\> 2.2.1
+- chef-provisioning-aws 2.1.0 -\> 2.2.0
+- chef-zero 5.2.0 -\> 5.3.1
+- chef 12.18.31 -\> 12.19.36
+- cheffish 4.1.0 -\> 5.0.1
+- chefspec 5.3.0 -\> 6.2.0
+- cookstyle 1.2.0 -\> 1.3.0
+- fauxhai 3.10.0 -\> 4.1.0
+- foodcritic 9.0.0 -\> 10.2.2
+- inspec 1.11.0 -\> 1.19.1
+- kitchen-dokken 1.1.0 -\> 2.1.2
+- kitchen-ec2 1.2.0 -\> 1.3.2
+- kitchen-vagrant 1.0.0 -\> 1.0.2
+- mixlib-install 2.1.11 -\> 2.1.12
+- opscode-pushy-client 2.1.2 -\> 2.2.0
+- specinfra 2.66.7 -\> 2.67.7
+- test-kitchen 1.15.0 -\> 1.16.0
+- train 0.22.1 -\> 0.23.0
 
 ## What's New in 1.2
 
 ### Delivery CLI
 
--   The `project.toml` file, which can be used to execute [local
+- The `project.toml` file, which can be used to execute [local
     phases](/delivery_cli/#delivery-local), now supports:
-    -   An optional `functional` phase.
-    -   New `remote_file` option to specify a remote `project.toml`.
-    -   The ability to run stages (collection of phases).
--   Fixed bug where the generated `project.toml` file did not include
+    - An optional `functional` phase.
+    - New `remote_file` option to specify a remote `project.toml`.
+    - The ability to run stages (collection of phases).
+- Fixed bug where the generated `project.toml` file did not include
     the prefix <span class="title-ref">chef exec</span> for some phases.
--   Project git remotes will now update automatically, if applicable,
+- Project git remotes will now update automatically, if applicable,
     based on the values in the `cli.toml` or options provided through
     the command-line.
--   Project names specified in project config (`cli.toml`) or options
+- Project names specified in project config (`cli.toml`) or options
     provided through the command-line will now be honored.
 
 ### Policyfiles
 
--   Added a `chef_server` default source option to
+- Added a `chef_server` default source option to
     [Policyfiles](/config_rb_policyfile/#settings).
 
 ### Automate Workflow Adopts SSH for Cookbook Generation
@@ -3040,31 +3040,31 @@ Docs](/runners/)
 
 ### FIPS (Windows and RHEL only)
 
--   ChefDK now comes bundled with the Stunnel tool and the FIPS OpenSSL
+- ChefDK now comes bundled with the Stunnel tool and the FIPS OpenSSL
     module for users who need to enforce FIPS compliance.
--   Support for FIPS options in <span class="title-ref">delivery</span>
+- Support for FIPS options in <span class="title-ref">delivery</span>
     CLI's `cli.toml` was added to handle communication with the Automate
     Server when FIPS mode is enabled.
 
 ### Notable Updated Gems
 
--   berkshelf 5.2.0 -\> 5.5.0
--   chef 12.17.44 -\> 12.18.31
--   chef-provisioning 2.0.2 -\> 2.1.0
--   chef-vault 2.9.0 -\> 2.9.1
--   chef-zero 5.1.0 -\> 5.2.0
--   cheffish 4.0.0 -\> 4.1.0
--   cookstyle 1.1.0 -\> 1.2.0
--   foodcritic 8.1.0 -\> 8.2.0
--   inspec 1.7.2 -\> 1.10.0
--   kitchen-dokken 1.0.9 -\> 1.1.0
--   kitchen-vagrant 0.21.1 -\> 1.0.0
--   knife-windows 1.7.1 -\> 1.8.0
--   mixlib-install 2.1.9 -\> 2.1.10
--   ohai 8.22.1 -\> 8.23.0
--   test-kitchen 1.14.2 -\> 1.15.0
--   train 0.22.0 -\> 0.22.1
--   winrm 2.1.0 -\> 2.1.2
+- berkshelf 5.2.0 -\> 5.5.0
+- chef 12.17.44 -\> 12.18.31
+- chef-provisioning 2.0.2 -\> 2.1.0
+- chef-vault 2.9.0 -\> 2.9.1
+- chef-zero 5.1.0 -\> 5.2.0
+- cheffish 4.0.0 -\> 4.1.0
+- cookstyle 1.1.0 -\> 1.2.0
+- foodcritic 8.1.0 -\> 8.2.0
+- inspec 1.7.2 -\> 1.10.0
+- kitchen-dokken 1.0.9 -\> 1.1.0
+- kitchen-vagrant 0.21.1 -\> 1.0.0
+- knife-windows 1.7.1 -\> 1.8.0
+- mixlib-install 2.1.9 -\> 2.1.10
+- ohai 8.22.1 -\> 8.23.0
+- test-kitchen 1.14.2 -\> 1.15.0
+- train 0.22.0 -\> 0.22.1
+- winrm 2.1.0 -\> 2.1.2
 
 ## What's New in 1.1
 
@@ -3104,30 +3104,30 @@ previously passed.
 
 **Newly Disabled Cops:**
 
--   Metrics/CyclomaticComplexity
--   Style/NumericLiterals
--   Style/RegexpLiteral in 'tests' directory
--   Style/AsciiComments
--   Style/TernaryParentheses
--   Metrics/ClassLength
--   All rails/\* cops
+- Metrics/CyclomaticComplexity
+- Style/NumericLiterals
+- Style/RegexpLiteral in 'tests' directory
+- Style/AsciiComments
+- Style/TernaryParentheses
+- Metrics/ClassLength
+- All rails/\* cops
 
 **Newly Enabled Cops:**
 
--   Bundler/DuplicatedGem
--   Style/SpaceInsideArrayPercentLiteral
--   Style/NumericPredicate
--   Style/EmptyCaseCondition
--   Style/EachForSimpleLoop
--   Style/PreferredHashMethods
--   Lint/UnifiedInteger
--   Lint/PercentSymbolArray
--   Lint/PercentStringArray
--   Lint/EmptyWhen
--   Lint/EmptyExpression
--   Lint/DuplicateCaseCondition
--   Style/TrailingCommaInLiteral
--   Lint/ShadowedException
+- Bundler/DuplicatedGem
+- Style/SpaceInsideArrayPercentLiteral
+- Style/NumericPredicate
+- Style/EmptyCaseCondition
+- Style/EachForSimpleLoop
+- Style/PreferredHashMethods
+- Lint/UnifiedInteger
+- Lint/PercentSymbolArray
+- Lint/PercentStringArray
+- Lint/EmptyWhen
+- Lint/EmptyExpression
+- Lint/DuplicateCaseCondition
+- Style/TrailingCommaInLiteral
+- Lint/ShadowedException
 
 ### New DCO tool included
 
@@ -3139,15 +3139,15 @@ a branch. See <https://github.com/coderanger/dco> for details.
 
 ### Notable Upgraded Gems
 
--   chef `12.16.42` -\> `12.17.44`
--   ohai `8.21.0` -\> `8.22.0`
--   inspec `1.4.1` -\> `1.7.2`
--   train `0.21.1` -\> `0.22.0`
--   test-kitchen `1.13.2` -\> `1.14.2`
--   kitchen-vagrant `0.20.0` -\> `0.21.1`
--   winrm-elevated `1.0.1` -\> `1.1.0`
--   winrm-fs `1.0.0` -\> `1.0.1`
--   cookstyle `0.0.1` -\> `1.1.0`
+- chef `12.16.42` -\> `12.17.44`
+- ohai `8.21.0` -\> `8.22.0`
+- inspec `1.4.1` -\> `1.7.2`
+- train `0.21.1` -\> `0.22.0`
+- test-kitchen `1.13.2` -\> `1.14.2`
+- kitchen-vagrant `0.20.0` -\> `0.21.1`
+- winrm-elevated `1.0.1` -\> `1.1.0`
+- winrm-fs `1.0.0` -\> `1.0.1`
+- cookstyle `0.0.1` -\> `1.1.0`
 
 ## What's New in 1.0
 
@@ -3160,8 +3160,8 @@ formal recognition of the stability of the product.
 
 ### Foodcritic
 
--   Foodcritic constraint updated to require v8.0 or greater.
--   Supermarket Foodcritic rules are now disabled by default when you
+- Foodcritic constraint updated to require v8.0 or greater.
+- Supermarket Foodcritic rules are now disabled by default when you
     run `chef generate cookbook`.
 
 ### InSpec
@@ -3176,14 +3176,14 @@ ChefDK adding chef server organization and user commands to knife
 
 ### Notable Upgraded Gems
 
--   chef `12.15.19` -\> `12.16.42`
--   inspec `1.2.0` -\> `1.4.1`
--   train `0.20.1` -\> `0.21.1`
--   kitchen-dokken `1.0.3` -\> `1.0.4`
--   kitchen-inspec `0.15.2` -\> `0.16.1`
--   berkshelf `5.1.0` -\> `5.2.0`
--   fauxhai `3.9.0` -\> `3.10.0`
--   foodcritic `7.1.0` -\> `8.1.0`
+- chef `12.15.19` -\> `12.16.42`
+- inspec `1.2.0` -\> `1.4.1`
+- train `0.20.1` -\> `0.21.1`
+- kitchen-dokken `1.0.3` -\> `1.0.4`
+- kitchen-inspec `0.15.2` -\> `0.16.1`
+- berkshelf `5.1.0` -\> `5.2.0`
+- fauxhai `3.9.0` -\> `3.10.0`
+- foodcritic `7.1.0` -\> `8.1.0`
 
 ## What's New in 0.19
 
@@ -3200,30 +3200,30 @@ binaries. Run `mixlib-install help` for command usage.
 
 ### Delivery CLI
 
--   Deprecation of GitHub V1 backed project initialization.
--   Initialization of GitHub V2 backed projects
+- Deprecation of GitHub V1 backed project initialization.
+- Initialization of GitHub V2 backed projects
     (`delivery init --github`). Requires Chef Automate server version
     `0.5.432` or above.
--   Project name verification with repository name for projects with
+- Project name verification with repository name for projects with
     Source Control Management (SCM) integration.
--   Increased clarity of the command structure by introducing the
+- Increased clarity of the command structure by introducing the
     `--pipeline` alias for the `--for` option.
--   Honor custom config on project initialization
+- Honor custom config on project initialization
     (`delivery init -c /my/config.json`).
--   Build cookbook is now generated using the more appropriate
+- Build cookbook is now generated using the more appropriate
     `chef generate build-cookbook` on project initialization.
--   Support providing your password non-interactively to
+- Support providing your password non-interactively to
     `delivery token` via the `AUTOMATE_PASSWORD` environment variable
     (`AUTOMATE_PASSWORD=password delivery token`).
 
 ### Notable Upgraded Gems
 
--   chef `12.14.89` -\> `12.15.19`
--   inspec `1.0.0` -\> `1.2.0`
--   kitchen-dokken `1.0.0` -\> `1.0.3`
--   knife-windows `1.6.0` -\> `1.7.0`
--   mixlib-install `2.0.1` -\> `2.1.1`
--   winrm `2.0.3` -\> `2.1.0`
+- chef `12.14.89` -\> `12.15.19`
+- inspec `1.0.0` -\> `1.2.0`
+- kitchen-dokken `1.0.0` -\> `1.0.3`
+- knife-windows `1.6.0` -\> `1.7.0`
+- mixlib-install `2.0.1` -\> `2.1.1`
+- winrm `2.0.3` -\> `2.1.0`
 
 ## Changelog
 

--- a/content/release_notes_client.md
+++ b/content/release_notes_client.md
@@ -5437,7 +5437,7 @@ In Ohai 13 we replaced the filesystem and cloud plugins with the filesystem2 and
 
 - **The mount resource's password property is now marked as **sensitive** Passwords passed to mount won't show up in logs.
 - **The windows_task resource now correctly handles start_day** Previously, the resource would accept any date that was formatted correctly in the local locale, unlike the Windows cookbook and Windows itself. We now support only the MM/DD/YYYY format, in keeping with the Windows cookbook.
--   **InSpec updated to 1.39.1**
+- **InSpec updated to 1.39.1**
 
 ### Ohai 13.5
 
@@ -5856,12 +5856,12 @@ In Chef/Ohai 14 (April 2018) we will remove the IpScopes plugin. The data return
 
 ## What's New in 13.0/13.1
 
--   **Blacklist attributes**
--   **RubyGems sources**
--   **windows_task resource**
--   **Chef client will now exit using the rfc062 defined exit codes**
--   **New default encrypted databag format**
--   **Backwards compatibility breaks**
+- **Blacklist attributes**
+- **RubyGems sources**
+- **windows_task resource**
+- **Chef client will now exit using the rfc062 defined exit codes**
+- **New default encrypted databag format**
+- **Backwards compatibility breaks**
 
 ### It is now possible to blacklist node attributes
 
@@ -6433,22 +6433,22 @@ directories are still appended.
 
 Some examples of changes:
 
--   `which ruby` in 12.x will return any system ruby and fall back to
+- `which ruby` in 12.x will return any system ruby and fall back to
     the embedded ruby if using omnibus
--   `which ruby` in 13.x will return any system ruby and will not find
+- `which ruby` in 13.x will return any system ruby and will not find
     the embedded ruby if using omnibus
--   `shell_out_with_systems_locale("which ruby")` behaves the same as
+- `shell_out_with_systems_locale("which ruby")` behaves the same as
     `which ruby` above
--   `shell_out("which ruby")` in 12.x will return any system ruby and
+- `shell_out("which ruby")` in 12.x will return any system ruby and
     fall back to the embedded ruby if using omnibus
--   `shell_out("which ruby")` in 13.x will always return the omnibus
+- `shell_out("which ruby")` in 13.x will always return the omnibus
     ruby first (but will find the system ruby if not using omnibus)
 
 The PATH in `shell_out` can also be overridden:
 
--   `shell_out("which ruby", env: { "PATH" => nil })` - behaves like
+- `shell_out("which ruby", env: { "PATH" => nil })` - behaves like
     shell_out_with_systems_locale()
--   `shell_out("which ruby", env: { "PATH" => [...include PATH string here...] })` -
+- `shell_out("which ruby", env: { "PATH" => [...include PATH string here...] })` -
     set it arbitrarily however you need
 
 Since most providers which launch custom user commands use
@@ -6477,7 +6477,7 @@ to be set in Chef Client's configuration file.
 
 ### New deprecations
 
--   [Removal of support for Ohai version 6
+- [Removal of support for Ohai version 6
     plugins](/deprecations_ohai_v6_plugins/)
 
 ## What's New in 12.22.3
@@ -6500,59 +6500,59 @@ information](https://www.chef.io/eol-chef12-and-chefdk1).
 
 ## What's New in 12.22.1
 
--   **Security Updates**
-    -   Ruby has been updated to 2.3.6 to resolve
+- **Security Updates**
+    - Ruby has been updated to 2.3.6 to resolve
         [CVE-2017-17405](https://nvd.nist.gov/vuln/detail/CVE-2017-17405)
-    -   Libxml2 has been updated to 2.9.7 to resolve
+    - Libxml2 has been updated to 2.9.7 to resolve
         [CVE-2017-15412](https://access.redhat.com/security/cve/cve-2017-15412)
--   **Ohai 8.26.1**
-    -   Ohai now provides EC2 metadata configuration information on the
+- **Ohai 8.26.1**
+    - Ohai now provides EC2 metadata configuration information on the
         new C5/M5 instance types running on Amazon's new hypervisor
-    -   The new LsPci plugin provides a `node['pci']` hash with
+    - The new LsPci plugin provides a `node['pci']` hash with
         information about the PCI bus based on `lspci`. Only runs on
         Linux.
-    -   The virtualization plugin has been updated to properly detect
+    - The virtualization plugin has been updated to properly detect
         Docker CE
 
 ## What's New in 12.21.31
 
--   **Support for AArch64 platform on Red Hat Enterprise Linux**
--   **mdadm support for arrays with more than 10 disks**
--   **OpenSSL updated to version 1.0.2**
+- **Support for AArch64 platform on Red Hat Enterprise Linux**
+- **mdadm support for arrays with more than 10 disks**
+- **OpenSSL updated to version 1.0.2**
 
 ## What's New in 12.21.26
 
--   **Security release of libxml2** libxml2 has been upgraded to 2.9.5
+- **Security release of libxml2** libxml2 has been upgraded to 2.9.5
     to resolve the following CVEs:
-    -   [CVE-2017-9050](https://www.cvedetails.com/cve/CVE-2017-9050/)
-    -   [CVE-2017-9049](https://www.cvedetails.com/cve/CVE-2017-9049/)
-    -   [CVE-2017-9048](https://www.cvedetails.com/cve/CVE-2017-9048/)
-    -   [CVE-2017-9047](https://www.cvedetails.com/cve/CVE-2017-9047/)
-    -   [CVE-2017-8872](https://www.cvedetails.com/cve/CVE-2017-8872/)
-    -   [CVE-2017-5969](https://www.cvedetails.com/cve/CVE-2017-5969/)
-    -   [CVE-2016-9318](https://www.cvedetails.com/cve/CVE-2016-9318/)
-    -   [CVE-2016-5131](https://www.cvedetails.com/cve/CVE-2016-5131/)
--   **Security release of libxlst** libxlst has been upgraded to 1.1.30
+    - [CVE-2017-9050](https://www.cvedetails.com/cve/CVE-2017-9050/)
+    - [CVE-2017-9049](https://www.cvedetails.com/cve/CVE-2017-9049/)
+    - [CVE-2017-9048](https://www.cvedetails.com/cve/CVE-2017-9048/)
+    - [CVE-2017-9047](https://www.cvedetails.com/cve/CVE-2017-9047/)
+    - [CVE-2017-8872](https://www.cvedetails.com/cve/CVE-2017-8872/)
+    - [CVE-2017-5969](https://www.cvedetails.com/cve/CVE-2017-5969/)
+    - [CVE-2016-9318](https://www.cvedetails.com/cve/CVE-2016-9318/)
+    - [CVE-2016-5131](https://www.cvedetails.com/cve/CVE-2016-5131/)
+- **Security release of libxlst** libxlst has been upgraded to 1.1.30
     to resolve the following CVEs:
-    -   [CVE-2017-5029](http://www.cvedetails.com/cve/CVE-2017-5029/)
-    -   [CVE-2015-9019](http://www.cvedetails.com/cve/CVE-2015-9019/)
--   **Security release of zlib** zlib has been upgraded to 1.2.11 to
+    - [CVE-2017-5029](http://www.cvedetails.com/cve/CVE-2017-5029/)
+    - [CVE-2015-9019](http://www.cvedetails.com/cve/CVE-2015-9019/)
+- **Security release of zlib** zlib has been upgraded to 1.2.11 to
     resolve the following CVEs:
-    -   [CVE-2016-9840](https://www.cvedetails.com/cve/CVE-2016-9840/)
-    -   [CVE-2016-9841](https://www.cvedetails.com/cve/CVE-2016-9841/)
-    -   [CVE-2016-9842](https://www.cvedetails.com/cve/CVE-2016-9842/)
-    -   [CVE-2016-9843](https://www.cvedetails.com/cve/CVE-2016-9843/)
--   **Security release of openssl** openssl has been upgraded to 1.0.2j
+    - [CVE-2016-9840](https://www.cvedetails.com/cve/CVE-2016-9840/)
+    - [CVE-2016-9841](https://www.cvedetails.com/cve/CVE-2016-9841/)
+    - [CVE-2016-9842](https://www.cvedetails.com/cve/CVE-2016-9842/)
+    - [CVE-2016-9843](https://www.cvedetails.com/cve/CVE-2016-9843/)
+- **Security release of openssl** openssl has been upgraded to 1.0.2j
     to resolve the following CVEs:
-    -   [CVE-2017-3731](http://www.cvedetails.com/cve/CVE-2017-3731)
-    -   [CVE-2017-3732](http://www.cvedetails.com/cve/CVE-2017-3732)
-    -   [CVE-2016-7055](http://www.cvedetails.com/cve/CVE-2016-7055)
--   **Security release of rubygems** rubygems has been upgraded to
+    - [CVE-2017-3731](http://www.cvedetails.com/cve/CVE-2017-3731)
+    - [CVE-2017-3732](http://www.cvedetails.com/cve/CVE-2017-3732)
+    - [CVE-2016-7055](http://www.cvedetails.com/cve/CVE-2016-7055)
+- **Security release of rubygems** rubygems has been upgraded to
     2.6.14 to resolve the following CVEs:
-    -   [CVE-2017-0903](http://www.cvedetails.com/cve/CVE-2017-0903)
--   **Ruby 2.2 compatibility** a regression in the 12.21.20 release has
+    - [CVE-2017-0903](http://www.cvedetails.com/cve/CVE-2017-0903)
+- **Ruby 2.2 compatibility** a regression in the 12.21.20 release has
     been corrected to restore full compatibility with Ruby 2.2 and later
--   **Ohai Critical Plugins** Ohai has been upgraded to 8.25 with
+- **Ohai Critical Plugins** Ohai has been upgraded to 8.25 with
     support for Ohai critical plugins.
 
 ### Ohai Critical Plugins Functionality
@@ -6568,48 +6568,48 @@ ohai.critical_plugins << :Filesystem
 
 ## What's New in 12.21.20
 
--   **Improved dsc_script logging** Converge logging in `dsc_script`
+- **Improved dsc_script logging** Converge logging in `dsc_script`
     has been improved
--   **DNF Improvements** Accuracy in determining when to use the
+- **DNF Improvements** Accuracy in determining when to use the
     `dnf_package` resource has been improved. DNF will no longer be used
     on RHEL 7 systems that have it installed, and the determination
     logic performance has been greatly improved.
 
 ## What's New in 12.21.14
 
--   **apt_repository APT key fingerprint fixes** `apt_repository` now
+- **apt_repository APT key fingerprint fixes** `apt_repository` now
     correctly checks APT key fingerprints on newer systems
 
 ## What's New in 12.21.12
 
--   **DSC Windows Management Framework 5** DSC has been updated to work
+- **DSC Windows Management Framework 5** DSC has been updated to work
     properly with Windows Management Framework 5
--   **Security release of Ruby** RubyGems has been upgraded to 2.3.5 to
+- **Security release of Ruby** RubyGems has been upgraded to 2.3.5 to
     address the following CVEs:
-    -   [CVE-2017-0898](https://nvd.nist.gov/vuln/detail/CVE-2017-0898)
-    -   [CVE-2017-10784](https://nvd.nist.gov/vuln/detail/CVE-2017-10784)
-    -   [CVE-2017-14033](https://nvd.nist.gov/vuln/detail/CVE-2017-14033)
-    -   [CVE-2017-14064](https://nvd.nist.gov/vuln/detail/CVE-2017-14064)
+    - [CVE-2017-0898](https://nvd.nist.gov/vuln/detail/CVE-2017-0898)
+    - [CVE-2017-10784](https://nvd.nist.gov/vuln/detail/CVE-2017-10784)
+    - [CVE-2017-14033](https://nvd.nist.gov/vuln/detail/CVE-2017-14033)
+    - [CVE-2017-14064](https://nvd.nist.gov/vuln/detail/CVE-2017-14064)
 
 ## What's New in 12.21.10
 
--   **Security release of RubyGems** RubyGems has been upgraded to
+- **Security release of RubyGems** RubyGems has been upgraded to
     2.6.13 to address the following:
-    -   [CVE-2017-0899](https://nvd.nist.gov/vuln/detail/CVE-2017-0899)
-    -   [CVE-2017-0900](https://nvd.nist.gov/vuln/detail/CVE-2017-0900)
-    -   [CVE-2017-0901](https://nvd.nist.gov/vuln/detail/CVE-2017-0901)
-    -   [CVE-2017-0902](https://nvd.nist.gov/vuln/detail/CVE-2017-0902)
--   **Attribute Performance** Attribute performance has been improved
+    - [CVE-2017-0899](https://nvd.nist.gov/vuln/detail/CVE-2017-0899)
+    - [CVE-2017-0900](https://nvd.nist.gov/vuln/detail/CVE-2017-0900)
+    - [CVE-2017-0901](https://nvd.nist.gov/vuln/detail/CVE-2017-0901)
+    - [CVE-2017-0902](https://nvd.nist.gov/vuln/detail/CVE-2017-0902)
+- **Attribute Performance** Attribute performance has been improved
     when utilizing large numbers of merged attributes
 
 ## What's New in 12.21.4
 
--   **Improved Resource Reporting** Resource reporting for Chef Automate
+- **Improved Resource Reporting** Resource reporting for Chef Automate
     has been improved
--   **Ruby Upgrade** Ruby has been updated to 2.3.4
--   **RubyGems Upgrade** RubyGems has been updated to 2.6.12 to prevent
+- **Ruby Upgrade** Ruby has been updated to 2.3.4
+- **RubyGems Upgrade** RubyGems has been updated to 2.6.12 to prevent
     a segfault on Windows
--   **Policyfile fix** Chef client now properly sends expanded run list
+- **Policyfile fix** Chef client now properly sends expanded run list
     events for policy file nodes
 
 ## What's New in 12.21.1
@@ -6618,10 +6618,10 @@ ohai.critical_plugins << :Filesystem
 
 zlib has been updated to resolve the following CVEs:
 
--   [CVE-2016-98406](https://nvd.nist.gov/vuln/detail/CVE-2016-98406)
--   [CVE-2016-98414](https://nvd.nist.gov/vuln/detail/CVE-2016-98414)
--   [CVE-2016-98423](https://nvd.nist.gov/vuln/detail/CVE-2016-98423)
--   [CVE-2016-98434](https://nvd.nist.gov/vuln/detail/CVE-2016-98434)
+- [CVE-2016-98406](https://nvd.nist.gov/vuln/detail/CVE-2016-98406)
+- [CVE-2016-98414](https://nvd.nist.gov/vuln/detail/CVE-2016-98414)
+- [CVE-2016-98423](https://nvd.nist.gov/vuln/detail/CVE-2016-98423)
+- [CVE-2016-98434](https://nvd.nist.gov/vuln/detail/CVE-2016-98434)
 
 ### On Debian prefer Systemd to Upstart
 
@@ -6767,9 +6767,9 @@ end
 
 ### Highlighted bug fixes for this release:
 
--   **Ensure that the Windows Administrator group can access the
+- **Ensure that the Windows Administrator group can access the
     chef-solo nodes directory**
--   **When loading a cookbook in Chef Solo, use \`\`metadata.json\`\` in
+- **When loading a cookbook in Chef Solo, use \`\`metadata.json\`\` in
     preference to \`\`metadata.rb\`\`.**
 
 ## What's New in 12.18
@@ -6777,19 +6777,19 @@ end
 The following items are new for chef-client 12.18 and/or are changes
 from previous versions. The short version:
 
--   **Can now specify the acceptable return codes from the
+- **Can now specify the acceptable return codes from the
     chocolatey_package resource using the returns property**
--   **Can now enable chef-client to run as a scheduled task directly
+- **Can now enable chef-client to run as a scheduled task directly
     from the client MSI on Windows hosts**
--   **Package provider now supports DNF packages for Fedora and upcoming
+- **Package provider now supports DNF packages for Fedora and upcoming
     RHEL releases**
 
 ### New deprecations
 
--   [Chef::Platform helper
+- [Chef::Platform helper
     methods](/deprecations_chef_platform_methods/)
--   [run_command helper method](/deprecations_run_command/)
--   [DNF package allow_downgrade
+- [run_command helper method](/deprecations_run_command/)
+- [DNF package allow_downgrade
     property](/deprecations_dnf_package_allow_downgrade/)
 
 ## What's New in 12.17
@@ -6797,10 +6797,10 @@ from previous versions. The short version:
 The following items are new for chef-client 12.17 and/or are changes
 from previous versions. The short version:
 
--   **Added msu_package resource and provider**
--   **Added alias unmount to umount action for mount resource**
--   **Can now delete multiple nodes/clients in knife**
--   **Haskell language plugin added to Ohai**
+- **Added msu_package resource and provider**
+- **Added alias unmount to umount action for mount resource**
+- **Can now delete multiple nodes/clients in knife**
+- **Haskell language plugin added to Ohai**
 
 ### msu_package resource
 
@@ -6888,10 +6888,10 @@ reflect the change.
 The following items are new for chef-client 12.16 and/or are changes
 from previous versions. The short version:
 
--   **Added new attribute_changed event hook**
--   **Automatic connection to Chef Automate's data collector through
+- **Added new attribute_changed event hook**
+- **Automatic connection to Chef Automate's data collector through
     Chef server**
--   **Added new --field-separator flag to knife show commands**
+- **Added new --field-separator flag to knife show commands**
 
 ### `attribute_changed` event hook
 
@@ -6999,15 +6999,15 @@ end
 The following items are new for chef-client 12.15 and/or are changes
 from previous versions. The short version:
 
--   **Omnibus packages are now available for Ubuntu 16.04**
--   **New cab_package resource** Supports the installation of cabinet
+- **Omnibus packages are now available for Ubuntu 16.04**
+- **New cab_package resource** Supports the installation of cabinet
     packages on Microsoft Windows.
--   **Added new Chef client exit code (213)** New exit code when Chef
+- **Added new Chef client exit code (213)** New exit code when Chef
     client exits during upgrade.
--   **Default for gpgcheck on yum_repository resource is set to true**
--   **Allow deletion of registry_key without the need for users to pass
+- **Default for gpgcheck on yum_repository resource is set to true**
+- **Allow deletion of registry_key without the need for users to pass
     data key in values hash**
--   **If provided, knife ssh will pass the -P option on the command line
+- **If provided, knife ssh will pass the -P option on the command line
     as the sudo password and will bypass prompting**
 
 ### cab_package
@@ -7049,14 +7049,14 @@ in the omnibus_updater cookbook for more information.
 The following items are new for chef-client 12.14 and/or are changes
 from previous versions. The short version:
 
--   **Upgraded Ruby version from 2.1.9 to 2.3.1** Adds several
+- **Upgraded Ruby version from 2.1.9 to 2.3.1** Adds several
     performance and functionality enhancements.
--   **Now support for Chef client runs on Windows Nano Server** A small
+- **Now support for Chef client runs on Windows Nano Server** A small
     patch to Ruby 2.3.1 and improvements to the Ohai network plugin now
     allow you to do chef client runs on Windows Nano Server.
--   **New yum_repository resource** Use the **yum_repository**
+- **New yum_repository resource** Use the **yum_repository**
     resource to manage a yum repository configuration file.
--   **Added the ability to mark a property of a custom resource as
+- **Added the ability to mark a property of a custom resource as
     sensitive** This will suppress the property's value when it's used
     in other outputs, such as messages used by the data collector.
 
@@ -7092,11 +7092,11 @@ property :db_password, String, sensitive: true
 The following items are new for chef-client 12.13 and/or are changes
 from previous versions. The short version:
 
--   **Ohai 8.18 includes new plugin for gathering available user
+- **Ohai 8.18 includes new plugin for gathering available user
     shells** Other additions include a new hardware plugin for macOS
     that gathers system information and detection of VMWare and
     VirtualBox installations.
--   **New Chef client option to override any config key/value pair** Use
+- **New Chef client option to override any config key/value pair** Use
     `chef-client --config-option` to override any config setting from
     the command line.
 
@@ -7113,39 +7113,39 @@ chef-client --config-option chef_server_url=http://example --config-option polic
 
 ### Updated Dependencies
 
--   ruby - 2.1.9 (from 2.1.8)
+- ruby - 2.1.9 (from 2.1.8)
 
 #### Updated Gems
 
--   chef-zero - 4.8.0 (from 4.7.0)
--   cheffish - 2.0.5 (from 2.0.4)
--   compat_resource - 12.10.7 (from 12.10.6)
--   ffi - 1.9.14 (from 1.9.10)
--   ffi-yajl - 2.3.0 (from 2.2.3)
--   fuzzyurl - 0.9.0 (from 0.8.0)
--   mixlib-cli - 1.7.0 (from 1.6.0)
--   mixlib-log - 1.7.0 (from 1.6.0)
--   ohai - 8.18.0 (from 8.17.1)
--   pry - 0.10.4 (from 0.10.3)
--   rspec - 3.5.0 (from 3.4.0)
--   rspec-core - 3.5.2 (from 3.4.4)
--   rspec-expectations - 3.5.0 (from 3.4.0)
--   rspec-mocks - 3.5.0 (from 3.4.1)
--   rspec-support - 3.5.0 (from 3.4.1)
--   simplecov - 0.12.0 (from 0.11.2)
--   specinfra - 2.60.3 (from 2.59.4)
--   mixlib-archive - 0.2.0 (added to package)
+- chef-zero - 4.8.0 (from 4.7.0)
+- cheffish - 2.0.5 (from 2.0.4)
+- compat_resource - 12.10.7 (from 12.10.6)
+- ffi - 1.9.14 (from 1.9.10)
+- ffi-yajl - 2.3.0 (from 2.2.3)
+- fuzzyurl - 0.9.0 (from 0.8.0)
+- mixlib-cli - 1.7.0 (from 1.6.0)
+- mixlib-log - 1.7.0 (from 1.6.0)
+- ohai - 8.18.0 (from 8.17.1)
+- pry - 0.10.4 (from 0.10.3)
+- rspec - 3.5.0 (from 3.4.0)
+- rspec-core - 3.5.2 (from 3.4.4)
+- rspec-expectations - 3.5.0 (from 3.4.0)
+- rspec-mocks - 3.5.0 (from 3.4.1)
+- rspec-support - 3.5.0 (from 3.4.1)
+- simplecov - 0.12.0 (from 0.11.2)
+- specinfra - 2.60.3 (from 2.59.4)
+- mixlib-archive - 0.2.0 (added to package)
 
 ## What's New in 12.12
 
 The following items are new for chef-client 12.12 and/or are changes
 from previous versions. The short version:
 
--   **New node attribute APIs** Common set of methods to read, write,
+- **New node attribute APIs** Common set of methods to read, write,
     delete, and check if node attributes exist.
--   **Data collector updates** Minor enhancements to data that the data
+- **Data collector updates** Minor enhancements to data that the data
     collector reports on.
--   **knife cookbook create has been deprecated** You should use [chef
+- **knife cookbook create has been deprecated** You should use [chef
     generate cookbook](/ctl_chef/#chef-generate-cookbook) instead.
 
 ### New node attribute read, write, unlink, and exist? APIs
@@ -7217,13 +7217,13 @@ see if `node.default["foo"]["bar"]` exists.
 
 The following methods have been deprecated in this release:
 
--   `node.set`
--   `node.set_unless`
+- `node.set`
+- `node.set_unless`
 
 ### data_collector updates
 
--   Adds `node` to the data_collector message.
--   `data_collector` reports on all resources and not just those that
+- Adds `node` to the data_collector message.
+- `data_collector` reports on all resources and not just those that
     have been processed.
 
 ## What's New in 12.11
@@ -7231,17 +7231,17 @@ The following methods have been deprecated in this release:
 The following items are new for chef-client 12.11 and/or are changes
 from previous versions. The short version:
 
--   **Support for standard exit codes in Chef client** Standard exit
+- **Support for standard exit codes in Chef client** Standard exit
     codes are now used by Chef client and should be identical across all
     OS platforms. New configuration setting `exit_status` has been added
     to specify how Chef client reports non-standard exit codes.
--   **New data collector functionality for run statistics** New feature
+- **New data collector functionality for run statistics** New feature
     that provides a unified method for sharing statistics about your
     Chef runs in webhook-like manner.
--   **Default chef-solo behavior is equivalent to chef-client local
+- **Default chef-solo behavior is equivalent to chef-client local
     mode** chef-solo now uses chef-client local mode. To use the
     previous `chef-solo` behavior, run in `chef-solo --legacy-mode`.
--   **New systemd_unit resource** Use the **systemd_unit** to manage
+- **New systemd_unit resource** Use the **systemd_unit** to manage
     systemd units.
 
 ### exit_status
@@ -7272,12 +7272,12 @@ solo legacy mode.
 To enable the data collector, specify the following settings in your
 client configuration file:
 
--   `data_collector.server_url`: Required. The URL to which the Chef
+- `data_collector.server_url`: Required. The URL to which the Chef
     client will POST the data collector messages
--   `data_collector.token`: Optional. An token which will be sent in a
+- `data_collector.token`: Optional. An token which will be sent in a
     x-data-collector-token HTTP header which can be used to authenticate
     the message.
--   `data_collector.mode`: The Chef mode in which the data collector
+- `data_collector.mode`: The Chef mode in which the data collector
     should run. Chef client mode is chef client configured to use Chef
     server to provide Chef client its resources and artifacts. Chef solo
     mode is Chef client configured to use a local Chef zero server
@@ -7285,10 +7285,10 @@ client configuration file:
     enable data collector in Chef solo mode but not Chef client mode.
     Available options are `:solo`, `:client`, or `:both`. Default is
     `:both`.
--   `data_collector.raise_on_failure`: If enabled, Chef will raise an
+- `data_collector.raise_on_failure`: If enabled, Chef will raise an
     exception and fail to run if the data collector cannot be reached at
     the start of the Chef run. Defaults to false.
--   `data_collector.organization`: Optional. In Chef solo mode, the
+- `data_collector.organization`: Optional. In Chef solo mode, the
     organization field in the messages will be set to this value.
     Default is `chef_solo`. This field does not apply to Chef client
     mode.
@@ -7341,11 +7341,11 @@ end
 
 where
 
--   `name` is the name of the unit
--   `user` is the user account that systemd units run under. If not
+- `name` is the name of the unit
+- `user` is the user account that systemd units run under. If not
     specified, systemd units will run under the system account.
--   `content` describes the behavior of the unit
--   `triggers_reload` controls if a <span
+- `content` describes the behavior of the unit
+- `triggers_reload` controls if a <span
     class="title-ref">daemon-reload</span> is executed to load the unit
 
 #### Actions
@@ -7455,13 +7455,13 @@ This resource has the following properties:
 The following items are new for chef-client 12.10 and/or are changes
 from previous versions. The short version:
 
--   **New layout property for mdadm resource** Use the `layout` property
+- **New layout property for mdadm resource** Use the `layout` property
     to set the RAID5 parity algorithm. Possible values:
     `left-asymmetric` (or `la`), `left-symmetric` (or `ls`),
     `right-asymmetric` (or `ra`), or `right-symmetric` (or `rs`).
--   **New with_run_context for the Chef Infra Language** Use `with_run_context`
+- **New with_run_context for the Chef Infra Language** Use `with_run_context`
     to run resource blocks as part of the root or parent run context.
--   **New Chef Infra Language methods for declaring, deleting, editing, and
+- **New Chef Infra Language methods for declaring, deleting, editing, and
     finding resources** Use the `declare_resource`, `delete_resource`,
     `edit_resource`, and `find_resource` methods to interact with
     resources in the resource collection. Use the `delete_resource!`,
@@ -7486,8 +7486,8 @@ end
 
 where `:type` may be one of the following:
 
--   `:root` runs the block as part of the root `run_context` hierarchy
--   `:parent` runs the block as part of the parent process in the
+- `:root` runs the block as part of the root `run_context` hierarchy
+- `:parent` runs the block as part of the parent process in the
     `run_context` hierarchy
 
 For example:
@@ -7519,15 +7519,15 @@ declare_resource(:resource_type, 'resource_name', resource_attrs_block)
 
 where:
 
--   `:resource_type` is the resource type, such as `:file` (for the
+- `:resource_type` is the resource type, such as `:file` (for the
     **file** resource), `:template` (for the **template** resource), and
     so on. Any resource available to Chef may be declared.
--   `resource_name` the property that is the default name of the
+- `resource_name` the property that is the default name of the
     resource, typically the string that appears in the
     `resource 'name' do` block of a resource (but not always); see the
     Syntax section for the resource to be declared to verify the default
     name property.
--   `resource_attrs_block` is a block in which properties of the
+- `resource_attrs_block` is a block in which properties of the
     instantiated resource are declared.
 
 For example:
@@ -7559,10 +7559,10 @@ delete_resource(:resource_type, 'resource_name')
 
 where:
 
--   `:resource_type` is the resource type, such as `:file` (for the
+- `:resource_type` is the resource type, such as `:file` (for the
     **file** resource), `:template` (for the **template** resource), and
     so on. Any resource available to Chef may be declared.
--   `resource_name` the property that is the default name of the
+- `resource_name` the property that is the default name of the
     resource, typically the string that appears in the
     `resource 'name' do` block of a resource (but not always); see the
     Syntax section for the resource to be declared to verify the default
@@ -7588,10 +7588,10 @@ delete_resource!(:resource_type, 'resource_name')
 
 where:
 
--   `:resource_type` is the resource type, such as `:file` (for the
+- `:resource_type` is the resource type, such as `:file` (for the
     **file** resource), `:template` (for the **template** resource), and
     so on. Any resource available to Chef may be declared.
--   `resource_name` the property that is the default name of the
+- `resource_name` the property that is the default name of the
     resource, typically the string that appears in the
     `resource 'name' do` block of a resource (but not always); see the
     Syntax section for the resource to be declared to verify the default
@@ -7607,8 +7607,8 @@ delete_resource!(:file, '/x/file.txt')
 
 Use the `edit_resource` method to:
 
--   Find a resource in the resource collection, and then edit it.
--   Define a resource block. If a resource block with the same name
+- Find a resource in the resource collection, and then edit it.
+- Define a resource block. If a resource block with the same name
     exists in the resource collection, it will be updated with the
     contents of the resource block defined by the `edit_resource`
     method. If a resource block does not exist in the resource
@@ -7622,15 +7622,15 @@ edit_resource(:resource_type, 'resource_name', resource_attrs_block)
 
 where:
 
--   `:resource_type` is the resource type, such as `:file` (for the
+- `:resource_type` is the resource type, such as `:file` (for the
     **file** resource), `:template` (for the **template** resource), and
     so on. Any resource available to Chef may be declared.
--   `resource_name` the property that is the default name of the
+- `resource_name` the property that is the default name of the
     resource, typically the string that appears in the
     `resource 'name' do` block of a resource (but not always); see the
     Syntax section for the resource to be declared to verify the default
     name property.
--   `resource_attrs_block` is a block in which properties of the
+- `resource_attrs_block` is a block in which properties of the
     instantiated resource are declared.
 
 For example:
@@ -7656,8 +7656,8 @@ end
 
 Use the `edit_resource!` method to:
 
--   Find a resource in the resource collection, and then edit it.
--   Define a resource block. If a resource with the same name exists in
+- Find a resource in the resource collection, and then edit it.
+- Define a resource block. If a resource with the same name exists in
     the resource collection, its properties will be updated with the
     contents of the resource block defined by the `edit_resource`
     method.
@@ -7672,15 +7672,15 @@ edit_resource!(:resource_type, 'resource_name')
 
 where:
 
--   `:resource_type` is the resource type, such as `:file` (for the
+- `:resource_type` is the resource type, such as `:file` (for the
     **file** resource), `:template` (for the **template** resource), and
     so on. Any resource available to Chef may be declared.
--   `resource_name` the property that is the default name of the
+- `resource_name` the property that is the default name of the
     resource, typically the string that appears in the
     `resource 'name' do` block of a resource (but not always); see the
     Syntax section for the resource to be declared to verify the default
     name property.
--   `resource_attrs_block` is a block in which properties of the
+- `resource_attrs_block` is a block in which properties of the
     instantiated resource are declared.
 
 For example:
@@ -7693,8 +7693,8 @@ edit_resource!(:file, '/x/y.rst')
 
 Use the `find_resource` method to:
 
--   Find a resource in the resource collection.
--   Define a resource block. If a resource block with the same name
+- Find a resource in the resource collection.
+- Define a resource block. If a resource block with the same name
     exists in the resource collection, it will be returned. If a
     resource block does not exist in the resource collection, it will be
     created.
@@ -7707,10 +7707,10 @@ find_resource(:resource_type, 'resource_name')
 
 where:
 
--   `:resource_type` is the resource type, such as `:file` (for the
+- `:resource_type` is the resource type, such as `:file` (for the
     **file** resource), `:template` (for the **template** resource), and
     so on. Any resource available to Chef may be declared.
--   `resource_name` the property that is the default name of the
+- `resource_name` the property that is the default name of the
     resource, typically the string that appears in the
     `resource 'name' do` block of a resource (but not always); see the
     Syntax section for the resource to be declared to verify the default
@@ -7746,10 +7746,10 @@ find_resource!(:resource_type, 'resource_name')
 
 where:
 
--   `:resource_type` is the resource type, such as `:file` (for the
+- `:resource_type` is the resource type, such as `:file` (for the
     **file** resource), `:template` (for the **template** resource), and
     so on. Any resource available to Chef may be declared.
--   `resource_name` the property that is the default name of the
+- `resource_name` the property that is the default name of the
     resource, typically the string that appears in the
     `resource 'name' do` block of a resource (but not always); see the
     Syntax section for the resource to be declared to verify the default
@@ -7766,28 +7766,28 @@ find_resource!(:template, '/x/y.erb')
 The following items are new for chef-client 12.9 and/or are changes from
 previous versions. The short version:
 
--   **New apt_repository resource**
--   **64-bit chef-client for Microsoft Windows** Starting with
+- **New apt_repository resource**
+- **64-bit chef-client for Microsoft Windows** Starting with
     chef-client 12.9, 64-bit
--   **New property for the mdadm resource** Use the `mdadm_defaults`
+- **New property for the mdadm resource** Use the `mdadm_defaults`
     property to set the default values for `chunk` and `metadata` to
     `nil`, which allows mdadm to apply its own default values.
--   **File redirection in Windows for 32-bit applications** Files on
+- **File redirection in Windows for 32-bit applications** Files on
     Microsoft Windows that are managed by the **file** and **directory**
     resources are subject to file redirection, depending if Chef Client
     is 64-bit or 32-bit.
--   **Registry key redirection in Windows for 32-bit applications**
+- **Registry key redirection in Windows for 32-bit applications**
     Registry keys on Microsoft Windows that are managed by the
     **registry_key** resource are subject to key redirection, depending
     if Chef Client is 64-bit or 32-bit.
--   **New values for log_location** Use `:win_evt` to write log output
+- **New values for log_location** Use `:win_evt` to write log output
     to the (Windows Event Logger and `:syslog` to write log output to
     the syslog daemon facility with the originator set as `chef-client`.
--   **New timeout setting for knife ssh** Set the `--ssh-timeout`
+- **New timeout setting for knife ssh** Set the `--ssh-timeout`
     setting to an integer (in seconds) as part of a `knife ssh` command.
     The `ssh_timeout` setting may also be configured (as seconds) in the
     knife.rb file.
--   **New "seconds to wait before first chef-client run" setting** The
+- **New "seconds to wait before first chef-client run" setting** The
     `-daemonized` option for Chef Client now allows the seconds to wait
     before starting Chef Client run to be specified. For example, if
     `--daemonize 10` is specified, Chef Client will wait ten seconds.
@@ -7802,8 +7802,8 @@ to depend on the apt cookbook to use the apt_repository resource.
 
 Chef Client now runs on 64-bit Microsoft Windows operating systems.
 
--   Support for file redirection
--   Support for key redirection
+- Support for file redirection
+- Support for key redirection
 
 #### File Redirection
 
@@ -7866,22 +7866,22 @@ Reflection](https://msdn.microsoft.com/en-us/library/windows/desktop/aa384235(v=
 The following items are new for chef-client 12.8 and/or are changes from
 previous versions. The short version:
 
--   **Support for OpenSSL validation of FIPS** Chef Client can be
+- **Support for OpenSSL validation of FIPS** Chef Client can be
     configured to allow OpenSSL to enforce FIPS-validated security
     during a chef-client run.
--   **Support for multiple configuration files** Chef Client supports
+- **Support for multiple configuration files** Chef Client supports
     reading multiple configuration files by putting them inside a `.d`
     configuration directory.
--   **New launchd resource** Use the **launchd** resource to manage
+- **New launchd resource** Use the **launchd** resource to manage
     system-wide services (daemons) and per-user services (agents) on the
     macOS platform.
--   **chef-zero support for Chef Server API endpoints** chef-zero now
+- **chef-zero support for Chef Server API endpoints** chef-zero now
     supports using all Chef server API version 12 endpoints, with the
     exception of `/universe`.
--   **Updated support for OpenSSL** OpenSSL is updated to version 1.0.1.
--   **Ohai auto-detects hosts for Azure instances** Ohai will
+- **Updated support for OpenSSL** OpenSSL is updated to version 1.0.1.
+- **Ohai auto-detects hosts for Azure instances** Ohai will
     auto-detect hosts for instances that are hosted by Microsoft Azure.
--   **gem attribute added to metadata.rb** Specify a gem dependency to
+- **gem attribute added to metadata.rb** Specify a gem dependency to
     be installed via the **chef_gem** resource after all cookbooks are
     synchronized, but before any other cookbook loading is done.
 
@@ -7907,22 +7907,22 @@ is not used for any cryptographic purpose.
 
 Notes about FIPS:
 
--   May be enabled for nodes running on Microsoft Windows and Enterprise
+- May be enabled for nodes running on Microsoft Windows and Enterprise
     Linux platforms
--   Should only be enabled for environments that require FIPS 140-2
+- Should only be enabled for environments that require FIPS 140-2
     compliance
--   May not be enabled for any version of Chef Client earlier than 12.8
+- May not be enabled for any version of Chef Client earlier than 12.8
 
 #### Enable FIPS Mode
 
 Allowing OpenSSL to enforce FIPS-validated security may be enabled by
 using any of the following ways:
 
--   Set the `fips` configuration setting to `true` in the client.rb or
+- Set the `fips` configuration setting to `true` in the client.rb or
     knife.rb files
--   Set the `--fips` command-line option when running any knife command
+- Set the `--fips` command-line option when running any knife command
     or Chef Client executable
--   Set the `--fips` command-line option when bootstrapping a node using
+- Set the `--fips` command-line option when bootstrapping a node using
     the `knife bootstrap` command
 
 #### Command Option
@@ -7969,19 +7969,19 @@ are loaded; other non-`.rb` files are ignored.
 `.d` directories may exist in any location where the `client.rb`,
 `config.rb`, or `solo.rb` files are present, such as:
 
--   `/etc/chef/client.d`
--   `/etc/chef/config.d`
--   `~/chef/solo.d`
+- `/etc/chef/client.d`
+- `/etc/chef/config.d`
+- `~/chef/solo.d`
 
 (There is no support for a `knife.d` directory; use `config.d` instead.)
 
 For example, when using knife, the following configuration files would
 be loaded:
 
--   `~/.chef/config.rb`
--   `~/.chef/config.d/company_settings.rb`
--   `~/.chef/config.d/ec2_configuration.rb`
--   `~/.chef/config.d/old_settings.rb.bak`
+- `~/.chef/config.rb`
+- `~/.chef/config.d/company_settings.rb`
+- `~/.chef/config.d/ec2_configuration.rb`
+- `~/.chef/config.d/old_settings.rb.bak`
 
 The `old_settings.rb.bak` file is ignored because it's not a
 configuration file. The `config.rb`, `company_settings.rb`, and
@@ -8079,11 +8079,11 @@ end
 
 where
 
--   `launchd` is the resource
--   `name` is the name of the resource block
--   `action` identifies the steps Chef Client will take to bring the
+- `launchd` is the resource
+- `name` is the name of the resource block
+- `action` identifies the steps Chef Client will take to bring the
     node into the desired state
--   `abandon_process_group`, `backup`, `cookbook`, `debug`, `disabled`,
+- `abandon_process_group`, `backup`, `cookbook`, `debug`, `disabled`,
     `enable_globbing`, `enable_transactions`, `environment_variables`,
     `exit_timeout`, `group`, `hard_resource_limits`, `hash`,
     `inetd_compatibility`, `init_groups`, `keep_alive`, `label`,
@@ -8686,23 +8686,23 @@ gem "chef-sugar"
 The following items are new for chef-client 12.7 and/or are changes from
 previous versions. The short version:
 
--   **Chef::REST =\> require 'chef/rest'** Internal API calls are moved
+- **Chef::REST =\> require 'chef/rest'** Internal API calls are moved
     from `Chef::REST` to `Chef::ServerAPI`. Any code that uses
     `Chef::REST` must use `require 'chef/rest'`.
--   **New chocolatey_package resource** Use the **chocolatey_package**
+- **New chocolatey_package resource** Use the **chocolatey_package**
     resource to manage packages using Chocolatey for the Microsoft
     Windows platform.
--   **New osx_profile resource** Use the **osx_profile** resource to
+- **New osx_profile resource** Use the **osx_profile** resource to
     manage configuration profiles (`.mobileconfig` files) on the macOS
     platform.
--   **New apt_update resource** Use the **apt_update** resource to
+- **New apt_update resource** Use the **apt_update** resource to
     manage Apt repository updates on Debian and Ubuntu platforms.
--   **Improved support for UTF-8** Chef Client 12.7 release fixes a
+- **Improved support for UTF-8** Chef Client 12.7 release fixes a
     UTF-8 handling bug present in chef-client versions 12.4, 12.5, and
     12.6.
--   **New options for the chef-client** Chef Client has a new option:
+- **New options for the chef-client** Chef Client has a new option:
     `--delete-entire-chef-repo`.
--   **Multi-package support for Chocolatey and Zypper** A resource may
+- **Multi-package support for Chocolatey and Zypper** A resource may
     specify multiple packages and/or versions for platforms that use
     Zypper or Chocolatey package managers (in addition to the existing
     support for specifying multiple packages for Yum and Apt packages).
@@ -8756,11 +8756,11 @@ end
 
 where
 
--   `chocolatey_package` tells Chef Client to manage a package
--   `'name'` is the name of the package
--   `action` identifies which steps Chef Client will take to bring the
+- `chocolatey_package` tells Chef Client to manage a package
+- `'name'` is the name of the package
+- `action` identifies which steps Chef Client will take to bring the
     node into the desired state
--   `options`, `package_name`, `source`, `timeout`, and `version` are
+- `options`, `package_name`, `source`, `timeout`, and `version` are
     properties of this resource, with the Ruby type shown. See
     "Properties" section below for more information about all of the
     properties that may be used with this resource.
@@ -9001,11 +9001,11 @@ end
 
 where
 
--   `osx_profile` is the resource
--   `name` is the name of the resource block
--   `action` identifies the steps Chef Client will take to bring the
+- `osx_profile` is the resource
+- `name` is the name of the resource block
+- `action` identifies the steps Chef Client will take to bring the
     node into the desired state
--   `profile`, `profile_name`, and `identifier` are properties of this
+- `profile`, `profile_name`, and `identifier` are properties of this
     resource, with the Ruby type shown. See "Properties" section below
     for more information about all of the properties that may be used
     with this resource.
@@ -9169,11 +9169,11 @@ end
 
 where
 
--   `apt_update` is the resource
--   `name` is the name of the resource block
--   `action` identifies the steps Chef Client will take to bring the
+- `apt_update` is the resource
+- `name` is the name of the resource block
+- `action` identifies the steps Chef Client will take to bring the
     node into the desired state
--   `frequency` is a property of this resource, with the Ruby type
+- `frequency` is a property of this resource, with the Ruby type
     shown. See "Properties" section below for more information about all
     of the properties that may be used with this resource.
 
@@ -9240,42 +9240,42 @@ Chef Client has the following new options:
 The following items are new for chef-client 12.6 and/or are changes from
 previous versions. The short version:
 
--   **New timer for resource notifications** Use the `:before` timer
+- **New timer for resource notifications** Use the `:before` timer
     with the `notifies` and `subscribes` properties to specify that the
     action on a notified resource should be run before processing the
     resource block in which the notification is located.
--   **New ksh resource** The **ksh** resource is added and is based on
+- **New ksh resource** The **ksh** resource is added and is based on
     the **script** resource.
--   **New metadata.rb settings** The metadata.rb file has settings for
+- **New metadata.rb settings** The metadata.rb file has settings for
     `chef_version` and `ohai_version` that allow ranges to be specified
     that declare the supported versions of Chef Client and Ohai.
--   **dsc_resource supports reboots** The **dsc_resource** resource
+- **dsc_resource supports reboots** The **dsc_resource** resource
     supports immediate and queued reboots. This uses the **reboot**
     resource and its `:reboot_now` or `:request_reboot` actions.
--   **New and changed knife bootstrap options** The `--identify-file`
+- **New and changed knife bootstrap options** The `--identify-file`
     option for the `knife bootstrap` subcommand is renamed to
     `--ssh-identity-file`; the `--sudo-preserve-home` is new.
--   **New installer types for the windows_package resource** The
+- **New installer types for the windows_package resource** The
     **windows_package** resource now supports the following installer
     types: `:custom`, Inno Setup (`:inno`), InstallShield
     (`:installshield`), Microsoft Installer Package (MSI) (`:msi`),
     Nullsoft Scriptable Install System (NSIS) (`:nsis`), Wise (`:wise`).
     Prior versions of Chef supported only `:msi`.
--   **dsc_resource resource may be run in non-disabled refresh mode**
+- **dsc_resource resource may be run in non-disabled refresh mode**
     The latest version of Windows Management Framework (WMF) 5 has
     relaxed the limitation that prevented Chef Client from running in
     non-disabled refresh mode. Requires Windows PowerShell 5.0.10586.0
     or higher.
--   **dsc_script and dsc_resource resources may be in the same
+- **dsc_script and dsc_resource resources may be in the same
     run-list** The latest version of Windows Management Framework (WMF)
     5 has relaxed the limitation that prevented Chef Client from running
     in non-disabled refresh mode, which allows the Local Configuration
     Manager to be set to `Push`. Requires Windows PowerShell 5.0.10586.0
     or higher.
--   **New --profile-ruby option** Use the `--profile-ruby` option to
+- **New --profile-ruby option** Use the `--profile-ruby` option to
     dump a (large) profiling graph into
     `/var/chef/cache/graph_profile.out`.
--   **New live_stream property for the execute resource** Set the
+- **New live_stream property for the execute resource** Set the
     `live_stream` property to `true` to send the output of a command run
     by the **execute** resource to Chef Client event stream.
 
@@ -9333,7 +9333,7 @@ end
 
 where
 
--   `code` specifies the command to run
+- `code` specifies the command to run
 
 The full syntax for all of the properties that are available to the
 **ksh** resource is:
@@ -9359,11 +9359,11 @@ end
 
 where
 
--   `ksh` is the resource
--   `name` is the name of the resource block
--   `action` identifies the steps Chef Client will take to bring the
+- `ksh` is the resource
+- `name` is the name of the resource block
+- `action` identifies the steps Chef Client will take to bring the
     node into the desired state
--   `code`, `creates`, `cwd`, `environment`, `flags`, `group`, `path`,
+- `code`, `creates`, `cwd`, `environment`, `flags`, `group`, `path`,
     `returns`, `timeout`, `user`, and `umask` are properties of this
     resource, with the Ruby type shown. See "Properties" section below
     for more information about all of the properties that may be used
@@ -9483,10 +9483,10 @@ The ksh resource has the following properties:
 
 Using the **dsc_resource** has the following requirements:
 
--   Windows Management Framework (WMF) 5.0 February Preview (or higher),
+- Windows Management Framework (WMF) 5.0 February Preview (or higher),
     which includes Windows PowerShell 5.0.10018.0 (or higher).
 
--   The `RefreshMode` configuration setting in the Local Configuration
+- The `RefreshMode` configuration setting in the Local Configuration
     Manager must be set to `Disabled`.
 
     {{< note spaces=4 >}}
@@ -9499,7 +9499,7 @@ Using the **dsc_resource** has the following requirements:
 
     {{< /note >}}
 
--   The **dsc_script** resource may not be used in the same run-list
+- The **dsc_script** resource may not be used in the same run-list
     with the **dsc_resource**. This is because the **dsc_script**
     resource requires that `RefreshMode` in the Local Configuration
     Manager be set to `Push`, whereas the **dsc_resource** resource
@@ -9516,7 +9516,7 @@ Using the **dsc_resource** has the following requirements:
 
     {{< /note >}}
 
--   The **dsc_resource** resource can only use binary- or script-based
+- The **dsc_resource** resource can only use binary- or script-based
     resources. Composite DSC resources may not be used.
 
     This is because composite resources aren't "real" resources from the
@@ -9588,25 +9588,25 @@ Use the `--profile-ruby` option to dump a (large) profiling graph into
 identify, and then resolve performance bottlenecks in a chef-client run.
 This option:
 
--   Generates a large amount of data about the chef-client run.
--   Has a dependency on the `ruby-prof` gem, which is packaged as part
+- Generates a large amount of data about the chef-client run.
+- Has a dependency on the `ruby-prof` gem, which is packaged as part
     of Chef and the ChefDK.
--   Increases the amount of time required to complete the chef-client
+- Increases the amount of time required to complete the chef-client
     run.
--   Should not be used in a production environment.
+- Should not be used in a production environment.
 
 ## What's New in 12.5
 
 The following items are new for chef-client 12.5 and/or are changes from
 previous versions. The short version:
 
--   **New way to build custom resources** The process for extending the
+- **New way to build custom resources** The process for extending the
     collection of resources that are built into Chef has been
     simplified. It is defined only in the `/resources` directory using a
     simplified syntax that easily leverages the built-in collection of
     resources. (All of the ways you used to build custom resources still
     work.)
--   **"resource attributes" are now known as "resource properties"** In
+- **"resource attributes" are now known as "resource properties"** In
     previous releases of Chef, resource properties are referred to as
     attributes, but this is confusing for users because nodes also have
     attributes. Starting with chef-client 12.5 release---and
@@ -9614,20 +9614,20 @@ previous versions. The short version:
     documentation---"resource attributes" are now referred to as
     "resource properties" and the word "attribute" now refers
     specifically to "node attributes".
--   **ps_credential helper to embed usernames and passwords** Use the
+- **ps_credential helper to embed usernames and passwords** Use the
     `ps_credential` helper on Microsoft Windows to create a
     `PSCredential` object---security credentials, such as a user name or
     password---that can be used in the **dsc_script** resource.
--   **New Handler DSL** A new DSL exists to make it easier to use events
+- **New Handler DSL** A new DSL exists to make it easier to use events
     that occur during Chef Client run from recipes. The `on` method is
     easily associated with events. The action Chef Client takes as a
     result of that event (when it occurs) is up to you.
--   **The -j / --json-attributes supports policy revisions and
+- **The -j / --json-attributes supports policy revisions and
     environments** The JSON file used by the `--json-attributes` option
     for Chef Client may now contain the policy name and policy group
     associated with a policy revision or may contain the name of the
     environment to which the node is associated.
--   **verify property now uses path, not file** The `verify` property,
+- **verify property now uses path, not file** The `verify` property,
     used by file-based resources such as **remote_file** and **file**,
     runs user-defined correctness checks against the proposed new file
     before making the change. For versions of Chef Client prior to 12.5,
@@ -9635,12 +9635,12 @@ previous versions. The short version:
     chef-client 12.5, use `path`. This change is documented as a warning
     across all versions in any topic in which the `version` attribute is
     documented.
--   **depth property added to deploy resource** The `depth` property
+- **depth property added to deploy resource** The `depth` property
     allows the depth of a git repository to be truncated to the
     specified number of versions.
--   **The knife ssl check subcommand supports SNI** Support for Server
+- **The knife ssl check subcommand supports SNI** Support for Server
     Name Indication (SNI) is added to the `knife ssl check` subcommand.
--   **Chef Policy group and name can now be part of the node object**
+- **Chef Policy group and name can now be part of the node object**
     Chef policy is a beta feature of Chef Client that will eventually
     replace roles, environments or manually specifying the run_list.
     Policy group and name can now be stored as part of the node object
@@ -9652,12 +9652,12 @@ previous versions. The short version:
 
 A custom resource:
 
--   Is a simple extension of Chef that adds your own resources
--   Is implemented and shipped as part of a cookbook
--   Follows easy, repeatable syntax patterns
--   Effectively leverages resources that are built into Chef and/or
+- Is a simple extension of Chef that adds your own resources
+- Is implemented and shipped as part of a cookbook
+- Follows easy, repeatable syntax patterns
+- Effectively leverages resources that are built into Chef and/or
     custom Ruby code
--   Is reusable in the same way as resources that are built into Chef
+- Is reusable in the same way as resources that are built into Chef
 
 For example, Chef includes built-in resources to manage files, packages,
 templates, and services, but it does not include a resource that manages
@@ -9675,9 +9675,9 @@ including a scenario that shows how to build a `website` resource.
 A custom resource is defined as a Ruby file and is located in a
 cookbook's `/resources` directory. This file
 
--   Declares the properties of the custom resource
--   Loads current state of properties, if the resource already exists
--   Defines each action the custom resource may take
+- Declares the properties of the custom resource
+- Loads current state of properties, if the resource already exists
+- Defines each action the custom resource may take
 
 The syntax for a custom resource is. For example:
 
@@ -9737,13 +9737,13 @@ end
 
 where
 
--   `homepage` is a property that sets the default HTML for the
+- `homepage` is a property that sets the default HTML for the
     `index.html` file with a default value of `'<h1>Hello world!</h1>'`
--   the `action` block uses the built-in collection of resources to tell
+- the `action` block uses the built-in collection of resources to tell
     Chef Client how to install Apache, start the service, and then
     create the contents of the file located at
     `/var/www/html/index.html`
--   `action :create` is the default resource, because it is listed
+- `action :create` is the default resource, because it is listed
     first; `action :delete` must be called specifically (because it is
     not the default resource)
 
@@ -9773,10 +9773,10 @@ end
 Use the Custom Resource DSL to define property behaviors within custom
 resources, such as:
 
--   Loading the value of a specific property
--   Comparing the current property value against a desired property
+- Loading the value of a specific property
+- Comparing the current property value against a desired property
     value
--   Telling Chef Client when and how to make changes
+- Telling Chef Client when and how to make changes
 
 #### action_class
 
@@ -9880,7 +9880,7 @@ executed and Chef Client output will print something similar to:
 Recipe: recipe_name::block
   * resource_name[blah] action create
     - update my_file[blah]
-    -   set content to "hola mundo" (was "hello world")
+    - set content to "hola mundo" (was "hello world")
 ```
 
 **Multiple Properties**
@@ -9914,10 +9914,10 @@ end
 
 where
 
--   `load_current_value` loads the property values for both `content`
+- `load_current_value` loads the property values for both `content`
     and `mode`
--   A `converge_if_changed` block tests only `content`
--   A `converge_if_changed` block tests only `mode`
+- A `converge_if_changed` block tests only `content`
+- A `converge_if_changed` block tests only `mode`
 
 Chef Client will only update the property values that require updates
 and will not make changes when the property values are already in the
@@ -10095,12 +10095,12 @@ property :property_name, ruby_type, default: 'value', parameter: 'value'
 
 where
 
--   `:property_name` is the name of the property
--   `ruby_type` is the optional Ruby type or array of types, such as
+- `:property_name` is the name of the property
+- `ruby_type` is the optional Ruby type or array of types, such as
     `String`, `Integer`, `true`, or `false`
--   `default: 'value'` is the optional default value loaded into the
+- `default: 'value'` is the optional default value loaded into the
     resource
--   `parameter: 'value'` optional parameters
+- `parameter: 'value'` optional parameters
 
 For example, the following properties define `username` and `password`
 properties with no default values specified:
@@ -10219,9 +10219,9 @@ property :enabled, equal_to: [true, false, 'true', 'false'], default: true
 Add `desired_state:` to set the desired state property for a resource.
 This value may be `true` or `false`, and all properties default to true.
 
--   When `true`, the state of the property is determined by the state of
+- When `true`, the state of the property is determined by the state of
     the system
--   When `false`, the value of the property impacts how the resource
+- When `false`, the value of the property impacts how the resource
     executes, but it is not determined by the state of the system.
 
 For example, if you were to write a resource to create volumes on a
@@ -10247,10 +10247,10 @@ property :cloud_password, String, desired_state: false
 Add `identity:` to set a resource to a particular set of properties.
 This value may be `true` or `false`.
 
--   When `true`, data for that property is returned as part of the
+- When `true`, data for that property is returned as part of the
     resource data set and may be available to external applications,
     such as reporting
--   When `false`, no data for that property is returned.
+- When `false`, no data for that property is returned.
 
 If no properties are marked `true`, the property that defaults to the
 `name` of the resource is marked `true`.
@@ -10476,9 +10476,9 @@ Use the Handler DSL to attach a callback to an event. If the event
 occurs during Chef Infra Client run, the associated callback is
 executed. For example:
 
--   Sending email if a chef-client run fails
--   Sending a notification to chat application if an audit run fails
--   Aggregating statistics about resources updated during a chef-client
+- Sending email if a chef-client run fails
+- Sending a notification to chat application if an audit run fails
+- Aggregating statistics about resources updated during a chef-client
     runs to StatsD
 
 #### on Method
@@ -10498,11 +10498,11 @@ end
 
 where
 
--   `Chef.event_handler` declares a block of code within a recipe that
+- `Chef.event_handler` declares a block of code within a recipe that
     is processed when the named event occurs during a chef-client run
--   `on` defines the block of code that will tell Chef Client how to
+- `on` defines the block of code that will tell Chef Client how to
     handle the event
--   `:event_type` is a valid exception event type, such as `:run_start`,
+- `:event_type` is a valid exception event type, such as `:run_start`,
     `:run_failed`, `:converge_failed`, `:resource_failed`, or
     `:recipe_not_found`
 
@@ -10521,10 +10521,10 @@ end
 Use the `on` method to create an event handler that sends email when
 Chef Client run fails. This will require:
 
--   A way to tell Chef Client how to send email
--   An event handler that describes what to do when the `:run_failed`
+- A way to tell Chef Client how to send email
+- An event handler that describes what to do when the `:run_failed`
     event is triggered
--   A way to trigger the exception and test the behavior of the event
+- A way to trigger the exception and test the behavior of the event
     handler
 
 {{< note >}}
@@ -10575,8 +10575,8 @@ Chef.event_handler do
 end
 ```
 
--   Use `Chef.event_handler` to define the event handler
--   Use the `on` method to specify the event type
+- Use `Chef.event_handler` to define the event handler
+- Use the `on` method to specify the event type
 
 Within the `on` block, tell Chef Client how to handle the event when
 it's triggered.
@@ -10776,36 +10776,36 @@ enable the use of policy files:
 The following items are new for chef-client 12.4 and/or are changes from
 previous versions. The short version:
 
--   **Validatorless bootstrap now requires the node name** Use of the
+- **Validatorless bootstrap now requires the node name** Use of the
     `-N node_name` option with a validatorless bootstrap is now
     required.
--   **remote_file resource supports Windows UNC paths for source
+- **remote_file resource supports Windows UNC paths for source
     location** A Microsoft Windows UNC path may be used to specify the
     location of a remote file.
--   **Run PowerShell commands without excessive quoting** Use the
+- **Run PowerShell commands without excessive quoting** Use the
     `Import-Module chef` module to run Windows PowerShell commands
     without excessive quotation.
--   **Logging may use the Windows Event Logger** Log files may be sent
+- **Logging may use the Windows Event Logger** Log files may be sent
     to the Windows Event Logger. Set the `log_location` setting in the
     client.rb file to `Chef::Log::WinEvt.new`.
--   **Logging may be configured to use daemon facility available to the
+- **Logging may be configured to use daemon facility available to the
     chef-client** Log files may be sent to the syslog available to the
     chef-client. Set the `log_location` setting in the client.rb file to
     `Chef::Log::Syslog.new("chef-client", ::Syslog::LOG_DAEMON)`.
--   **Package locations on the Windows platform may be specified using a
+- **Package locations on the Windows platform may be specified using a
     URL** The location of a package may be at URL when using the
     **windows_package** resource.
--   **Package locations on the Windows platform may be specified by
+- **Package locations on the Windows platform may be specified by
     passing attributes to the remote_file resource** Use the
     `remote_file_attributes` attribute to pass a Hash of attributes that
     modifies the **remote_file** resource.
--   **Public key management for users and clients** The `knife client`
+- **Public key management for users and clients** The `knife client`
     and `knife user` subcommands may now create, delete, edit, list, and
     show public keys.
--   **knife client create and knife user create options have changed**
+- **knife client create and knife user create options have changed**
     With the new key management subcommands, the options for
     `knife client create` and `knife user create` have changed.
--   **chef-client audit-mode is no longer marked as "experimental"** The
+- **chef-client audit-mode is no longer marked as "experimental"** The
     recommended version of audit-mode is chef-client 12.4, where it is
     no longer marked as experimental. Chef Client will report audit
     failures independently of converge failures.
@@ -11348,14 +11348,14 @@ This argument has the following options:
 The following items are new for chef-client 12.3 and/or are changes from
 previous versions. The short version:
 
--   **Socketless local mode with chef-zero** Port binding and HTTP
+- **Socketless local mode with chef-zero** Port binding and HTTP
     requests on localhost may be disabled in favor of socketless mode.
--   **Minimal Ohai plugins** Run only the plugins required for name
+- **Minimal Ohai plugins** Run only the plugins required for name
     resolution and resource/provider detection.
--   **Dynamic resource and provider resolution** Four helper methods may
+- **Dynamic resource and provider resolution** Four helper methods may
     be used in a library file to get resource and/or provider mapping
     details, and then set them per-resource or provider.
--   **New clear_sources attribute for the chef_gem and gem_package
+- **New clear_sources attribute for the chef_gem and gem_package
     resources** Set to `true` to download a gem from the path specified
     by the `source` property (and not from RubyGems).
 
@@ -11445,9 +11445,9 @@ Chef.set_resource_priority_array(:package, [ Chef::Resource::MacportsPackage ], 
 The following items are new for chef-client 12.2 and/or are changes from
 previous versions. The short version:
 
--   **New dsc_resource** Use the **dsc_resource** resource to use any
+- **New dsc_resource** Use the **dsc_resource** resource to use any
     DSC resource in a Chef recipe.
--   **New --exit-on-error option for knife-ssh** Use the
+- **New --exit-on-error option for knife-ssh** Use the
     `--exit-on-error` option to have the `knife ssh` subcommand exit on
     any error.
 
@@ -11479,10 +11479,10 @@ resource collection.
 
 Using the **dsc_resource** has the following requirements:
 
--   Windows Management Framework (WMF) 5.0 February Preview (or higher),
+- Windows Management Framework (WMF) 5.0 February Preview (or higher),
     which includes Windows PowerShell 5.0.10018.0 (or higher).
 
--   The `RefreshMode` configuration setting in the Local Configuration
+- The `RefreshMode` configuration setting in the Local Configuration
     Manager must be set to `Disabled`.
 
     {{< note spaces=4 >}}
@@ -11495,13 +11495,13 @@ Using the **dsc_resource** has the following requirements:
 
     {{< /note >}}
 
--   The **dsc_script** resource may not be used in the same run-list
+- The **dsc_script** resource may not be used in the same run-list
     with the **dsc_resource**. This is because the **dsc_script**
     resource requires that `RefreshMode` in the Local Configuration
     Manager be set to `Push`, whereas the **dsc_resource** resource
     requires it to be set to `Disabled`.
 
--   The **dsc_resource** resource can only use binary- or script-based
+- The **dsc_resource** resource can only use binary- or script-based
     resources. Composite DSC resources may not be used. This is because
     composite resources aren't "real" resources from the perspective of
     the Local Configuration Manager (LCM). Composite resources are used
@@ -11555,13 +11555,13 @@ end
 
 where
 
--   `dsc_resource` is the resource
--   `name` is the name of the resource block
--   `property` is zero (or more) properties in the DSC resource, where
+- `dsc_resource` is the resource
+- `name` is the name of the resource block
+- `property` is zero (or more) properties in the DSC resource, where
     each property is entered on a separate line, `:dsc_property_name` is
     the case-insensitive name of that property, and `"property_value"`
     is a Ruby value to be applied by the chef-client
--   `module_name`, `property`, and `resource` are properties of this
+- `module_name`, `property`, and `resource` are properties of this
     resource, with the Ruby type shown. See "Properties" section below
     for more information about all of the properties that may be used
     with this resource.
@@ -11859,41 +11859,41 @@ end
 The following items are new for chef-client 12.1 and/or are changes from
 previous versions. The short version:
 
--   **chef-client may be run in audit-mode** Use audit-mode to run audit
+- **chef-client may be run in audit-mode** Use audit-mode to run audit
     tests against a node.
--   **control method added to Chef Infra Language** Use the `control` method to
+- **control method added to Chef Infra Language** Use the `control` method to
     define specific tests that match directories, files, packages,
     ports, and services. A `control` method must be contained within a
     `control_group` block.
--   **control_group method added to Chef Infra Language** Use the
+- **control_group method added to Chef Infra Language** Use the
     `control_group` method to group one (or more) `control` methods into
     a single audit.
--   **Bootstrap nodes without using the ORGANIZATION-validator.key
+- **Bootstrap nodes without using the ORGANIZATION-validator.key
     file** A node may now be bootstrapped using the USER.pem file,
     instead of the ORGANIZATION-validator.pem file. Also known as a
     "validatorless bootstrap".
--   **New options for knife-bootstrap** Use the
+- **New options for knife-bootstrap** Use the
     `--bootstrap-vault-file`, `--bootstrap-vault-item`, and
     `--bootstrap-vault-json` options with `knife bootstrap` to specify
     items that are stored in chef-vault.
--   **New verify attribute for cookbook_file, file, remote_file, and
+- **New verify attribute for cookbook_file, file, remote_file, and
     template resources** Use the `verify` attribute to test a file using
     a block of code or a string.
--   **New imports attribute for dsc_script resource** Use the `imports`
+- **New imports attribute for dsc_script resource** Use the `imports`
     attribute to import DSC resources from modules.
--   **New attribute for chef_gem resource** Use the `compile_time`
+- **New attribute for chef_gem resource** Use the `compile_time`
     attribute to disable compile-time installation of gems.
--   **New openbsd_package resource** Use the **openbsd_package**
+- **New openbsd_package resource** Use the **openbsd_package**
     resource to install packages on the OpenBSD platform.
--   **New --proxy-auth option for knife raw subcommand** Enable proxy
+- **New --proxy-auth option for knife raw subcommand** Enable proxy
     authentication to the Chef server web user interface..
--   **New watchdog_timeout setting for the Windows platform** Use the
+- **New watchdog_timeout setting for the Windows platform** Use the
     `windows_service.watchdog_timeout` setting in the client.rb file to
     specify the maximum amount of time allowed for a chef-client run on
     the Microsoft Windows platform.
--   **Support for multiple packages and versions** Multiple packages and
+- **Support for multiple packages and versions** Multiple packages and
     versions may be specified for platforms that use Yum or Apt.
--   **New attributes for windows_service resource** Use the
+- **New attributes for windows_service resource** Use the
     `run_as_user` and `run_as_password` attributes to specify the user
     under which a Microsoft Windows service should run.
 
@@ -11903,9 +11903,9 @@ Chef Client may be run in audit-mode. Use audit-mode to evaluate custom
 rules---also referred to as audits---that are defined in recipes.
 audit-mode may be run in the following ways:
 
--   By itself (i.e. a chef-client run that does not build the resource
+- By itself (i.e. a chef-client run that does not build the resource
     collection or converge the node)
--   As part of Chef Client run, where audit-mode runs after all
+- As part of Chef Client run, where audit-mode runs after all
     resources have been converged on the node
 
 Each audit is authored within a recipe using the `control_group` and
@@ -12001,19 +12001,19 @@ end
 
 where:
 
--   `control_group` groups one (or more) `control` blocks
--   `control 'name' do` defines an individual audit
--   Each `control` block must define at least one validation
--   Each `it` statement defines a single validation. `it` statements are
+- `control_group` groups one (or more) `control` blocks
+- `control 'name' do` defines an individual audit
+- Each `control` block must define at least one validation
+- Each `it` statement defines a single validation. `it` statements are
     processed individually when Chef Client is run in audit-mode
--   An `expect(something).to/.to_not be_something` is a statement that
+- An `expect(something).to/.to_not be_something` is a statement that
     represents the individual test. In other words, this statement tests
     if something is expected to be (or not be) something. For example, a
     test that expects the PostgreSQL package to not be installed would
     be similar to `expect(package('postgresql')).to_not be_installed`
     and a test that ensures a service is enabled would be similar to
     `expect(service('init')).to be_enabled`
--   An `it` statement may contain multiple `expect` statements
+- An `it` statement may contain multiple `expect` statements
 
 #### directory Matcher
 
@@ -12518,7 +12518,7 @@ end
 
 where
 
--   `let(:config_file) { file('/etc/ssh/sshd_config') }` uses the `file`
+- `let(:config_file) { file('/etc/ssh/sshd_config') }` uses the `file`
     matcher to test specific settings within the `sshd` configuration
     file
 
@@ -12576,11 +12576,11 @@ end
 
 where:
 
--   `control_group` groups one (or more) `control` blocks
--   `'name'` is the unique name for the `control_group`; Chef Client
+- `control_group` groups one (or more) `control` blocks
+- `'name'` is the unique name for the `control_group`; Chef Client
     will raise an exception if duplicate `control_group` names are
     present
--   `control` defines each individual audit within the `control_group`
+- `control` defines each individual audit within the `control_group`
     block. There is no limit to the number of `control` blocks that may
     defined within a `control_group` block
 
@@ -12850,8 +12850,8 @@ rm -f /home/lamont/.chef/myorg-validator.pem
 
 and then make the following changes in the config.rb file:
 
--   Remove the `validation_client_name` setting
--   Edit the `validation_key` setting to be something that isn't a path
+- Remove the `validation_client_name` setting
+- Edit the `validation_key` setting to be something that isn't a path
     to an existent ORGANIZATION-validator.pem file. For example:
     `/nonexist`.
 
@@ -13109,11 +13109,11 @@ end
 
 where:
 
--   `paludis_package` is the resource.
--   `name` is the name given to the resource block.
--   `action` identifies which steps Chef Client will take to bring the
+- `paludis_package` is the resource.
+- `name` is the name given to the resource block.
+- `action` identifies which steps Chef Client will take to bring the
     node into the desired state.
--   `options`, `package_name`, `source`, `recursive`, `timeout`, and
+- `options`, `package_name`, `source`, `recursive`, `timeout`, and
     `version` are properties of this resource, with the Ruby type shown.
     See "Properties" section below for more information about all of the
     properties that may be used with this resource.
@@ -13329,11 +13329,11 @@ end
 
 where:
 
--   `openbsd_package` is the resource.
--   `name` is the name given to the resource block.
--   `action` identifies which steps Chef Client will take to bring the
+- `openbsd_package` is the resource.
+- `name` is the name given to the resource block.
+- `action` identifies which steps Chef Client will take to bring the
     node into the desired state
--   `options`, `package_name`, `source`, `timeout`, and `version` are
+- `options`, `package_name`, `source`, `timeout`, and `version` are
     properties of this resource, with the Ruby type shown. See
     "Properties" section below for more information about all of the
     properties that may be used with this resource.
@@ -13543,9 +13543,9 @@ that use Yum, DNF, Apt, Zypper, or Chocolatey package managers.
 Specifying multiple packages and/or versions allows a single transaction
 to:
 
--   Download the specified packages and versions via a single HTTP
+- Download the specified packages and versions via a single HTTP
     transaction
--   Update or install multiple packages with a single resource during
+- Update or install multiple packages with a single resource during
     Chef Client run
 
 For example, installing multiple packages:
@@ -13611,149 +13611,149 @@ properties.
 The following items are new for chef-client 12.0 and/or are changes from
 previous versions. The short version:
 
--   **Changing attributes** Attributes may be modified for named
+- **Changing attributes** Attributes may be modified for named
     precedence levels, all precedence levels, and be fully assigned.
     These changes were [based on
     RFC-23](https://github.com/chef/chef-rfc/blob/master/rfc023-chef-12-attributes-changes.md).
--   **Ruby 2.0 (or higher) for Windows; and Ruby 2.1 (or higher) for
+- **Ruby 2.0 (or higher) for Windows; and Ruby 2.1 (or higher) for
     Unix/Linux** Ruby versions 1.8.7, 1.9.1, 1.9.2, and 1.9.3 are no
     longer supported. See [this blog
     post](https://blog.chef.io/ruby-1-9-3-eol-and-chef-12)
     for more info.
--   **The number of changes between Ruby 1.9 and 2.0 is small** Please
+- **The number of changes between Ruby 1.9 and 2.0 is small** Please
     review the [Ruby 2.0 release
     notes](https://github.com/ruby/ruby/blob/v2_0_0_0/NEWS) or [Ruby 2.1
     release notes](https://github.com/ruby/ruby/blob/v2_1_0/NEWS) for
     the full list of changes.
--   **provides method for building custom resources** Use the `provides`
+- **provides method for building custom resources** Use the `provides`
     method to associate a custom resource with a built-in chef-client
     resource and to specify platforms on which the custom resource may
     be used.
--   **Chef Client supports the AIX platform** Chef Client may now be
+- **Chef Client supports the AIX platform** Chef Client may now be
     used to configure nodes that are running on the AIX platform,
     versions 6.1 (TL6 or higher, recommended) and 7.1 (TL0 SP3 or
     higher, recommended). The **service** resource supports starting,
     stopping, and restarting services that are managed by System
     Resource Controller (SRC), as well as managing all service states
     with BSD-based init systems.
--   **New bff_package resource** Use the **bff_package** resource to
+- **New bff_package resource** Use the **bff_package** resource to
     install packages on the AIX platform.
--   **New homebrew_package resource** Use the **homebrew_package**
+- **New homebrew_package resource** Use the **homebrew_package**
     resource to install packages on the macOS platform. The
     **homebrew_package** resource also replaces the
     **macports_package** resource as the default package installer on
     the macOS platform.
--   **New reboot resource** Use the **reboot** resource to reboot a node
+- **New reboot resource** Use the **reboot** resource to reboot a node
     during or at the end of a chef-client run.
--   **New windows_service resource** Use the **windows_service**
+- **New windows_service resource** Use the **windows_service**
     resource to manage services on the Microsoft Windows platform.
--   **New --bootstrap-template option** Use the `--bootstrap-template`
+- **New --bootstrap-template option** Use the `--bootstrap-template`
     option to install Chef Client with a bootstrap template. Specify the
     name of a template, such as `chef-full`, or specify the path to a
     custom bootstrap template. This option deprecates the `--distro` and
     `--template-file` options.
--   **New SSL options for bootstrap operations** The `knife bootstrap`
+- **New SSL options for bootstrap operations** The `knife bootstrap`
     subcommand has new options that support SSL with bootstrap
     operations. Use the `--[no-]node-verify-api-cert` option to perform
     SSL validation of the connection to the Chef server. Use the
     `--node-ssl-verify-mode` option to validate SSL certificates.
--   **New format options for knife status** Use the `--medium` and
+- **New format options for knife status** Use the `--medium` and
     `--long` options to include attributes in the output and to format
     that output as JSON.
--   **New fsck_device property for mount resource** The **mount**
+- **New fsck_device property for mount resource** The **mount**
     resource supports fsck devices for the Solaris platform with the
     `fsck_device` property.
--   **New settings for metadata.rb** The metadata.rb file has two new
+- **New settings for metadata.rb** The metadata.rb file has two new
     settings: `issues_url` and `source_url`. These settings are used to
     capture the source location and issues tracking location for a
     cookbook. These settings are also used with Chef Supermarket. In
     addition, the `name` setting is now **required**.
--   **The http_request GET and HEAD requests drop the hard-coded query
+- **The http_request GET and HEAD requests drop the hard-coded query
     string** The `:get` and `:head` actions appended a hard-coded query
     string---`?message=resource_name`---that cannot be overridden. This
     hard-coded string is deprecated in Chef Client 12.0 release.
     Cookbooks that rely on this string need to be updated to manually
     add it to the URL as it is passed to the resource.
--   **New Chef Infra Language methods** The Chef Infra Language has three new methods:
+- **New Chef Infra Language methods** The Chef Infra Language has three new methods:
     `shell_out`, `shell_out!`, and `shell_out_with_systems_locale`.
--   **File specificity updates** File specificity for the **template**
+- **File specificity updates** File specificity for the **template**
     and **cookbook_file** resources now supports using the `source`
     attribute to define an explicit lookup path as an array.
--   **Improved user password security for the user resource, macOS
+- **Improved user password security for the user resource, macOS
     platform** The **user** resource now supports salted password hashes
     for macOS 10.7 (and higher). Use the `iterations` and `salt`
     attributes to calculate SALTED-SHA512 password shadow hashes for
     macOS version 10.7 and SALTED-SHA512-PBKDF2 password shadow hashes
     for version 10.8 (and higher).
--   **data_bag_item method in the Chef Infra Language supports encrypted data
+- **data_bag_item method in the Chef Infra Language supports encrypted data
     bag items** Use `data_bag_item(bag_name, item, secret)` to specify
     the secret to use for an encrypted data bag item. If `secret` is not
     specified, Chef Client looks for a secret at the path specified by
     the `encrypted_data_bag_secret` setting in the client.rb file.
--   **value_for_platform method in the Chef Infra Language supports version
+- **value_for_platform method in the Chef Infra Language supports version
     constraints** Version constraints---`>`, `<`, `>=`, `<=`, `~>`---may
     be used when specifying a version. An exception is raised if two
     version constraints match. An exact match will always take
     precedence over a match made from a version constraint.
--   **knife cookbook site share supports --dry-run** Use the `--dry-run`
+- **knife cookbook site share supports --dry-run** Use the `--dry-run`
     option with the `knife cookbook site` to take no action and only
     print out results.
--   **chef-client configuration setting updates** Chef Client now
+- **chef-client configuration setting updates** Chef Client now
     supports running an override run-list (via the `--override-runlist`
     option) without clearing the cookbook cache on the node. In
     addition, the `--chef-zero-port` option allows specifying a range of
     ports.
--   **Unforked interval runs are no longer allowed** The `--[no-]fork`
+- **Unforked interval runs are no longer allowed** The `--[no-]fork`
     option may no longer be used in the same command with the
     `--daemonize` and `--interval` options.
--   **Splay and interval values are applied before Chef Client run** The
+- **Splay and interval values are applied before Chef Client run** The
     `--interval` and `--splay` values are applied before Chef Client run
     when using Chef Client and chef-solo executables.
--   **All files and templates in a cookbook are synchronized at the
+- **All files and templates in a cookbook are synchronized at the
     start of Chef Client run** The `no_lazy_load` configuration setting
     in the client.rb file now defaults to `true`. This avoids issues
     where time-sensitive URLs in a cookbook manifest timeout before the
     **cookbook_file** or **template** resources converged.
--   **File staging now defaults to the destination directory by
+- **File staging now defaults to the destination directory by
     default** Staging into a system's temporary directory---typically
     `/tmp` or `/var/tmp`---as opposed to the destination directory may
     cause issues with permissions, available space, or cross-device
     renames. Files are now staged to the destination directory by
     default.
--   **Partial search updates** Use `:filter_result` to build search
+- **Partial search updates** Use `:filter_result` to build search
     results into a Hash. This replaces the previous functionality that
     was provided by the `partial_search` cookbook, albeit with a
     different API. Use the `--filter-result` option to return only
     attributes that match the specified filter. For example:
     `\"ServerName=name, Kernel=kernel.version\"`.
--   **Client-side key generation is enabled by default** When a new
+- **Client-side key generation is enabled by default** When a new
     chef-client is created using the validation client account, the Chef
     server allows Chef Client to generate a key-pair locally, and then
     send the public key to the Chef server. This behavior is controlled
     by the `local_key_generation` attribute in the client.rb file and
     now defaults to `true`.
--   **New guard_interpreter property defaults** The `guard_interpreter`
+- **New guard_interpreter property defaults** The `guard_interpreter`
     property now defaults to `:batch` for the **batch** resource and
     `:powershell_script` for the **powershell_script** resource.
--   **Events are sent to the Application event log on the Windows
+- **Events are sent to the Application event log on the Windows
     platform by default** Events are sent to the Microsoft Windows
     "Application" event log at the start and end of a chef-client run,
     and also if a chef-client run fails. Set the `disable_event_logger`
     configuration setting in the client.rb file to `true` to disable
     event logging.
--   **The installer_type property for the windows_package resource
+- **The installer_type property for the windows_package resource
     uses a symbol instead of a string** Previous versions of Chef Client
     (starting with version 11.8) used a string.
--   **The path property is deprecated for the execute resource** Use the
+- **The path property is deprecated for the execute resource** Use the
     `environment` property instead.
--   **SSL certificate validation improvements** The default settings for
+- **SSL certificate validation improvements** The default settings for
     SSL certificate validation now default in favor of validation. In
     addition, using the `knife ssl fetch` subcommand is now an important
     part of setting up your workstation.
--   **New property for git resource** The **git** resource has a new
+- **New property for git resource** The **git** resource has a new
     property: `environment`, which takes a Hash of environment variables
     in the form of `{"ENV_VARIABLE" => "VALUE"}`.
--   **New encrypted a version 3** Format utilizes aes-256-gcm ciphers
+- **New encrypted a version 3** Format utilizes aes-256-gcm ciphers
     for enhanced security.
 
 Please view the notes for more background
@@ -13763,9 +13763,9 @@ on the upgrade process from chef-client 11 to chef-client 12.
 
 Starting with chef-client 12.0, attribute precedence levels may be
 
--   Removed for a specific, named attribute precedence level
--   Removed for all attribute precedence levels
--   Fully assigned attributes
+- Removed for a specific, named attribute precedence level
+- Removed for all attribute precedence levels
+- Fully assigned attributes
 
 #### Remove Precedence Level
 
@@ -13774,15 +13774,15 @@ attributes may be removed by using one of the following syntax patterns.
 
 For default attributes:
 
--   `node.rm_default('foo', 'bar')`
+- `node.rm_default('foo', 'bar')`
 
 For normal attributes:
 
--   `node.rm_normal('foo', 'bar')`
+- `node.rm_normal('foo', 'bar')`
 
 For override attributes:
 
--   `node.rm_override('foo', 'bar')`
+- `node.rm_override('foo', 'bar')`
 
 These patterns return the computed value of the key being deleted for
 the specified precedence level.
@@ -13933,7 +13933,7 @@ node.rm_default("no", "such", "thing") #=> nil
 All attribute precedence levels may be removed by using the following
 syntax pattern:
 
--   `node.rm('foo', 'bar')`
+- `node.rm('foo', 'bar')`
 
 {{< note >}}
 
@@ -13993,11 +13993,11 @@ Use `!` to clear out the key for the named attribute precedence level,
 and then complete the write by using one of the following syntax
 patterns:
 
--   `node.default!['foo']['bar'] = {...}`
--   `node.force_default!['foo']['bar'] = {...}`
--   `node.normal!['foo']['bar'] = {...}`
--   `node.override!['foo']['bar'] = {...}`
--   `node.force_override!['foo']['bar'] = {...}`
+- `node.default!['foo']['bar'] = {...}`
+- `node.force_default!['foo']['bar'] = {...}`
+- `node.normal!['foo']['bar'] = {...}`
+- `node.override!['foo']['bar'] = {...}`
+- `node.force_override!['foo']['bar'] = {...}`
 
 **Examples**
 
@@ -14123,15 +14123,15 @@ existing resource/provider, and then to also specify the platform(s) on
 which the behavior of the custom resource/provider will be applied. This
 method enables scenarios like:
 
--   Building a custom resource that is based on an existing resource
--   Defining platform mapping specific to a custom resource
--   Handling situations where a resource on a particular platform may
+- Building a custom resource that is based on an existing resource
+- Defining platform mapping specific to a custom resource
+- Handling situations where a resource on a particular platform may
     have more than one provider, such as the behavior on the Ubuntu
     platform where both SysVInit and systemd are present
--   Allowing the custom resource to declare what platforms are
+- Allowing the custom resource to declare what platforms are
     supported, enabling the creator of the custom resource to use
     arbitrary criteria if desired
--   Not using the previous naming
+- Not using the previous naming
     convention---`#{cookbook_name}_#{provider_filename}`
 
 {{< warning >}}
@@ -14150,11 +14150,11 @@ provides :resource_name, os: [ 'platform', 'platform', ...], platform_family: 'f
 
 where:
 
--   `:resource_name` is a chef-client resource: `:cookbook_file`,
+- `:resource_name` is a chef-client resource: `:cookbook_file`,
     `:package`, `:rpm_package`, and so on
--   `'platform'` is a comma-separated list of platforms: `'windows'`,
+- `'platform'` is a comma-separated list of platforms: `'windows'`,
     `'solaris2'`, `'linux'`, and so on
--   `platform_family` is optional and may specify the same parameters as
+- `platform_family` is optional and may specify the same parameters as
     the `platform_family?` method in the Chef Infra Language; `platform` is
     optional and also supported (and is the same as the `platform?`
     method in the Chef Infra Language)
@@ -14213,10 +14213,10 @@ Chef Client has the [same system
 requirements](/chef_system_requirements/#chef-infra-client) on the
 AIX platform as any other platform, with the following notes:
 
--   Expand the file system on the AIX platform using `chfs` or by
+- Expand the file system on the AIX platform using `chfs` or by
     passing the `-X` flag to `installp` to automatically expand the
     logical partition (LPAR)
--   The EN_US (UTF-8) character set should be installed on the logical
+- The EN_US (UTF-8) character set should be installed on the logical
     partition prior to installing the chef-client
 
 **Install Chef Client on the AIX platform**
@@ -14439,8 +14439,8 @@ end
 The Chef Infra Language provides access to data bags and data bag items
 (including encrypted data bag items) with the following methods:
 
--   `data_bag(bag)`, where `bag` is the name of the data bag.
--   `data_bag_item('bag_name', 'item', 'secret')`, where `bag` is the
+- `data_bag(bag)`, where `bag` is the name of the data bag.
+- `data_bag_item('bag_name', 'item', 'secret')`, where `bag` is the
     name of the data bag and `item` is the name of the data bag item. If
     `'secret'` is not specified, Chef Client will look for a secret at
     the path specified by the `encrypted_data_bag_secret` setting in the
@@ -14523,11 +14523,11 @@ end
 
 where:
 
--   `bff_package` is the resource.
--   `name` is the name given to the resource block.
--   `action` identifies which steps Chef Client will take to bring the
+- `bff_package` is the resource.
+- `name` is the name given to the resource block.
+- `action` identifies which steps Chef Client will take to bring the
     node into the desired state.
--   `options`, `package_name`, `source`, `timeout`, and `version` are
+- `options`, `package_name`, `source`, `timeout`, and `version` are
     properties of this resource, with the Ruby type shown. See
     "Properties" section below for more information about all of the
     properties that may be used with this resource.
@@ -14767,11 +14767,11 @@ end
 
 where:
 
--   `homebrew_package` is the resource.
--   `name` is the name given to the resource block.
--   `action` identifies which steps Chef Client will take to bring the
+- `homebrew_package` is the resource.
+- `name` is the name given to the resource block.
+- `action` identifies which steps Chef Client will take to bring the
     node into the desired state.
--   `homebrew_user`, `options`, `package_name`, `source`, `timeout`, and
+- `homebrew_user`, `options`, `package_name`, `source`, `timeout`, and
     `version` are properties of this resource, with the Ruby type shown.
     See "Properties" section below for more information about all of the
     properties that may be used with this resource.
@@ -15026,11 +15026,11 @@ end
 
 where
 
--   `reboot` is the resource
--   `name` is the name of the resource block
--   `action` identifies the steps Chef Client will take to bring the
+- `reboot` is the resource
+- `name` is the name of the resource block
+- `action` identifies the steps Chef Client will take to bring the
     node into the desired state
--   `delay_mins` and `reason` are properties of this resource, with the
+- `delay_mins` and `reason` are properties of this resource, with the
     Ruby type shown. See "Properties" section below for more information
     about all of the properties that may be used with this resource.
 
@@ -15228,11 +15228,11 @@ end
 
 where
 
--   `windows_service` is the resource
--   `name` is the name of the resource block
--   `action` identifies the steps Chef Client will take to bring the
+- `windows_service` is the resource
+- `name` is the name of the resource block
+- `action` identifies the steps Chef Client will take to bring the
     node into the desired state
--   `init_command`, `pattern`, `reload_command`, `restart_command`,
+- `init_command`, `pattern`, `reload_command`, `restart_command`,
     `run_as_password`, `run_as_user`, `service_name`, `start_command`,
     `startup_type`, `status_command`, `stop_command`, `supports`, and
     `timeout` are properties of this resource, with the Ruby type shown.
@@ -15871,12 +15871,12 @@ end
 
 where:
 
--   `:index` is of name of the index on the Chef server against which
+- `:index` is of name of the index on the Chef server against which
     the search query will run: `:client`, `:data_bag_name`,
     `:environment`, `:node`, and `:role`
--   `'query'` is a valid search query against an object on the Chef
+- `'query'` is a valid search query against an object on the Chef
     server
--   `:filter_result` defines a Hash of values to be returned
+- `:filter_result` defines a Hash of values to be returned
 
 For example:
 
@@ -15997,10 +15997,10 @@ version should be inspected and updated.
 Cookbooks that contain custom resources in the `/libraries` directory of
 a cookbook should:
 
--   Be inspected for instances of a) the `Chef::Provider` base class,
+- Be inspected for instances of a) the `Chef::Provider` base class,
     and then b) for the presence of any core resources from the
     chef-client
--   Be updated to use the `LWRPBase` base class
+- Be updated to use the `LWRPBase` base class
 
 For example:
 

--- a/content/release_notes_server.md
+++ b/content/release_notes_server.md
@@ -513,15 +513,15 @@ libxml2 has been updated from 2.9.8 to 2.9.9 to resolve the following CVEs:
 
 This release contains some minor improvements and updates to include software:
 
--   Added request id to nginx log to easily track the Chef request through the logs.
--   Erchef and Bookshelf can optionally use mTLS protocol for their internal communications.
--   Habitat package improvements:
-    -   Increased `authn:keygen_timeout` amount for `oc_erchef` hab pkg.
-    -   Removed `do_end` function from `chef-server-ctl` hab plan.
-    -   Enhanced `chef-server-ctl` to function in more habitat environments.
-    -   `chef-server-ctl` commands pass relevant TLS options during bifrost API calls.
--   Used standard ruby-cleanup definition, which shrinks install size by \~5% on disk.
--   Removed unused couchdb configurables.
+- Added request id to nginx log to easily track the Chef request through the logs.
+- Erchef and Bookshelf can optionally use mTLS protocol for their internal communications.
+- Habitat package improvements:
+    - Increased `authn:keygen_timeout` amount for `oc_erchef` hab pkg.
+    - Removed `do_end` function from `chef-server-ctl` hab plan.
+    - Enhanced `chef-server-ctl` to function in more habitat environments.
+    - `chef-server-ctl` commands pass relevant TLS options during bifrost API calls.
+- Used standard ruby-cleanup definition, which shrinks install size by \~5% on disk.
+- Removed unused couchdb configurables.
 
 ### Security
 
@@ -629,35 +629,35 @@ This release:
 
 This release:
 
--   Fixes a regression in IPv6 address handling
+- Fixes a regression in IPv6 address handling
 
--   Allows you to disable request logging via the following optional
+- Allows you to disable request logging via the following optional
     settings:
 
-    -   `opscode-erchef['enable_request_logging']`
-    -   `oc_bifrost['enable_request_logging']`
-    -   `bookshelf['enable_request_logging']`
+    - `opscode-erchef['enable_request_logging']`
+    - `oc_bifrost['enable_request_logging']`
+    - `bookshelf['enable_request_logging']`
 
     See the [Chef server optional
     settings](/server/config_rb_server_optional_settings/) guide for
     additional details
 
--   `chef-server-ctl reconfigure` fixes permissions on gems with an
+- `chef-server-ctl reconfigure` fixes permissions on gems with an
     overly restrictive umask
 
--   Makes the display of the welcome page configurable via the
+- Makes the display of the welcome page configurable via the
     `nginx['show_welcome_page']` setting. See the [Chef server optional
     settings](/server/config_rb_server_optional_settings/) guide for
     additional details
 
--   Infers the current database migration level and necessary upgrades
+- Infers the current database migration level and necessary upgrades
     for `chef-server-ctl upgrade`
 
--   Catches `server_name` resolution errors during
+- Catches `server_name` resolution errors during
     `chef-server-ctl reconfigure`, and continues with the
     reconfiguration
 
--   No longer creates the default RabbitMQ `guest` user
+- No longer creates the default RabbitMQ `guest` user
 
 See the detailed [change
 log](https://github.com/chef/chef-server/blob/master/CHANGELOG.md#121715-2017-12-21)
@@ -678,12 +678,12 @@ for a full list of changes.
 
 The following items are new for Chef server 12.17.3:
 
--   Java has been updated to version 8u144 to address
+- Java has been updated to version 8u144 to address
     [CVE-2017-3526](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-3526)
--   A `/_stats` endpoint has been added to Erchef. It exposes statistics
+- A `/_stats` endpoint has been added to Erchef. It exposes statistics
     about connection pool usage inside Erchef, Postgresql, and the
     Erlang VM
--   The `strict_host_header` and `use_implicit_hosts` settings have been
+- The `strict_host_header` and `use_implicit_hosts` settings have been
     added for nginx. These options help to prevent against cache
     poisoning attacks by ensuring that nginx only responds to requests
     with host headers that match the configured FQDN for the given
@@ -814,10 +814,10 @@ automatically restart the dependent services.
 
 The following items are new for Chef server 12.15:
 
--   **Supports SUSE Linux Enterprise on x86_64**
--   **Add required_recipe endpoint**
--   **ACLs and groups can refer to global groups**
--   **User customization of field mapping**
+- **Supports SUSE Linux Enterprise on x86_64**
+- **Add required_recipe endpoint**
+- **ACLs and groups can refer to global groups**
+- **User customization of field mapping**
 
 ### Supports SUSE Linux Enterprise Server on x86_64
 
@@ -891,7 +891,7 @@ request is valid.
 
 The following items are new for Chef server 12.14:
 
--   **Reduce password proliferation**
+- **Reduce password proliferation**
 
 ### Reduce password proliferation
 
@@ -936,9 +936,9 @@ for more details.
 
 The following items are new for Chef server 12.13:
 
--   **Supports Red Hat Enterprise Linux 6 on s390x (RHEL6/s390x)**
--   **Disables the Solr4 Admin API/UI by default**
--   **FIPS runtime flag exposed on RHEL systems** Setting `fips true`
+- **Supports Red Hat Enterprise Linux 6 on s390x (RHEL6/s390x)**
+- **Disables the Solr4 Admin API/UI by default**
+- **FIPS runtime flag exposed on RHEL systems** Setting `fips true`
     and reconfiguring will start the server in FIPS mode. Packages for
     other systems will not have the required OpenSSL FIPS module and
     will fail to start if reconfigured with `fips true`.
@@ -975,18 +975,18 @@ will fail to start if reconfigured with `fips true`.
 
 The following items are new for Chef server 12.12:
 
--   **chef-server-ctl backup correctly backs up configuration data**
+- **chef-server-ctl backup correctly backs up configuration data**
     Starting in version 12.10.0, a bug in the `backup` command produced
     backups that did not include the configuration data in the resulting
     tarball. This bug is now resolved. We recommend taking a new backup
     after upgrading to 12.12.0.
--   **Correct number of rows are returned when searching with
+- **Correct number of rows are returned when searching with
     Elasticsearch** When configured to use Elasticsearch, Chef server
     now correctly respects the `rows` parameter in search requests
     rather than returning all rows.
--   **Solr 4 GC logging is now used by Chef server** Java's native
+- **Solr 4 GC logging is now used by Chef server** Java's native
     rotation is used for the gclog.
--   **New oc_id email configuration options** Outbound email address
+- **New oc_id email configuration options** Outbound email address
     can now be configured.
 
 ### Solr 4 GC Logging
@@ -1032,12 +1032,12 @@ The following items are new for Chef server 12.11:
 
 ### New Endpoints
 
--   **/organizations/ORGNAME/validate/PATH** accepts a signed request
+- **/organizations/ORGNAME/validate/PATH** accepts a signed request
     and validates it as if it had been sent to <span
     class="title-ref">PATH</span>. It returns 200 if the request is
     authentic and 401 if it is not.
 
--   **/organizations/ORGNAME/data-collector** forwards requests for a
+- **/organizations/ORGNAME/data-collector** forwards requests for a
     data-collector service after authenticating the request using Chef
     Server's standard authentication headers. To use this endpoint,
     users must set both of the following options in
@@ -1048,7 +1048,7 @@ The following items are new for Chef server 12.11:
     data_collector['root_url']
     ```
 
--   **/organizations/ORGNAME/owners/OWNER/compliance\[/PROFILE\]**
+- **/organizations/ORGNAME/owners/OWNER/compliance\[/PROFILE\]**
     forwards requests for compliance profiles to a user-configurable
     Chef Automate server after authenticating the request using Chef
     Server's standard authentication headers. To use this endpoint,
@@ -1062,37 +1062,37 @@ The following items are new for Chef server 12.11:
 
 ### Security Updates
 
--   The default allowed SSL ciphers now include AES256-GCM-SHA384 to
+- The default allowed SSL ciphers now include AES256-GCM-SHA384 to
     ensure compatibility with AWS's Classic ELB health check tool.
--   **chef-server-ctl psql** previously revealed the postgresql password
+- **chef-server-ctl psql** previously revealed the postgresql password
     via <span class="title-ref">ps</span>.
 
 ## What's New in 12.10
 
 The following items are new for Chef server 12.10:
 
--   Smaller download - the download size has been reduced by around 35%
+- Smaller download - the download size has been reduced by around 35%
     via removal of redundant, cached, and unused components. The
     installed size has been similarly reduced.
--   add retry support to opscode-expander
--   chef-server-ctl reindex will now continue even if some objects are
+- add retry support to opscode-expander
+- chef-server-ctl reindex will now continue even if some objects are
     not indexable, and will show which objects failed at the conclusion
     of the run.
--   Data Collector support for Policyfiles.
--   chef-server-ctl install add-on installation now pulls from the
+- Data Collector support for Policyfiles.
+- chef-server-ctl install add-on installation now pulls from the
     correct source.
--   Regression fix: that caused errors on reconfigure when LDAP bind
+- Regression fix: that caused errors on reconfigure when LDAP bind
     password is nil has been fixed.
 
 ### Security Updates
 
--   Upgrade to OpenSSL 1.0.2j. The prior release (1.0.1u) is approaching
+- Upgrade to OpenSSL 1.0.2j. The prior release (1.0.1u) is approaching
     EOL.
--   Updated TLS ciphers. See compatibility notes, below.
+- Updated TLS ciphers. See compatibility notes, below.
 
 ### Compatibility Notes
 
--   The change of TLS ciphers can cause older tooling to fail to
+- The change of TLS ciphers can cause older tooling to fail to
     negotiate SSL sessions with the Chef Server. The changes to the
     cipher list are captured here. Upgrading any custom clients of the
     Chef Server API to use a current SSL release will resolve this.
@@ -1102,7 +1102,7 @@ The following items are new for Chef server 12.10:
     compatible with your tooling, then running chef-server-ctl
     reconfigure to pick up the changes.
 
--   With this TLS cipher suite change, the Reporting add-on will report
+- With this TLS cipher suite change, the Reporting add-on will report
     errors when opscode-reporting-ctl test is run. A fix for this is
     available in the current channel for reporting, and will be released
     to stable in November. This issue does not otherwise affect the
@@ -1116,23 +1116,23 @@ The following items are new for Chef server 12.9.1:
 
 The update of OpenSSL 1.0.1u addresses the following CVEs:
 
--   CVE-2016-6304
--   CVE-2016-2183
--   CVE-2016-6303
--   CVE-2016-6302
--   CVE-2016-2182
--   CVE-2016-2180
--   CVE-2016-2177
--   CVE-2016-2178
--   CVE-2016-2179
--   CVE-2016-2181
--   CVE-2016-6306
+- CVE-2016-6304
+- CVE-2016-2183
+- CVE-2016-6303
+- CVE-2016-6302
+- CVE-2016-2182
+- CVE-2016-2180
+- CVE-2016-2177
+- CVE-2016-2178
+- CVE-2016-2179
+- CVE-2016-2181
+- CVE-2016-6306
 
 ## What's New in 12.9
 
 The following items are new for Chef server 12.9:
 
--   **New warning and functionality when trying to delete user in
+- **New warning and functionality when trying to delete user in
     multiple 'admin' groups** If a user is in an administrator group in
     any organization, the `chef-server-ctl user-delete` subcommand does
     not allow you to remove the user from that group. To provide more
@@ -1141,10 +1141,10 @@ The following items are new for Chef server 12.9:
     administrator of. Using the new flag `--remove-from-admin-groups`,
     you can now remove that user provided they are not the only user in
     the `admin` group.
--   **LDAP bind passwords now support special characters**
--   **Updated to OpenSSL 1.0.1u** Updated version of OpenSSL to address
+- **LDAP bind passwords now support special characters**
+- **Updated to OpenSSL 1.0.1u** Updated version of OpenSSL to address
     security vulnerabilities.
--   **Multiple ACL updates on the Chef server API** The `_acl` endpoint
+- **Multiple ACL updates on the Chef server API** The `_acl` endpoint
     now requires that any users being added to an object's ACL exist in
     the same organization as the object itself. Existing users that are
     not organization members and have already been added to an ACL will
@@ -1156,21 +1156,21 @@ The following items are new for Chef server 12.9:
 
 The following items are new for Chef server 12.8:
 
--   **Initial support for sending updates to a data collector service**
--   **Minor bug fixes in postgresql setup**
+- **Initial support for sending updates to a data collector service**
+- **Minor bug fixes in postgresql setup**
 
 ## What's New in 12.7
 
 The following items are new for Chef server 12.7:
 
--   **Support for service credential rotation through Veil** Veil is a
+- **Support for service credential rotation through Veil** Veil is a
     library for securely creating, storing, and rotating Chef server
     secrets. It is also required when using the new
     `chef-server-ctl require-credential-rotation` command.
--   **Filtering by external authentication ID in Chef server API** Users
+- **Filtering by external authentication ID in Chef server API** Users
     can now be filtered by `external_authentication_uid`, which is
     needed to support SAML authentication in Chef Manage.
--   **Updated to OpenSSL 1.0.1t** Version 1.0.1t contains several
+- **Updated to OpenSSL 1.0.1t** Version 1.0.1t contains several
     security fixes.
 
 ### Service credential rotation support
@@ -1183,11 +1183,11 @@ each Chef server in a cluster.
 
 Five new commands have been created to support credential rotation:
 
--   [require-credential-rotation](/ctl_chef_server/#require-credential-rotation)
--   [rotate-all-credentials](/ctl_chef_server/#rotate-all-credentials)
--   [rotate-credentials](/ctl_chef_server/#rotate-credentials)
--   [rotate-shared-secrets](/ctl_chef_server/#rotate-shared-secrets)
--   [show-service-credentials](/ctl_chef_server/#show-service-credentials)
+- [require-credential-rotation](/ctl_chef_server/#require-credential-rotation)
+- [rotate-all-credentials](/ctl_chef_server/#rotate-all-credentials)
+- [rotate-credentials](/ctl_chef_server/#rotate-credentials)
+- [rotate-shared-secrets](/ctl_chef_server/#rotate-shared-secrets)
+- [show-service-credentials](/ctl_chef_server/#show-service-credentials)
 
 Your secrets file is located at
 `/etc/opscode/private-chef-secrets.json`, so whenever you rotate your
@@ -1209,7 +1209,7 @@ GET /users?external_authentication_uid=jane%40doe.com
 
 The following items are new for Chef server 12.6:
 
--   **Chef licenses** All Chef products have a license that governs the
+- **Chef licenses** All Chef products have a license that governs the
     entire product and includes links to license files for any
     third-party software included in Chef packages. This release updates
     the Chef server for the Chef license.
@@ -1239,7 +1239,7 @@ license](https://www.apache.org/licenses/LICENSE-2.0).
 
 The following items are new for Chef server 12.5:
 
--   **New group for key-related Chef server API endpoints** The
+- **New group for key-related Chef server API endpoints** The
     `public_key_read_access` group defines which users and clients have
     read permissions to key-related endpoints in the Chef server API.
 
@@ -1248,10 +1248,10 @@ The following items are new for Chef server 12.5:
 The `public_key_read_access` group controls which users and clients have
 [read permissions to the following endpoints](/api_chef_server/):
 
--   GET /clients/CLIENT/keys
--   GET /clients/CLIENT/keys/KEY
--   GET /users/USER/keys
--   GET /users/USER/keys/
+- GET /clients/CLIENT/keys
+- GET /clients/CLIENT/keys/KEY
+- GET /users/USER/keys
+- GET /users/USER/keys/
 
 By default, the `public_key_read_access` assigns all members of the
 `users` and `clients` group permission to these endpoints:
@@ -1307,12 +1307,12 @@ By default, the `public_key_read_access` assigns all members of the
 
 The following items are new for Chef server 12.4:
 
--   **/universe endpoint** Use the `/universe` endpoint to retrieve the
+- **/universe endpoint** Use the `/universe` endpoint to retrieve the
     known collection of cookbooks, and then use it with Berkshelf and
     Chef Supermarket.
--   **opscode-expander-reindexer service** The
+- **opscode-expander-reindexer service** The
     `opscode-expander-reindexer` service is deprecated.
--   **Global server administrator list** Use the
+- **Global server administrator list** Use the
     `grant-server-admin-permissions`, `remove-server-admin-permissions`,
     and `list-server-admins` to manage the list of users who belong to
     the `server-admins` group.
@@ -1381,12 +1381,12 @@ with its location information and dependencies:
 
 The following items are new for Chef server 12.4:
 
--   **/universe endpoint** Use the `/universe` endpoint to retrieve the
+- **/universe endpoint** Use the `/universe` endpoint to retrieve the
     known collection of cookbooks, and then use it with Berkshelf and
     Chef Supermarket.
--   **opscode-expander-reindexer service** The
+- **opscode-expander-reindexer service** The
     `opscode-expander-reindexer` service is deprecated.
--   **Global server administrator list** Use the
+- **Global server administrator list** Use the
     `grant-server-admin-permissions`, `remove-server-admin-permissions`,
     and `list-server-admins` to manage the list of users who belong to
     the `server-admins` group.
@@ -1550,11 +1550,11 @@ dan
 Alice is now a server administrator and can use the following knife
 subcommands to manage users on the Chef server:
 
--   `knife user-create`
--   `knife user-delete`
--   `knife user-edit`
--   `knife user-list`
--   `knife user-show`
+- `knife user-create`
+- `knife user-delete`
+- `knife user-edit`
+- `knife user-list`
+- `knife user-show`
 
 For example, Alice runs the following command:
 
@@ -1591,9 +1591,9 @@ Alice's action is unauthorized even with membership in the
 Membership of the `server-admins` group is managed with a set of
 `chef-server-ctl` subcommands:
 
--   `chef-server-ctl grant-server-admin-permissions`
--   `chef-server-ctl list-server-admins`
--   `chef-server-ctl remove-server-admin-permissions`
+- `chef-server-ctl grant-server-admin-permissions`
+- `chef-server-ctl list-server-admins`
+- `chef-server-ctl remove-server-admin-permissions`
 
 #### Add Members
 
@@ -1677,11 +1677,11 @@ dan
 
 The following items are new for Chef server 12.3:
 
--   **Nginx stub_status module is enabled** The Nginx `stub_status`
+- **Nginx stub_status module is enabled** The Nginx `stub_status`
     module is enabled by default and may be viewed at the
     `/nginx_status` endpoint. The settings for this module are
     configurable.
--   **RabbitMQ queue tuning** New settings for managing RabbitMQ queues
+- **RabbitMQ queue tuning** New settings for managing RabbitMQ queues
     allow the size of the queue used by Chef Analytics to be configured,
     including settings for the queue length monitor and for tuning the
     rabbitmq-management plugin.
@@ -1846,18 +1846,18 @@ Chef Analytics and the Chef server:
 
 The following items are new for Chef server 12.2:
 
--   **Solr to Solr4 settings** Built-in transition for Apache Solr
+- **Solr to Solr4 settings** Built-in transition for Apache Solr
     memory and JVM settings from Enterprise Chef to Chef server
     version 12.
--   **Configurable Postgresql** Postgresql can be configured for an
+- **Configurable Postgresql** Postgresql can be configured for an
     external database.
--   **New endpoints for the Chef server API** Endpoints have been added
+- **New endpoints for the Chef server API** Endpoints have been added
     to the Chef server API: `DELETE /policy_groups`.
--   **New subcommmands for chef-server-ctl** Use the `backup` and
+- **New subcommmands for chef-server-ctl** Use the `backup` and
     `restore` subcommmands to back up and restore Chef server data. Use
     the `psql` subcommmand to log into a PostgreSQL database that is
     associated with a service running in the Chef server configuration.
--   **New options for chef-server-ctl reindex** The `reindex` subcommand
+- **New options for chef-server-ctl reindex** The `reindex` subcommand
     has new options: `--all-orgs` (reindex all organizations),
     `--disable-api` (disable the Chef server API during reindexing),
     `--with-timing` (print timing information), and `--wait` (wait for
@@ -1972,14 +1972,14 @@ then to restore those backups.
 The `backup` subcommand is used to back up all Chef server data. This
 subcommand:
 
--   Requires rsync to be installed on the Chef server prior to running
+- Requires rsync to be installed on the Chef server prior to running
     the command
--   Requires a `chef-server-ctl reconfigure` prior to running the
+- Requires a `chef-server-ctl reconfigure` prior to running the
     command
--   Should not be run in a Chef server configuration with an external
+- Should not be run in a Chef server configuration with an external
     PostgreSQL database; [use knife ec
     backup](https://github.com/chef/knife-ec-backup) instead
--   Puts the initial backup in the `/var/opt/chef-backup` directory as a
+- Puts the initial backup in the `/var/opt/chef-backup` directory as a
     tar.gz file; move this backup to a new location for safe keeping
 
 **Options**
@@ -2006,11 +2006,11 @@ backup that was created by the `backup` subcommand. This subcommand may
 also be used to add Chef server data to a newly-installed server. This
 subcommand:
 
--   Requires rsync to be installed on the Chef server prior to running
+- Requires rsync to be installed on the Chef server prior to running
     the command
--   Requires a `chef-server-ctl reconfigure` prior to running the
+- Requires a `chef-server-ctl reconfigure` prior to running the
     command
--   Should not be run in a Chef server configuration with an external
+- Should not be run in a Chef server configuration with an external
     PostgreSQL database; [use knife ec
     backup](https://github.com/chef/knife-ec-backup) instead
 
@@ -2048,11 +2048,11 @@ chef-server-ctl restore /path/to/tar/archive.tar.gz
 The `psql` subcommand is used to log into the PostgreSQL database
 associated with the named service. This subcommand:
 
--   Uses `psql` (the interactive terminal for PostgreSQL)
--   Has read-only access by default
--   Is the recommended way to interact with any PostgreSQL database that
+- Uses `psql` (the interactive terminal for PostgreSQL)
+- Has read-only access by default
+- Is the recommended way to interact with any PostgreSQL database that
     is part of the Chef server
--   Automatically handles authentication
+- Automatically handles authentication
 
 **Syntax**
 
@@ -2596,24 +2596,24 @@ The response returns the policy details and is similar to:
 
 The following items are new for Chef server 12.1:
 
--   **chef-server-ctl key commands use the chef-client Chef::Key
+- **chef-server-ctl key commands use the chef-client Chef::Key
     object** The key rotation commands (`chef-server-ctl key`) for
     `create`, `delete`, `edit`, `list`, and `show` keys for users and
     clients. These were a preview in the Chef server 12.0.3 release, and
     are now fully integrated.
--   **New version headers for Chef Server API** The Chef server API uses
+- **New version headers for Chef Server API** The Chef server API uses
     the `X-Ops-Server-API-Version` header to specify the version of the
     API that is used as part of a request to the Chef server API.
--   **New endpoints for policy and policy files** The Chef server API
+- **New endpoints for policy and policy files** The Chef server API
     adds the following endpoints: `/policies`, `/policy_groups`, and
     `/POLICY_GROUP/policies/POLICY_NAME`.
--   **New endpoints for client key management** The Chef server API adds
+- **New endpoints for client key management** The Chef server API adds
     the following endpoints: `/clients/CLIENT/keys` and
     `/clients/CLIENT/keys/KEY`.
--   **New endpoints for user key management** The Chef server API adds
+- **New endpoints for user key management** The Chef server API adds
     the following endpoints: `/user/USER/keys` and
     `/user/USER/keys/KEY`.
--   **New configuration setting** Use the `estatsd['protocol']` setting
+- **New configuration setting** Use the `estatsd['protocol']` setting
     to send application statistics with StatsD protocol formatting.
 
 ### Key Rotation
@@ -3365,10 +3365,10 @@ Each node has a 1:many relationship with policy settings stored on the
 Chef server. This relationship is based on the policy group to which the
 node is associated, and then the policy settings assigned to that group:
 
--   A policy is typically named after the functional role ahost
+- A policy is typically named after the functional role ahost
     performs, such as "application server", "chat server", "load
     balancer", and so on
--   A policy group defines a set of hosts in a deployed units, typically
+- A policy group defines a set of hosts in a deployed units, typically
     mapped to organizational requirements such as "dev", "test",
     "staging", and "production", but can also be mapped to more detailed
     requirements as needed
@@ -3457,10 +3457,10 @@ Each node has a 1:many relationship with policy settings stored on the
 Chef server. This relationship is based on the policy group to which the
 node is associated, and then the policy settings assigned to that group:
 
--   A policy is typically named after the functional role ahost
+- A policy is typically named after the functional role ahost
     performs, such as "application server", "chat server", "load
     balancer", and so on
--   A policy group defines a set of hosts in a deployed units, typically
+- A policy group defines a set of hosts in a deployed units, typically
     mapped to organizational requirements such as "dev", "test",
     "staging", and "production", but can also be mapped to more detailed
     requirements as needed
@@ -3931,76 +3931,76 @@ The following configuration settings are new for the Chef server:
 
 The following items are new for Chef server 12:
 
--   **Upgrades from Open Source Chef and Enterprise Chef servers to Chef
+- **Upgrades from Open Source Chef and Enterprise Chef servers to Chef
     12 server** Upgrades to Chef server 12 are supported from Enterprise
     Chef 11 high availability and standalone configurations and Open
     Source Chef 11 standalone configurations. View the topic [Upgrade to
     Chef Server 12](/upgrade_server/) for more information about
     these processes.
--   **chef-server.rb configuration file is created by default** Previous
+- **chef-server.rb configuration file is created by default** Previous
     versions of the Chef server did not create the chef-server.rb file
     and users had to create the file first, before updates to tuneable
     settings could be made.
--   **Pluggable high availability architecture** Support for high
+- **Pluggable high availability architecture** Support for high
     availability now provides alternatives to DRBD, including using
     Amazon Web Services (AWS).
--   **High availability using Amazon Web Services** Amazon Web Services
+- **High availability using Amazon Web Services** Amazon Web Services
     (AWS) is a supported high availability configuration option for the
     Chef server. Machines are stored as Amazon Elastic Block Store (EBS)
     volumes. A passive node monitors the availability of the active node,
     and will take over if required.
--   **Chef server replication** Chef replication provides a way to
+- **Chef server replication** Chef replication provides a way to
     asynchronously distribute cookbook, environment, role, and data bag
     data from a single, primary Chef server to one (or more) replicas of
     that Chef server.
--   **New chef-server-ctl command line tool** The chef-server-ctl
+- **New chef-server-ctl command line tool** The chef-server-ctl
     command line tool is an update of the private-chef-ctl command line
     tool. All of the previous functionality remains, with some new
     commands added that are specific to Chef server version 12.
--   **New command for installing features of the Chef server** The
+- **New command for installing features of the Chef server** The
     `install` subcommand may be used to install Chef management console,
     Chef Push Jobs, Chef replication, and Reporting.
--   **New commands for managing organizations** New subcommands for the
+- **New commands for managing organizations** New subcommands for the
     chef-server-ctl command line tool: `org-user-add`, `org-create`,
     `org-delete`, `org-user-remove`, `org-list`, and `org-show`.
--   **New commands for managing users** New subcommands for the
+- **New commands for managing users** New subcommands for the
     chef-server-ctl command line tool: `user-create`, `user-delete`,
     `user-edit`, `user-list`, and `user-show`.
--   **New command for log files** Use the `gather-logs` command to
+- **New command for log files** Use the `gather-logs` command to
     create a tarball of important log files and system information.
--   **Solr has been upgraded to Solr 4** The search capabilities of the
+- **Solr has been upgraded to Solr 4** The search capabilities of the
     Chef server now use Apache Solr 4. The config item for Apache Solr 4
     has changed names from opscode-solr to opscode-solr4. Change
     `/etc/opscode/chef-server.rb` accordingly.
--   **CouchDB removed** CouchDB is no longer a component of the Chef
+- **CouchDB removed** CouchDB is no longer a component of the Chef
     server. All data is migrated to PostgreSQL.
--   **Services removed** The following services have been removed from
+- **Services removed** The following services have been removed from
     the Chef server: `opscode-account`, `opscode-certificate`,
     `oc_authz_migrator`, `opscode-org-creator`, `orgmapper`, and
     `opscode-webui`. `opscode-webui` is replaced by the Chef management
     console.
--   **private-chef.rb is now called chef-server.rb** The name of the
+- **private-chef.rb is now called chef-server.rb** The name of the
     configuration file used by the Chef server has been changed. A
     symlink from private-chef.rb to chef-server.rb is created during
     upgrades from older versions of the Chef server.
--   **New setting for the default organization name** Use the
+- **New setting for the default organization name** Use the
     `default_orgname` setting to ensure compatibility with Open Source
     Chef version 11.
--   **New settings for oc_chef_authz** The **opscode-authz** service
+- **New settings for oc_chef_authz** The **opscode-authz** service
     handles authorization requests to the Chef server.
--   **Organization policy changes** Users must be removed from the
+- **Organization policy changes** Users must be removed from the
     `admins` security group before they can be removed from an
     organization. The chef-client is not granted **Create**, **Delete**,
     or **Update** permissions to data bags when organizations are
     created.
--   **Administrators cannot be removed from organizations** The Chef
+- **Administrators cannot be removed from organizations** The Chef
     server requires that a member of an organization's `admins` group
     cannot be removed from the organization without first being removed
     from the `admins` group.
--   **New settings for managing LDAP encryption** New settings that
+- **New settings for managing LDAP encryption** New settings that
     manage LDAP encryption have been added, existing settings have been
     deprecated.
--   **New commands for managing keys** The following commands are new:
+- **New commands for managing keys** The following commands are new:
     `add-client-key`, `add-user-key`, `delete-client-key`,
     `delete-user-key`, `list-client-keys`, and `list-user-keys`. (These
     are preview commands, new as-of the Chef server 12.0.3 release.)
@@ -4052,10 +4052,10 @@ and for example, a single primary Chef server and multiple replicas:
 
 Chef replication should not be used for:
 
--   Disaster recovery or backup/restore processes. The replication
+- Disaster recovery or backup/restore processes. The replication
     process is read-only and cannot be changed to read-write
--   Synchronizing a replica instance with another replica instance
--   Node re-registration. A node may be associated only with a single
+- Synchronizing a replica instance with another replica instance
+- Node re-registration. A node may be associated only with a single
     Chef server
 
 **How Replication Works**
@@ -4333,10 +4333,10 @@ chef-server-ctl org-create ORG_NAME "ORG_FULL_NAME" (options)
 
 where:
 
--   The name must begin with a lower-case letter or digit, may only
+- The name must begin with a lower-case letter or digit, may only
     contain lower-case letters, digits, hyphens, and underscores, and
     must be between 1 and 255 characters. For example: `chef`.
--   The full name must begin with a non-white space character and must
+- The full name must begin with a non-white space character and must
     be between 1 and 1023 characters. For example:
     `"Chef Software, Inc."`.
 

--- a/content/roles.md
+++ b/content/roles.md
@@ -238,20 +238,20 @@ The JSON format has two additional settings:
 
 There are several ways to manage roles:
 
--   knife can be used to create, edit, view, list, tag, and delete
+- knife can be used to create, edit, view, list, tag, and delete
     roles.
--   The Chef Infra Client can be used to manage role data using the
+- The Chef Infra Client can be used to manage role data using the
     command line and JSON files (that contain a hash, the elements of
     which are added as role attributes). In addition, the `run_list`
     setting allows roles and/or recipes to be added to the role.
--   The open source Chef Infra Server can be used to manage role data
+- The open source Chef Infra Server can be used to manage role data
     using the command line and JSON files (that contain a hash, the
     elements of which are added as role attributes). In addition, the
     `run_list` setting allows roles and/or recipes to be added to the
     role.
--   The Chef Infra Server API can be used to create and manage roles
+- The Chef Infra Server API can be used to create and manage roles
     directly, although using knife directly is the most common way to manage roles.
--   The command line can also be used with JSON files and third-party
+- The command line can also be used with JSON files and third-party
     services, such as Amazon EC2, where the JSON files can contain
     per-instance metadata stored in a file on-disk and then read by
     chef-solo or Chef Infra Client as required.
@@ -302,12 +302,12 @@ used. For example:
 
 where:
 
--   `webserver` is the name of the role
--   `env_run_lists` is a hash of per-environment run-lists for
+- `webserver` is the name of the role
+- `env_run_lists` is a hash of per-environment run-lists for
     `production`, `preprod`, `test`, and `dev`
--   `production` and `preprod` use the default run-list because they do
+- `production` and `preprod` use the default run-list because they do
     not have a per-environment run-list
--   `run_list` defines the default run-list
+- `run_list` defines the default run-list
 
 ### Delete from Run-list
 

--- a/content/ruby.md
+++ b/content/ruby.md
@@ -427,8 +427,8 @@ This section covers best practices for cookbook and recipe authoring.
 Although not strictly a Chef style thing, please always ensure your
 `user.name` and `user.email` are set properly in your `.gitconfig` file.
 
--   `user.name` should be your given name (e.g., "Julian Dunn")
--   `user.email` should be an actual, working e-mail address
+- `user.name` should be your given name (e.g., "Julian Dunn")
+- `user.email` should be an actual, working e-mail address
 
 This will prevent commit log entries similar to
 `"guestuser <login@Bobs-Macbook-Pro.local>"`, which are unhelpful.
@@ -445,21 +445,21 @@ SecondMarket, use `sm` as a prefix: `sm_postgresql` or `sm_httpd`.
 
 ### Cookbook Versioning
 
--   Use semantic versioning when numbering cookbooks.
--   Only upload stable cookbooks from master.
--   Only upload unstable cookbooks from the dev branch. Merge to master
+- Use semantic versioning when numbering cookbooks.
+- Only upload stable cookbooks from master.
+- Only upload unstable cookbooks from the dev branch. Merge to master
     and bump the version when stable.
--   Always update CHANGELOG.md with any changes, with the JIRA ticket
+- Always update CHANGELOG.md with any changes, with the JIRA ticket
     and a brief description.
 
 ### Naming
 
 Name things uniformly for their system and component. For example:
 
--   attributes: `node['foo']['bar']`
--   recipe: `foo::bar`
--   role: `foo-bar`
--   directories: `foo/bar` (if specific to component), `foo` (if not).
+- attributes: `node['foo']['bar']`
+- recipe: `foo::bar`
+- role: `foo-bar`
+- directories: `foo/bar` (if specific to component), `foo` (if not).
     For example: `/var/log/foo/bar`.
 
 Name attributes after the recipe in which they are primarily used. e.g.
@@ -469,12 +469,12 @@ Name attributes after the recipe in which they are primarily used. e.g.
 
 Follow this order for information in each resource declaration:
 
--   Source
--   Cookbook
--   Resource ownership
--   Permissions
--   Notifications
--   Action
+- Source
+- Cookbook
+- Resource ownership
+- Permissions
+- Notifications
+- Action
 
 For example:
 

--- a/content/server_ldap.md
+++ b/content/server_ldap.md
@@ -29,16 +29,16 @@ credentials instead of having a separate username and password.
 
 The following attributes **MUST** be in the user LDAP record:
 
--   `mail:`
--   `sAMAccountName:` or `uid:`
+- `mail:`
+- `sAMAccountName:` or `uid:`
 
 The following attributes **SHOULD** be in the user LDAP record:
 
--   `displayname:`
--   `givenname:`
--   `sn:`
--   `c:`
--   `l:`
+- `displayname:`
+- `givenname:`
+- `sn:`
+- `c:`
+- `l:`
 
 {{< /warning >}}
 

--- a/content/server_orgs.md
+++ b/content/server_orgs.md
@@ -74,8 +74,8 @@ organization on the Chef Infra Server.
 A user may belong to multiple organizations under the following
 conditions:
 
--   Role-based access control is configured per-organization
--   For a single user to interact with the Chef Infra Server using knife
+- Role-based access control is configured per-organization
+- For a single user to interact with the Chef Infra Server using knife
     from the same chef-repo, that user may need to edit their config.rb
     file prior to that interaction
 
@@ -84,11 +84,11 @@ the same toolset, coding patterns and practices, physical hardware, and
 product support effort is being applied across the entire company, even
 when:
 
--   Multiple product groups must be supported---each product group can
+- Multiple product groups must be supported---each product group can
     have its own security requirements, schedule, and goals
--   Updates occur on different schedules---the nodes in one organization
+- Updates occur on different schedules---the nodes in one organization
     are managed completely independently from the nodes in another
--   Individual teams have competing needs for object and object
+- Individual teams have competing needs for object and object
     types---data bags, environments, roles, and cookbooks are unique to
     each organization, even if they share the same name
 
@@ -435,10 +435,10 @@ The `clients` group is assigned the following:
 The `public_key_read_access` group controls which users and clients have
 [read permissions to the following endpoints](/api_chef_server/):
 
--   GET /clients/CLIENT/keys
--   GET /clients/CLIENT/keys/KEY
--   GET /users/USER/keys
--   GET /users/USER/keys/
+- GET /clients/CLIENT/keys
+- GET /clients/CLIENT/keys/KEY
+- GET /users/USER/keys
+- GET /users/USER/keys/
 
 By default, the `public_key_read_access` assigns all members of the
 `users` and `clients` group permission to these endpoints:

--- a/content/server_users.md
+++ b/content/server_users.md
@@ -17,12 +17,12 @@ product = ["server"]
 The following tasks are available for user management in Chef Infra
 Server:
 
--   Creating users
--   Editing a user's profile
--   Changing a password
--   Recovering a password
--   Regenerating a private key
--   Viewing a user's profile
+- Creating users
+- Editing a user's profile
+- Changing a password
+- Recovering a password
+- Regenerating a private key
+- Viewing a user's profile
 
 ## chef-server-ctl
 

--- a/content/supermarket_backup_restore.md
+++ b/content/supermarket_backup_restore.md
@@ -49,12 +49,12 @@ following syntax:
 
 where, in a typical installation:
 
-:   -   `/opt/supermarket/embedded/bin/pg_dump` is the path to the
+:   - `/opt/supermarket/embedded/bin/pg_dump` is the path to the
         database export utility included in the Supermarket installation
-    -   `localhost` may alternatively be 127.0.0.1
-    -   `15432` is the PostgreSQL port number, which may need to be
+    - `localhost` may alternatively be 127.0.0.1
+    - `15432` is the PostgreSQL port number, which may need to be
         modified
-    -   `--format c` sets the output to PostgreSQL's "custom" binary
+    - `--format c` sets the output to PostgreSQL's "custom" binary
         file format
 
 Be sure to update the various local values in the `pg_dump` command as

--- a/content/upgrade_client.md
+++ b/content/upgrade_client.md
@@ -49,16 +49,16 @@ and mitigate many common issues.
 
 Install the version of chef client you plan on using after the upgrade on a small number of test nodes and verify:
 
-:   -   All nodes can authenticate and converge successfully.
-    -   Custom Ohai plugins still work as expected.
-    -   Custom Handlers still work as expected.
+:   - All nodes can authenticate and converge successfully.
+    - Custom Ohai plugins still work as expected.
+    - Custom Handlers still work as expected.
 
 Ensure that all of the cookbooks used by your organization are correctly located and identified:
 
-:   -   Do all cookbooks used by your organization exist in source
+:   - Do all cookbooks used by your organization exist in source
         control? Upload any missing cookbooks and dependencies.
-    -   Do all cookbooks have a `metadata.rb` or `metadata.json` file?
-    -   Delete unused cookbook versions. First, run
+    - Do all cookbooks have a `metadata.rb` or `metadata.json` file?
+    - Delete unused cookbook versions. First, run
         `knife cookbook list` to view a list of cookbooks. Next, for
         each cookbook, run `knife cookbook show COOKBOOK_NAME` to view
         its versions. Then, delete each unused version with
@@ -66,9 +66,9 @@ Ensure that all of the cookbooks used by your organization are correctly located
 
 Download all cookbooks and validate the following against each cookbook:
 
-:   -   Run `egrep -L ^name */metadata.rb`. Does each have a
+:   - Run `egrep -L ^name */metadata.rb`. Does each have a
         `metadata.rb` file?
-    -   Does the cookbook name in the `metadata.rb` file match the name
+    - Does the cookbook name in the `metadata.rb` file match the name
         in the run-list? (Some older versions of Chef Infra Client used
         the cookbook name for the run-list based on the directory name
         of the cookbook and not the cookbook_name in the `metadata.rb`
@@ -76,20 +76,20 @@ Download all cookbooks and validate the following against each cookbook:
 
 Cook as lean as possible:
 
-:   -   Verify cookbook size and mitigate the size of large cookbooks
+:   - Verify cookbook size and mitigate the size of large cookbooks
         where possible. Most cookbooks are quite small, under \~200 KB.
         For any cookbook over 200 KB, consider why they are that large.
         Are there binary files?
-    -   Clean up `git` history for any cookbook found to be excessively
+    - Clean up `git` history for any cookbook found to be excessively
         large.
 
 Verify nodes and clients that are in use:
 
-:   -   Are all nodes and/or clients in use? Clean up any extra nodes
+:   - Are all nodes and/or clients in use? Clean up any extra nodes
         and clients. Use the `knife node list`, `knife client list`, and
         [knife status](/workstation/knife_status/) commands to verify nodes and
         clients in use.
-    -   Use the
+    - Use the
         `` knife client delete` command to remove unused clients. Use the ``knife
         node delete\`\` command to remove unused nodes.
 

--- a/content/vmware.md
+++ b/content/vmware.md
@@ -32,9 +32,9 @@ Chef:
 
 [\[GitHub\]](https://github.com/chef-partners/knife-vsphere)
 
--   Supports vCenter \> 5.0
--   Most VMware compute use cases are covered
--   The main starting point for Chef and VMware
+- Supports vCenter \> 5.0
+- Most VMware compute use cases are covered
+- The main starting point for Chef and VMware
 
 These are the necessary settings for your `config.rb` file:
 
@@ -101,10 +101,10 @@ the Chef Infra Server.
 
 [\[GitHub\]](https://github.com/chef/knife-vcenter)
 
--   Supports vCenter \>= 6.5 REST API
--   Supports the main use cases of knife: `bootstrap`, `create`,
+- Supports vCenter \>= 6.5 REST API
+- Supports the main use cases of knife: `bootstrap`, `create`,
     `destroy`, and `list`
--   If you have the
+- If you have the
     [VCSA](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcsa.doc/GUID-223C2821-BD98-4C7A-936B-7DBE96291BA4.html)
     or are planning on upgrading to vCenter 6.5+, this is the plugin to
     use
@@ -156,17 +156,17 @@ WARNING: Deleted client example-01
 
 [\[GitHub\]](https://github.com/chef-partners/knife-vrealize)
 
--   Supports both vRealize Automation and vRealize Orchestrator
--   Supports vRealize Automation 7.0+
--   If you have vRealize Automation \< 7.0, you will need to downgrade
+- Supports both vRealize Automation and vRealize Orchestrator
+- Supports vRealize Automation 7.0+
+- If you have vRealize Automation \< 7.0, you will need to downgrade
     the
     [vmware-vra-gem](https://github.com/chef-partners/vmware-vra-gem) to
     version `1.7.0`
--   Supports the main use cases of knife: `bootstrap`, `create`,
+- Supports the main use cases of knife: `bootstrap`, `create`,
     `destroy`, and `list`
--   Directly integrates with vRA to call out predetermined blueprints or
+- Directly integrates with vRA to call out predetermined blueprints or
     catalogs
--   Can integrate directly with vRO to call out predetermined workflows
+- Can integrate directly with vRO to call out predetermined workflows
 
 The main settings for your `config.rb`:
 
@@ -199,22 +199,22 @@ available.
 
 Common parameters to specify are:
 
--   `--cpus`: number of CPUs
--   `--memory`: amount of RAM in MB
--   `--requested-for`: vRA login that should be listed as the owner
--   `--lease-days`: number of days for the resource lease
--   `--notes`: any optional notes you'd like to be logged with your
+- `--cpus`: number of CPUs
+- `--memory`: amount of RAM in MB
+- `--requested-for`: vRA login that should be listed as the owner
+- `--lease-days`: number of days for the resource lease
+- `--notes`: any optional notes you'd like to be logged with your
     request
--   `--subtenant-id`: all resources must be tied back to a Business
+- `--subtenant-id`: all resources must be tied back to a Business
     Group, or "subtenant." If your catalog item is tied to a specific
     Business Group, you do not need to specify this. However, if your
     catalog item is a global catalog item, then the subtenant ID is not
     available to knife; you will need to provide it. It usually looks
     like a UUID. See your vRA administrator for assistance in
     determining your subtenant ID.
--   `--connection-password`: for Linux hosts, the password to use during
+- `--connection-password`: for Linux hosts, the password to use during
     bootstrap
--   `--winrm-password`: for Windows hosts, the password to use during
+- `--winrm-password`: for Windows hosts, the password to use during
     bootstrap
 
 <!-- -->
@@ -283,11 +283,11 @@ Chef:
 
 [\[GitHub\]](https://github.com/chef-partners/chef-provisioning-vsphere)
 
--   Built into the chef-provisioning-vsphere driver
--   A community driven project, with Chef Partners maintaining the
+- Built into the chef-provisioning-vsphere driver
+- A community driven project, with Chef Partners maintaining the
     releases
--   Leverages the typical test-kitchen workflow for vCenter \> 5.0+
--   There is a
+- Leverages the typical test-kitchen workflow for vCenter \> 5.0+
+- There is a
     [kitchen-vsphere](https://rubygems.org/gems/kitchen-vsphere) gem,
     but it is not supported at this time
 
@@ -351,9 +351,9 @@ suites:
 
 [\[GitHub\]](https://github.com/chef/kitchen-vcenter)
 
--   Supports vCenter \>= 6.5 REST API
--   Leverages the typical test-kitchen workflow for vCenter \>= 6.5+
--   If you have the
+- Supports vCenter \>= 6.5 REST API
+- Leverages the typical test-kitchen workflow for vCenter \>= 6.5+
+- If you have the
     [VCSA](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcsa.doc/GUID-223C2821-BD98-4C7A-936B-7DBE96291BA4.html)
     or are planning on upgrading to vCenter 6.5+, use this plugin
 
@@ -385,8 +385,8 @@ platforms:
 
 [\[GitHub\]](https://github.com/chef-partners/kitchen-vra)
 
--   An integration point with vRA and test-kitchen
--   For companies required to use vRA this is a natural progression for
+- An integration point with vRA and test-kitchen
+- For companies required to use vRA this is a natural progression for
     Chef Development
 
 #### Usage Examples
@@ -415,8 +415,8 @@ platforms:
 
 [\[GitHub\]](https://github.com/chef-partners/kitchen-vro)
 
--   An integration point with vRO and test-kitchen
--   Leverages specific Workflows in vRO if it's required by VMware
+- An integration point with vRO and test-kitchen
+- Leverages specific Workflows in vRO if it's required by VMware
     admins
 
 #### Usage Examples
@@ -456,8 +456,8 @@ VMware stack.
 
 [\[GitHub\]](https://github.com/chef/inspec-vmware)
 
--   Supports vCenter \> 5.0
--   11 resources available at the time of writing, with more planned
+- Supports vCenter \> 5.0
+- 11 resources available at the time of writing, with more planned
 
 #### Usage Examples
 
@@ -477,15 +477,15 @@ end
 
 ### vRA Example Blueprints
 
--   [Linux](https://code.vmware.com/samples?id=1371)
--   [Windows](https://code.vmware.com/samples?id=1390)
+- [Linux](https://code.vmware.com/samples?id=1371)
+- [Windows](https://code.vmware.com/samples?id=1390)
 
 ### vRO plugin
 
--   The [Chef plugin for vRealize
+- The [Chef plugin for vRealize
     Orchestrator](https://solutionexchange.vmware.com/store/products/chef-plugin-for-vrealize-orchestrator)
     (vRO) is a VMware-supplied plugin
--   If you use vRO this provides the majority of the necessary features
+- If you use vRO this provides the majority of the necessary features
 
 For more information, see the plugin demo on
 [YouTube](https://www.youtube.com/watch?v=HlvoZ4Zdwc4).

--- a/themes/docs-new/layouts/shortcodes/chef_client_bootstrap_node.md
+++ b/themes/docs-new/layouts/shortcodes/chef_client_bootstrap_node.md
@@ -4,6 +4,6 @@ Chef Infra Client on a target system so that it can run as a client and
 sets the node up to communicate with a Chef Infra Server. There are two
 ways to do this:
 
--   Run the `knife bootstrap` command from a workstation.
--   Perform an unattended install to bootstrap from the node itself,
+- Run the `knife bootstrap` command from a workstation.
+- Perform an unattended install to bootstrap from the node itself,
     without requiring SSH or WinRM connectivity.

--- a/themes/docs-new/layouts/shortcodes/chef_manager.md
+++ b/themes/docs-new/layouts/shortcodes/chef_manager.md
@@ -1,11 +1,11 @@
 Chef management console is a web-based interface for the Chef Infra
 Server that provides users a way to manage the following objects:
 
--   Nodes
--   Cookbooks and recipes
--   Roles
--   Stores of JSON data (data bags), including encrypted data
--   Environments
--   Searching of indexed data
--   User accounts and user data for the individuals who have permission
+- Nodes
+- Cookbooks and recipes
+- Roles
+- Stores of JSON data (data bags), including encrypted data
+- Environments
+- Searching of indexed data
+- User accounts and user data for the individuals who have permission
     to log on to and access the Chef server

--- a/themes/docs-new/layouts/shortcodes/chef_repo_description.md
+++ b/themes/docs-new/layouts/shortcodes/chef_repo_description.md
@@ -1,10 +1,10 @@
 The chef-repo is a directory on your workstation that stores everything
 you need to define your infrastructure with Chef Infra:
 
--   Cookbooks (including recipes, attributes, custom resources,
+- Cookbooks (including recipes, attributes, custom resources,
     libraries, and templates)
--   Data bags
--   Policyfiles
+- Data bags
+- Policyfiles
 
 The chef-repo directory should be synchronized with a version control
 system, such as git. All of the data in the chef-repo should be treated

--- a/themes/docs-new/layouts/shortcodes/chef_shell_config.md
+++ b/themes/docs-new/layouts/shortcodes/chef_shell_config.md
@@ -8,7 +8,7 @@ following:
 3.  If no NAMED_CONF is given chef-shell will load
     \~/.chef/chef_shell.rb if it exists
 4.  If no chef_shell.rb can be found, chef-shell falls back to load:
-    -   /etc/chef/client.rb if -z option is given.
-    -   /etc/chef/solo.rb if --solo-legacy-mode option is given.
-    -   .chef/config.rb if -s option is given.
-    -   .chef/knife.rb if -s option is given.
+    - /etc/chef/client.rb if -z option is given.
+    - /etc/chef/solo.rb if --solo-legacy-mode option is given.
+    - .chef/config.rb if -s option is given.
+    - .chef/knife.rb if -s option is given.

--- a/themes/docs-new/layouts/shortcodes/chef_shell_manage.md
+++ b/themes/docs-new/layouts/shortcodes/chef_shell_manage.md
@@ -10,7 +10,7 @@ chef-shell -z named_configuration
 
 Where:
 
--   `named_configuration` is an existing configuration file in
+- `named_configuration` is an existing configuration file in
     `~/.chef/named_configuration/chef_shell.rb`, such as `production`,
     `staging`, or `test`.
 
@@ -22,9 +22,9 @@ chef (preprod) > items.command
 
 Where:
 
--   `items` is the type of item to search for: `cookbooks`, `clients`,
+- `items` is the type of item to search for: `cookbooks`, `clients`,
     `nodes`, `roles`, `environments` or a data bag.
--   `command` is the command: `list`, `show`, `find`, or `edit`.
+- `command` is the command: `list`, `show`, `find`, or `edit`.
 
 For example, to list all of the nodes in a configuration named
 "preprod", enter:

--- a/themes/docs-new/layouts/shortcodes/chef_solo_summary.md
+++ b/themes/docs-new/layouts/shortcodes/chef_solo_summary.md
@@ -5,10 +5,10 @@ mode](/ctl_chef_client.html#run-in-local-mode), and **does not support**
 the following functionality present in Chef Infra Client / server
 configurations:
 
--   Centralized distribution of cookbooks
--   A centralized API that interacts with and integrates infrastructure
+- Centralized distribution of cookbooks
+- A centralized API that interacts with and integrates infrastructure
     components
--   Authentication or authorization
+- Authentication or authorization
 
 <div class="admonition-note">
 

--- a/themes/docs-new/layouts/shortcodes/chefspec_summary.md
+++ b/themes/docs-new/layouts/shortcodes/chefspec_summary.md
@@ -1,5 +1,5 @@
 Use ChefSpec to simulate the convergence of resources on a node:
 
--   Is an extension of RSpec, a behavior-driven development (BDD)
+- Is an extension of RSpec, a behavior-driven development (BDD)
     framework for Ruby
--   Is the fastest way to test resources and recipes
+- Is the fastest way to test resources and recipes

--- a/themes/docs-new/layouts/shortcodes/config_rb_client_dot_d_directories.md
+++ b/themes/docs-new/layouts/shortcodes/config_rb_client_dot_d_directories.md
@@ -6,19 +6,19 @@ are loaded; other non-`.rb` files are ignored.
 `.d` directories may exist in any location where the `client.rb`,
 `config.rb`, or `solo.rb` files are present, such as:
 
--   `/etc/chef/client.d`
--   `/etc/chef/config.d`
--   `~/chef/solo.d`
+- `/etc/chef/client.d`
+- `/etc/chef/config.d`
+- `~/chef/solo.d`
 
 (There is no support for a `knife.d` directory; use `config.d` instead.)
 
 For example, when using knife, the following configuration files would
 be loaded:
 
--   `~/.chef/config.rb`
--   `~/.chef/config.d/company_settings.rb`
--   `~/.chef/config.d/ec2_configuration.rb`
--   `~/.chef/config.d/old_settings.rb.bak`
+- `~/.chef/config.rb`
+- `~/.chef/config.d/company_settings.rb`
+- `~/.chef/config.d/ec2_configuration.rb`
+- `~/.chef/config.d/old_settings.rb.bak`
 
 The `old_settings.rb.bak` file is ignored because it's not a
 configuration file. The `config.rb`, `company_settings.rb`, and

--- a/themes/docs-new/layouts/shortcodes/config_rb_client_summary.md
+++ b/themes/docs-new/layouts/shortcodes/config_rb_client_summary.md
@@ -1,10 +1,10 @@
 The client.rb file specifies how Chef Infra Client is configured on a
 node and has the following characteristics:
 
--   This file is loaded every time the chef-client executable is run.
--   On Microsoft Windows machines, the default location for this file is
+- This file is loaded every time the chef-client executable is run.
+- On Microsoft Windows machines, the default location for this file is
     `C:\chef\client.rb`. On all other systems the default location for
     this file is `/etc/chef/client.rb`.
--   Use the `--config` option from the command line to override the
+- Use the `--config` option from the command line to override the
     default location of the configuration file.
--   This file is not created by default
+- This file is not created by default

--- a/themes/docs-new/layouts/shortcodes/config_rb_server_settings_ldap.md
+++ b/themes/docs-new/layouts/shortcodes/config_rb_server_settings_ldap.md
@@ -5,10 +5,10 @@
 The following settings **MUST** be in the config file for LDAP
 authentication to Active Directory to work:
 
--   `base_dn`
--   `bind_dn`
--   `group_dn`
--   `host`
+- `base_dn`
+- `bind_dn`
+- `group_dn`
+- `host`
 
 If those settings are missing, you will get authentication errors and be
 unable to proceed.

--- a/themes/docs-new/layouts/shortcodes/cookbooks_recipe.md
+++ b/themes/docs-new/layouts/shortcodes/cookbooks_recipe.md
@@ -1,18 +1,18 @@
 A recipe is the most fundamental configuration element within the
 organization. A recipe:
 
--   Is authored using Ruby, which is a programming language designed to
+- Is authored using Ruby, which is a programming language designed to
     read and behave in a predictable manner
--   Is mostly a collection of [resources](/resources/), defined
+- Is mostly a collection of [resources](/resources/), defined
     using patterns (resource names, attribute-value pairs, and actions);
     helper code is added around this using Ruby, when needed
--   Must define everything that is required to configure part of a
+- Must define everything that is required to configure part of a
     system
--   Must be stored in a cookbook
--   May be included in another recipe
--   May use the results of a search query and read the contents of a
+- Must be stored in a cookbook
+- May be included in another recipe
+- May use the results of a search query and read the contents of a
     data bag (including an encrypted data bag)
--   May have a dependency on one (or more) recipes
--   Must be added to a run-list before it can be used by Chef Infra
+- May have a dependency on one (or more) recipes
+- Must be added to a run-list before it can be used by Chef Infra
     Client
--   Is always executed in the same order as listed in a run-list
+- Is always executed in the same order as listed in a run-list

--- a/themes/docs-new/layouts/shortcodes/cookbooks_summary.md
+++ b/themes/docs-new/layouts/shortcodes/cookbooks_summary.md
@@ -2,9 +2,9 @@ A cookbook is the fundamental unit of configuration and policy
 distribution. A cookbook defines a scenario and contains everything that
 is required to support that scenario:
 
--   Recipes that specify the resources to use and the order in which
+- Recipes that specify the resources to use and the order in which
     they are to be applied
--   Attribute values
--   File distributions
--   Templates
--   Extensions to Chef, such as custom resources and libraries
+- Attribute values
+- File distributions
+- Templates
+- Extensions to Chef, such as custom resources and libraries

--- a/themes/docs-new/layouts/shortcodes/ctl_chef_client_elevated_privileges_windows.md
+++ b/themes/docs-new/layouts/shortcodes/ctl_chef_client_elevated_privileges_windows.md
@@ -4,10 +4,10 @@ Infra Client completed its run successfully, but the changes will not
 have been made. When this occurs, do one of the following to run Chef
 Infra Client as the administrator:
 
--   Log in to the administrator account. (This is not the same as an
+- Log in to the administrator account. (This is not the same as an
     account in the administrator's security group.)
 
--   Run Chef Infra Client process from the administrator account while
+- Run Chef Infra Client process from the administrator account while
     being logged into another account. Run the following command:
 
     ```bash
@@ -16,7 +16,7 @@ Infra Client as the administrator:
 
     This will prompt for the administrator account password.
 
--   Open a command prompt by right-clicking on the command prompt
+- Open a command prompt by right-clicking on the command prompt
     application, and then selecting **Run as administrator**. After the
     command window opens, Chef Infra Client can be run as the
     administrator

--- a/themes/docs-new/layouts/shortcodes/ctl_chef_client_options_format.md
+++ b/themes/docs-new/layouts/shortcodes/ctl_chef_client_options_format.md
@@ -1,8 +1,8 @@
 The output format: `doc` (default) or `min`.
 
--   Use `doc` to print the progress of a Chef Infra Client run using
+- Use `doc` to print the progress of a Chef Infra Client run using
     full strings that display a summary of updates as they occur.
--   Use `min` to print the progress of a Chef Infra Client run using
+- Use `min` to print the progress of a Chef Infra Client run using
     single characters.
 
 A summary of updates is printed at the end of a Chef Infra Client run. A

--- a/themes/docs-new/layouts/shortcodes/ctl_chef_server_backup.md
+++ b/themes/docs-new/layouts/shortcodes/ctl_chef_server_backup.md
@@ -1,12 +1,12 @@
 The `backup` subcommand is used to back up all Chef Infra Server data.
 This subcommand:
 
--   Requires rsync to be installed on the Chef Infra Server prior to
+- Requires rsync to be installed on the Chef Infra Server prior to
     running the command
--   Requires a `chef-server-ctl reconfigure` prior to running the
+- Requires a `chef-server-ctl reconfigure` prior to running the
     command
--   Should not be run in a Chef Infra Server configuration with an
+- Should not be run in a Chef Infra Server configuration with an
     external PostgreSQL database; [use knife ec
     backup](https://github.com/chef/knife-ec-backup) instead
--   Puts the initial backup in the `/var/opt/chef-backup` directory as a
+- Puts the initial backup in the `/var/opt/chef-backup` directory as a
     tar.gz file; move this backup to a new location for safe keeping

--- a/themes/docs-new/layouts/shortcodes/ctl_chef_server_org_create_syntax.md
+++ b/themes/docs-new/layouts/shortcodes/ctl_chef_server_org_create_syntax.md
@@ -6,9 +6,9 @@ chef-server-ctl org-create ORG_NAME "ORG_FULL_NAME" (options)
 
 where:
 
--   The name must begin with a lower-case letter or digit, may only
+- The name must begin with a lower-case letter or digit, may only
     contain lower-case letters, digits, hyphens, and underscores, and
     must be between 1 and 255 characters. For example: `chef`.
--   The full name must begin with a non-white space character and must
+- The full name must begin with a non-white space character and must
     be between 1 and 1023 characters. For example:
     `"Chef Software, Inc."`.

--- a/themes/docs-new/layouts/shortcodes/ctl_chef_server_restore.md
+++ b/themes/docs-new/layouts/shortcodes/ctl_chef_server_restore.md
@@ -3,10 +3,10 @@ a backup that was created by the `backup` subcommand. This subcommand
 may also be used to add Chef Infra Server data to a newly-installed
 server. This subcommand:
 
--   Requires rsync to be installed on the Chef Infra Server prior to
+- Requires rsync to be installed on the Chef Infra Server prior to
     running the command
--   Requires a `chef-server-ctl reconfigure` prior to running the
+- Requires a `chef-server-ctl reconfigure` prior to running the
     command
--   Should not be run in a Chef Infra Server configuration with an
+- Should not be run in a Chef Infra Server configuration with an
     external PostgreSQL database; [use knife ec
     backup](https://github.com/chef/knife-ec-backup) instead

--- a/themes/docs-new/layouts/shortcodes/ctl_chef_server_server_admin.md
+++ b/themes/docs-new/layouts/shortcodes/ctl_chef_server_server_admin.md
@@ -1,6 +1,6 @@
 Membership of the `server-admins` group is managed with a set of
 `chef-server-ctl` subcommands:
 
--   `chef-server-ctl grant-server-admin-permissions`
--   `chef-server-ctl list-server-admins`
--   `chef-server-ctl remove-server-admin-permissions`
+- `chef-server-ctl grant-server-admin-permissions`
+- `chef-server-ctl list-server-admins`
+- `chef-server-ctl remove-server-admin-permissions`

--- a/themes/docs-new/layouts/shortcodes/ctl_chef_server_status.md
+++ b/themes/docs-new/layouts/shortcodes/ctl_chef_server_status.md
@@ -26,11 +26,11 @@ run: service_name: (pid 12345) 12345s; run: log: (pid 1234) 67890s
 
 where
 
--   `run:` is the state of the service (`run:` or `down:`)
--   `service_name:` is the name of the service for which status is
+- `run:` is the state of the service (`run:` or `down:`)
+- `service_name:` is the name of the service for which status is
     returned
--   `(pid 12345)` is the process identifier
--   `12345s` is the uptime of the service, in seconds
+- `(pid 12345)` is the process identifier
+- `12345s` is the uptime of the service, in seconds
 
 For example:
 

--- a/themes/docs-new/layouts/shortcodes/ctl_chef_server_status_logs.md
+++ b/themes/docs-new/layouts/shortcodes/ctl_chef_server_status_logs.md
@@ -7,13 +7,13 @@ run: name_of_service: (pid 1486) 7819s; run: log: (pid 1485) 7819s
 
 where:
 
--   `run` describes the state in which the supervisor attempts to keep
+- `run` describes the state in which the supervisor attempts to keep
     processes. This state is either `run` or `down`. If a service is in
     a `down` state, it should be stopped
--   `name_of_service` is the service name, for example: `opscode-erchef`
--   `(pid 1486) 7819s;` is the process identifier followed by the amount
+- `name_of_service` is the service name, for example: `opscode-erchef`
+- `(pid 1486) 7819s;` is the process identifier followed by the amount
     of time (in seconds) the service has been running
--   `run: log: (pid 1485) 7819s` is the log process. It is typical for a
+- `run: log: (pid 1485) 7819s` is the log process. It is typical for a
     log process to have a longer run time than a service; this is
     because the supervisor does not need to restart the log process in
     order to connect the supervised process
@@ -27,7 +27,7 @@ down: opscode-erchef: 3s, normally up; run: log: (pid 1485) 8526s
 
 where
 
--   `down` indicates that the service is in a down state
--   `3s, normally up;` indicates that the service is normally in a run
+- `down` indicates that the service is in a down state
+- `3s, normally up;` indicates that the service is normally in a run
     state and that the supervisor would attempt to restart this service
     after a reboot

--- a/themes/docs-new/layouts/shortcodes/ctl_chef_undelete.md
+++ b/themes/docs-new/layouts/shortcodes/ctl_chef_undelete.md
@@ -1,9 +1,9 @@
 Use the `chef undelete` subcommand to recover a deleted policy or policy
 group. This command:
 
--   Does not detect conflicts. If a deleted item has been recreated,
+- Does not detect conflicts. If a deleted item has been recreated,
     running this command will overwrite it
--   Does not include cookbooks that may be referenced by policy files;
+- Does not include cookbooks that may be referenced by policy files;
     cookbooks that are cleaned after running this command may not be
     fully restorable to their previous state
--   Does not store access control data
+- Does not store access control data

--- a/themes/docs-new/layouts/shortcodes/data_bag_item.md
+++ b/themes/docs-new/layouts/shortcodes/data_bag_item.md
@@ -15,7 +15,7 @@ of a data bag item is that it must have an `id`:
 
 where
 
--   `key` and `value` are the `key:value` pair for each additional
+- `key` and `value` are the `key:value` pair for each additional
     attribute within the data bag item
--   `/* ... */` and `// ...` show two ways to add comments to the data
+- `/* ... */` and `// ...` show two ways to add comments to the data
     bag item

--- a/themes/docs-new/layouts/shortcodes/data_bag_recipes.md
+++ b/themes/docs-new/layouts/shortcodes/data_bag_recipes.md
@@ -1,8 +1,8 @@
 Data bags can be accessed by a recipe in the following ways:
 
--   Loaded by name when using the Chef Infra Language. Use this approach when a
+- Loaded by name when using the Chef Infra Language. Use this approach when a
     only single, known data bag item is required.
--   Accessed through the search indexes. Use this approach when more
+- Accessed through the search indexes. Use this approach when more
     than one data bag item is required or when the contents of a data
     bag are looped through. The search indexes will bulk-load all of the
     data bag items, which will result in a lower overhead than if each

--- a/themes/docs-new/layouts/shortcodes/data_bag_recipes_edit_within_recipe.md
+++ b/themes/docs-new/layouts/shortcodes/data_bag_recipes_edit_within_recipe.md
@@ -4,12 +4,12 @@ bag or a data bag item is to use knife and the `knife data bag`
 subcommand. If this action must be done from a recipe, please note the
 following:
 
--   If two operations concurrently attempt to update the contents of a
+- If two operations concurrently attempt to update the contents of a
     data bag, the last-written attempt will be the operation to update
     the contents of the data bag. This situation can lead to data loss,
     so organizations should take steps to ensure that only one Chef
     Infra Client is making updates to a data bag at a time.
--   Altering data bags from the node when using the open source Chef
+- Altering data bags from the node when using the open source Chef
     Infra Server requires the node's API client to be granted admin
     privileges. In most cases, this is not advisable.
 

--- a/themes/docs-new/layouts/shortcodes/data_bag_recipes_load_using_recipe_dsl.md
+++ b/themes/docs-new/layouts/shortcodes/data_bag_recipes_load_using_recipe_dsl.md
@@ -1,8 +1,8 @@
 The Chef Infra Language provides access to data bags and data bag items
 (including encrypted data bag items) with the following methods:
 
--   `data_bag(bag)`, where `bag` is the name of the data bag.
--   `data_bag_item('bag_name', 'item', 'secret')`, where `bag` is the
+- `data_bag(bag)`, where `bag` is the name of the data bag.
+- `data_bag_item('bag_name', 'item', 'secret')`, where `bag` is the
     name of the data bag and `item` is the name of the data bag item. If
     `'secret'` is not specified, Chef Infra Client will look for a
     secret at the path specified by the `encrypted_data_bag_secret`

--- a/themes/docs-new/layouts/shortcodes/data_bag_store.md
+++ b/themes/docs-new/layouts/shortcodes/data_bag_store.md
@@ -1,9 +1,9 @@
 When the chef-repo is cloned from GitHub, the following occurs:
 
--   A directory named `data_bags` is created.
--   For each data bag, a sub-directory is created that has the same name
+- A directory named `data_bags` is created.
+- For each data bag, a sub-directory is created that has the same name
     as the data bag.
--   For each data bag item, a JSON file is created and placed in the
+- For each data bag item, a JSON file is created and placed in the
     appropriate sub-directory.
 
 The `data_bags` directory can be placed under version source control.

--- a/themes/docs-new/layouts/shortcodes/delivery_cli_fips.md
+++ b/themes/docs-new/layouts/shortcodes/delivery_cli_fips.md
@@ -2,7 +2,7 @@
 
 ### Prerequisites
 
--   Supported Systems - CentOS or Red Hat Enterprise Linux 6 or later
+- Supported Systems - CentOS or Red Hat Enterprise Linux 6 or later
 
 ### Configuration
 
@@ -52,7 +52,7 @@ generate the file.
 
 ### Prerequisites
 
--   Supported Systems - Windows, CentOS and Red Hat Enterprise Linux
+- Supported Systems - Windows, CentOS and Red Hat Enterprise Linux
 
 Now that FIPS mode is enabled in your `.delivery/cli.toml`, running any
 project-specific Delivery CLI command will automatically use

--- a/themes/docs-new/layouts/shortcodes/delivery_config_example_test_patterns.md
+++ b/themes/docs-new/layouts/shortcodes/delivery_config_example_test_patterns.md
@@ -24,11 +24,11 @@ are located in the specified cookbook directories:
 
 where:
 
--   `ignore_rules` is set to ignore Foodcritic rules `FC009`, `FC057`,
+- `ignore_rules` is set to ignore Foodcritic rules `FC009`, `FC057`,
     `FC058`
--   `only_rules` is set to run only Foodcritic rule `FC002`; omit this
+- `only_rules` is set to run only Foodcritic rule `FC002`; omit this
     setting to specify all rules not specified by `ignore_rules`
--   `excludes` prevents Foodcritic rules from running if they are
+- `excludes` prevents Foodcritic rules from running if they are
     present in a cookbook's `/spec` and/or `/test` directories
--   `fail_tags` states which rules should cause the run to fail; omit
+- `fail_tags` states which rules should cause the run to fail; omit
     this setting to specify `correctness`

--- a/themes/docs-new/layouts/shortcodes/delivery_config_json_setting_dependencies.md
+++ b/themes/docs-new/layouts/shortcodes/delivery_config_json_setting_dependencies.md
@@ -3,10 +3,10 @@ current project depends. These dependency associations affect how
 projects are promoted through the Union, Rehearsal, and Delivered
 stages. Dependencies may be defined in the following ways:
 
--   `"project_name"`
--   `"project_name:pipeline_name"`
--   `"org_name/project_name"`
--   `"org_name/project_name:pipeline_name"`
+- `"project_name"`
+- `"project_name:pipeline_name"`
+- `"org_name/project_name"`
+- `"org_name/project_name:pipeline_name"`
 
 If only a project name is provided, the master pipeline for that project
 is the dependency.

--- a/themes/docs-new/layouts/shortcodes/delivery_integration_ldap_users_add.md
+++ b/themes/docs-new/layouts/shortcodes/delivery_integration_ldap_users_add.md
@@ -19,9 +19,9 @@ To add or edit a user to Workflow:
 4.  In the Add New a User text area, select one of two types for user.
     The selection box is grey for the active selection.
 
-    -   **Internal** means you are manually adding the user to the
+    - **Internal** means you are manually adding the user to the
         Workflow database.
-    -   **LDAP** means the user is in an LDAP system that has been
+    - **LDAP** means the user is in an LDAP system that has been
         integrated to this Workflow.
 
     If you select **Internal**, options for **Name and Email**, first

--- a/themes/docs-new/layouts/shortcodes/delivery_server_tuning_general.md
+++ b/themes/docs-new/layouts/shortcodes/delivery_server_tuning_general.md
@@ -1,9 +1,9 @@
 The following settings are typically added to the server configuration
 file, including:
 
--   Logging directories
--   Maximum file sizes at which log rotation occurs
--   The number of log files to keep
+- Logging directories
+- Maximum file sizes at which log rotation occurs
+- The number of log files to keep
 
 These values have the same default across all Chef Automate services,
 but individual services can have their values overwritten. Add the

--- a/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_converge_if_changed.md
+++ b/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_converge_if_changed.md
@@ -48,5 +48,5 @@ the Chef Infra Client output will print something similar to:
 Recipe: recipe_name::block
   * resource_name[blah] action create
     - update my_file[blah]
-    -   set content to "hola mundo" (was "hello world")
+    - set content to "hola mundo" (was "hello world")
 ```

--- a/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_converge_if_changed_multiple.md
+++ b/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_converge_if_changed_multiple.md
@@ -27,10 +27,10 @@ end
 
 where
 
--   `load_current_value` loads the property values for both `content`
+- `load_current_value` loads the property values for both `content`
     and `mode`
--   A `converge_if_changed` block tests only `content`
--   A `converge_if_changed` block tests only `mode`
+- A `converge_if_changed` block tests only `content`
+- A `converge_if_changed` block tests only `mode`
 
 Chef Infra Client will only update the property values that require
 updates and will not make changes when the property values are already

--- a/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_property.md
+++ b/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_property.md
@@ -7,12 +7,12 @@ property :property_name, ruby_type, default: 'value', parameter: 'value'
 
 where
 
--   `:property_name` is the name of the property
--   `ruby_type` is the optional Ruby type or array of types, such as
+- `:property_name` is the name of the property
+- `ruby_type` is the optional Ruby type or array of types, such as
     `String`, `Integer`, `true`, or `false`
--   `default: 'value'` is the optional default value loaded into the
+- `default: 'value'` is the optional default value loaded into the
     resource
--   `parameter: 'value'` optional parameters
+- `parameter: 'value'` optional parameters
 
 For example, the following properties define `username` and `password`
 properties with no default values specified:

--- a/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_property_desired_state.md
+++ b/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_property_desired_state.md
@@ -1,9 +1,9 @@
 Add `desired_state:` to set the desired state property for a resource.
 This value may be `true` or `false`, and all properties default to true.
 
--   When `true`, the state of the property is determined by the state of
+- When `true`, the state of the property is determined by the state of
     the system
--   When `false`, the value of the property impacts how the resource
+- When `false`, the value of the property impacts how the resource
     executes, but it is not determined by the state of the system.
 
 For example, if you were to write a resource to create volumes on a

--- a/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_property_identity.md
+++ b/themes/docs-new/layouts/shortcodes/dsl_custom_resource_method_property_identity.md
@@ -1,10 +1,10 @@
 Add `identity:` to set a resource to a particular set of properties.
 This value may be `true` or `false`.
 
--   When `true`, data for that property is returned as part of the
+- When `true`, data for that property is returned as part of the
     resource data set and may be available to external applications,
     such as reporting
--   When `false`, no data for that property is returned.
+- When `false`, no data for that property is returned.
 
 If no properties are marked `true`, the property that defaults to the
 `name` of the resource is marked `true`.

--- a/themes/docs-new/layouts/shortcodes/dsl_handler_method_on.md
+++ b/themes/docs-new/layouts/shortcodes/dsl_handler_method_on.md
@@ -13,12 +13,12 @@ end
 
 where
 
--   `Chef.event_handler` declares a block of code within a recipe that
+- `Chef.event_handler` declares a block of code within a recipe that
     is processed when the named event occurs during a Chef Infra Client
     run
--   `on` defines the block of code that will tell Chef Infra Client how
+- `on` defines the block of code that will tell Chef Infra Client how
     to handle the event
--   `:event_type` is a valid exception event type, such as `:run_start`,
+- `:event_type` is a valid exception event type, such as `:run_start`,
     `:run_failed`, `:converge_failed`, `:resource_failed`, or
     `:recipe_not_found`
 

--- a/themes/docs-new/layouts/shortcodes/dsl_handler_slide_send_email.md
+++ b/themes/docs-new/layouts/shortcodes/dsl_handler_slide_send_email.md
@@ -1,8 +1,8 @@
 Use the `on` method to create an event handler that sends email when a
 Chef Infra Client run fails. This will require:
 
--   A way to tell Chef Infra Client how to send email
--   An event handler that describes what to do when the `:run_failed`
+- A way to tell Chef Infra Client how to send email
+- An event handler that describes what to do when the `:run_failed`
     event is triggered
--   A way to trigger the exception and test the behavior of the event
+- A way to trigger the exception and test the behavior of the event
     handler

--- a/themes/docs-new/layouts/shortcodes/dsl_handler_slide_send_email_handler.md
+++ b/themes/docs-new/layouts/shortcodes/dsl_handler_slide_send_email_handler.md
@@ -10,8 +10,8 @@ Chef.event_handler do
 end
 ```
 
--   Use `Chef.event_handler` to define the event handler
--   Use the `on` method to specify the event type
+- Use `Chef.event_handler` to define the event handler
+- Use the `on` method to specify the event type
 
 Within the `on` block, tell Chef Infra Client how to handle the event
 when it's triggered.

--- a/themes/docs-new/layouts/shortcodes/dsl_handler_summary.md
+++ b/themes/docs-new/layouts/shortcodes/dsl_handler_summary.md
@@ -2,6 +2,6 @@ Use the Handler DSL to attach a callback to an event. If the event
 occurs during a Chef Infra Client run, the associated callback is
 executed. For example:
 
--   Sending email if a Chef Infra Client run fails
--   Aggregating statistics about resources updated during a Chef Infra
+- Sending email if a Chef Infra Client run fails
+- Aggregating statistics about resources updated during a Chef Infra
     Client runs to StatsD

--- a/themes/docs-new/layouts/shortcodes/fips_intro_client.md
+++ b/themes/docs-new/layouts/shortcodes/fips_intro_client.md
@@ -26,7 +26,7 @@ and is not used for any cryptographic purpose.
 
 Notes about FIPS:
 
--   May be enabled for nodes running on Microsoft Windows and Enterprise
+- May be enabled for nodes running on Microsoft Windows and Enterprise
     Linux platforms
--   Should only be enabled for environments that require FIPS 140-2
+- Should only be enabled for environments that require FIPS 140-2
     compliance

--- a/themes/docs-new/layouts/shortcodes/handler_type_exception_report.md
+++ b/themes/docs-new/layouts/shortcodes/handler_type_exception_report.md
@@ -2,9 +2,9 @@ Exception and report handlers are used to trigger certain behaviors in
 response to specific situations, typically identified during a Chef
 Infra Client run.
 
--   An exception handler is used to trigger behaviors when a defined
+- An exception handler is used to trigger behaviors when a defined
     aspect of a Chef Infra Client run fails.
--   A report handler is used to trigger behaviors when a defined aspect
+- A report handler is used to trigger behaviors when a defined aspect
     of a Chef Infra Client run is successful.
 
 Both types of handlers can be used to gather data about a Chef Infra
@@ -15,9 +15,9 @@ organization.
 Exception and report handlers are made available to a Chef Infra Client
 run in one of the following ways:
 
--   By adding the **chef_handler** resource to a recipe, and then
+- By adding the **chef_handler** resource to a recipe, and then
     adding that recipe to the run-list for a node. (The
     **chef_handler** resource is available from the **chef_handler**
     cookbook.)
--   By adding the handler to one of the following settings in the node's
+- By adding the handler to one of the following settings in the node's
     client.rb file: `exception_handlers` and/or `report_handlers`

--- a/themes/docs-new/layouts/shortcodes/handler_type_start.md
+++ b/themes/docs-new/layouts/shortcodes/handler_type_start.md
@@ -8,8 +8,8 @@ handler.
 Start handlers are made available to a Chef Infra Client run in one of
 the following ways:
 
--   By adding a start handler to the **chef-client** cookbook, which
+- By adding a start handler to the **chef-client** cookbook, which
     installs the handler on the node so that it is available to Chef
     Infra Client at the start of a Chef Infra Client run
--   By adding the handler to one of the following settings in the node's
+- By adding the handler to one of the following settings in the node's
     client.rb file: `start_handlers`

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_data_exists.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_data_exists.md
@@ -28,21 +28,21 @@ registry_data_exists?(
 
 where:
 
--   `KEY_PATH` is the path to the registry key value. The path must
+- `KEY_PATH` is the path to the registry key value. The path must
     include the registry hive, which can be specified either as its full
     name or as the 3- or 4-letter abbreviation. For example, both
     `HKLM\SECURITY` and `HKEY_LOCAL_MACHINE\SECURITY` are both valid and
     equivalent. The following hives are valid: `HKEY_LOCAL_MACHINE`,
     `HKLM`, `HKEY_CURRENT_CONFIG`, `HKCC`, `HKEY_CLASSES_ROOT`, `HKCR`,
     `HKEY_USERS`, `HKU`, `HKEY_CURRENT_USER`, and `HKCU`.
--   `{ name: 'NAME', type: TYPE, data: DATA }` is a hash that contains
+- `{ name: 'NAME', type: TYPE, data: DATA }` is a hash that contains
     the expected name, type, and data of the registry key value
--   `type:` represents the values available for registry keys in
+- `type:` represents the values available for registry keys in
     Microsoft Windows. Use `:binary` for REG_BINARY, `:string` for
     REG_SZ, `:multi_string` for REG_MULTI_SZ, `:expand_string` for
     REG_EXPAND_SZ, `:dword` for REG_DWORD, `:dword_big_endian` for
     REG_DWORD_BIG_ENDIAN, or `:qword` for REG_QWORD.
--   `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
+- `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
     or `:machine`. Set to `:i386` to read or write 32-bit registry keys
     on 64-bit machines running Microsoft Windows. Set to`:x86_64` to
     force write to a 64-bit registry location, however Chef Infra Client

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_get_subkeys.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_get_subkeys.md
@@ -23,14 +23,14 @@ subkey_array = registry_get_subkeys(KEY_PATH, ARCHITECTURE)
 
 where:
 
--   `KEY_PATH` is the path to the registry key. The path must include
+- `KEY_PATH` is the path to the registry key. The path must include
     the registry hive, which can be specified either as its full name or
     as the 3- or 4-letter abbreviation. For example, both
     `HKLM\SECURITY` and `HKEY_LOCAL_MACHINE\SECURITY` are both valid and
     equivalent. The following hives are valid: `HKEY_LOCAL_MACHINE`,
     `HKLM`, `HKEY_CURRENT_CONFIG`, `HKCC`, `HKEY_CLASSES_ROOT`, `HKCR`,
     `HKEY_USERS`, `HKU`, `HKEY_CURRENT_USER`, and `HKCU`.
--   `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
+- `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
     or `:machine`. Set to `:i386` to read or write 32-bit registry keys
     on 64-bit machines running Microsoft Windows. Set to`:x86_64` to
     force write to a 64-bit registry location, however Chef Infra Client

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_get_values.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_get_values.md
@@ -23,14 +23,14 @@ subkey_array = registry_get_values(KEY_PATH, ARCHITECTURE)
 
 where:
 
--   `KEY_PATH` is the path to the registry key. The path must include
+- `KEY_PATH` is the path to the registry key. The path must include
     the registry hive, which can be specified either as its full name or
     as the 3- or 4-letter abbreviation. For example, both
     `HKLM\SECURITY` and `HKEY_LOCAL_MACHINE\SECURITY` are both valid and
     equivalent. The following hives are valid: `HKEY_LOCAL_MACHINE`,
     `HKLM`, `HKEY_CURRENT_CONFIG`, `HKCC`, `HKEY_CLASSES_ROOT`, `HKCR`,
     `HKEY_USERS`, `HKU`, `HKEY_CURRENT_USER`, and `HKCU`.
--   `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
+- `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
     or `:machine`. Set to `:i386` to read or write 32-bit registry keys
     on 64-bit machines running Microsoft Windows. Set to`:x86_64` to
     force write to a 64-bit registry location, however Chef Infra Client

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_has_subkeys.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_has_subkeys.md
@@ -23,14 +23,14 @@ registry_has_subkeys?(KEY_PATH, ARCHITECTURE)
 
 where:
 
--   `KEY_PATH` is the path to the registry key. The path must include
+- `KEY_PATH` is the path to the registry key. The path must include
     the registry hive, which can be specified either as its full name or
     as the 3- or 4-letter abbreviation. For example, both
     `HKLM\SECURITY` and `HKEY_LOCAL_MACHINE\SECURITY` are both valid and
     equivalent. The following hives are valid: `HKEY_LOCAL_MACHINE`,
     `HKLM`, `HKEY_CURRENT_CONFIG`, `HKCC`, `HKEY_CLASSES_ROOT`, `HKCR`,
     `HKEY_USERS`, `HKU`, `HKEY_CURRENT_USER`, and `HKCU`.
--   `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
+- `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
     or `:machine`. Set to `:i386` to read or write 32-bit registry keys
     on 64-bit machines running Microsoft Windows. Set to`:x86_64` to
     force write to a 64-bit registry location, however Chef Infra Client

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_key_exists.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_key_exists.md
@@ -23,14 +23,14 @@ registry_key_exists?(KEY_PATH, ARCHITECTURE)
 
 where:
 
--   `KEY_PATH` is the path to the registry key. The path must include
+- `KEY_PATH` is the path to the registry key. The path must include
     the registry hive, which can be specified either as its full name or
     as the 3- or 4-letter abbreviation. For example, both
     `HKLM\SECURITY` and `HKEY_LOCAL_MACHINE\SECURITY` are both valid and
     equivalent. The following hives are valid: `HKEY_LOCAL_MACHINE`,
     `HKLM`, `HKEY_CURRENT_CONFIG`, `HKCC`, `HKEY_CLASSES_ROOT`, `HKCR`,
     `HKEY_USERS`, `HKU`, `HKEY_CURRENT_USER`, and `HKCU`.
--   `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
+- `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
     or `:machine`. Set to `:i386` to read or write 32-bit registry keys
     on 64-bit machines running Microsoft Windows. Set to`:x86_64` to
     force write to a 64-bit registry location, however Chef Infra Client

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_value_exists.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_value_exists.md
@@ -28,22 +28,22 @@ registry_value_exists?(
 
 where:
 
--   `KEY_PATH` is the path to the registry key. The path must include
+- `KEY_PATH` is the path to the registry key. The path must include
     the registry hive, which can be specified either as its full name or
     as the 3- or 4-letter abbreviation. For example, both
     `HKLM\SECURITY` and `HKEY_LOCAL_MACHINE\SECURITY` are both valid and
     equivalent. The following hives are valid: `HKEY_LOCAL_MACHINE`,
     `HKLM`, `HKEY_CURRENT_CONFIG`, `HKCC`, `HKEY_CLASSES_ROOT`, `HKCR`,
     `HKEY_USERS`, `HKU`, `HKEY_CURRENT_USER`, and `HKCU`.
--   `{ name: 'NAME' }` is a hash that contains the name of the registry
+- `{ name: 'NAME' }` is a hash that contains the name of the registry
     key value; if either `type:` or `:value` are specified in the hash,
     they are ignored
--   `type:` represents the values available for registry keys in
+- `type:` represents the values available for registry keys in
     Microsoft Windows. Use `:binary` for REG_BINARY, `:string` for
     REG_SZ, `:multi_string` for REG_MULTI_SZ, `:expand_string` for
     REG_EXPAND_SZ, `:dword` for REG_DWORD, `:dword_big_endian` for
     REG_DWORD_BIG_ENDIAN, or `:qword` for REG_QWORD.
--   `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
+- `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
     or `:machine`. Set to `:i386` to read or write 32-bit registry keys
     on 64-bit machines running Microsoft Windows. Set to`:x86_64` to
     force write to a 64-bit registry location, however Chef Infra Client

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_search_filter_result.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_search_filter_result.md
@@ -20,12 +20,12 @@ end
 
 where:
 
--   `:index` is of name of the index on the Chef Infra Server against
+- `:index` is of name of the index on the Chef Infra Server against
     which the search query will run: `:client`, `:data_bag_name`,
     `:environment`, `:node`, and `:role`
--   `'query'` is a valid search query against an object on the Chef
+- `'query'` is a valid search query against an object on the Chef
     server
--   `:filter_result` defines a Hash of values to be returned
+- `:filter_result` defines a Hash of values to be returned
 
 For example:
 

--- a/themes/docs-new/layouts/shortcodes/knife_bootstrap_no_validator.md
+++ b/themes/docs-new/layouts/shortcodes/knife_bootstrap_no_validator.md
@@ -15,8 +15,8 @@ rm -f /home/lamont/.chef/myorg-validator.pem
 
 and then make the following changes in the config.rb file:
 
--   Remove the `validation_client_name` setting
--   Edit the `validation_key` setting to be something that isn't a path
+- Remove the `validation_client_name` setting
+- Edit the `validation_key` setting to be something that isn't a path
     to an existent ORGANIZATION-validator.pem file. For example:
     `/nonexist`.
 

--- a/themes/docs-new/layouts/shortcodes/knife_upload_summary.md
+++ b/themes/docs-new/layouts/shortcodes/knife_upload_summary.md
@@ -2,10 +2,10 @@ Use the `knife upload` subcommand to upload data to the Chef Infra
 Server from the current working directory in the chef-repo. The
 following types of data may be uploaded with this subcommand:
 
--   Cookbooks
--   Data bags
--   Roles stored as JSON data
--   Environments stored as JSON data
+- Cookbooks
+- Data bags
+- Roles stored as JSON data
+- Environments stored as JSON data
 
 (Roles and environments stored as Ruby data will not be uploaded.) This
 subcommand is often used in conjunction with `knife diff`, which can be

--- a/themes/docs-new/layouts/shortcodes/node_attribute_when_to_use.md
+++ b/themes/docs-new/layouts/shortcodes/node_attribute_when_to_use.md
@@ -7,11 +7,11 @@ using knife, or are retrieved by Ohai from each node prior to every Chef
 Infra Client run. All attributes are indexed for search on the Chef
 Infra Server. Good candidates for attributes include:
 
--   any cross-platform abstraction for an application, such as the path
+- any cross-platform abstraction for an application, such as the path
     to a configuration file
--   default values for tunable settings, such as the amount of memory
+- default values for tunable settings, such as the amount of memory
     assigned to a process or the number of workers to spawn
--   anything that may need to be persisted in node data between Chef
+- anything that may need to be persisted in node data between Chef
     Infra Client runs
 
 In general, attribute precedence is set to enable cookbooks and roles to

--- a/themes/docs-new/layouts/shortcodes/node_run_list.md
+++ b/themes/docs-new/layouts/shortcodes/node_run_list.md
@@ -1,11 +1,11 @@
 A run-list defines all of the information necessary for Chef to
 configure a node into the desired state. A run-list is:
 
--   An ordered list of roles and/or recipes that are run in the exact
+- An ordered list of roles and/or recipes that are run in the exact
     order defined in the run-list; if a recipe appears more than once in
     the run-list, Chef Infra Client will not run it twice
--   Always specific to the node on which it runs; nodes may have a
+- Always specific to the node on which it runs; nodes may have a
     run-list that is identical to the run-list used by other nodes
--   Stored as part of the node object on the Chef server
--   Maintained using knife and then uploaded from the workstation to the
+- Stored as part of the node object on the Chef server
+- Maintained using knife and then uploaded from the workstation to the
     Chef Infra Server, or maintained using Chef Automate

--- a/themes/docs-new/layouts/shortcodes/node_run_list_empty.md
+++ b/themes/docs-new/layouts/shortcodes/node_run_list_empty.md
@@ -4,6 +4,6 @@ This is a quick way to discover if the underlying cause of a Chef Infra
 Client run failure is a configuration issue. If a failure persists even
 if the run-list is empty, check the following:
 
--   Configuration settings in the config.rb file
--   Permissions for the user to both the Chef Infra Server and to the
+- Configuration settings in the config.rb file
+- Permissions for the user to both the Chef Infra Server and to the
     node on which a Chef Infra Client run is to take place

--- a/themes/docs-new/layouts/shortcodes/packages_install_script.md
+++ b/themes/docs-new/layouts/shortcodes/packages_install_script.md
@@ -1,8 +1,8 @@
 The Chef Software install script can be used to install any Chef Software, including things like Chef Infra Client, Chef Infra Server, Chef InSpec. This script does the following:
 
--   Detects the platform, version, and architecture of the machine on
+- Detects the platform, version, and architecture of the machine on
     which the installer is being executed
--   Fetches the appropriate package, for the requested product and
+- Fetches the appropriate package, for the requested product and
     version
--   Validates the package content by comparing SHA-256 checksums
--   Installs the package
+- Validates the package content by comparing SHA-256 checksums
+- Installs the package

--- a/themes/docs-new/layouts/shortcodes/policy_summary.md
+++ b/themes/docs-new/layouts/shortcodes/policy_summary.md
@@ -1,13 +1,13 @@
 Policy maps business and operational requirements, process, and workflow
 to settings and objects stored on the Chef Infra Server:
 
--   Roles define server types, such as "web server" or "database server"
--   Environments define process, such as "dev", "staging", or
+- Roles define server types, such as "web server" or "database server"
+- Environments define process, such as "dev", "staging", or
     "production"
--   Certain types of data---passwords, user account data, and other
+- Certain types of data---passwords, user account data, and other
     sensitive items---can be placed in data bags, which are located in a
     secure sub-area on the Chef Infra Server that can only be accessed
     by nodes that authenticate to the Chef Infra Server with the correct
     SSL certificates
--   The cookbooks (and cookbook versions) in which organization-specific
+- The cookbooks (and cookbook versions) in which organization-specific
     configuration policies are maintained

--- a/themes/docs-new/layouts/shortcodes/policyfile_lock_json.md
+++ b/themes/docs-new/layouts/shortcodes/policyfile_lock_json.md
@@ -2,9 +2,9 @@ When the `chef install` command is run, Chef Workstation caches any
 necessary cookbooks and emits a `Policyfile.lock.json` file that
 describes:
 
--   The versions of cookbooks in use
--   A Hash of cookbook content
--   The source for all cookbooks
+- The versions of cookbooks in use
+- A Hash of cookbook content
+- The source for all cookbooks
 
 A `Policyfile.lock.json` file is associated with a specific policy
 group, i.e. is associated with one (or more) nodes that use the same

--- a/themes/docs-new/layouts/shortcodes/remote_directory_recursive_directories_example.md
+++ b/themes/docs-new/layouts/shortcodes/remote_directory_recursive_directories_example.md
@@ -1,13 +1,13 @@
 This section contains a more detailed example of how Chef Infra Client
 manages recursive directory structures:
 
--   A cookbook named `cumbria` that is used to build a website
--   A subfolder in the `/files/default` directory named `/website`
--   A file named `index.html`, which is the root page for the website
--   Directories within `/website` named `/cities`, `/places`, and
+- A cookbook named `cumbria` that is used to build a website
+- A subfolder in the `/files/default` directory named `/website`
+- A file named `index.html`, which is the root page for the website
+- Directories within `/website` named `/cities`, `/places`, and
     `/football`, which contains pages about cities, places, and football
     teams
--   A directory named `/images`, which contains images
+- A directory named `/images`, which contains images
 
 These files are placed in the `/files/default` directory in the
 `cumbria` cookbook, like this:

--- a/themes/docs-new/layouts/shortcodes/remote_file_prevent_re_downloads.md
+++ b/themes/docs-new/layouts/shortcodes/remote_file_prevent_re_downloads.md
@@ -2,13 +2,13 @@ To prevent Chef Infra Client from re-downloading files that are already
 present on a node, use one of the following attributes in a recipe:
 `use_conditional_get` (default) or `checksum`.
 
--   The `use_conditional_get` attribute is the default behavior of Chef
+- The `use_conditional_get` attribute is the default behavior of Chef
     Infra Client. If the remote file is located on a server that
     supports ETag and/or If-Modified-Since headers, Chef Infra Client
     will use a conditional `GET` to determine if the file has been
     updated. If the file has been updated, Chef Infra Client will
     re-download the file.
--   The `checksum` attribute will ask Chef Infra Client to compare the
+- The `checksum` attribute will ask Chef Infra Client to compare the
     checksum for the local file to the one at the remote location. If
     they match, Chef Infra Client will not re-download the file. Using a
     local checksum for comparison requires that the local checksum be

--- a/themes/docs-new/layouts/shortcodes/resource_breakpoint_syntax.md
+++ b/themes/docs-new/layouts/shortcodes/resource_breakpoint_syntax.md
@@ -8,5 +8,5 @@ end
 
 where
 
--   `:break` will tell Chef Infra Client to stop running a recipe; can
+- `:break` will tell Chef Infra Client to stop running a recipe; can
     only be used when Chef Infra Client is being run in chef-shell mode

--- a/themes/docs-new/layouts/shortcodes/resource_execute_use_search_dsl_method.md
+++ b/themes/docs-new/layouts/shortcodes/resource_execute_use_search_dsl_method.md
@@ -45,10 +45,10 @@ end
 
 where
 
--   the search will use both of the **execute** resources, unless the
+- the search will use both of the **execute** resources, unless the
     condition specified by the `not_if` commands are met
--   the `environments` property in the first **execute** resource is
+- the `environments` property in the first **execute** resource is
     being used to define values that appear as variables in the OpenVPN
     configuration
--   the **template** resource tells Chef Infra Client which template to
+- the **template** resource tells Chef Infra Client which template to
     use

--- a/themes/docs-new/layouts/shortcodes/resource_log_syntax.md
+++ b/themes/docs-new/layouts/shortcodes/resource_log_syntax.md
@@ -21,8 +21,8 @@ end
 
 where:
 
--   `log` is the resource.
--   `name` is the name given to the resource block.
--   `action` identifies which steps Chef Infra Client will take to bring
+- `log` is the resource.
+- `name` is the name given to the resource block.
+- `action` identifies which steps Chef Infra Client will take to bring
     the node into the desired state.
--   `level` and `message` are the properties available to this resource.
+- `level` and `message` are the properties available to this resource.

--- a/themes/docs-new/layouts/shortcodes/resource_package_install_gem_with_gemrc.md
+++ b/themes/docs-new/layouts/shortcodes/resource_package_install_gem_with_gemrc.md
@@ -8,9 +8,9 @@ directory:
 
 A recipe can be built that does the following:
 
--   Builds a `.gemrc` file based on a `gemrc.erb` template
--   Runs a `Gem.configuration` command
--   Installs a package using the `.gemrc` file
+- Builds a `.gemrc` file based on a `gemrc.erb` template
+- Runs a `Gem.configuration` command
+- Installs a package using the `.gemrc` file
 
 <!-- -->
 

--- a/themes/docs-new/layouts/shortcodes/resource_package_options.md
+++ b/themes/docs-new/layouts/shortcodes/resource_package_options.md
@@ -2,12 +2,12 @@ The RubyGems package provider attempts to use the RubyGems API to
 install gems without spawning a new process, whenever possible. A gems
 command to install will be spawned under the following conditions:
 
--   When a `gem_binary` property is specified (as a hash, a string, or
+- When a `gem_binary` property is specified (as a hash, a string, or
     by a .gemrc file), Chef Infra Client will run that command to
     examine its environment settings and then again to install the gem.
--   When install options are specified as a string, Chef Infra Client
+- When install options are specified as a string, Chef Infra Client
     will span a gems command with those options when installing the gem.
--   The Chef installer will search the `PATH` for a gem command rather
+- The Chef installer will search the `PATH` for a gem command rather
     than defaulting to the current gem environment. As part of
     `enforce_default_paths`, the `bin` directories area added to the
     `PATH`, which means when there are no other proceeding RubyGems, the

--- a/themes/docs-new/layouts/shortcodes/resource_package_options_hash.md
+++ b/themes/docs-new/layouts/shortcodes/resource_package_options_hash.md
@@ -6,13 +6,13 @@ needing to spawn an external gem process.
 The following RubyGems options are available for inclusion within a hash
 and are passed to the RubyGems DependencyInstaller:
 
--   `:env_shebang`
--   `:force`
--   `:format_executable`
--   `:ignore_dependencies`
--   `:prerelease`
--   `:security_policy`
--   `:wrappers`
+- `:env_shebang`
+- `:force`
+- `:format_executable`
+- `:ignore_dependencies`
+- `:prerelease`
+- `:security_policy`
+- `:wrappers`
 
 For more information about these options, see the RubyGems
 documentation:

--- a/themes/docs-new/layouts/shortcodes/resource_powershell_rename_join_reboot.md
+++ b/themes/docs-new/layouts/shortcodes/resource_powershell_rename_join_reboot.md
@@ -21,12 +21,12 @@ end
 
 where:
 
--   The **powershell_script** resource block renames a computer, and
+- The **powershell_script** resource block renames a computer, and
     then joins a domain
--   The **reboot** resource restarts the computer
--   The `not_if` guard prevents the Windows PowerShell script from
+- The **reboot** resource restarts the computer
+- The `not_if` guard prevents the Windows PowerShell script from
     running when the settings in the `not_if` guard match the desired
     state
--   The `notifies` statement tells the **reboot** resource block to run
+- The `notifies` statement tells the **reboot** resource block to run
     if the **powershell_script** block was executed during a Chef Infra
     Client run

--- a/themes/docs-new/layouts/shortcodes/resource_remote_file_install_with_bash.md
+++ b/themes/docs-new/layouts/shortcodes/resource_remote_file_install_with_bash.md
@@ -2,9 +2,9 @@ The following is an example of how to install the `foo123` module for
 Nginx. This module adds shell-style functionality to an Nginx
 configuration file and does the following:
 
--   Declares three variables
--   Gets the Nginx file from a remote location
--   Installs the file using Bash to the path specified by the
+- Declares three variables
+- Gets the Nginx file from a remote location
+- Installs the file using Bash to the path specified by the
     `src_filepath` variable
 
 <!-- -->

--- a/themes/docs-new/layouts/shortcodes/resource_remote_file_store_certain_settings.md
+++ b/themes/docs-new/layouts/shortcodes/resource_remote_file_store_certain_settings.md
@@ -25,12 +25,12 @@ default['python']['checksum'] = '80e387...85fd61'
 and then the methods in the recipe may refer to these values. A recipe
 that is used to install Python will need to do the following:
 
--   Identify each package to be installed (implied in this example, not
+- Identify each package to be installed (implied in this example, not
     shown)
--   Define variables for the package `version` and the `install_path`
--   Get the package from a remote location, but only if the package does
+- Define variables for the package `version` and the `install_path`
+- Get the package from a remote location, but only if the package does
     not already exist on the target system
--   Use the **bash** resource to install the package on the node, but
+- Use the **bash** resource to install the package on the node, but
     only when the package is not already installed
 
 <!-- -->

--- a/themes/docs-new/layouts/shortcodes/resource_service_stop_do_stuff_start.md
+++ b/themes/docs-new/layouts/shortcodes/resource_service_stop_do_stuff_start.md
@@ -2,11 +2,11 @@ The following example shows how to use the **execute**, **service**, and
 **mount** resources together to ensure that a node running on Amazon EC2
 is running MySQL. This example does the following:
 
--   Checks to see if the Amazon EC2 node has MySQL
--   If the node has MySQL, stops MySQL
--   Installs MySQL
--   Mounts the node
--   Restarts MySQL
+- Checks to see if the Amazon EC2 node has MySQL
+- If the node has MySQL, stops MySQL
+- Installs MySQL
+- Mounts the node
+- Restarts MySQL
 
 <!-- -->
 
@@ -49,7 +49,7 @@ end
 
 where
 
--   the two **service** resources are used to stop, and then restart the
+- the two **service** resources are used to stop, and then restart the
     MySQL service
--   the **execute** resource is used to install MySQL
--   the **mount** resource is used to mount the node and enable MySQL
+- the **execute** resource is used to install MySQL
+- the **mount** resource is used to mount the node and enable MySQL

--- a/themes/docs-new/layouts/shortcodes/resource_template_set_ip_address_with_variables_and_template.md
+++ b/themes/docs-new/layouts/shortcodes/resource_template_set_ip_address_with_variables_and_template.md
@@ -9,10 +9,10 @@ default['nginx']['dir'] = '/etc/nginx'
 
 The recipe then does the following to:
 
--   Declare two variables at the beginning of the recipe, one for the
+- Declare two variables at the beginning of the recipe, one for the
     remote IP address and the other for the authorized IP address
--   Use the **service** resource to restart and reload the Nginx service
--   Load a template named `authorized_ip.erb` from the `/templates`
+- Use the **service** resource to restart and reload the Nginx service
+- Load a template named `authorized_ip.erb` from the `/templates`
     directory that is used to set the IP address values based on the
     variables specified in the recipe
 

--- a/themes/docs-new/layouts/shortcodes/resources_common.md
+++ b/themes/docs-new/layouts/shortcodes/resources_common.md
@@ -1,9 +1,9 @@
 A resource is a statement of configuration policy that:
 
--   Describes the desired state for a configuration item
--   Declares the steps needed to bring that item to the desired state
--   Specifies a resource type---such as `package`, `template`, or
+- Describes the desired state for a configuration item
+- Declares the steps needed to bring that item to the desired state
+- Specifies a resource type---such as `package`, `template`, or
     `service`
--   Lists additional details (also known as resource properties), as
+- Lists additional details (also known as resource properties), as
     necessary
--   Are grouped into recipes, which describe working configurations
+- Are grouped into recipes, which describe working configurations

--- a/themes/docs-new/layouts/shortcodes/resources_common_guard_interpreter_attributes_inherit.md
+++ b/themes/docs-new/layouts/shortcodes/resources_common_guard_interpreter_attributes_inherit.md
@@ -48,11 +48,11 @@ end
 To inherit properties, add the `guard_interpreter` property to the
 resource block and set it to the appropriate value:
 
--   `:bash` for **bash**
--   `:csh` for **csh**
--   `:perl` for **perl**
--   `:python` for **python**
--   `:ruby` for **ruby**
+- `:bash` for **bash**
+- `:csh` for **csh**
+- `:perl` for **perl**
+- `:python` for **python**
+- `:ruby` for **ruby**
 
 For example, using the same example as from above, but this time adding
 the `guard_interpreter` property and setting it to `:bash`:

--- a/themes/docs-new/layouts/shortcodes/resources_common_guards.md
+++ b/themes/docs-new/layouts/shortcodes/resources_common_guards.md
@@ -4,12 +4,12 @@ evaluation, a guard property is then used to tell Chef Infra Client if
 it should continue executing a resource. A guard property accepts either
 a string value or a Ruby block value:
 
--   A string is executed as a shell command. If the command returns `0`,
+- A string is executed as a shell command. If the command returns `0`,
     the guard is applied. If the command returns any other value, then
     the guard property is not applied. String guards in a
     **powershell_script** run Windows PowerShell commands and may
     return `true` in addition to `0`.
--   A block is executed as Ruby code that must return either `true` or
+- A block is executed as Ruby code that must return either `true` or
     `false`. If the block returns `true`, the guard property is applied.
     If the block returns `false`, the guard property is not applied.
 

--- a/themes/docs-new/layouts/shortcodes/resources_common_multiple_packages.md
+++ b/themes/docs-new/layouts/shortcodes/resources_common_multiple_packages.md
@@ -3,9 +3,9 @@ that use Apt, Chocolatey, DNF, Homebrew, Pacman, or Zypper package managers.
 Specifying multiple packages and/or versions allows a single transaction
 to:
 
--   Download the specified packages and versions via a single HTTP
+- Download the specified packages and versions via a single HTTP
     transaction
--   Update or install multiple packages with a single resource during a
+- Update or install multiple packages with a single resource during a
     Chef Infra Client run
 
 For example, installing multiple packages:

--- a/themes/docs-new/layouts/shortcodes/resources_common_windows_security_acl.md
+++ b/themes/docs-new/layouts/shortcodes/resources_common_windows_security_acl.md
@@ -95,12 +95,12 @@ rights :write, 'Sally', applies_to_children: :containers_only, applies_to_self: 
 
 Some other important things to know when using the `rights` attribute:
 
--   Only inherited rights remain. All existing explicit rights on the
+- Only inherited rights remain. All existing explicit rights on the
     object are removed and replaced.
--   If rights are not specified, nothing will be changed. Chef Infra
+- If rights are not specified, nothing will be changed. Chef Infra
     Client does not clear out the rights on a file or directory if
     rights are not specified.
--   Changing inherited rights can be expensive. Microsoft Windows will
+- Changing inherited rights can be expensive. Microsoft Windows will
     propagate rights to all children recursively due to inheritance.
     This is a normal aspect of Microsoft Windows, so consider the
     frequency with which this type of action is necessary and take steps

--- a/themes/docs-new/layouts/shortcodes/ruby_summary.md
+++ b/themes/docs-new/layouts/shortcodes/ruby_summary.md
@@ -1,18 +1,18 @@
 Ruby is a simple programming language:
 
--   Chef uses Ruby as its reference language to define the patterns that
+- Chef uses Ruby as its reference language to define the patterns that
     are found in resources, recipes, and cookbooks
--   Use these patterns to configure, deploy, and manage nodes across the
+- Use these patterns to configure, deploy, and manage nodes across the
     network
 
 Ruby is also a powerful and complete programming language:
 
--   Use the Ruby programming language to make decisions about what
+- Use the Ruby programming language to make decisions about what
     should happen to specific resources and recipes
--   Extend Chef in any manner that your organization requires
+- Extend Chef in any manner that your organization requires
 
 To learn more about Ruby, see:
 
--   [Ruby Documentation](https://www.ruby-lang.org/en/documentation/)
--   [Ruby Standard Library
+- [Ruby Documentation](https://www.ruby-lang.org/en/documentation/)
+- [Ruby Standard Library
     Documentation](https://www.ruby-doc.org/stdlib/)

--- a/themes/docs-new/layouts/shortcodes/search_pattern_wildcard.md
+++ b/themes/docs-new/layouts/shortcodes/search_pattern_wildcard.md
@@ -3,8 +3,8 @@ matches that replace zero (or more) characters in the search pattern
 with anything that could match the replaced character. There are two
 types of wildcard searches:
 
--   A question mark (`?`) can be used to replace exactly one character
+- A question mark (`?`) can be used to replace exactly one character
     (as long as that character is not the first character in the search
     pattern)
--   An asterisk (`*`) can be used to replace any number of characters
+- An asterisk (`*`) can be used to replace any number of characters
     (including zero)

--- a/themes/docs-new/layouts/shortcodes/server_rbac_server_admins_scenario.md
+++ b/themes/docs-new/layouts/shortcodes/server_rbac_server_admins_scenario.md
@@ -69,11 +69,11 @@ dan
 Alice is now a server administrator and can use the following knife
 subcommands to manage users on the Chef Infra Server:
 
--   `knife user-create`
--   `knife user-delete`
--   `knife user-edit`
--   `knife user-list`
--   `knife user-show`
+- `knife user-create`
+- `knife user-delete`
+- `knife user-edit`
+- `knife user-list`
+- `knife user-show`
 
 For example, Alice runs the following command:
 

--- a/themes/docs-new/layouts/shortcodes/server_services_erchef.md
+++ b/themes/docs-new/layouts/shortcodes/server_services_erchef.md
@@ -2,10 +2,10 @@ The **opscode-erchef** service is an Erlang-based service that is used
 to handle Chef Infra Server API requests to the following areas within
 the Chef Infra Server:
 
--   Cookbooks
--   Data bags
--   Environments
--   Nodes
--   Roles
--   Sandboxes
--   Search
+- Cookbooks
+- Data bags
+- Environments
+- Nodes
+- Roles
+- Sandboxes
+- Search

--- a/themes/docs-new/layouts/shortcodes/server_tuning_postgresql.md
+++ b/themes/docs-new/layouts/shortcodes/server_tuning_postgresql.md
@@ -9,9 +9,9 @@ The following setting is often modified from the default as part of the tuning e
     but also the number of services that are running on each of these
     machines.
 
-    -   Each front end machine always runs the **oc_bifrost** and
+    - Each front end machine always runs the **oc_bifrost** and
         **opscode-erchef** services.
-    -   The Reporting add-on adds the **reporting** service.
+    - The Reporting add-on adds the **reporting** service.
 
     Each of these services requires 25 connections, above the default
     value.

--- a/themes/docs-new/layouts/shortcodes/supermarket_private_source_code.md
+++ b/themes/docs-new/layouts/shortcodes/supermarket_private_source_code.md
@@ -1,7 +1,7 @@
 The source code for Chef Supermarket is located at the following URLs:
 
--   The application itself: <https://github.com/chef/supermarket>.
+- The application itself: <https://github.com/chef/supermarket>.
     Report issues to: <https://github.com/chef/supermarket/issues>.
--   The cookbook that is run by the `supermarket-ctl reconfigure`
+- The cookbook that is run by the `supermarket-ctl reconfigure`
     command:
     <https://github.com/chef/supermarket/tree/master/omnibus/cookbooks/omnibus-supermarket>

--- a/themes/docs-new/layouts/shortcodes/supermarket_summary.md
+++ b/themes/docs-new/layouts/shortcodes/supermarket_summary.md
@@ -4,9 +4,9 @@ that are part of the Chef Supermarket are accessible by any Chef user.
 
 There are two ways to use Chef Supermarket:
 
--   The public Chef Supermarket is hosted by Chef Software and is
+- The public Chef Supermarket is hosted by Chef Software and is
     located at [Chef Supermarket](https://supermarket.chef.io/).
--   A private Chef Supermarket may be installed on-premise behind the
+- A private Chef Supermarket may be installed on-premise behind the
     firewall on the internal network. Cookbook retrieval from a private
     Chef Supermarket is often faster than from the public Chef
     Supermarket because of closer proximity and fewer cookbooks to

--- a/themes/docs-new/layouts/shortcodes/system_requirements_ha.md
+++ b/themes/docs-new/layouts/shortcodes/system_requirements_ha.md
@@ -1,15 +1,15 @@
 **Frontend Requirements**
 
--   4 cores (physical or virtual)
--   4GB RAM
--   20 GB of free disk space (SSD if on premises, Premium Storage in
+- 4 cores (physical or virtual)
+- 4GB RAM
+- 20 GB of free disk space (SSD if on premises, Premium Storage in
     Microsoft Azure, EBS-Optimized GP2 in AWS)
 
 **Backend Requirements**
 
--   2 cores (physical or virtual)
--   8GB RAM
--   50 GB/backend server (SSD if on premises, Premium Storage in
+- 2 cores (physical or virtual)
+- 8GB RAM
+- 50 GB/backend server (SSD if on premises, Premium Storage in
     Microsoft Azure, EBS-Optimized GP2 in AWS)
 
 <div class="admonition-warning">

--- a/themes/docs-new/layouts/shortcodes/system_requirements_server_software.md
+++ b/themes/docs-new/layouts/shortcodes/system_requirements_server_software.md
@@ -1,36 +1,36 @@
 Before installing the Chef Infra Server, ensure that each machine has
 the following installed and configured properly:
 
--   **Hostnames** --- Ensure that all systems have properly configured
+- **Hostnames** --- Ensure that all systems have properly configured
     hostnames. The hostname for the Chef Infra Server must be a FQDN,
     have fewer than 64 characters including the domain suffix, be
     lowercase, and resolvable. See [Hostnames,
     FQDNs](/install_server_pre.html#hostnames) for more information
--   **FQDNs** --- Ensure that all systems have a resolvable FQDN
--   **NTP** --- Ensure that every server is connected to NTP; the Chef
+- **FQDNs** --- Ensure that all systems have a resolvable FQDN
+- **NTP** --- Ensure that every server is connected to NTP; the Chef
     Infra Server is sensitive to clock drift
--   **Mail Relay** --- The Chef Infra Server uses email to send
+- **Mail Relay** --- The Chef Infra Server uses email to send
     notifications for various events; a local mail transfer agent should
     be installed and available to the Chef server
--   **cron** --- Periodic maintenance tasks are performed using cron
--   **git** --- git must be installed so that various internal services
+- **cron** --- Periodic maintenance tasks are performed using cron
+- **git** --- git must be installed so that various internal services
     can confirm revisions
--   **libfreetype and libpng** --- These libraries are required
--   **Apache Qpid** --- This daemon must be disabled on CentOS and Red
+- **libfreetype and libpng** --- These libraries are required
+- **Apache Qpid** --- This daemon must be disabled on CentOS and Red
     Hat systems
--   **Required users** --- If the environment in which the Chef Infra
+- **Required users** --- If the environment in which the Chef Infra
     Server will run has restrictions on the creation of local user and
     group accounts, ensure that the correct users and groups exist
     before reconfiguring
--   **Firewalls and ports** --- If host-based firewalls (iptables, ufw,
+- **Firewalls and ports** --- If host-based firewalls (iptables, ufw,
     etc.) are being used, ensure that ports 80 and 443 are open. These
     ports are used by the **nginx** service
 
 In addition:
 
--   **Browser** --- Firefox, Google Chrome, Safari, or Internet Explorer
+- **Browser** --- Firefox, Google Chrome, Safari, or Internet Explorer
     (versions 9 or better)
--   **Chef Infra Client communication with the Chef Infra Server** The
+- **Chef Infra Client communication with the Chef Infra Server** The
     Chef Infra Server must be able to communicate with every node that
     will be configured by Chef Infra Client and every workstation that
     will upload data to the Chef Infra

--- a/themes/docs-new/layouts/shortcodes/template_helpers.md
+++ b/themes/docs-new/layouts/shortcodes/template_helpers.md
@@ -1,9 +1,9 @@
 A helper is a method or a module that can be used to extend a template.
 There are three approaches:
 
--   An inline helper method
--   An inline helper module
--   A cookbook library module
+- An inline helper method
+- An inline helper module
+- A cookbook library module
 
 Use the `helper` attribute in a recipe to define an inline helper
 method. Use the `helpers` attribute to define an inline helper module or

--- a/themes/docs-new/layouts/shortcodes/template_partials.md
+++ b/themes/docs-new/layouts/shortcodes/template_partials.md
@@ -3,5 +3,5 @@ one (or more) smaller template files. (These smaller template files are
 also referred to as partials.) A partial can be referenced from a
 template file in one of the following ways:
 
--   By using the `render` method in the template file
--   By using the **template** resource and the `variables` property.
+- By using the `render` method in the template file
+- By using the **template** resource and the `variables` property.

--- a/themes/docs-new/layouts/shortcodes/test_kitchen.md
+++ b/themes/docs-new/layouts/shortcodes/test_kitchen.md
@@ -1,10 +1,10 @@
 Use [Test Kitchen](https://kitchen.ci/) to automatically test cookbooks
 across any combination of platforms and test suites:
 
--   Test suites are defined in a kitchen.yml file. See the
+- Test suites are defined in a kitchen.yml file. See the
     [configuration](/workstation/config_yml_kitchen/) documentation for options
     and syntax information.
--   Supports cookbook testing across many cloud providers and
+- Supports cookbook testing across many cloud providers and
     virtualization technologies.
--   Uses a comprehensive set of operating system base images from Chef's
+- Uses a comprehensive set of operating system base images from Chef's
     [Bento](https://github.com/chef/bento) project.

--- a/themes/docs-new/layouts/shortcodes/test_kitchen_yml_syntax.md
+++ b/themes/docs-new/layouts/shortcodes/test_kitchen_yml_syntax.md
@@ -38,35 +38,35 @@ suites:
 
 where:
 
--   `driver_name` is the name of a driver that will be used to create
+- `driver_name` is the name of a driver that will be used to create
     platform instances used during cookbook testing. This is the default
     driver used for all platforms and suites **unless** a platform or
     suite specifies a `driver` to override the default driver for that
     platform or suite; a driver specified for a suite will override a
     driver set for a platform
 
--   `provisioner_name` specifies how Chef Infra Client will be simulated
+- `provisioner_name` specifies how Chef Infra Client will be simulated
     during testing. `chef_zero` and `chef_solo` are the most common
     provisioners used for testing cookbooks
 
--   `verifier_name` specifies which application to use when running
+- `verifier_name` specifies which application to use when running
     tests, such as `inspec`
 
--   `transport_name` specifies which transport to use when executing
+- `transport_name` specifies which transport to use when executing
     commands remotely on the test instance. `winrm` is the default
     transport on Windows. The `ssh` transport is the default on all
     other operating systems.
 
--   `platform-version` is the name of a platform on which Test Kitchen
+- `platform-version` is the name of a platform on which Test Kitchen
     will perform cookbook testing, for example, `ubuntu-16.04` or
     `centos-7`; depending on the platform, additional driver
     details---for example, instance names and URLs used with cloud
     platforms like OpenStack or Amazon EC2---may be required
 
--   `platforms` may define Chef Infra Server attributes that are common
+- `platforms` may define Chef Infra Server attributes that are common
     to the collection of test suites
 
--   `suites` is a collection of test suites, with each `suite_name`
+- `suites` is a collection of test suites, with each `suite_name`
     grouping defining an aspect of a cookbook to be tested. Each
     `suite_name` must specify a run-list, for example:
 
@@ -76,10 +76,10 @@ where:
       - recipe[cookbook_name::recipe_name]
     ```
 
--   Each `suite_name` grouping may specify `attributes` as a Hash:
+- Each `suite_name` grouping may specify `attributes` as a Hash:
     `{ foo: "bar" }`
 
--   A `suite_name` grouping may use `excludes` and `includes` to
+- A `suite_name` grouping may use `excludes` and `includes` to
     exclude/include one (or more) platforms. For example:
 
     ```ruby

--- a/themes/docs-new/layouts/shortcodes/windows_environment_variable_path.md
+++ b/themes/docs-new/layouts/shortcodes/windows_environment_variable_path.md
@@ -1,8 +1,8 @@
 On Microsoft Windows, Chef Infra Client must have two entries added to
 the `PATH` environment variable:
 
--   `C:\opscode\chef\bin`
--   `C:\opscode\chef\embedded\bin`
+- `C:\opscode\chef\bin`
+- `C:\opscode\chef\embedded\bin`
 
 This is typically done during the installation of Chef Infra Client
 automatically. If these values (for any reason) are not in the `PATH`

--- a/themes/docs-new/layouts/shortcodes/windows_install_overview.md
+++ b/themes/docs-new/layouts/shortcodes/windows_install_overview.md
@@ -1,10 +1,10 @@
 Chef Infra Client can be installed on machines running Microsoft Windows
 in the following ways:
 
--   By bootstraping Chef Infra Client using [knife
+- By bootstraping Chef Infra Client using [knife
     bootstrap](/workstation/knife_bootstrap/) from a local workstation using
     WinRM
--   By downloading Chef Infra Client to the target node, and then
+- By downloading Chef Infra Client to the target node, and then
     running the Microsoft Installer Package (MSI) locally
--   By using an existing process already in place for managing Microsoft
+- By using an existing process already in place for managing Microsoft
     Windows machines, such as System Center


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>


## Description

We don't need to use three spaces after an unordered list marker in Markdown. I've bulk-edited them to use one space.

## Definition of Done

It doesn't look weird.

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
