### PR TITLE
Add info about permission integers

### DIFF
--- a/themes/docs-new/layouts/shortcodes/resources_common_windows_security_acl.md
+++ b/themes/docs-new/layouts/shortcodes/resources_common_windows_security_acl.md
@@ -16,7 +16,7 @@ where
     possible values are: `:read`, `:write`, `read_execute`, `:modify`,
     `:full_control`, or an integer.
     
-:    Integers used for permissions must match from the following list
+:    Integers used for permissions must match the following list
     [FileSystemRights Enum](https://docs.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.filesystemrights?view=windowsdesktop-5.0#fields) fields.
 
     These permissions are cumulative. If `:write` is specified, then it

--- a/themes/docs-new/layouts/shortcodes/resources_common_windows_security_acl.md
+++ b/themes/docs-new/layouts/shortcodes/resources_common_windows_security_acl.md
@@ -14,7 +14,10 @@ where
 
 :   Use to specify which rights are granted to the `principal`. The
     possible values are: `:read`, `:write`, `read_execute`, `:modify`,
-    and `:full_control`.
+    `:full_control`, or an integer.
+    
+:    Integers used for permissions must match from the following list
+    [FileSystemRights Enum](https://docs.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.filesystemrights?view=windowsdesktop-5.0#fields) fields.
 
     These permissions are cumulative. If `:write` is specified, then it
     includes `:read`. If `:full_control` is specified, then it includes


### PR DESCRIPTION
## Description

There is nothing specified in the documentation around how to leverage the integer property of ACL permissions.

## Definition of Done

Reference added about how to use permission integers.

## Issues Resolved

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
