### PR TITLE
Remove EOL Ubuntu 16.04 from docs

### DIFF
--- a/content/config_rb_metadata.md
+++ b/content/config_rb_metadata.md
@@ -19,13 +19,9 @@ aliases = ["/config_rb_metadata.html"]
 A metadata.rb file is:
 
 - Located at the top level of a cookbook's directory structure.
-- Compiled whenever a cookbook is uploaded to the Chef Infra Server or
-    when the `knife cookbook metadata` subcommand is run, and then
-    stored as JSON data.
-- Created automatically by knife whenever the `knife cookbook create`
-    subcommand is run.
-- Edited using a text editor, and then re-uploaded to the Chef Infra
-    Server as part of a cookbook upload.
+- Compiled whenever a cookbook is uploaded to the Chef Infra Server or when the `knife cookbook metadata` subcommand is run, and then stored as JSON data.
+- Created automatically by knife whenever the `knife cookbook create` subcommand is run.
+- Edited using a text editor, and then re-uploaded to the Chef Infra Server as part of a cookbook upload.
 
 ## Error Messages
 
@@ -119,18 +115,18 @@ This configuration file has the following settings:
     operators](#version-constraints)
     are applicable to this field.
 
-    For example, to match any 14.x version of the Chef Client, but not
-    13.x or 15.x:
+    For example, to match any 16.x version of the Chef Client, but not
+    15.x or 17.x:
 
     ```ruby
-    chef_version '~> 14.0'
+    chef_version '~> 16.0'
     ```
 
     A more complex example where you set both a lower and upper bound of
     the Chef Infra Client version:
 
     ```ruby
-    chef_version '>= 14.2.1', '< 14.5.1'
+    chef_version '>= 17.2', '< 17.4'
     ```
 
 `depends`
@@ -258,7 +254,7 @@ This configuration file has the following settings:
     For example:
 
     ```ruby
-    maintainer 'Adam Jacob'
+    maintainer 'Bob Bobberson'
     ```
 
 `maintainer_email`
@@ -271,7 +267,7 @@ This configuration file has the following settings:
     For example:
 
     ```ruby
-    maintainer_email 'adam@example.com'
+    maintainer_email 'bob@example.com'
     ```
 
 `name`
@@ -341,16 +337,16 @@ This configuration file has the following settings:
     supports 'ubuntu'
     ```
 
-    or, to support versions of Ubuntu greater than or equal to 16.04:
+    or, to support versions of Ubuntu greater than or equal to 20.04:
 
     ```ruby
-    supports 'ubuntu', '>= 16.04'
+    supports 'ubuntu', '>= 20.04'
     ```
 
-    or, to support only Ubuntu 18.04:
+    or, to support only Ubuntu 20.04:
 
     ```ruby
-    supports 'ubuntu', '= 18.04'
+    supports 'ubuntu', '= 20.04'
     ```
 
     Here is a list of all of the supported specific operating systems:

--- a/content/google.md
+++ b/content/google.md
@@ -108,10 +108,10 @@ platforms:
     driver:
       image_project: centos-cloud
       image_name: centos-7-v20170124
-  - name: ubuntu-16.04
+  - name: ubuntu-18.04
     driver:
      image_project: ubuntu-os-cloud
-     image_family: ubuntu-1604-lts
+     image_family: ubuntu-1804-lts
   - name: windows
     driver:
      image_project: windows-cloud

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -298,8 +298,8 @@ versions for the Chef Workstation:
 </tr>
 <tr>
 <td>Ubuntu</td>
-<td><code>x86_64</code>,<code>aarch64</code> (18.04/20.04 only)</td>
-<td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>
+<td><code>x86_64</code>,<code>aarch64</code></td>
+<td><code>18.04</code>, <code>20.04</code></td>
 </tr>
 <tr>
 <td>Microsoft Windows</td>
@@ -362,7 +362,7 @@ The following table lists the commercially-supported platforms and versions for 
 <tr>
 <td>Ubuntu</td>
 <td><code>x86_64</code></td>
-<td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>
+<td><code>18.04</code>, <code>20.04</code></td>
 </tr>
 <tr>
 <td>Microsoft Windows</td>
@@ -438,7 +438,7 @@ The following table lists the commercially-supported platforms for Chef Backend,
 <tr>
 <td>Ubuntu (LTS releases)</td>
 <td><code>x86_64</code></td>
-<td><code>16.04</code>, <code>18.04</code></td>
+<td><code>18.04</code></td>
 </tr>
 </tbody>
 </table>
@@ -481,7 +481,7 @@ The following table lists the commercially-supported platforms for Chef Manage:
 <tr>
 <td>Ubuntu (LTS releases)</td>
 <td><code>x86_64</code></td>
-<td><code>16.04</code>, <code>18.04</code></td>
+<td><code>18.04</code></td>
 </tr>
 </tbody>
 </table>

--- a/themes/docs-new/layouts/shortcodes/cookbook_file_specificity.md
+++ b/themes/docs-new/layouts/shortcodes/cookbook_file_specificity.md
@@ -59,7 +59,7 @@ end
 ```
 
 This resource is matched in the same order as the `/files` directory
-structure. For a node that is running Ubuntu 16.04, the second item
+structure. For a node that is running Ubuntu 20.04, the second item
 would be the matching item and the location to which the file identified
 in the **cookbook_file** resource would be distributed:
 

--- a/themes/docs-new/layouts/shortcodes/test_kitchen_driver_vagrant_config.md
+++ b/themes/docs-new/layouts/shortcodes/test_kitchen_driver_vagrant_config.md
@@ -3,8 +3,8 @@ the download URL that have been published by Chef. For example:
 
 ```ruby
 platforms:
-- name: ubuntu-16.04
 - name: ubuntu-18.04
+- name: ubuntu-20.04
 - name: centos-7
 - name: centos-8
 - name: debian-10
@@ -14,11 +14,11 @@ which will generate a configuration file similar to:
 
 ```ruby
 platforms:
-- name: ubuntu-16.04
-  driver:
-    box: bento/ubuntu-16.04
 - name: ubuntu-18.04
   driver:
     box: bento/ubuntu-18.04
+- name: ubuntu-20.04
+  driver:
+    box: bento/ubuntu-20.04
 # ...
 ```

--- a/themes/docs-new/layouts/shortcodes/test_kitchen_yml_syntax.md
+++ b/themes/docs-new/layouts/shortcodes/test_kitchen_yml_syntax.md
@@ -58,7 +58,7 @@ where:
     other operating systems.
 
 - `platform-version` is the name of a platform on which Test Kitchen
-    will perform cookbook testing, for example, `ubuntu-16.04` or
+    will perform cookbook testing, for example, `ubuntu-20.04` or
     `centos-7`; depending on the platform, additional driver
     details---for example, instance names and URLs used with cloud
     platforms like OpenStack or Amazon EC2---may be required
@@ -98,7 +98,7 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu-18.04
+  - name: ubuntu-20.04
   - name: centos-8
   - name: debian-10
 
@@ -110,7 +110,7 @@ suites:
       - debian-10
 ```
 
-This file uses Vagrant as the driver, which requires no additional
+This file uses HashiCorp Vagrant as the driver, which requires no additional
 configuration because it's the default driver used by Test Kitchen,
 chef-zero as the provisioner, and a single (default) test suite that
-runs on Ubuntu 18.04, and CentOS 7.
+runs on Ubuntu 20.04, and CentOS 7.


### PR DESCRIPTION
We don't support this anymore. Remove it from supported platforms and
from examples.

Signed-off-by: Tim Smith <tsmith@chef.io>