### PR TITLE
Remove redundant install menu item

### DIFF
--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -392,12 +392,6 @@ identifier = "chef_infra"
   weight = 50
 
   [[infra]]
-  title = "Install"
-  identifier = "chef_infra/configure"
-  parent = "chef_infra"
-  weight = 50
-
-  [[infra]]
   title = "Features"
   identifier = "chef_infra/features"
   parent = "chef_infra"


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <Ian.Maddaus@progress.com>


## Description

There are two "Install" menu sections in `kg/concepts-nav`; this removes one of them.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
