### PR TITLE
remove go version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,6 @@
 
 [build.environment]
   HUGO_ENABLEGITINFO = "true"
-  GO_VERSION = "1.17"
   NODE_VERSION = "17"
 
 [build.processing]


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

As it turns out, we don't need to specify a go version.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
