### PR TITLE
Fix mistake in "force" warning syntax

### DIFF
--- a/data/infra/resources/user.yaml
+++ b/data/infra/resources/user.yaml
@@ -87,7 +87,7 @@ properties_list:
 
       action.'
   - warning:
-    - markdown: 'Using this property may leave the system in an inconsistent state.
+      markdown: 'Using this property may leave the system in an inconsistent state.
 
         For example, a user account will be removed even if the user is
 


### PR DESCRIPTION
This should be a hash with a key of `markdown` not an array containing an element that's a hash with a key of `markdown`
Fixes #3521


## Description

This should fix the bug reported in #3521 based on how the working `note` field in the [git docs](https://github.com/chef/chef-web-docs/blob/1b58656d72b0b101b4ed2a07bfe352796f498046/data/infra/resources/git.yaml#L110-L117) is done

## Definition of Done

## Issues Resolved

* #3521 

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
