### PR TITLE
More detail on Solaris 11.3 working versions

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -100,7 +100,7 @@ The following table lists the commercially-supported platforms and versions for 
 <tr>
 <td>Solaris</td>
 <td><code>sparc</code>, <code>i86pc</code></td>
-<td><code>11.3</code>, <code>11.4</code></td>
+<td><code>11.3(16.17.4 and later versions ONLY)</code>, <code>11.4</code></td>
 </tr>
 <tr>
 <td>SUSE Enterprise Linux Server</td>

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -100,7 +100,7 @@ The following table lists the commercially-supported platforms and versions for 
 <tr>
 <td>Solaris</td>
 <td><code>sparc</code>, <code>i86pc</code></td>
-<td><code>11.3(16.17.4 and later versions ONLY)</code>, <code>11.4</code></td>
+<td><code>11.3 (16.17.4 and later only)</code>, <code>11.4</code></td>
 </tr>
 <tr>
 <td>SUSE Enterprise Linux Server</td>


### PR DESCRIPTION
We've found from RelEng that builds for 11.3 started being built with Solaris 11.4, which broke their installs. We once again have builds being produced with support for 11.3 starting at Chef Infra Client 16.17.4 and later versions


## Description

Help customers understand what Chef Infra Client versions work on Solaris 11.3

## Definition of Done

## Issues Resolved

[[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]
](https://getchef.zendesk.com/agent/tickets/29623)

## Related PRs

## Check List

- [X] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
