### PR TITLE
Reorganize Automate Nav

### DIFF
--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -88,13 +88,13 @@ title = "Chef Automate"
 identifier = "automate"
 
   [[automate]]
-  name = "Getting Started"
+  name = "Get Started"
   weight = 10
   identifier = "automate/getting_started"
   parent = "automate"
 
   [[automate]]
-  name = "Configuring Automate"
+  name = "Configure Automate"
   weight = 20
   identifier = "automate/configuring_automate"
   parent = "automate"
@@ -106,15 +106,33 @@ identifier = "automate"
   parent = "automate"
 
   [[automate]]
-  name = "Infrastructure"
-  weight = 50
-  identifier = "automate/infrastructure"
+  name = "Authorization"
+  weight = 40
+  identifier = "automate/authorization"
   parent = "automate"
 
   [[automate]]
   name = "Compliance"
+  weight = 50
+  identifier = "automate/compliance"
+  parent = "automate"
+
+  [[automate]]
+  name = "Dashboards"
   weight = 60
   identifier = "automate/compliance"
+  parent = "automate"
+
+  [[automate]]
+  name = "Infrastructure"
+  weight = 70
+  identifier = "automate/infrastructure"
+  parent = "automate"
+
+  [[automate]]
+  name = "Integrations"
+  weight = 80
+  identifier = "automate/integrations"
   parent = "automate"
 
   [[automate]]
@@ -124,14 +142,8 @@ identifier = "automate"
   parent = "automate"
 
   [[automate]]
-  name = "Authorization"
-  weight = 100
-  identifier = "automate/authorization"
-  parent = "automate"
-
-  [[automate]]
   name = "Reference"
-  weight = 110
+  weight = 200
   identifier = "automate/reference"
   parent = "automate"
 


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>


## Description

Updates the Automate left nav

- Adds **Integrations** entry for ServiceNow docs
- Adds **Dashboards** entry for Data Feed and Desktop Dashboard docs
- Puts the Nav entries in _alphabetical_ order (with Reference at the bottom)

## Definition of Done

In the Automate Repo:
Add the new header to the ServiceNow docs
Add aliases to Data Feed, Desktop Dashboard, and ServiceNow Notifications docs
Add 2nd entry for "Node Integrations" under the "Integrations" header.

![Screen Shot 2021-07-19 at 9 21 17 PM](https://user-images.githubusercontent.com/4400151/126262867-11bcc172-bcd1-4b78-859a-993d0dac0cc4.png)

This needs 2 weeks a/b testing before merge.

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
