### PR TITLE
Fix mid-word underscores in release notes

### DIFF
--- a/themes/docs-new/assets/js/releases.js
+++ b/themes/docs-new/assets/js/releases.js
@@ -38,7 +38,7 @@ function loadReleaseNotesContents(releases, version, product) {
 
   var pageTOCButton = "<button type=\"button\" class=\"TOC-button hide-for-large\" data-toggle=\"offCanvasRightTOC\" data-close=\"left-nav-off-canvas\"><i class=\"fas fa-bars\"></i> Table of Contents</button>"
 
-  var converter = new showdown.Converter();
+  var converter = new showdown.Converter({literalMidWordUnderscores: true});
 
   if (product === 'automate'){
     $.get(releases[index]["_links"]["release_notes"], function(rawReleaseNotes) {


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <Ian.Maddaus@progress.com>


## Description

Showdown is treating mid-word underscores as italics in release notes; this makes Showdown treat them as regular underscores.

https://github.com/showdownjs/showdown/wiki/Showdown-Options#literalmidwordunderscores


## Definition of Done

## Issues Resolved

See here: https://docs.chef.io/release_notes_client/?v=17.3.48

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
