### PR TITLE
Add a better common example for retry properties

### DIFF
--- a/archetypes/all_the_resources.md
+++ b/archetypes/all_the_resources.md
@@ -75,9 +75,9 @@ The following examples show how to use common properties in a recipe.
 
 {{% resource_package_use_ignore_failure_attribute %}}
 
-**Use the retries common property**
+**Use the retries and retry_delay common properties**
 
-{{% resource_service_use_supports_attribute %}}
+{{% resource_service_use_retries_properties %}}
 
 ### Guards
 

--- a/content/resource_common.md
+++ b/content/resource_common.md
@@ -43,9 +43,9 @@ The following examples show how to use common properties in a recipe.
 
 {{% resource_package_use_ignore_failure_attribute %}}
 
-**Use the retries common property**
+**Use the retries and retry_delay common properties**
 
-{{% resource_service_use_supports_attribute %}}
+{{% resource_service_use_retries_properties %}}
 
 ## Guards
 

--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -59,7 +59,7 @@ The following properties are common to every resource:
 `retry_delay`
 : **Ruby Type:** Integer | **Default Value:** `2`
 
-  The retry delay (in seconds).
+  The delay in seconds between retry attempts.
 
 `sensitive`
 : **Ruby Type:** true, false | **Default Value:** `false`
@@ -74,9 +74,9 @@ The following examples show how to use common properties in a recipe.
 
 {{% resource_package_use_ignore_failure_attribute %}}
 
-**Use the retries common property**
+**Use the retries and retry_delay common properties**
 
-{{% resource_service_use_supports_attribute %}}
+{{% resource_service_use_retries_properties %}}
 
 ### Guards
 

--- a/data/infra/resources/chef_acl.yaml
+++ b/data/infra/resources/chef_acl.yaml
@@ -125,18 +125,6 @@ properties_list:
       remove_rights :all, :users => [ ''jkeiser'', ''adam'' ]
 
       ```'
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: rights
   ruby_type: null
   required: false

--- a/data/infra/resources/chef_client.yaml
+++ b/data/infra/resources/chef_client.yaml
@@ -97,18 +97,6 @@ properties_list:
       \      ...\n                  1234567890abcdefghijklmnopq\\n\n             \
       \     ...\n                  -----END CERTIFICATE-----\\n\",\n  \"name\": \"\
       node_name\"\n}\n```"
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: source_key
   ruby_type: null
   required: false

--- a/data/infra/resources/chef_container.yaml
+++ b/data/infra/resources/chef_container.yaml
@@ -58,18 +58,6 @@ properties_list:
   - shortcode: resources_common_notification_timers.md
   - markdown: ''
   - shortcode: resources_common_notification_notifies_syntax.md
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: subscribes
   ruby_type: Symbol, Chef::Resource\[String\]
   required: false

--- a/data/infra/resources/chef_data_bag.yaml
+++ b/data/infra/resources/chef_data_bag.yaml
@@ -57,18 +57,6 @@ properties_list:
   - shortcode: resources_common_notification_timers.md
   - markdown: ''
   - shortcode: resources_common_notification_notifies_syntax.md
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: subscribes
   ruby_type: Symbol, Chef::Resource\[String\]
   required: false

--- a/data/infra/resources/chef_data_bag_item.yaml
+++ b/data/infra/resources/chef_data_bag_item.yaml
@@ -90,18 +90,6 @@ properties_list:
   description_list:
   - markdown: "The data bag item as JSON data. For example:\n\n```javascript\n{\n\
       \  \"id\": \"adam\",\n  \"real_name\": \"Adam Brent Jacob\"\n}\n```"
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: subscribes
   ruby_type: Symbol, Chef::Resource\[String\]
   required: false

--- a/data/infra/resources/chef_environment.yaml
+++ b/data/infra/resources/chef_environment.yaml
@@ -101,18 +101,6 @@ properties_list:
       \ \"name\":\"backend\",\n  \"description\":\"\",\n  \"cookbook_versions\":{},\n\
       \  \"json_class\":\"Chef::Environment\",\n  \"chef_type\":\"environment\",\n\
       \  \"default_attributes\":{},\n  \"override_attributes\":{}\n}\n```"
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: subscribes
   ruby_type: Symbol, Chef::Resource\[String\]
   required: false

--- a/data/infra/resources/chef_group.yaml
+++ b/data/infra/resources/chef_group.yaml
@@ -92,18 +92,6 @@ properties_list:
   required: false
   description_list:
   - markdown: '...'
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: subscribes
   ruby_type: Symbol, Chef::Resource\[String\]
   required: false

