### PR TITLE
Fix SCSS deprecations

### DIFF
--- a/themes/docs-new/assets/sass/_variables.scss
+++ b/themes/docs-new/assets/sass/_variables.scss
@@ -1,6 +1,14 @@
 // Foundation overrides
 // https://raw.githubusercontent.com/zurb/foundation-sites/master/scss/settings/_settings.scss
 
+// Sass Deprecation Fixes
+$primary-color: null
+$secondary-color: null
+$success-color: null
+$alert-color: null
+$-zf-size: null
+$-zf-bp-value: null
+
 // TODO: Pull these colors into Sass variables.
 
 $charcoal: #424242;


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

## Description
Update: Unfortunately, we can't override the deprecated values in our SCSS, which as I expected. We need to do some research & understand if the future of Foundation & if we should switch to another framework, such as Bootstrap or ???.

They're still planning on releasing [Foundation 7](https://foundation.discourse.group/t/july-hangout-for-foundation-7/4611), but not any time soon.

This PR mindlessly followed the instructions in the deprecation notices. Let's see what happens.

```
DEPRECATION WARNING on line 115 of /Users/kimberlygarmoe/repos/chef-web-docs/themes/docs-new/node_modules/foundation-sites/scss/util/_color.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$primary-color: null` at the top level.

DEPRECATION WARNING on line 120 of /Users/kimberlygarmoe/repos/chef-web-docs/themes/docs-new/node_modules/foundation-sites/scss/util/_color.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$secondary-color: null` at the top level.

DEPRECATION WARNING on line 125 of /Users/kimberlygarmoe/repos/chef-web-docs/themes/docs-new/node_modules/foundation-sites/scss/util/_color.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$success-color: null` at the top level.

DEPRECATION WARNING on line 130 of /Users/kimberlygarmoe/repos/chef-web-docs/themes/docs-new/node_modules/foundation-sites/scss/util/_color.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$warning-color: null` at the top level.

DEPRECATION WARNING on line 135 of /Users/kimberlygarmoe/repos/chef-web-docs/themes/docs-new/node_modules/foundation-sites/scss/util/_color.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$alert-color: null` at the top level.

DEPRECATION WARNING on line 164 of /Users/kimberlygarmoe/repos/chef-web-docs/themes/docs-new/node_modules/foundation-sites/scss/util/_breakpoint.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$-zf-size: null` at the top level.

DEPRECATION WARNING on line 369 of /Users/kimberlygarmoe/repos/chef-web-docs/themes/docs-new/node_modules/foundation-sites/scss/util/_mixins.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$-zf-bp-value: null` at the top level.
```

A community member submitted a [fix](https://github.com/foundation/foundation-sites/pull/12195), which is not yet released.

## Definition of Done

Does not look weird and does not have deprecation warnings.

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
