### PR TITLE
Remove old platforms that aren't really community supported

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -179,22 +179,12 @@ The following platforms are supported only via the community:
 <td>current non-EOL releases</td>
 </tr>
 <tr>
-<td>Gentoo</td>
-<td><code>x86_64</code></td>
-<td>current version</td>
-</tr>
-<tr>
 <td>Kali Linux</td>
 <td><code>x86_64</code></td>
 <td>current non-EOL releases</td>
 </tr>
 <tr>
 <td>Linux Mint</td>
-<td><code>x86_64</code></td>
-<td>current non-EOL releases</td>
-</tr>
-<tr>
-<td>OmniOS Community Edition</td>
 <td><code>x86_64</code></td>
 <td>current non-EOL releases</td>
 </tr>


### PR DESCRIPTION
Gentoo and OmniOS aren't really supported in any meaningful way at this point and we shouldn't claim compatibility.

Signed-off-by: Tim Smith <tsmith@chef.io>