### PR TITLE
Memory Requirement updated for Supermarket

### DIFF
--- a/_vendor/github.com/chef/supermarket/docs-chef-io/content/supermarket/install_supermarket.md
+++ b/_vendor/github.com/chef/supermarket/docs-chef-io/content/supermarket/install_supermarket.md
@@ -23,7 +23,7 @@ A private Chef Supermarket has the following requirements:
     higher) to act as the OAuth 2.0 provider
 - A user account on the Chef Infra Server with `admins` privileges
 - A key for the user account on the Chef server
-- An x86_64 compatible Linux host with at least 1 GB memory
+- An x86_64 compatible Linux host with minimum of 2 GB memory
 - System clocks synchronized on the Chef Infra Server and Supermarket
     hosts
 - Sufficient disk space on host to meet project cookbook storage


### PR DESCRIPTION
Signed-off-by: Dishank Tiwari <dtiwari@progress.com>

## Description

Updated the memory requirement from 1 GB to 2 GB.

## Related PRs

- https://github.com/chef/chef-web-docs/issues/3462

## Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
