### PR TITLE
Fix missing custom resource example

### DIFF
--- a/content/custom_resources.md
+++ b/content/custom_resources.md
@@ -96,6 +96,10 @@ Once written, you can use a custom resource may be used in a recipe with the sam
 
 Call a resource in a recipe by its `resource_name`. For example:
 
+```ruby
+site 'foo'
+```
+
 ## Learn More
 
 Learn Chef interactive tutorial: [Extending Chef Infra: Custom Resources](https://learn.chef.io/courses/course-v1:chef+Infra201+Perpetual/about)


### PR DESCRIPTION
## Description

As noted by @gene1wood , the custom resource documentation was missing an example. 

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
