### PR TITLE
Completely uninstall Manage

### DIFF
--- a/content/uninstall.md
+++ b/content/uninstall.md
@@ -30,6 +30,8 @@ To uninstall the Chef management console, do the following:
 
     ```bash
     chef-manage-ctl cleanse
+    rm -fr /var/opt/opscode/nginx/etc/addon.d/*manage*
+    chef-server-ctl restart nginx
     ```
 
 2. Use the package manager for the platform on which the Chef


### PR DESCRIPTION
To completely uninstall Manage, we need to remove some extra config files from the Chef Server nginx config area

Signed-off-by: Sean Horn <sean_horn@opscode.com>

## Description

Additional file removals are needed to completely uninstall Manage from a Chef Infra Server

## Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
