### PR TITLE
Edit people in Commmunity Guidelines page

### DIFF
--- a/content/community_guidelines.md
+++ b/content/community_guidelines.md
@@ -172,13 +172,8 @@ the person(s) assigned to each role:
 </thead>
 <tbody>
 <tr>
-<td>Decider</td>
-<td>Jenny Armstrong-Owen</td>
-<td><a href="mailto:jowen@chef.io">jowen@chef.io</a></td>
-</tr>
-<tr>
 <td>Community Advocate</td>
-<td>Benny Vasquez</td>
+<td>benny Vasquez</td>
 <td><a href="benny.vasquez@progress.com">benny.vasquez@progress.com</a></td>
 </tr>
 </tbody>


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description
Fix people's names in the Community Guidelines page.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
