### PR TITLE
Add attribute query and delimiter details to ohai command line documentation

### DIFF
--- a/content/ctl_ohai.md
+++ b/content/ctl_ohai.md
@@ -24,6 +24,30 @@ aliases = ["/ctl_ohai.html"]
 
 The following examples show how to use the Ohai command-line tool:
 
+### Query for a specific attribute
+
+To query for an attribute with the ohai command-line tool, pass the attribute
+as an argument
+
+```bash
+ohai os
+```
+
+Which would return something like
+
+```javascript
+[
+  "linux"
+]
+```
+
+To query for an attribute deeper in the tree, use a forward slash (`/`) as a
+delimiter. For example to query for free memory, run
+
+```bash
+ohai memory/free
+```
+
 ### Run a plugin independently of a Chef Infra Client run
 
 An Ohai plugin can be run independently of a Chef Infra Client run.

--- a/themes/docs-new/layouts/shortcodes/ctl_ohai_options.md
+++ b/themes/docs-new/layouts/shortcodes/ctl_ohai_options.md
@@ -8,7 +8,7 @@ This tool has the following options:
 
 `ATTRIBUTE_NAME ATTRIBUTE NAME ...`
 
-:   Use to have Ohai show only output for named attributes.
+:   Use to have Ohai show only output for named attributes. To address attributes deeper in the tree, use a `/` delimiter between each level, for example `memory/free`.
 
 `-c CONFIG`, `--config CONFIG`
 


### PR DESCRIPTION
## Description

This adds clarifying details to the ohai command line documentation on how to query for an attribute as well as how delimiters work in those attribute queries.

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
