### PR TITLE
Specify that headings shouldn't be used to define terms

### DIFF
--- a/content/style_guide/markdown.md
+++ b/content/style_guide/markdown.md
@@ -117,35 +117,39 @@ Use a definition list to define terms, including CLI commands, command flags, pa
 
 You can include more than definition for a term and more than one paragraph for a definition. Each definition should have a `:` at the beginning of the line of text, a space, and then the definition text. Additional paragraphs just need to be indented by two spaces. See the example below:
 
-<!-- markdownlint-disable MD040 -->
+{{< note >}}
+
+You can add a linkable ID to a definition list term by wrapping the term in brackets and adding `(@)` after the term. For example, `[term](@)`. In the example below, [another term](#another-term) has an ID.
+
+{{< /note >}}
+
 ```md
 term
 : Term definition.
 
-another term
+[another term](@)
 : Another term definition.
 
   You can include multiple paragraphs in a definition if you need to.
 
-: And you can include more than one definition for a term by starting another line with a colon.
+: You can include more than one definition for a term by starting another line with a colon.
 
-: In est sit exercitation pariatur commodo sunt tempor mollit cillum magna et. Irure tempor cillum cupidatat sint velit veniam reprehenderit non et reprehenderit duis. Dolor magna aute dolore in sint eu fugiat irure laborum ea quis ipsum esse duis.
+: Adding square brackets and the `(@)` symbol around the term (`[another term](@)`) add a linkable ID to the term.
 ```
-<!-- markdownlint-enable MD040 -->
 
 The example above produces the following output:
 
 term
 : Term definition.
 
-another term
+[another term](@)
 : Another term definition.
 
   You can include multiple paragraphs in a definition if you need to.
 
-: And you can include more than one definition for a term by starting another line with a colon.
+: You can include more than one definition for a term by starting another line with a colon.
 
-: In est sit exercitation pariatur commodo sunt tempor mollit cillum magna et. Irure tempor cillum cupidatat sint velit veniam reprehenderit non et reprehenderit duis. Dolor magna aute dolore in sint eu fugiat irure laborum ea quis ipsum esse duis.
+: Adding square brackets and the `(@)` symbol around the term (`[another term](@)`) add a linkable ID to the term.
 
 ## Tables
 

--- a/content/style_guide/markdown.md
+++ b/content/style_guide/markdown.md
@@ -23,6 +23,12 @@ Unless the topics are about installing things or about API endpoints, the headin
 
 The width of heading adornment must be at least equal to the length of the text in the heading and the same width for headings is used everywhere. Consistent width is preferred.
 
+{{< note >}}
+
+Don't use headings to define CLI commands, properties, parameters, or other terms. Use a [definition list](#definition-lists) to define terms.
+
+{{< /note >}}
+
 ### H1
 
 The H1 heading is reserved for the page title which is created by the Hugo page template. The Markdown file text should not have any H1 headings.
@@ -107,12 +113,12 @@ Start each ordered list item with the number 1 (1.). Hugo will generate the corr
 
 ### Definition Lists
 
-Use a definition list to define a term, including CLI commands, command flags, parameters, and properties.
+Use a definition list to define terms, including CLI commands, command flags, parameters, and properties.
 
 You can include more than definition for a term and more than one paragraph for a definition. Each definition should have a `:` at the beginning of the line of text, a space, and then the definition text. Additional paragraphs just need to be indented by two spaces. See the example below:
 
 <!-- markdownlint-disable MD040 -->
-```
+```md
 term
 : Term definition.
 

--- a/themes/docs-new/layouts/_default/_markup/render-link.html
+++ b/themes/docs-new/layouts/_default/_markup/render-link.html
@@ -1,0 +1,7 @@
+{{- if eq .Destination "@" -}}
+  <span id="{{ .PlainText | anchorize }}">{{ .Text | safeHTML }}</span>
+{{ else }}
+    <a href="{{ .Destination }}">{{ .PlainText }}</a>
+{{- end -}}
+
+{{/* See https://gohugo.io/templates/render-hooks/ and https://discourse.gohugo.io/t/automatically-add-id-attribute-to-dt-element/38191 */}}

--- a/themes/docs-new/layouts/_default/_markup/render-link.html
+++ b/themes/docs-new/layouts/_default/_markup/render-link.html
@@ -1,7 +1,7 @@
 {{- if eq .Destination "@" -}}
   <span id="{{ .PlainText | anchorize }}">{{ .Text | safeHTML }}</span>
-{{ else }}
-    <a href="{{ .Destination }}">{{ .PlainText }}</a>
+{{- else -}}
+  <a href="{{ .Destination }}">{{ .PlainText }}</a>
 {{- end -}}
 
 {{/* See https://gohugo.io/templates/render-hooks/ and https://discourse.gohugo.io/t/automatically-add-id-attribute-to-dt-element/38191 */}}


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

Update style guide to say that headings shouldn't be used to define terms.

Also, add a link [render hook](https://gohugo.io/templates/render-hooks/#readout) so we can add heading IDs to definition list terms.

https://discourse.gohugo.io/t/automatically-add-id-attribute-to-dt-element/38191

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
