### PR TITLE
Fix malformed warnings in two resources

### DIFF
--- a/data/infra/resources/dsc_script.yaml
+++ b/data/infra/resources/dsc_script.yaml
@@ -160,7 +160,7 @@ properties_list:
   required: false
   description_list:
   - warning:
-    - markdown: This property **MUST** be used with the `code` attribute.
+      markdown: This property **MUST** be used with the `code` attribute.
   - markdown: 'Use to import DSC resources from a module.
 
 

--- a/data/infra/resources/registry_key.yaml
+++ b/data/infra/resources/registry_key.yaml
@@ -159,7 +159,7 @@ properties_list:
 
       REG_DWORD_BIG_ENDIAN, or `:qword` for REG_QWORD.'
   - warning:
-    - markdown: '`:multi_string` must be an array, even if there is only a single
+      markdown: '`:multi_string` must be an array, even if there is only a single
 
         string.'
 resources_common_properties: false


### PR DESCRIPTION
This is the same bug as in #3521 that I fixed in #3522 but on two other doc pages.
These doc pages render an empty Warning block because the YAML contains an array of hashes
instead of a hash. This should be a hash with a key of `markdown` not an array containing an element that's a hash with a key of `markdown`.

## Description

Fixes empty Warning blocks

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

* #3522

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
