### PR TITLE
Add readfile shortcode

### DIFF
--- a/content/attribute_types.md
+++ b/content/attribute_types.md
@@ -19,9 +19,9 @@ competing values available during a Chef Infra Client run:
 
 | Attribute Type | Description                             |
 |----------------|-----------------------------------------|
-| default        | {{< readFile_shortcode file_path="layouts/shortcodes/node_attribute_type_default.md" >}}                               |
+| default        | {{< readfile file="layouts/shortcodes/node_attribute_type_default.md" >}}                               |
 | force_default  | Use the force_default attribute to ensure that an attribute defined in a cookbook (by an attribute file or by a recipe) takes precedence over a default attribute set by a role or an environment.    |
-| normal         | {{< readFile_shortcode file_path="layouts/shortcodes/node_attribute_type_normal.md" >}}         |
-| override       | {{< readFile_shortcode file_path="layouts/shortcodes/node_attribute_type_override.md" >}}       |
+| normal         | {{< readfile file="layouts/shortcodes/node_attribute_type_normal.md" >}}         |
+| override       | {{< readfile file="layouts/shortcodes/node_attribute_type_override.md" >}}       |
 | force_override | Use the force_override attribute to ensure that an attribute defined in a cookbook (by an attribute file or by a recipe) takes precedence over an override attribute set by a role or an environment. |
-| automatic      | {{< readFile_shortcode file_path="layouts/shortcodes/node_attribute_type_automatic.md" >}}     |
+| automatic      | {{< readfile file="layouts/shortcodes/node_attribute_type_automatic.md" >}}     |

--- a/content/chef_client_overview.md
+++ b/content/chef_client_overview.md
@@ -36,8 +36,8 @@ Chef Infra Client's Compliance Phase lets you automatically execute compliance a
 <tbody>
 <tr>
 <td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="image" /></p></td>
-<td><p>{{< readFile_shortcode file_path="layouts/shortcodes/chef_client_summary.md" >}}</p>
-<p>{{< readFile_shortcode file_path="layouts/shortcodes/security_key_pairs_chef_client.md" >}}</p></td>
+<td><p>{{< readfile file="layouts/shortcodes/chef_client_summary.md" >}}</p>
+<p>{{< readfile file="layouts/shortcodes/security_key_pairs_chef_client.md" >}}</p></td>
 </tr>
 </tbody>
 </table>

--- a/content/chef_overview.md
+++ b/content/chef_overview.md
@@ -72,7 +72,7 @@ Chef Infra has the following major components:
 </tr>
 <tr>
 <td><p><img src="/images/icon_node.svg" class="align-center" width="130" alt="image" /></p></td>
-<td><p>{{< readFile_shortcode file_path="layouts/shortcodes/node.md" >}}</p></td>
+<td><p>{{< readfile file="layouts/shortcodes/node.md" >}}</p></td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="image" /></p></td>
@@ -128,7 +128,7 @@ Some important tools and components of Chef Workstation include:
 <tbody>
 <tr>
 <td><p><img src="/images/icon_workstation.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/chef_workstation.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef_workstation.md" >}}</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_ctl_chef.svg" class="align-center" width="130" alt="image" /></p>
@@ -155,11 +155,11 @@ Some important tools and components of Chef Workstation include:
 </tr>
 <tr>
 <td><p><img src="/images/icon_kitchen.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/test_kitchen.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/test_kitchen.md" >}}</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_chefspec.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/chefspec_summary.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/chefspec_summary.md" >}}</td>
 </tr>
 </tbody>
 </table>
@@ -193,34 +193,34 @@ Cookbooks are comprised of the following components:
 <tbody>
 <tr>
 <td><p><img src="/images/icon_cookbook_attributes.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/cookbooks_attribute.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/cookbooks_attribute.md" >}}</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_cookbook_files.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/resource_cookbook_file_summary.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/resource_cookbook_file_summary.md" >}}</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_cookbook_libraries.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/libraries_summary.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/libraries_summary.md" >}}</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_cookbook_metadata.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/cookbooks_metadata.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/cookbooks_metadata.md" >}}</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_cookbook_recipes.svg" class="align-center" width="130" alt="image" /></p></td>
