### PR TITLE
Fix the name of SUSE Linux Enterprise Server

### DIFF
--- a/content/infra_language/checking_platforms.md
+++ b/content/infra_language/checking_platforms.md
@@ -138,7 +138,7 @@ where:
 </tr>
 <tr>
 <td><code>suse</code></td>
-<td>SUSE Enterprise Linux Server.</td>
+<td>SUSE Linux Enterprise Server.</td>
 </tr>
 <tr>
 <td><code>ubuntu</code></td>

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -113,7 +113,7 @@ The following table lists the commercially-supported platforms and versions for 
 <td><code>11.3 (16.17.4 and later only)</code>, <code>11.4</code></td>
 </tr>
 <tr>
-<td>SUSE Enterprise Linux Server</td>
+<td>SUSE Linux Enterprise Server</td>
 <td><code>x86_64</code>, <code>aarch64</code> (15.x only), <code>s390x</code></td>
 <td><code>12</code>, <code>15</code></td>
 </tr>
@@ -366,7 +366,7 @@ The following table lists the commercially-supported platforms and versions for 
 <td><code>8.x</code></td>
 </tr>
 <tr>
-<td>SUSE Enterprise Linux Server</td>
+<td>SUSE Linux Enterprise Server</td>
 <td><code>x86_64</code>, <code>aarch64</code> (15.x only)</td>
 <td><code>12.x</code>, <code>15.x</code></td>
 </tr>

--- a/themes/docs-new/layouts/shortcodes/adopted_platforms_server.md
+++ b/themes/docs-new/layouts/shortcodes/adopted_platforms_server.md
@@ -35,7 +35,7 @@ The following table lists the commercially-supported platforms and versions for 
 <td><code>7.x</code>, <code>8.x</code></td>
 </tr>
 <tr>
-<td>SUSE Enterprise Linux Server</td>
+<td>SUSE Linux Enterprise Server</td>
 <td><code>x86_64</code></td>
 <td><code>12.x</code>, <code>15.x</code></td>
 </tr>


### PR DESCRIPTION
It's SLES not SELS

Signed-off-by: Tim Smith <tsmith84@gmail.com>