### PR TITLE
Development versions are only for testing

### DIFF
--- a/content/versions.md
+++ b/content/versions.md
@@ -57,6 +57,12 @@ Unless otherwise stated, versions older than those listed below are EOL.
 
 ## Supported Commercial Distributions
 
+{{< note >}}
+
+Development releases of any product are not supported for any usage other than testing. A stable build may be produced from the results of testing with a development build, but support can be offered for stable versions only.
+
+{{< /note >}}
+
 Use of these and later versions of these distributions must be in
 accordance with the [Chef End User License
 Agreement](https://www.chef.io/end-user-license-agreement) or a


### PR DESCRIPTION
No development versions. Test with them, then get back to the mainstream

Signed-off-by: Sean Horn <sean_horn@opscode.com>


## Description

A customer notice about development versions' status

## Definition of Done

N/A

## Issues Resolved

Possible confusion in support offering

## Check List

- [X] Spell Check
- [X] Local build
- [X] Examine the local build
- [ ] All tests pass