-<td><p>{{< readFile_shortcode file_path="layouts/shortcodes/cookbooks_recipe.md" >}}</p>
+<td><p>{{< readfile file="layouts/shortcodes/cookbooks_recipe.md" >}}</p>
 <p>The Chef Infra Client will run a recipe only when asked. When the Chef Infra Client runs the same recipe more than once, the results will be the same system state each time. When a recipe is run against a system, but nothing has changed on either the system or in the recipe, the Chef Infra Client will not change anything.</p>
-<p>{{< readFile_shortcode file_path="layouts/shortcodes/infra_lang_summary.md" >}}</p></td>
+<p>{{< readfile file="layouts/shortcodes/infra_lang_summary.md" >}}</p></td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_cookbook_resources.svg" class="align-center" width="130" alt="image" /></p></td>
-<td><p>{{< readFile_shortcode file_path="layouts/shortcodes/resources_common.md" >}}</p>
+<td><p>{{< readfile file="layouts/shortcodes/resources_common.md" >}}</p>
 <p>Chef has <a href="/resources/">many built-in resources</a> that cover all of the most common actions across all of the most common platforms. You can <a href="/custom_resources/">build your own resources</a> to handle any situation that is not covered by a built-in resource.</p></td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_cookbook_templates.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/template.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/template.md" >}}</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_cookbook_tests.svg" class="align-center" width="130" alt="image" /></p></td>
@@ -255,12 +255,12 @@ The key components of nodes that are under management by Chef include:
 <tbody>
 <tr>
 <td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="image" /></p></td>
-<td><p>{{< readFile_shortcode file_path="layouts/shortcodes/chef_client_summary.md" >}}</p>
-<p>{{< readFile_shortcode file_path="layouts/shortcodes/security_key_pairs_chef_client.md" >}}</p></td>
+<td><p>{{< readfile file="layouts/shortcodes/chef_client_summary.md" >}}</p>
+<p>{{< readfile file="layouts/shortcodes/security_key_pairs_chef_client.md" >}}</p></td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_ohai.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/ohai_summary.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/ohai_summary.md" >}}</td>
 </tr>
 </tbody>
 </table>
@@ -283,15 +283,15 @@ The key components of nodes that are under management by Chef include:
 <tbody>
 <tr>
 <td><p><img src="/images/icon_search.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/search.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/search.md" >}}</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_manage.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/chef_manager.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef_manager.md" >}}</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_data_bags.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/data_bag.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/data_bag.md" >}}</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_policy.svg" class="align-center" width="130" alt="image" /></p></td>
@@ -320,19 +320,19 @@ Some important aspects of policy include:
 <tbody>
 <tr>
 <td><p><img src="/images/icon_roles.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/role.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/role.md" >}}</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_environments.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/environment.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/environment.md" >}}</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_cookbook_versions.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/cookbooks_version.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/cookbooks_version.md" >}}</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_run_lists.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/node_run_list.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/node_run_list.md" >}}</td>
 </tr>
 </tbody>
 </table>

--- a/content/cookbooks.md
+++ b/content/cookbooks.md
@@ -46,12 +46,12 @@ A cookbook is comprised of recipes and other optional components as files or dir
 <tr>
 <td><a href="/recipes/">Recipes</a></td>
 <td>recipes/</td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/cookbooks_recipe.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/cookbooks_recipe.md" >}}</td>
 </tr>
 <tr>
 <td><a href="/attributes/">Attributes</a></td>
 <td>attributes/</td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/cookbooks_attribute.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/cookbooks_attribute.md" >}}</td>
 </tr>
 <tr>
 <td><a href="/files/">Files</a></td>

--- a/content/ctl_chef_client.md
+++ b/content/ctl_chef_client.md
@@ -116,7 +116,7 @@ This command has the following options:
 
     **Run-lists**
 
-    {{< readFile_shortcode file_path="layouts/shortcodes/node_ctl_run_list.md" >}}
+    {{< readfile file="layouts/shortcodes/node_ctl_run_list.md" >}}
 
     **Environments**
 
@@ -146,7 +146,7 @@ This command has the following options:
 
     **All attributes are normal attributes**
 
