### PR TITLE
Use Windows

### DIFF
--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -474,7 +474,7 @@ identifier = "chef_infra"
     parent = "chef_infra/integrations"
 
     [[infra]]
-    title = "Microsoft Windows"
+    title = "Windows"
     identifier = "chef_infra/integrations/windows"
     parent = "chef_infra/integrations"
 
@@ -646,7 +646,7 @@ identifier = "chef_infra"
     parent = "chef_infra/integrations"
 
     [[infra]]
-    title = "Microsoft Windows"
+    title = "Windows"
     identifier = "chef_infra/integrations/windows"
     parent = "chef_infra/integrations"
 

--- a/content/api_omnitruck.md
+++ b/content/api_omnitruck.md
@@ -134,7 +134,7 @@ Omnitruck accepts the following platforms:
 <td><code>10.04</code>, <code>10.10</code>, <code>11.04</code>, <code>11.10</code>, <code>12.04</code>, <code>12.10</code>, <code>13.04</code>, <code>13.10</code>, <code>14.04</code>, <code>14.10</code>, <code>16.04</code>, <code>16.10</code>, <code>17.04</code>, <code>17.10</code>, <code>18.04</code>, <code>18.10</code>, <code>19.04</code>, <code>20.04</code>, <code>20.10</code>, <code>21.04</code>, <code>21.10</code></td>
 </tr>
 <tr>
-<td>Microsoft Windows</td>
+<td>Windows</td>
 <td><code>windows</code></td>
 <td><code>x86_64</code>, <code>i386</code></td>
 <td><code>7</code>, <code>8</code>, <code>10</code>, <span class="title-ref">2008r2</span>, <code>2012</code>, <code>2012r2</code>, <code>2016</code>, <code>2019</code>, <code>11</code>, <code>2022</code></td>

--- a/content/azure_powershell.md
+++ b/content/azure_powershell.md
@@ -52,7 +52,7 @@ machine running on Microsoft Azure.
 
 This cmdlet has the following syntax.
 
-For Microsoft Windows:
+For Windows:
 
 ```bash
 Set-AzureVMChefExtension -ValidationPem <String> -VM <IPersistentVM> -Windows [-ChefServerUrl <String> ] [-ClientRb <String> ] [-OrganizationName <String> ] [-RunList <String> ] [-ValidationClientName <String> ] [-Version <String> ] [ <CommonParameters>]
@@ -122,7 +122,7 @@ This cmdlet has the following options:
 
 `-Windows`
 
-: Sets the Azure Chef Extension to run Microsoft Windows.
+: Sets the Azure Chef Extension to run Windows.
 
 #### Examples
 

--- a/content/chef_install_script.md
+++ b/content/chef_install_script.md
@@ -23,7 +23,7 @@ product = ["automate", "client", "server", "habitat", "inspec", "workstation"]
 
 {{% packages_install_script_run_unix_linux %}}
 
-### Microsoft Windows
+### Windows
 
 {{% packages_install_script_run_windows %}}
 

--- a/content/config_rb_client.md
+++ b/content/config_rb_client.md
@@ -157,7 +157,7 @@ This configuration file has the following settings:
 : The maximum size (in bytes) of a diff file Chef Infra Client can create. Default value: `1000000`.
 
 `disable_event_logger`
-: Enable or disable sending Chef Infra Client internal state events to the Microsoft Windows "Application" event log. Set to `false` to send events to the Microsoft Windows "Application" event log at the start and end of a Chef Infra Client run, and also if a Chef Infra Client run fails. Use `log_location` to set the destination of your Chef Infra Client logs to the Windows event log. Set to `true` to disable event logging. Default value: `false`.
+: Enable or disable sending Chef Infra Client internal state events to the Windows "Application" event log. Set to `false` to send events to the Windows "Application" event log at the start and end of a Chef Infra Client run, and also if a Chef Infra Client run fails. Use `log_location` to set the destination of your Chef Infra Client logs to the Windows event log. Set to `true` to disable event logging. Default value: `false`.
 
 `enable_reporting`
 : Cause Chef Infra Client to send run data to the Automate server.

--- a/content/ctl_chef_client.md
+++ b/content/ctl_chef_client.md
@@ -42,7 +42,7 @@ This command has the following options:
 
 `-A`, `--fatal-windows-admin-check`
 
-: Cause a Chef Infra Client run to fail when the Chef Infra Client  does not have administrator privileges in Microsoft Windows.
+: Cause a Chef Infra Client run to fail when the Chef Infra Client  does not have administrator privileges in Windows.
 
 `-c CONFIG`, `--config CONFIG`
 
@@ -68,7 +68,7 @@ This command has the following options:
 
 : Run the executable as a daemon. Use `SECONDS` to specify the number of seconds to wait before the first daemonized Chef Infra Client run. `SECONDS` is set to `0` by default. Left unset, the daemon uses the default `--interval` an `--splay` values.
 
-  This option is only available on machines that run in UNIX or Linux environments. For machines that are running Microsoft Windows that require similar functionality, use the `chef-client::service` recipe in the `chef-client` cookbook: <https://supermarket.chef.io/cookbooks/chef-client>. This will install a Chef Infra Client service under Microsoft Windows using the Windows Service Wrapper.
+  This option is only available on machines that run in UNIX or Linux environments. For machines that are running Windows that require similar functionality, use the `chef-client::service` recipe in the `chef-client` cookbook: <https://supermarket.chef.io/cookbooks/chef-client>. This will install a Chef Infra Client service under Windows using the Windows Service Wrapper.
 
 `--delete-entire-chef-repo`
 
@@ -526,7 +526,7 @@ be used:
 : Use to wake up sleeping Chef Infra Client and trigger node
     convergence.
 
-On Microsoft Windows, both the `HUP` and `QUIT` signals are not
+On Windows, both the `HUP` and `QUIT` signals are not
 supported.
 
 ## Run with Elevated Privileges

--- a/content/ctl_chef_solo.md
+++ b/content/ctl_chef_solo.md
@@ -32,7 +32,7 @@ This command has the following options:
 
 `-d`, `--daemonize`
 
-: Run the executable as a daemon. This option may not be used in the same command with the `--[no-]fork` option. This option is only available on machines that run in UNIX or Linux environments. For machines that are running Microsoft Windows that require similar functionality, use the `chef-client::service` recipe in the `chef-client` cookbook: <https://supermarket.chef.io/cookbooks/chef-client>. This will install a Chef Infra Client service under Microsoft Windows using the Windows Service Wrapper.
+: Run the executable as a daemon. This option may not be used in the same command with the `--[no-]fork` option. This option is only available on machines that run in UNIX or Linux environments. For machines that are running Windows that require similar functionality, use the `chef-client::service` recipe in the `chef-client` cookbook: <https://supermarket.chef.io/cookbooks/chef-client>. This will install a Chef Infra Client service under Windows using the Windows Service Wrapper.
 
 `-E ENVIRONMENT_NAME`, `--environment ENVIRONMENT_NAME`
 

--- a/content/infra_language/checking_platforms.md
+++ b/content/infra_language/checking_platforms.md
@@ -150,7 +150,7 @@ where:
 </tr>
 <tr>
 <td><code>windows</code></td>
-<td>Microsoft Windows</td>
+<td>Windows</td>
 </tr>
 <tr>
 <td><code>xenserver</code></td>

--- a/content/install_windows.md
+++ b/content/install_windows.md
@@ -30,7 +30,7 @@ There are several methods available to install Chef Infra Client depending on th
 
 ### Use MSI Installer
 
-A Microsoft Installer Package (MSI) is available for installing Chef Infra Client on a Microsoft Windows machine at [Chef Downloads](https://www.chef.io/downloads/tools/infra-client?os=windows).
+A Microsoft Installer Package (MSI) is available for installing Chef Infra Client on a Windows machine at [Chef Downloads](https://www.chef.io/downloads/tools/infra-client?os=windows).
 
 {{% windows_msiexec %}}
 
@@ -40,7 +40,7 @@ A Microsoft Installer Package (MSI) is available for installing Chef Infra Clien
 
 #### Running as a Scheduled Task
 
-On Microsoft Windows, run Chef Infra Client periodically as a scheduled task. Scheduled tasks provides visibility, configurability, and reliability around log rotation and permissions. You can configure the Chef Infra Client to run as a scheduled task using the [chef_client_scheduled_task](/resources/chef_client_scheduled_task/) resource.
+On Windows, run Chef Infra Client periodically as a scheduled task. Scheduled tasks provides visibility, configurability, and reliability around log rotation and permissions. You can configure the Chef Infra Client to run as a scheduled task using the [chef_client_scheduled_task](/resources/chef_client_scheduled_task/) resource.
 
 #### Scheduled Task Options
 

--- a/content/ohai.md
+++ b/content/ohai.md
@@ -16,7 +16,7 @@ aliases = ["/ohai.html"]
 
 {{% ohai_summary %}}
 
-Ohai collects data for many platforms, including AIX, macOS, Linux, FreeBSD, Solaris, and any Microsoft Windows operating systems.
+Ohai collects data for many platforms, including AIX, macOS, Linux, FreeBSD, Solaris, and any Windows operating systems.
 
 See the [Chef Infra Client release notes](/release_notes_client/) for the latest information on Ohai.
 

--- a/content/ohai_custom.md
+++ b/content/ohai_custom.md
@@ -161,7 +161,7 @@ end
 where:
 
 - `:default` is the name of the default `collect_data` block
-- `:platform` is the name of a platform, such as `:aix` for AIX or `:windows` for Microsoft Windows
+- `:platform` is the name of a platform, such as `:aix` for AIX or `:windows` for Windows
 
 #### Use a Mash
 
@@ -229,7 +229,7 @@ end
 
 ### require
 
-The `require` method is a standard Ruby method that can be used to list files that may be required by a platform, such as an external class library. As a best practice, even though the `require` method is often used at the top of a Ruby file, it is recommended that the use of the `require` method be used as part of the platform-specific `collect_data` block. For example, the Ruby WMI is required with Microsoft Windows:
+The `require` method is a standard Ruby method that can be used to list files that may be required by a platform, such as an external class library. As a best practice, even though the `require` method is often used at the top of a Ruby file, it is recommended that the use of the `require` method be used as part of the platform-specific `collect_data` block. For example, the Ruby WMI is required with Windows:
 
 ```ruby
 collect_data(:windows) do

--- a/content/packages.md
+++ b/content/packages.md
@@ -153,7 +153,7 @@ To set up a Yum package repository for Enterprise Linux platforms:
 
 {{% packages_install_script_run_unix_linux %}}
 
-#### Microsoft Windows
+#### Windows
 
 {{% packages_install_script_run_windows %}}
 

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -123,7 +123,7 @@ The following table lists the commercially-supported platforms and versions for 
 <td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>
 </tr>
 <tr>
-<td>Microsoft Windows</td>
+<td>Windows</td>
 <td><code>x86</code>, <code>x64</code></td>
 <td><code>8.1</code>, <code>2012</code>, <code>2012 R2</code>, <code>2016</code>, <code>10 (all channels except "insider" builds)</code>, <code>2019 (Long-term servicing channel (LTSC), both Desktop Experience and Server Core)</code><code>11</code>, <code>2022</code></td>
 </tr>
@@ -303,7 +303,7 @@ versions for the Chef Workstation:
 <td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>
 </tr>
 <tr>
-<td>Microsoft Windows</td>
+<td>Windows</td>
 <td><code>x64</code></td>
 <td><code>8.1</code>, <code>2012</code>, <code>2012 R2</code>, <code>2016</code>, <code>10 (all channels except "insider" builds)</code>, <code>2019 (Long-term servicing channel (LTSC), Desktop Experience only)</code>, <code>11</code>, <code>2022</code></td>
 </tr>
@@ -376,7 +376,7 @@ The following table lists the commercially-supported platforms and versions for 
 <td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>
 </tr>
 <tr>
-<td>Microsoft Windows</td>
+<td>Windows</td>
 <td><code>x86_64</code></td>
 <td><code>8.1</code>, <code>2012</code>, <code>2012 R2</code>, <code>2016</code>, <code>10 (all channels except "insider" builds)</code>, <code>2019</code>, <code>11</code>, <code>2022</code></td>
 </tr>
@@ -562,7 +562,7 @@ according to those vendors' terms:
 <td>IBM End of Support Date</td>
 </tr>
 <tr>
-<td>Microsoft Windows</td>
+<td>Windows</td>
 <td>End of Extended Support</td>
 </tr>
 <tr>
@@ -665,22 +665,22 @@ that platform and version.
 <td>December 31, 2017</td>
 </tr>
 <tr>
-<td>Microsoft Windows Server 2008 (SP2)/R2 (SP1)</td>
+<td>Windows Server 2008 (SP2)/R2 (SP1)</td>
 <td>January 13, 2015</td>
 <td>January 14, 2020</td>
 </tr>
 <tr>
-<td>Microsoft Windows Server 2012/2012 R2</td>
+<td>Windows Server 2012/2012 R2</td>
 <td>October 10, 2023</td>
 <td>October 10, 2023</td>
 </tr>
 <tr>
-<td>Microsoft Windows Server 2016</td>
+<td>Windows Server 2016</td>
 <td>November 11, 2027</td>
 <td>November 11, 2027</td>
 </tr>
 <tr>
-<td>Microsoft Windows Server 2019</td>
+<td>Windows Server 2019</td>
 <td>October 10, 2028</td>
 <td>October 10, 2028</td>
 </tr>

--- a/content/plugin_community.md
+++ b/content/plugin_community.md
@@ -80,11 +80,11 @@ The following Ohai plugins are available from the open source community:
 </tr>
 <tr>
 <td><a href="https://github.com/timops/ohai-plugins/blob/master/win32_software.rb">win32_software.rb</a></td>
-<td>Adds the ability for Ohai to use Windows Management Instrumentation (WMI) to discover useful information about software that is installed on any node that is running Microsoft Windows.</td>
+<td>Adds the ability for Ohai to use Windows Management Instrumentation (WMI) to discover useful information about software that is installed on any node that is running Windows.</td>
 </tr>
 <tr>
 <td><a href="https://github.com/timops/ohai-plugins/blob/master/win32_svc.rb">win32_svc.rb</a></td>
-<td>Adds the ability for Ohai to query using Windows Management Instrumentation (WMI) to get information about all services that are registered on a node that is running Microsoft Windows.</td>
+<td>Adds the ability for Ohai to query using Windows Management Instrumentation (WMI) to get information about all services that are registered on a node that is running Windows.</td>
 </tr>
 </tbody>
 </table>

--- a/content/proxies.md
+++ b/content/proxies.md
@@ -20,7 +20,7 @@ Chef to work in an environment that requires proxies, set the
 `http_proxy`, `https_proxy`, `ftp_proxy`, and/or `no_proxy` environment
 variables to specify the proxy settings using a lowercase value.
 
-## Microsoft Windows
+## Windows
 
 {{% proxy_windows %}}
 

--- a/content/uninstall.md
+++ b/content/uninstall.md
@@ -129,7 +129,7 @@ rpm -qa *chef-workstation*
 sudo yum remove -y <package>
 ```
 
-### Microsoft Windows
+### Windows
 
 Use **Add / Remove Programs** to remove Chef Workstation on the
-Microsoft Windows platform.
+Windows platform.

--- a/content/windows.md
+++ b/content/windows.md
@@ -1,5 +1,5 @@
 +++
-title = "Chef for Microsoft Windows"
+title = "Chef for Windows"
 draft = false
 
 gh_repo = "chef-web-docs"
@@ -8,8 +8,8 @@ aliases = ["/windows.html"]
 
 [menu]
   [menu.infra]
-    title = "Chef for Microsoft Windows"
-    identifier = "chef_infra/integrations/windows/windows.md Chef for Microsoft Windows"
+    title = "Chef for Windows"
+    identifier = "chef_infra/integrations/windows/windows.md Chef for Windows"
     parent = "chef_infra/integrations/windows"
     weight = 10
 +++
@@ -17,7 +17,7 @@ aliases = ["/windows.html"]
 ## Overview
 
 The Chef Infra Client has specific components that are designed to
-support unique aspects of the Microsoft Windows platform, including
+support unique aspects of the Windows platform, including
 PowerShell, PowerShell DSC, and Internet Information Services (IIS).
 
 {{% windows_install_overview %}}
@@ -25,7 +25,7 @@ PowerShell, PowerShell DSC, and Internet Information Services (IIS).
 ## Setting up Windows Workstations
 
 To set up your Windows workstation follow the steps on [Chef for
-Microsoft Windows](/workstation/install_workstation/)
+Windows](/workstation/install_workstation/)
 
 ## Install Chef Infra Client on Windows Nodes
 
@@ -37,12 +37,12 @@ This command has the following syntax:
 chef-client OPTION VALUE OPTION VALUE ...
 ```
 
