### PR TITLE
Update supported platforms for Backend / Manage

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -428,7 +428,7 @@ The following table lists the commercially-supported platforms for Chef Backend,
 <tr>
 <td>Ubuntu (LTS releases)</td>
 <td><code>x86_64</code></td>
-<td><code>18.04</code></td>
+<td><code>16.04</code>, <code>18.04</code></td>
 </tr>
 </tbody>
 </table>
@@ -456,22 +456,22 @@ The following table lists the commercially-supported platforms for Chef Manage:
 <tr>
 <td>CentOS</td>
 <td><code>x86_64</code></td>
-<td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
+<td><code>7.x</code>, <code>8.x</code></td>
 </tr>
 <tr>
 <td>Oracle Enterprise Linux</td>
 <td><code>x86_64</code></td>
-<td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
+<td><code>7.x</code>, <code>8.x</code></td>
 </tr>
 <tr>
 <td>Red Hat Enterprise Linux</td>
 <td><code>x86_64</code></td>
-<td><code>6.x</code>, <code>7.x</code>, <code>8.x</code></td>
+<td><code>7.x</code>, <code>8.x</code></td>
 </tr>
 <tr>
 <td>Ubuntu (LTS releases)</td>
 <td><code>x86_64</code></td>
-<td><code>18.04</code></td>
+<td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
We've expanded things here a bit and killed of RHEL 6 for Manage

Signed-off-by: Tim Smith <tsmith@chef.io>