### PR TITLE
Update Linux Distros we support and fix AlmaLinux spelling

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -139,8 +139,8 @@ The following platforms are supported only via the community:
 </thead>
 <tbody>
 <tr>
-<td>Alma Linux</td>
-<td><code>x86_64</code></td>
+<td>AlmaLinux</td>
+<td><code>x86_64</code>, <code>aarch64</code></td>
 <td><code>8.x</code></td>
 </tr>
 <tr>
@@ -217,6 +217,11 @@ The following platforms are supported only via the community:
 <td>Raspberry Pi OS</td>
 <td><code>aarch64</code></td>
 <td>current non-EOL releases</td>
+</tr>
+<tr>
+<td>Rocky Linux</td>
+<td><code>x86_64</code>, <code>aarch64</code></td>
+<td>8.x</td>
 </tr>
 <tr>
 <td>SmartOS</td>

--- a/content/release_notes_client.md
+++ b/content/release_notes_client.md
@@ -991,11 +991,11 @@ On AWS instances, we now gather data from the latest metadata API versions, expo
 - placement/region
 - spot/instance-action
 
-#### Alma Linux Detection
+#### AlmaLinux Detection
 
-Chef Infra Client now maps [Alma Linux](https://almalinux.org/) to the `rhel` `platform_family` value. Alma Linux is a new open-source RHEL fork produced by the CloudLinux team. Alma Linux falls under Chef's [Community Support](https://docs.chef.io/platforms/#community-support) platform support policy providing community driven support without the extensive testing given to commercially supported platforms in Chef Infra Client.
+Chef Infra Client now maps [AlmaLinux](https://almalinux.org/) to the `rhel` `platform_family` value. AlmaLinux is a new open-source RHEL fork produced by the CloudLinux team. Alma Linux falls under Chef's [Community Support](https://docs.chef.io/platforms/#community-support) platform support policy providing community driven support without the extensive testing given to commercially supported platforms in Chef Infra Client.
 
-You can test cookbooks on Alma Linux in Test Kitchen using [Alma Linux 8 Vagrant Images](https://app.vagrantup.com/bento/boxes/almalinux-8 on VirtualBox, Parallels, and VMware hypervisors as follows:
+You can test cookbooks on AlmaLinux in Test Kitchen using [AlmaLinux 8 Vagrant Images](https://app.vagrantup.com/bento/boxes/almalinux-8 on VirtualBox, Parallels, and VMware hypervisors as follows:
 
 ```yaml
 platforms:


### PR DESCRIPTION
Turns out AlmaLinux is one word

Signed-off-by: Tim Smith <tsmith@chef.io>