### PR TITLE
Fix toc for chef_handler resource docs

### DIFF
--- a/themes/docs-new/layouts/_default/infra_resource.html
+++ b/themes/docs-new/layouts/_default/infra_resource.html
@@ -100,15 +100,15 @@
         <!-------------- Handler Types ------------------->
 
         {{ with index $yaml_file "handler_types" }}
-          <h2 id="handler_types">Handler Types</h2>
+          <h2 id="handler-types">Handler Types</h2>
           {{ readFile "layouts/shortcodes/handler_types.md" | markdownify }}
 
-          <h3 id="handler_type_exception_report">Exception / Report</h3>
+          <h3 id="handler-type-exception-report">Exception / Report</h3>
           {{ readFile "layouts/shortcodes/handler_type_exception_report.md" | markdownify }}
           {{ readFile "layouts/shortcodes/handler_type_exception_report_run_from_recipe.md" | markdownify }}
 
 
-          <h3 id="handler_type_start">Start</h3>
+          <h3 id="handler-type-start">Start</h3>
           {{ readFile "layouts/shortcodes/handler_type_start.md" | markdownify }}
           {{ readFile "layouts/shortcodes/handler_type_start_run_from_recipe.md" | markdownify }}
 

--- a/themes/docs-new/layouts/partials/infra_resource_toc.html
+++ b/themes/docs-new/layouts/partials/infra_resource_toc.html
@@ -12,7 +12,6 @@
   <a href="#{{ anchorize ( .Title )}}">{{ .Title }}</a>
   <ul>
     {{ if index $yaml_file "handler_types" }}
-    <ul>
       <li>
         <a href="#handler-types">Handler Types</a>
         <ul>
@@ -24,7 +23,6 @@
           </li>
         </ul>
       </li>
-    </ul>
     {{ end }}
 
     <li>
@@ -256,24 +254,6 @@
       </li>
     {{ end }}
 
-    {{ if index $yaml_file "handler_custom" }}
-    <li>
-      <a href="#handler-custom">Custom Handlers</a>
-      <ul>
-        <li><a href="#handler-custom-syntax">Syntax</a></li>
-        <li><a href="#handler-custom-interface-report">report Interface</a></li>
-        <li>
-          <a href="#handler-custom-optional-interfaces">Optional Interfaces</a>
-          <ul>
-            <li><a href="#handler-custom-interface-data">data</a></li>
-            <li><a href="#handler-custom-interface-run-report-safely">run_report_safely</a></li>
-            <li><a href="#handler-custom-interface-run-report-unsafe">run_report_unsafe</a></li>
-          </ul>
-        </li>
-        <li><a href="#handler-custom-object-run-status">run_status Object</a></li>
-      </ul>
-    </li>
-    {{ end }}
     {{ if index $yaml_file "cookbook_file_specificity" }}
     <ul>
       <li><a href="#cookbook-file-specificity">File Specificity</a></li>

--- a/themes/docs-new/layouts/partials/infra_resources_all_toc.html
+++ b/themes/docs-new/layouts/partials/infra_resources_all_toc.html
@@ -269,24 +269,6 @@
               {{ end }}
             </li>
             {{ end }}
-            {{ if index $yaml_file "handler_custom" }}
-            <li>
-              <a href="#handler-custom">Custom Handlers</a>
-              <ul>
-                <li><a href="#handler-custom-syntax">Syntax</a></li>
-                <li><a href="#handler-custom-interface-report">report Interface</a></li>
-                <li>
-                  <a href="#handler-custom-optional-interfaces">Optional Interfaces</a>
-                  <ul>
-                    <li><a href="#handler-custom-interface-data">data</a></li>
-                    <li><a href="#handler-custom-interface-run-report-safely">run_report_safely</a></li>
-                    <li><a href="#handler-custom-interface_run-report-unsafe">run_report_unsafe</a></li>
-                  </ul>
-                </li>
-                <li><a href="#handler-custom-object-run-status">run_status Object</a></li>
-              </ul>
-            </li>
-            {{ end }}
             {{ if index $yaml_file "cookbook_file_specificity" }}
             <ul>
               <li><a href="#cookbook-file-specificity">File Specificity</a></li>


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

The TOC for the chef_handler resource docs is off. 

This is a bit of cleanup from this PR:
https://github.com/chef/chef-web-docs/pull/3246

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
