### PR TITLE
adds Hashi approle examples for secrets helper

### DIFF
--- a/content/infra_language/secrets.md
+++ b/content/infra_language/secrets.md
@@ -113,7 +113,7 @@ secret(name: 'secret/example',
       })
 ```
 
-Fetching secret data using a token along with an AppRole name which will create a Secret ID associated to the AppRole:
+Fetching secret data using a token and an AppRole name creates a Secret ID associated with that AppRole:
 
 ```ruby
 secret(name: 'secret/example',

--- a/content/infra_language/secrets.md
+++ b/content/infra_language/secrets.md
@@ -78,7 +78,7 @@ secret(name: 'vault-name/test1', version: 'v1', service: :azure_key_vault)
 #### Fetching Secrets From HashiCorp Vault Using AWS IAM
 
 ```ruby
-secret(name: 'secret/example', 
+secret(name: 'secret/example',
       service: :hashi_vault,
       config: {
         vault_addr: 'vault.example.com',
@@ -93,6 +93,35 @@ secret(name: 'secret/example',
       service: :hashi_vault,
       config: {
         vault_addr: 'vault.example.com',
+        auth_method: :token,
+        token: '123456'
+      })
+```
+
+#### Fetching Secrets From HashiCorp Vault Using AppRole Authentication
+
+Fetching secret data using an AppRole ID and an associated AppRole Secret ID:
+
+```ruby
+secret(name: 'secret/example',
+      service: :hashi_vault,
+      config: {
+        vault_addr: 'vault.example.com',
+        auth_method: :approle,
+        approle_id: "11111111-abcd-1111-abcd-111111111111",
+        approle_secret_id: "22222222-abcd-2222-abcd-222222222222"
+      })
+```
+
+Fetching secret data using a token along with an AppRole name which will create a Secret ID associated to the AppRole:
+
+```ruby
+secret(name: 'secret/example',
+      service: :hashi_vault,
+      config: {
+        vault_addr: 'vault.example.com',
+        auth_method: :approle,
+        approle_name: "my-approle",
         token: '123456'
       })
 ```


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>


## Description

Adds examples of using AppRole authentication type with HashiCorp Vault for the `secrets` helper.

This PR is associated to https://github.com/chef/chef/pull/12300 and should not be merged until that is merged.

## Definition of Done



## Related PRs

https://github.com/chef/chef/pull/12300

## Check List

- [X] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
