### PR TITLE
Spellcheck should rely on dictionaries

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -41,9 +41,5 @@
     "{{(.+)(?=}})"
   ],
   "words": [
-    "ctl",
-    "gz",
-    "markdownlint",
-    "Policyfiles"
   ]
 }


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>


## Description

Spellcheck should use the dictionaries. This PR removes some accepted words from config.