-    {{< readFile_shortcode file_path="layouts/shortcodes/node_ctl_attribute.md" >}}
+    {{< readfile file="layouts/shortcodes/node_ctl_attribute.md" >}}
 
     {{< note spaces=4 >}}
 

--- a/content/ctl_chef_solo.md
+++ b/content/ctl_chef_solo.md
@@ -70,11 +70,11 @@ This command has the following options:
 
 : The path to a file that contains JSON data.
 
-    {{< readFile_shortcode file_path="layouts/shortcodes/node_ctl_run_list.md" spaces=4 >}}
+    {{< readfile file="layouts/shortcodes/node_ctl_run_list.md" spaces=4 >}}
 
     {{< warning spaces=4 >}}
 
-    {{< readFile_shortcode file_path="layouts/shortcodes/node_ctl_attribute.md">}}
+    {{< readfile file="layouts/shortcodes/node_ctl_attribute.md">}}
 
     {{< /warning >}}
 

--- a/content/environments.md
+++ b/content/environments.md
@@ -54,11 +54,11 @@ There are two types of attributes that can be used with environments:
 <tbody>
 <tr>
 <td><code>default</code></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/node_attribute_type_default.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/node_attribute_type_default.md" >}}</td>
 </tr>
 <tr>
 <td><code>override</code></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/node_attribute_type_override.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/node_attribute_type_override.md" >}}</td>
 </tr>
 </tbody>
 </table>

--- a/content/install_chef_air_gap.md
+++ b/content/install_chef_air_gap.md
@@ -79,7 +79,7 @@ group.
 
 2. Upload the package to the machine that will run the Chef Infra Server, and then record its location on the file system. The rest of these steps assume this location is in the `/tmp` directory.
 
-3. {{< readFile_shortcode file_path="layouts/shortcodes/install_chef_server_install_package.md" >}}
+3. {{< readfile file="layouts/shortcodes/install_chef_server_install_package.md" >}}
 
 4. Run the following to start all of the services:
 
@@ -91,9 +91,9 @@ group.
     that work together to create a functioning system, this step may
     take a few minutes to complete.
 
-5. {{< readFile_shortcode file_path="layouts/shortcodes/ctl_chef_server_user_create_admin.md">}}
+5. {{< readfile file="layouts/shortcodes/ctl_chef_server_user_create_admin.md">}}
 
-6. {{< readFile_shortcode file_path="layouts/shortcodes/ctl_chef_server_org_create_summary.md">}}
+6. {{< readfile file="layouts/shortcodes/ctl_chef_server_org_create_summary.md">}}
 
 ## Chef Workstation
 
@@ -268,7 +268,7 @@ Supermarket.
 
 2. Update the `/etc/opscode/chef-server.rb` configuration file.
 
-    {{< readFile_shortcode file_path="layouts/shortcodes/config_ocid_application_hash_supermarket.md" >}}
+    {{< readfile file="layouts/shortcodes/config_ocid_application_hash_supermarket.md" >}}
 
 3. Reconfigure the Chef Infra Server.
 

--- a/content/nodes.md
+++ b/content/nodes.md
@@ -33,12 +33,12 @@ The key components of nodes that are under management by Chef include:
 <tbody>
 <tr>
 <td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="image" /></p></td>
-<td><p>{{< readFile_shortcode file_path="layouts/shortcodes/chef_client_summary.md" >}}</p>
-<p>{{< readFile_shortcode file_path="layouts/shortcodes/security_key_pairs_chef_client.md" >}}</p></td>
+<td><p>{{< readfile file="layouts/shortcodes/chef_client_summary.md" >}}</p>
+<p>{{< readfile file="layouts/shortcodes/security_key_pairs_chef_client.md" >}}</p></td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_ohai.svg" class="align-center" width="130" alt="image" /></p></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/ohai_summary.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/ohai_summary.md" >}}</td>
 </tr>
 </tbody>
 </table>

--- a/content/roles.md
+++ b/content/roles.md
@@ -43,11 +43,11 @@ There are two types of attributes that can be used with roles:
 <tbody>
 <tr>
 <td><code>default</code></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/node_attribute_type_default.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/node_attribute_type_default.md" >}}</td>
 </tr>
 <tr>
 <td><code>override</code></td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/node_attribute_type_override.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/node_attribute_type_override.md" >}}</td>
 </tr>
 </tbody>
 </table>