--- a/data/infra/resources/chef_node.yaml
+++ b/data/infra/resources/chef_node.yaml
@@ -105,18 +105,6 @@ properties_list:
       : \"Chef::Node\",\n  \"attributes\": {\n    \"hardware_type\": \"laptop\"\n\
       \  },\n  \"run_list\": [\n    \"recipe[apache2]\"\n  ],\n  \"defaults\": {}\n\
       }\n```"
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: run_list
   ruby_type: null
   required: false

--- a/data/infra/resources/chef_organization.yaml
+++ b/data/infra/resources/chef_organization.yaml
@@ -121,18 +121,6 @@ properties_list:
   - markdown: 'Use to remove the specified users from an organization. Invitations
 
       that have not been accepted will be cancelled.'
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: subscribes
   ruby_type: Symbol, Chef::Resource\[String\]
   required: false

--- a/data/infra/resources/chef_role.yaml
+++ b/data/infra/resources/chef_role.yaml
@@ -100,18 +100,6 @@ properties_list:
       ,\n  \"default_attributes\": {},\n  \"description\": \"A webserver\",\n  \"\
       run_list\": [\n    \"recipe[apache2]\"\n  ],\n  \"override_attributes\": {}\n\
       }\n```"
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: run_list
   ruby_type: null
   required: false

--- a/data/infra/resources/chef_user.yaml
+++ b/data/infra/resources/chef_user.yaml
@@ -107,18 +107,6 @@ properties_list:
   required: false
   description_list:
   - markdown: '...'
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: source_key
   ruby_type: null
   required: false

--- a/data/infra/resources/package.yaml
+++ b/data/infra/resources/package.yaml
@@ -230,18 +230,6 @@ properties_list:
   - markdown: '**apt_package** and **dpkg_package** resources only. A Hash of
 
       response file variables in the form of `{"VARIABLE" => "VALUE"}`.'
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: source
   ruby_type: String
   required: false

--- a/data/infra/resources/perl.yaml
+++ b/data/infra/resources/perl.yaml
@@ -93,18 +93,6 @@ properties_list:
   - shortcode: resources_common_notification_timers.md
   - markdown: ''
   - shortcode: resources_common_notification_notifies_syntax.md
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: returns
   ruby_type: Integer, Array
   required: false

--- a/data/infra/resources/python.yaml
+++ b/data/infra/resources/python.yaml
@@ -94,18 +94,6 @@ properties_list:
   - shortcode: resources_common_notification_timers.md
   - markdown: ''
   - shortcode: resources_common_notification_notifies_syntax.md
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: returns
   ruby_type: Integer, Array
   required: false

--- a/data/infra/resources/ruby.yaml
+++ b/data/infra/resources/ruby.yaml
@@ -95,18 +95,6 @@ properties_list:
   - shortcode: resources_common_notification_timers.md
   - markdown: ''
   - shortcode: resources_common_notification_notifies_syntax.md
-- property: retries
-  ruby_type: Integer
-  required: false
-  default_value: '0'
-  description_list:
-  - markdown: The number of attempts to catch exceptions and retry the resource.
-- property: retry_delay
-  ruby_type: Integer
-  required: false
-  default_value: '2'
-  description_list:
-  - markdown: The retry delay (in seconds).
 - property: returns
   ruby_type: Integer, Array
   required: false

--- a/themes/docs-new/layouts/shortcodes/resource_service_use_retries_properties.md
+++ b/themes/docs-new/layouts/shortcodes/resource_service_use_retries_properties.md
@@ -2,5 +2,6 @@
 service 'apache' do
   action [ :enable, :start ]
   retries 3
+  retry_delay 5
 end
 ```

--- a/themes/docs-new/layouts/shortcodes/resources_common_properties.md
+++ b/themes/docs-new/layouts/shortcodes/resources_common_properties.md
@@ -22,10 +22,10 @@ The following properties are common to every resource:
 
 :   **Ruby Type:** Integer \| **Default Value:** `2`
 
-    The retry delay (in seconds).
+    The delay in seconds between retry attempts.
 
 `sensitive`
 
 :   **Ruby Type:** true, false \| **Default Value:** `false`
 
-    Ensure that sensitive resource data is not logged by Chef InfraClient.
+    Ensure that sensitive resource data is not logged by Chef Infra Client.


### PR DESCRIPTION
This snippet was clearly reused. The name didn't match what it did at all.

Signed-off-by: Tim Smith <tsmith@chef.io>