### PR TITLE
Remove class_eval from Custom Resource example

### DIFF
--- a/content/custom_resources_notes.md
+++ b/content/custom_resources_notes.md
@@ -26,8 +26,8 @@ This page mentions multiple ways of building custom resources. Chef Software rec
 
 This is the recommended way of writing resources for all users. There are two gotchas which we're working through:
 
-1. For helper functions that you used to write in your provider code or used to mixin to your provider code, you have to use an `action_class.class_eval do ... end` block.
-1. You cannot subclass, and must use mixins for code-sharing (which is really a best practice anyway -- e.g. see languages like rust which do not support sub-classing).
+1. For helper functions that you used to write in your provider code or used to mixin to your provider code, you have to use an `action_class do ... end` block.
+2. You cannot subclass, and must use mixins for code-sharing (which is really a best practice anyway -- e.g. see languages like rust which do not support sub-classing).
 
 in `resources/whatever.rb`:
 
@@ -47,7 +47,7 @@ action :run do
   puts new_resource.foo
 end
 
-action_class.class_eval do
+action_class do
   include MyProviderHelperFunctions
 
   def a_helper

--- a/content/custom_resources_notes.md
+++ b/content/custom_resources_notes.md
@@ -27,7 +27,7 @@ This page mentions multiple ways of building custom resources. Chef Software rec
 This is the recommended way of writing resources for all users. There are two gotchas which we're working through:
 
 1. For helper functions that you used to write in your provider code or used to mixin to your provider code, you have to use an `action_class do ... end` block.
-2. You cannot subclass, and must use mixins for code-sharing (which is really a best practice anyway -- e.g. see languages like rust which do not support sub-classing).
+1. You cannot subclass, and must use mixins for code-sharing (which is really a best practice anyway -- e.g. see languages like rust which do not support sub-classing).
 
 in `resources/whatever.rb`:
 


### PR DESCRIPTION
## Description

Remove class_eval from Custom Resource example
This has been deprecated for a few releases. 

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
