### PR TITLE
Fix style of paragraphs in a list

### DIFF
--- a/themes/docs-new/assets/sass/typography/_lists.scss
+++ b/themes/docs-new/assets/sass/typography/_lists.scss
@@ -3,6 +3,7 @@
   ul, ol {
     margin-top: 1em;
     margin-bottom: 1em;
+    border: 2px solid crimson;
   }
 
   ol {
@@ -38,6 +39,7 @@
       }
       p:first-child {
         margin-top: -1.7em;
+        background-color: darkgreen;
       }
       div.highlight{
         margin-top: -3em;

--- a/themes/docs-new/assets/sass/typography/_lists.scss
+++ b/themes/docs-new/assets/sass/typography/_lists.scss
@@ -1,12 +1,8 @@
 #main-content,
 .content {
   ul, ol {
-
-    li {
-      @extend .p;
-      margin-bottom: 0px;
-    }
-
+    margin-top: 1em;
+    margin-bottom: 1em;
   }
 
   ol {
@@ -40,9 +36,8 @@
         margin-left: -1em;
         font-weight: 900;
       }
-      p {
+      p:first-child {
         margin-top: -1.7em;
-        margin-bottom: 2em;
       }
       div.highlight{
         margin-top: -3em;
@@ -51,51 +46,6 @@
       >button.copy-code-button{
         margin-top: -2em;
         margin-bottom: 3.7em;
-      }
-
-    }
-
-    &.reset {
-      @include reset-ul();
-    }
-
-    &.bordered-items {
-      @extend ul, .reset;
-      margin-bottom: 50px;
-      margin-top: rem-calc(24);
-
-      li {
-        padding-left: rem-calc(16);
-        position: relative;
-        margin-bottom: rem-calc(24);
-
-        &:before {
-          display: block;
-          content: "";
-          position: absolute;
-          top: 0;
-          left: 0;
-          height: 100%;
-          width: 2px;
-          background-color: $blue;
-          margin: 0;
-          padding: 0;
-        }
-
-        .title {
-          @extend .p;
-          text-transform: uppercase;
-          margin-bottom: rem-calc(8);
-          font-weight: bold;
-          font-size: rem-calc(14);
-        }
-
-        .desc {
-          @extend .p;
-          margin-bottom: 0;
-          color: rgba($white, 0.65);
-          font-size: rem-calc(14);
-        }
       }
     }
   }

--- a/themes/docs-new/assets/sass/typography/_lists.scss
+++ b/themes/docs-new/assets/sass/typography/_lists.scss
@@ -3,7 +3,6 @@
   ul, ol {
     margin-top: 1em;
     margin-bottom: 1em;
-    border: 2px solid crimson;
   }
 
   ol {
@@ -39,7 +38,6 @@
       }
       p:first-child {
         margin-top: -1.7em;
-        background-color: darkgreen;
       }
       div.highlight{
         margin-top: -3em;


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

We've got some CSS list style issues. Primarily it's with the styling of paragraphs within an unordered list. The first paragraph is fine, but the spacing is off in subsequent paragraphs. This also cleans out some styling that we don't use.

This change converts this:

<img width="1115" alt="Screen Shot 2022-01-13 at 11 32 55 AM" src="https://user-images.githubusercontent.com/8138169/149370980-af38ab64-3a85-447b-beb7-526d2e59cafa.png">

Into this:

<img width="1115" alt="Screen Shot 2022-01-13 at 12 04 07 PM" src="https://user-images.githubusercontent.com/8138169/149375762-66be461b-0634-47b5-86aa-c74226af54a9.png">




## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
