### PR TITLE
Add Guides menu item under Chef Habitat.  Supports Habitat PR #8429

### DIFF
--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -300,6 +300,12 @@ identifier = "habitat"
   weight = 70
 
   [[habitat]]
+  title = "Guides"
+  identifier = "habitat/guides"
+  parent = "habitat"
+  weight = 85
+
+  [[habitat]]
   title = "Reference"
   identifier = "habitat/reference"
   parent = "habitat"


### PR DESCRIPTION
Signed-off-by: Davin Taddeo <davin@chef.io>


## Description

This is intended to go with [Habitat PR 8429](https://github.com/habitat-sh/habitat/pull/8429).  The desire is to start a Guides section for our products (starting first with Hab) where we can put how-to information on commonly requested things to take pressure off of Support and other Customer Facing Teams that are repeatedly answering these questions now.

Starting with Habitat, but also hoping to do this for Automate, Infra, Infra Server, and InSpec in the future as we organize on the CFT side of things.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [ ] All tests pass
