### PR TITLE
Add Planning and Configure headers

### DIFF
--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -386,10 +386,41 @@ identifier = "chef_infra"
   weight = 10
 
   [[infra]]
+  title = "Planning"
+  identifier = "chef_infra/planning"
+  parent = "chef_infra"
+  weight = 20
+
+  [[infra]]
   title = "Install"
   identifier = "chef_infra/install"
   parent = "chef_infra"
-  weight = 50
+  weight = 30
+
+  [[infra]]
+  title = "Configure"
+  identifier = "chef_infra/configure"
+  parent = "chef_infra"
+  weight = 40
+
+  [[infra]]
+  title = "Policy"
+  identifier = "chef_infra/policyfiles"
+  parent = "chef_infra"
+  weight = 100
+
+  [[infra]]
+  title = "Security"
+  identifier = "chef_infra/security"
+  parent = "chef_infra"
+  weight = 80
+
+    [[infra]]
+    title = "FIPS-mode"
+    identifier = "chef_infra/security/ctl_chef_client.md#run-in-fips-mode FIPS-mode"
+    parent = "chef_infra/security"
+    url = "/ctl_chef_client/#run-in-fips-mode"
+    weight = 30
 
   [[infra]]
   title = "Features"
@@ -459,23 +490,20 @@ identifier = "chef_infra"
 
     [[infra]]
     title = "Custom Resources DSL"
-    identifier = "chef_infra/reference/dsl_custom_resource.md Custom Resources Commands"
+    identifier = "chef_infra/resources/dsl_custom_resource.md Custom Resources Commands"
     parent = "chef_infra/reference"
-    url = "/dsl_custom_resource/"
     weight = 30
 
     [[infra]]
     title = "Handler DSL"
-    identifier = "chef_infra/reference/dsl_handler.md Handler Commands"
+    identifier = "chef_infra/reference/extension_apis/handlers/dsl_handler.md Handler Commands"
     parent = "chef_infra/reference"
-    url = "/dsl_handler/"
     weight = 40
 
     [[infra]]
     title = "ohai (executable)"
-    identifier = "chef_infra/reference/ctl_ohai.md ohai (executable)"
+    identifier = "chef_infra/features/ohai/ctl_ohai.md ohai (executable)"
     parent = "chef_infra/reference"
-    url = "/ctl_ohai/"
     weight = 50
 
     [[infra]]
@@ -511,13 +539,6 @@ identifier = "chef_infra"
     identifier = "chef_infra/reference/config_rb_solo.md solo.rb"
     parent = "chef_infra/reference"
     url = "/config_rb_solo/"
-    weight = 100
-
-    [[infra]]
-    title = "Troubleshooting"
-    identifier = "chef_infra/reference/errors.md Troubleshooting"
-    parent = "chef_infra/reference"
-    url = "/errors/"
     weight = 100
 
   [[infra]]

--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -490,19 +490,19 @@ identifier = "chef_infra"
 
     [[infra]]
     title = "Custom Resources DSL"
-    identifier = "chef_infra/resources/dsl_custom_resource.md Custom Resources Commands"
+    identifier = "chef_infra/reference/dsl_custom_resource.md Custom Resources Commands"
     parent = "chef_infra/reference"
     weight = 30
 
     [[infra]]
     title = "Handler DSL"
-    identifier = "chef_infra/reference/extension_apis/handlers/dsl_handler.md Handler Commands"
+    identifier = "chef_infra/reference/dsl_handler.md Handler Commands"
     parent = "chef_infra/reference"
     weight = 40
 
     [[infra]]
     title = "ohai (executable)"
-    identifier = "chef_infra/features/ohai/ctl_ohai.md ohai (executable)"
+    identifier = "chef_infra/reference/ctl_ohai.md ohai (executable)"
     parent = "chef_infra/reference"
     weight = 50
 

--- a/content/chef_system_requirements.md
+++ b/content/chef_system_requirements.md
@@ -8,8 +8,8 @@ product = ["client", "server", "workstation"]
 [menu]
   [menu.infra]
     title = "System Requirements"
-    identifier = "chef_infra/install/chef_system_requirements.md System Requirements"
-    parent = "chef_infra/install"
+    identifier = "chef_infra/planning/chef_system_requirements.md System Requirements"
+    parent = "chef_infra/planning"
     weight = 5
 +++
 

--- a/content/config_rb_client.md
+++ b/content/config_rb_client.md
@@ -9,8 +9,8 @@ aliases = ["/config_rb_client.html"]
 [menu]
   [menu.infra]
     title = "client.rb"
-    identifier = "chef_infra/install/config_rb_client.md client.rb Configuration"
-    parent = "chef_infra/install"
+    identifier = "chef_infra/configure/config_rb_client.md client.rb Configuration"
+    parent = "chef_infra/configure"
     weight = 40
 +++
 

--- a/content/errors.md
+++ b/content/errors.md
@@ -8,9 +8,8 @@ product = ["client", "server", "workstation"]
 [menu]
   [menu.infra]
     title = "Troubleshooting"
-    identifier = "chef_infra/install/errors.md Troubleshooting"
-    parent = "chef_infra/install"
-    weight = 40
+    identifier = "chef_infra/reference/errors.md Troubleshooting"
+    parent = "chef_infra/reference"
 +++
 
 The following sections describe how to troubleshoot the Chef Infra


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>


## Description

Adds left nave entries for "Planning" and "Configure"

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
