### PR TITLE
Add Automate Integrations Nav Entry

### DIFF
--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -135,6 +135,18 @@ identifier = "automate"
   identifier = "automate/integrations"
   parent = "automate"
 
+    [[automate]]
+    name = "Cloud Integrations"
+    weight = 10
+    identifier = "automate/integrations/cloud"
+    parent = "automate/integrations"
+
+    [[automate]]
+    name = "ServiceNow"
+    weight = 20
+    identifier = "automate/integrations/servicenow"
+    parent = "automate/integrations"
+
   [[automate]]
   name = "Settings"
   weight = 80

--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -130,8 +130,14 @@ identifier = "automate"
   parent = "automate"
 
   [[automate]]
-  name = "Settings"
+  name = "Integrations"
   weight = 70
+  identifier = "automate/integrations"
+  parent = "automate"
+
+  [[automate]]
+  name = "Settings"
+  weight = 80
   identifier = "automate/settings"
   parent = "automate"
 


### PR DESCRIPTION
## Description

Automate nav entry for ServiceNow headers. Merge just before the next Automate promotion, sync with a `make serve` in the  Automate repo to test the change, then proceed with the normal docs promotion.

* Integrations
* Integrations > Cloud Integrations (will contain aws, gcp, azure)
* Integrations > ServiceNow

![Screen Shot 2021-08-18 at 11 46 32 AM](https://user-images.githubusercontent.com/4400151/129954952-c1f317fc-e1b8-4a1a-b74e-10c70c417d24.png)

## Definition of Done


## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass

