### PR TITLE
Remove white-space pre-wrap from css

### DIFF
--- a/themes/docs-new/assets/sass/typography/_code.scss
+++ b/themes/docs-new/assets/sass/typography/_code.scss
@@ -21,7 +21,6 @@ pre {
   border-radius: $border-radius-base;
   margin-bottom: rem-calc(16);
   padding: .25rem;
-  white-space: pre-wrap;
 
   code {
     background-color: transparent;


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

`white-space: pre-wrap` is moving the last word in a code block onto the next line in some cases. Removing it seems to fix things.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
