### PR TITLE
Remove duplicate fips security entry

### DIFF
--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -437,13 +437,6 @@ identifier = "chef_infra"
   parent = "chef_infra"
   weight = 100
 
-    [[infra]]
-    title = "FIPS-mode"
-    identifier = "chef_infra/security/ctl_chef_client.md#run-in-fips-mode FIPS-mode"
-    parent = "chef_infra/security"
-    url = "/ctl_chef_client/#run-in-fips-mode"
-    weight = 30
-
   [[infra]]
   title = "Reference"
   identifier = "chef_infra/reference"


### PR DESCRIPTION
The overall FIPS page already includes information on enabling fips in the client with --fips. If we want to split out the monolithic fips docs into per product docs, we can, but this setup made no sense.

Signed-off-by: Tim Smith <tsmith@chef.io>