--- a/content/server_ldap.md
+++ b/content/server_ldap.md
@@ -53,7 +53,7 @@ the following:
     Availability installation as well as on Chef servers in a standalone
     installation.
 
-    {{< readFile_shortcode file_path="layouts/shortcodes/config_rb_server_settings_ldap.md" >}}
+    {{< readfile file="layouts/shortcodes/config_rb_server_settings_ldap.md" >}}
 
     {{< note spaces=4 >}}
 
@@ -62,7 +62,7 @@ the following:
 
     {{< /note >}}
 
-3. {{< readFile_shortcode file_path="layouts/shortcodes/install_chef_server_reconfigure.md" >}}
+3. {{< readfile file="layouts/shortcodes/install_chef_server_reconfigure.md" >}}
 
 At this point, all users should be able to use their Active Directory or
 LDAP usernames and passwords to log in to the Chef Infra Server.

--- a/content/server_manage_cookbooks.md
+++ b/content/server_manage_cookbooks.md
@@ -65,27 +65,27 @@ A cookbook can contain the following types of files:
 <tbody>
 <tr>
 <td>Attributes</td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/cookbooks_attribute.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/cookbooks_attribute.md" >}}</td>
 </tr>
 <tr>
 <td>Files</td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/resource_cookbook_file_summary.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/resource_cookbook_file_summary.md" >}}</td>
 </tr>
 <tr>
 <td>Libraries</td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/libraries_summary.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/libraries_summary.md" >}}</td>
 </tr>
 <tr>
 <td>Recipes</td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/cookbooks_recipe.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/cookbooks_recipe.md" >}}</td>
 </tr>
 <tr>
 <td>Resources</td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/resources_common.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/resources_common.md" >}}</td>
 </tr>
 <tr>
 <td>Templates</td>
-<td>{{< readFile_shortcode file_path="layouts/shortcodes/template.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/template.md" >}}</td>
 </tr>
 </tbody>
 </table>

--- a/content/style_guide/reuse.md
+++ b/content/style_guide/reuse.md
@@ -336,3 +336,31 @@ The following shortcode examples will display these icons: {{< fontawesome class
 {{</* fontawesome class="fas fa-archive" color="#cc814b" margin="0 0 0 12px"*/>}}
 {{</* fontawesome class="far fa-address-book" background-color="DarkBlue" color="rgb(168, 218, 220)" */>}}
 ```
+
+## readfile Shortcode
+
+The readfile shortcode adds text from a file to a page. You can add a Markdown file, HTML file, or code file by specifying the path to the file from the project root directory.
+
+By default it accepts a Markdown file, for example:
+
+```markdown
+{{</* readfile file="layouts/shortcodes/example.md" */>}}
+```
+
+You can also add an HTML file:
+
+```markdown
+{{</* readfile file="layouts/shortcodes/example.html" html="true" */>}}
+```
+
+And you can pass in a sample code file:
+
+```markdown
+{{</* readfile file="path/to/file/example.rb" highlight="ruby" */>}}
+```
+
+or:
+
+```markdown
+{{</* readfile file="path/to/data/file.json" highlight="json" */>}}
+```

--- a/themes/docs-new/layouts/shortcodes/readfile.html
+++ b/themes/docs-new/layouts/shortcodes/readfile.html
@@ -1,0 +1,8 @@
+{{$file := .Get "file"}}
+  {{- if eq (.Get "html") "true" -}}
+    {{- $file  | readFile | safeHTML -}}
+  {{- else if  (.Get "highlight") -}}
+    {{-  highlight ($file  | readFile) (.Get "highlight") "" -}}
+  {{- else -}}
+    {{ $file  | readFile | markdownify }}
+{{- end -}}


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

A few things:

- Adds a readfile shortcode 
- Updates several pages so they use the `readfile` shortcode instead of the `readFile_shortcode` shortcode
- Updates the `style_guide/reuse.md` page to describe how to use the `readfile` shortcode.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
