### PR TITLE
Fix client example cookbook name in quick_start.md

### DIFF
--- a/content/quick_start.md
+++ b/content/quick_start.md
@@ -40,7 +40,7 @@ The quickest way to get started using Chef Infra is to install Chef Workstation 
 5.  Run Chef Infra Client using the `default.rb` recipe:
 
     ```bash
-    chef-client --local-mode --override-runlist first_cookbook
+    chef-client --local-mode --override-runlist example
     ```
 
 This creates a file named `test.txt` at the home path on your computer. Open that file and it will say `This file was created by Chef Infra!`.


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <Ian.Maddaus@progress.com>


## Description

The cookbook name should be `example` not `first_cookbook`.

## Definition of Done

## Issues Resolved

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
