### PR TITLE
Remove an old Infra Server version warning

### DIFF
--- a/content/chef_compliance_phase.md
+++ b/content/chef_compliance_phase.md
@@ -261,7 +261,7 @@ The following examples:
 
 ## Customize Profiles
 
-You can upload profiles to Chef Automate using the ['Chef Automate API'](https://docs.chef.io/automate/api/#operation/Create) or the `inspec compliance` command.
+You can upload profiles to Chef Automate using the [Chef Automate API](https://docs.chef.io/automate/api/#operation/Create) or the `inspec compliance` command.
 
 ### Waivers
 

--- a/content/chef_compliance_phase.md
+++ b/content/chef_compliance_phase.md
@@ -226,11 +226,6 @@ The following examples:
   default['audit']['reporter'] = 'chef-server-automate'
   ```
 
-  {{< warning >}}
-
-  This requires Chef Infra Server version 12.11.1 and Chef Automate 0.6.6 or newer, as well as ['integration between the Chef Infra Server and Chef Automate'](https://docs.chef.io/automate/data_collection/#configure-your-chef-infra-server-to-send-data-to-chef-automate).
-
-  {{</ warning >}}
   {{< /foundation_tabs_panel >}}
     {{< foundation_tabs_panel panel-id="local-reporter" >}}
   ```ruby


### PR DESCRIPTION
These are both super old versions and we shouldn't worry about that stuff anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>