### PR TITLE
Remove Cloud Integrations header

### DIFF
--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -136,12 +136,6 @@ identifier = "automate"
   parent = "automate"
 
     [[automate]]
-    name = "Cloud Integrations"
-    weight = 10
-    identifier = "automate/integrations/cloud"
-    parent = "automate/integrations"
-
-    [[automate]]
     name = "ServiceNow"
     weight = 20
     identifier = "automate/integrations/servicenow"


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>


## Description

The cloud integration shortcodes are not ready for prime time. Dropping the header for this batch of work.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