-This command has the following option specific to Microsoft Windows:
+This command has the following option specific to Windows:
 
 `-A`, `--fatal-windows-admin-check`
 
 :   Cause a Chef Infra Client run to fail when Chef Infra Client does
-    not have administrator privileges in Microsoft Windows.
+    not have administrator privileges in Windows.
 
 ### System Requirements
 
@@ -115,7 +115,7 @@ Se the [knife windows](/workstation/knife_windows/) for more information.
 ### Install Chef Infra Client using the MSI Installer
 
 A Microsoft Installer Package (MSI) is available for installing Chef
-Infra Client on a Microsoft Windows machine from [Chef
+Infra Client on a Windows machine from [Chef
 Downloads](https://www.chef.io/downloads/tools/infra-client?os=windows).
 
 #### Msiexec.exe
@@ -137,7 +137,7 @@ Downloads](https://www.chef.io/downloads/tools/infra-client?os=windows).
 ## Windows Cookbooks
 
 Some of the most popular Chef-maintained cookbooks that contain custom
-resources useful when configuring machines running Microsoft Windows are
+resources useful when configuring machines running Windows are
 listed below:
 
 <table>
@@ -242,7 +242,7 @@ Chef Infra provides a growing number of Windows-specific resources.
 ### Windows Compatible Resources
 
 The most popular core resources in Chef Infra Client work the same way
-in Microsoft Windows as they do on any UNIX or Linux-based platform.
+in Windows as they do on any UNIX or Linux-based platform.
 
 - [cookbook_file](/resources/cookbook_file/)
 - [directory](/resources/directory/)
@@ -261,7 +261,7 @@ in Microsoft Windows as they do on any UNIX or Linux-based platform.
 - [user](/resources/user/)
 
 The file-based resources have attributes that support unique
-requirements within the Microsoft Windows platform, including `inherits`
+requirements within the Windows platform, including `inherits`
 (for file inheritance), `mode` (for octal modes), and `rights` (for
 access control lists, or ACLs).
 

--- a/themes/docs-new/layouts/shortcodes/chef_client_bootstrap_stages.md
+++ b/themes/docs-new/layouts/shortcodes/chef_client_bootstrap_stages.md
@@ -37,7 +37,7 @@ During a `knife bootstrap` bootstrap operation, the following happens:
 <tr>
 <td><p><strong>Start a Chef Infra Client run</strong></p></td>
 <td><p>On UNIX and Linux-based machines: The second shell script executes the <code>chef-client</code> binary with a set of initial settings stored within <code>first-boot.json</code> on the node. <code>first-boot.json</code> is generated from the workstation as part of the initial <code>knife bootstrap</code> subcommand.</p>
-<p>On Microsoft Windows machines: The batch file that is derived from the windows-chef-client-msi.erb bootstrap template executes the <code>chef-client</code> binary with a set of initial settings stored within <code>first-boot.json</code> on the node. <code>first-boot.json</code> is generated from the workstation as part of the initial <code>knife bootstrap</code> subcommand.</p></td>
+<p>On Windows machines: The batch file that is derived from the windows-chef-client-msi.erb bootstrap template executes the <code>chef-client</code> binary with a set of initial settings stored within <code>first-boot.json</code> on the node. <code>first-boot.json</code> is generated from the workstation as part of the initial <code>knife bootstrap</code> subcommand.</p></td>
 </tr>
 <tr>
 <td><p><strong>Complete a Chef Infra Client run</strong></p></td>

--- a/themes/docs-new/layouts/shortcodes/config_rb_client_summary.md
+++ b/themes/docs-new/layouts/shortcodes/config_rb_client_summary.md
@@ -2,7 +2,7 @@ The client.rb file specifies how Chef Infra Client is configured on a
 node and has the following characteristics:
 
 - This file is loaded every time the chef-client executable is run.
-- On Microsoft Windows machines, the default location for this file is
+- On Windows machines, the default location for this file is
     `C:\chef\client.rb`. On all other systems the default location for
     this file is `/etc/chef/client.rb`.
 - Use the `--config` option from the command line to override the

--- a/themes/docs-new/layouts/shortcodes/ctl_chef_client_elevated_privileges.md
+++ b/themes/docs-new/layouts/shortcodes/ctl_chef_client_elevated_privileges.md
@@ -1,5 +1,5 @@
 The Chef Infra Client may need to be run with elevated privileges in
 order to get a recipe to converge correctly. On UNIX and UNIX-like
 operating systems this can be done by running the command as root. On
-Microsoft Windows this can be done by running the command prompt as an
+Windows this can be done by running the command prompt as an
 administrator.

--- a/themes/docs-new/layouts/shortcodes/ctl_chef_client_elevated_privileges_windows.md
+++ b/themes/docs-new/layouts/shortcodes/ctl_chef_client_elevated_privileges_windows.md
@@ -1,4 +1,4 @@
-On Microsoft Windows, running without elevated privileges (when they are
+On Windows, running without elevated privileges (when they are
 necessary) is an issue that fails silently. It will appear that Chef
 Infra Client completed its run successfully, but the changes will not
 have been made. When this occurs, do one of the following to run Chef

--- a/themes/docs-new/layouts/shortcodes/fips_intro_client.md
+++ b/themes/docs-new/layouts/shortcodes/fips_intro_client.md
@@ -24,7 +24,7 @@ and is not used for any cryptographic purpose.
 
 Notes about FIPS:
 
-- May be enabled for nodes running on Microsoft Windows and Enterprise
+- May be enabled for nodes running on Windows and Enterprise
     Linux platforms
 - Should only be enabled for environments that require FIPS 140-2
     compliance

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_data_exists.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_data_exists.md
@@ -36,13 +36,13 @@ where:
 - `{ name: 'NAME', type: TYPE, data: DATA }` is a hash that contains
     the expected name, type, and data of the registry key value
 - `type:` represents the values available for registry keys in
-    Microsoft Windows. Use `:binary` for REG_BINARY, `:string` for
+    Windows. Use `:binary` for REG_BINARY, `:string` for
     REG_SZ, `:multi_string` for REG_MULTI_SZ, `:expand_string` for
     REG_EXPAND_SZ, `:dword` for REG_DWORD, `:dword_big_endian` for
     REG_DWORD_BIG_ENDIAN, or `:qword` for REG_QWORD.
 - `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
     or `:machine`. Set to `:i386` to read or write 32-bit registry keys
-    on 64-bit machines running Microsoft Windows. Set to`:x86_64` to
+    on 64-bit machines running Windows. Set to`:x86_64` to
     force write to a 64-bit registry location, however Chef Infra Client
     returns an exception if `:x86_64` is used on a 32-bit machine. Set
     to `:machine` to allow Chef Infra Client to allow Chef Infra Client

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_get_subkeys.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_get_subkeys.md
@@ -1,5 +1,5 @@
 Use the `registry_get_subkeys` method to get a list of registry key
-values that are present for a Microsoft Windows registry key.
+values that are present for a Windows registry key.
 
 <div class="admonition-note">
 
@@ -30,7 +30,7 @@ where:
     `HKEY_USERS`, `HKU`, `HKEY_CURRENT_USER`, and `HKCU`.
 - `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
     or `:machine`. Set to `:i386` to read or write 32-bit registry keys
-    on 64-bit machines running Microsoft Windows. Set to`:x86_64` to
+    on 64-bit machines running Windows. Set to`:x86_64` to
     force write to a 64-bit registry location, however Chef Infra Client
     returns an exception if `:x86_64` is used on a 32-bit machine. Set
     to `:machine` to allow Chef Infra Client to allow Chef Infra Client

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_get_values.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_get_values.md
@@ -1,5 +1,5 @@
 Use the `registry_get_values` method to get the registry key values
-(name, type, and data) for a Microsoft Windows registry key.
+(name, type, and data) for a Windows registry key.
 
 <div class="admonition-note">
 
@@ -30,7 +30,7 @@ where:
     `HKEY_USERS`, `HKU`, `HKEY_CURRENT_USER`, and `HKCU`.
 - `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
     or `:machine`. Set to `:i386` to read or write 32-bit registry keys
-    on 64-bit machines running Microsoft Windows. Set to`:x86_64` to
+    on 64-bit machines running Windows. Set to`:x86_64` to
     force write to a 64-bit registry location, however Chef Infra Client
     returns an exception if `:x86_64` is used on a 32-bit machine. Set
     to `:machine` to allow Chef Infra Client to allow Chef Infra Client

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_has_subkeys.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_has_subkeys.md
@@ -30,7 +30,7 @@ where:
     `HKEY_USERS`, `HKU`, `HKEY_CURRENT_USER`, and `HKCU`.
 - `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
     or `:machine`. Set to `:i386` to read or write 32-bit registry keys
-    on 64-bit machines running Microsoft Windows. Set to`:x86_64` to
+    on 64-bit machines running Windows. Set to`:x86_64` to
     force write to a 64-bit registry location, however Chef Infra Client
     returns an exception if `:x86_64` is used on a 32-bit machine. Set
     to `:machine` to allow Chef Infra Client to allow Chef Infra Client

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_key_exists.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_key_exists.md
@@ -1,4 +1,4 @@
-Use the `registry_key_exists?` method to find out if a Microsoft Windows
+Use the `registry_key_exists?` method to find out if a Windows
 registry key exists at the specified path.
 
 <div class="admonition-note">
@@ -30,7 +30,7 @@ where:
     `HKEY_USERS`, `HKU`, `HKEY_CURRENT_USER`, and `HKCU`.
 - `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
     or `:machine`. Set to `:i386` to read or write 32-bit registry keys
-    on 64-bit machines running Microsoft Windows. Set to`:x86_64` to
+    on 64-bit machines running Windows. Set to`:x86_64` to
     force write to a 64-bit registry location, however Chef Infra Client
     returns an exception if `:x86_64` is used on a 32-bit machine. Set
     to `:machine` to allow Chef Infra Client to allow Chef Infra Client

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_value_exists.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_registry_value_exists.md
@@ -37,13 +37,13 @@ where:
     key value; if either `type:` or `:value` are specified in the hash,
     they are ignored
 - `type:` represents the values available for registry keys in
-    Microsoft Windows. Use `:binary` for REG_BINARY, `:string` for
+    Windows. Use `:binary` for REG_BINARY, `:string` for
     REG_SZ, `:multi_string` for REG_MULTI_SZ, `:expand_string` for
     REG_EXPAND_SZ, `:dword` for REG_DWORD, `:dword_big_endian` for
     REG_DWORD_BIG_ENDIAN, or `:qword` for REG_QWORD.
 - `ARCHITECTURE` is one of the following values: `:x86_64`, `:i386`,
     or `:machine`. Set to `:i386` to read or write 32-bit registry keys
-    on 64-bit machines running Microsoft Windows. Set to`:x86_64` to
+    on 64-bit machines running Windows. Set to`:x86_64` to
     force write to a 64-bit registry location, however Chef Infra Client
     returns an exception if `:x86_64` is used on a 32-bit machine. Set
     to `:machine` to allow Chef Infra Client to allow Chef Infra Client

--- a/themes/docs-new/layouts/shortcodes/infra_lang_method_windows_methods.md
+++ b/themes/docs-new/layouts/shortcodes/infra_lang_method_windows_methods.md
@@ -1,5 +1,5 @@
 Six methods are present in the Chef Infra Language to help verify the registry
-during a Chef Infra Client run on the Microsoft Windows
+during a Chef Infra Client run on the Windows
 platform---`registry_data_exists?`, `registry_get_subkeys`,
 `registry_get_values`, `registry_has_subkeys?`, `registry_key_exists?`,
 and `registry_value_exists?`---these helpers ensure the

--- a/themes/docs-new/layouts/shortcodes/knife_common_windoquotes.md
+++ b/themes/docs-new/layouts/shortcodes/knife_common_windoquotes.md
@@ -1,4 +1,4 @@
-When running knife in Microsoft Windows, a string may be interpreted as
+When running knife in Windows, a string may be interpreted as
 a wildcard pattern when quotes are not present in the command. The
 number of quotes to use depends on the shell from which the command is
 being run.

--- a/themes/docs-new/layouts/shortcodes/knife_common_windows_quotes.md
+++ b/themes/docs-new/layouts/shortcodes/knife_common_windows_quotes.md
@@ -1,4 +1,4 @@
-When running knife in Microsoft Windows, a string may be interpreted as
+When running knife in Windows, a string may be interpreted as
 a wildcard pattern when quotes are not present in the command. The
 number of quotes to use depends on the shell from which the command is
 being run.

--- a/themes/docs-new/layouts/shortcodes/packages_install_script_examples.md
+++ b/themes/docs-new/layouts/shortcodes/packages_install_script_examples.md
@@ -6,7 +6,7 @@ To install Chef Client 15.8.23:
 curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -v 15.8.23
 ```
 
-To install the latest version of Chef Workstation on Microsoft Windows
+To install the latest version of Chef Workstation on Windows
 from the `current` channel:
 
 ```none

--- a/themes/docs-new/layouts/shortcodes/packages_install_script_options.md
+++ b/themes/docs-new/layouts/shortcodes/packages_install_script_options.md
@@ -1,47 +1,47 @@
 In addition to the default install behavior, the Chef Software Install script
 supports the following options:
 
-`-c` (`-channel` on Microsoft Windows)
+`-c` (`-channel` on Windows)
 
 :   The release channel from which a package is pulled. Possible values:
     `current` or `stable`. Default value: `stable`.
 
-`-d` (`-download_directory` on Microsoft Windows)
+`-d` (`-download_directory` on Windows)
 
 :   The directory into which a package is downloaded. When a package
     already exists in this directory and the checksum matches, the
     package is not re-downloaded. When `-d` and `-f` are not specified,
     a package is downloaded to a temporary directory.
 
-`-f` (`-filename` on Microsoft Windows)
+`-f` (`-filename` on Windows)
 
 :   The name of the file and the path at which that file is located.
     When a filename already exists at this path and the checksum
     matches, the package is not re-downloaded. When `-d` and `-f` are
     not specified, a package is downloaded to a temporary directory.
 
-`-P` (`-project` on Microsoft Windows)
+`-P` (`-project` on Windows)
 
 :   The product name to install. Supported versions of Chef products are
     `automate`, `chef`, `chef-server`, `inspec`, `chef-workstation`,
     `chefdk`, `supermarket`, `chef-backend`, `push-jobs-client`, and
     `push-jobs-server`. Default value: `chef`.
 
-`-s` (`-install_strategy` on Microsoft Windows)
+`-s` (`-install_strategy` on Windows)
 
 :   The method of package installations. The default strategy is to
     always install when the install.sh script runs. Set to "once" to
     skip installation if the product is already installed on the node.
 
-`-l` (`-download_url_override` on Microsoft Windows)
+`-l` (`-download_url_override` on Windows)
 
 :   Install package downloaded from a direct URL.
 
-`-a` (`-checksum` on Microsoft Windows)
+`-a` (`-checksum` on Windows)
 
 :   The SHA256 for download_url_override
 
-`-v` (`-version` on Microsoft Windows)
+`-v` (`-version` on Windows)
 
 :   The version of the package to be installed. A version always takes
     the form x.y.z, where x, y, and z are decimal numbers that are used

--- a/themes/docs-new/layouts/shortcodes/packages_install_script_run.md
+++ b/themes/docs-new/layouts/shortcodes/packages_install_script_run.md
@@ -1,1 +1,1 @@
-The Chef Software Install script can be run on UNIX, Linux, and Microsoft Windows platforms. The terms 'omnibus' and 'omnitruck' are only relevant to the build processes used internally at Chef Software.
+The Chef Software Install script can be run on UNIX, Linux, and Windows platforms. The terms 'omnibus' and 'omnitruck' are only relevant to the build processes used internally at Chef Software.

--- a/themes/docs-new/layouts/shortcodes/packages_install_script_run_windows.md
+++ b/themes/docs-new/layouts/shortcodes/packages_install_script_run_windows.md
@@ -1,4 +1,4 @@
-On Microsoft Windows systems, invoke the Chef Software Install script using
+On Windows systems, invoke the Chef Software Install script using
 Windows PowerShell:
 
 ```none

--- a/themes/docs-new/layouts/shortcodes/proxy_windows.md
+++ b/themes/docs-new/layouts/shortcodes/proxy_windows.md
@@ -1,4 +1,4 @@
-To determine the current proxy server on the Microsoft Windows platform:
+To determine the current proxy server on the Windows platform:
 
 1.  Open **Internet Properties**.
 2.  Open **Connections**.
@@ -6,7 +6,7 @@ To determine the current proxy server on the Microsoft Windows platform:
 4.  View the **Proxy server** setting. If this setting is blank, then a
     proxy server may not be available.
 
-To configure proxy settings in Microsoft Windows:
+To configure proxy settings in Windows:
 
 1.  Open **System Properties**.
 2.  Open **Environment Variables**.

--- a/themes/docs-new/layouts/shortcodes/resources_common_powershell.md
+++ b/themes/docs-new/layouts/shortcodes/resources_common_powershell.md
@@ -1,6 +1,6 @@
 Windows PowerShell is a task-based command-line shell and scripting
 language developed by Microsoft. Windows PowerShell uses a
-document-oriented approach for managing Microsoft Windows-based
+document-oriented approach for managing Windows-based
 machines, similar to the approach that is used for managing Unix and
 Linux-based machines. Windows PowerShell is [a tool-agnostic
 platform](https://docs.microsoft.com/en-us/powershell/scripting/powershell-scripting)

--- a/themes/docs-new/layouts/shortcodes/resources_common_relative_paths.md
+++ b/themes/docs-new/layouts/shortcodes/resources_common_relative_paths.md
@@ -3,4 +3,4 @@ The following relative paths can be used with any resource:
 `#{ENV['HOME']}`
 
 :   Use to return the `~` path in Linux and macOS or the `%HOMEPATH%` in
-    Microsoft Windows.
+    Windows.

--- a/themes/docs-new/layouts/shortcodes/resources_common_windows_security.md
+++ b/themes/docs-new/layouts/shortcodes/resources_common_windows_security.md
@@ -1,4 +1,4 @@
-To support Microsoft Windows security, the **template**, **file**,
+To support Windows security, the **template**, **file**,
 **remote_file**, **cookbook_file**, **directory**, and
 **remote_directory** resources support the use of inheritance and
 access control lists (ACLs) within recipes.

--- a/themes/docs-new/layouts/shortcodes/resources_common_windows_security_acl.md
+++ b/themes/docs-new/layouts/shortcodes/resources_common_windows_security_acl.md
@@ -15,7 +15,7 @@ where
 :   Use to specify which rights are granted to the `principal`. The
     possible values are: `:read`, `:write`, `read_execute`, `:modify`,
     `:full_control`, or an integer.
-    
+
 :    Integers used for permissions must match the following list
     [FileSystemRights Enum](https://docs.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.filesystemrights?view=windowsdesktop-5.0#fields) fields.
 
@@ -23,7 +23,7 @@ where
     includes `:read`. If `:full_control` is specified, then it includes
     both `:write` and `:read`.
 
-    (For those who know the Microsoft Windows API: `:read` corresponds
+    (For those who know the Windows API: `:read` corresponds
     to `GENERIC_READ`; `:write` corresponds to `GENERIC_WRITE`;
     `:read_execute` corresponds to `GENERIC_READ` and `GENERIC_EXECUTE`;
     `:modify` corresponds to `GENERIC_WRITE`, `GENERIC_READ`,
@@ -35,7 +35,7 @@ where
 
 :   Use to specify a group or user. The principal can be specified by
     either name or SID. When using name, this is identical to what is
-    entered in the login box for Microsoft Windows, such as `user_name`,
+    entered in the login box for Windows, such as `user_name`,
     `domain\user_name`, or `user_name@fully_qualified_domain_name`. When
     using a SID, you may use either the standard string representation of
     a SID (S-R-I-S-S) or one of the [SDDL string constants](https://docs.microsoft.com/en-us/windows/win32/secauthz/sid-strings). Chef
@@ -103,9 +103,9 @@ Some other important things to know when using the `rights` attribute:
 - If rights are not specified, nothing will be changed. Chef Infra
     Client does not clear out the rights on a file or directory if
     rights are not specified.
-- Changing inherited rights can be expensive. Microsoft Windows will
+- Changing inherited rights can be expensive. Windows will
     propagate rights to all children recursively due to inheritance.
-    This is a normal aspect of Microsoft Windows, so consider the
+    This is a normal aspect of Windows, so consider the
     frequency with which this type of action is necessary and take steps
     to control this type of action if performance is the primary
     consideration.

--- a/themes/docs-new/layouts/shortcodes/search_boolean_and.md
+++ b/themes/docs-new/layouts/shortcodes/search_boolean_and.md
@@ -20,7 +20,7 @@ to return something like:
 }
 ```
 
-Or, to find all of the computers running on the Microsoft Windows
+Or, to find all of the computers running on the Windows
 platform that are associated with a role named `jenkins`, enter:
 
 ```bash

--- a/themes/docs-new/layouts/shortcodes/test_kitchen_driver_vagrant_settings.md
+++ b/themes/docs-new/layouts/shortcodes/test_kitchen_driver_vagrant_settings.md
@@ -27,7 +27,7 @@ Chef:
 </tr>
 <tr>
 <td><code>communicator</code></td>
-<td>Use to override the <code>config.vm.communicator</code> setting in Vagrant. For example, when a base box is a Microsoft Windows operating system that does not have SSH installed and enabled, Vagrant will not be able to boot without a custom Vagrant file. Default value: <code>nil</code> (assumes SSH is available).</td>
+<td>Use to override the <code>config.vm.communicator</code> setting in Vagrant. For example, when a base box is a Windows operating system that does not have SSH installed and enabled, Vagrant will not be able to boot without a custom Vagrant file. Default value: <code>nil</code> (assumes SSH is available).</td>
 </tr>
 <tr>
 <td><code>customize</code></td>

--- a/themes/docs-new/layouts/shortcodes/windotop_level_directory_names.md
+++ b/themes/docs-new/layouts/shortcodes/windotop_level_directory_names.md
@@ -2,5 +2,5 @@ Windows will throw errors when path name lengths are too long. For this
 reason, it's often helpful to use a very short top-level directory, much
 like what is done in UNIX and Linux. For example, Chef uses `/opt/` to
 install Chef Workstation on macOS. A similar approach can be done on
-Microsoft Windows, by creating a top-level directory with a short name.
+Windows, by creating a top-level directory with a short name.
 For example: `C:\chef`.

--- a/themes/docs-new/layouts/shortcodes/windows_environment_variable_path.md
+++ b/themes/docs-new/layouts/shortcodes/windows_environment_variable_path.md
@@ -1,4 +1,4 @@
-On Microsoft Windows, Chef Infra Client must have two entries added to
+On Windows, Chef Infra Client must have two entries added to
 the `PATH` environment variable:
 
 - `C:\opscode\chef\bin`

--- a/themes/docs-new/layouts/shortcodes/windows_install_overview.md
+++ b/themes/docs-new/layouts/shortcodes/windows_install_overview.md
@@ -1,4 +1,4 @@
-Chef Infra Client can be installed on machines running Microsoft Windows
+Chef Infra Client can be installed on machines running Windows
 in the following ways:
 
 - By bootstraping Chef Infra Client using [knife

--- a/themes/docs-new/layouts/shortcodes/windows_install_system_center.md
+++ b/themes/docs-new/layouts/shortcodes/windows_install_system_center.md
@@ -1,4 +1,4 @@
 Many organizations already have processes in place for managing the
-applications and settings on various Microsoft Windows machines. For
+applications and settings on various Windows machines. For
 example, System Center. Chef Infra Client can be installed using this
 method.

--- a/themes/docs-new/layouts/shortcodes/windows_msiexec_addlocal.md
+++ b/themes/docs-new/layouts/shortcodes/windows_msiexec_addlocal.md
@@ -19,7 +19,7 @@ Client. These options can be passed along with an Msiexec.exe command:
 </tr>
 <tr>
 <td><code>ChefSchTaskFeature</code></td>
-<td>Use to configure Chef Infra Client as a scheduled task in Microsoft Windows.</td>
+<td>Use to configure Chef Infra Client as a scheduled task in Windows.</td>
 </tr>
 <tr>
 <td><code>ChefPSModuleFeature</code></td>

--- a/themes/docs-new/layouts/shortcodes/windows_registry_key_backslashes.md
+++ b/themes/docs-new/layouts/shortcodes/windows_registry_key_backslashes.md
@@ -1,4 +1,4 @@
-A Microsoft Windows registry key can be used as a string in Ruby code,
+A Windows registry key can be used as a string in Ruby code,
 such as when a registry key is used as the name of a recipe. In Ruby,
 when a registry key is enclosed in a double-quoted string (`" "`), the
 same backslash character (`\`) that is used to define the registry key

--- a/themes/docs-new/layouts/shortcodes/windows_top_level_directory_names.md
+++ b/themes/docs-new/layouts/shortcodes/windows_top_level_directory_names.md
@@ -2,5 +2,5 @@ Windows will throw errors when path name lengths are too long. For this
 reason, it's often helpful to use a very short top-level directory, much
 like what is done in UNIX and Linux. For example, Chef uses `/opt/` to
 install Chef Workstation on macOS. A similar approach can be done on
-Microsoft Windows, by creating a top-level directory with a short name.
+Windows, by creating a top-level directory with a short name.
 For example: `C:\chef`.


### PR DESCRIPTION
Signed-off-by: kagarmoe <kimberly.garmoe@progress.com>


## Description

Lint fix: use `Windows` not `Microsoft Windows`

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
