### PR TITLE
Fix page menu link

### DIFF
--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -682,13 +682,6 @@ identifier = "chef_infra"
     parent = "chef_infra/extension_apis"
     weight = 40
 
-      [[infra]]
-      title = "Community Plugins"
-      identifier = "chef_infra/extension_apis/ohai_plugins/plugin_community.md#ohai Community Plugins"
-      parent = "chef_infra/extension_apis/ohai_plugins"
-      url = "/plugin_community/#ohai"
-      weight = 20
-
   [[infra]]
   title = "Integrations"
   identifier = "chef_infra/integrations"

--- a/content/ohai.md
+++ b/content/ohai.md
@@ -193,14 +193,30 @@ windows
 
 Ohai ships several optional plugins that you can enable in the [client.rb configuration file](/config_rb_client/).
 
-- `:Grub2` - Information from the Linux Grub2 bootloader
-- `:IPC` - SysV IPC shmem information (New in Chef Infra Client 16)
-- `:Interupts` - Data from /proc/interrupts and /proc/irq (New in Chef Infra Client 16)
-- `:Lspci` - PCI device information on Linux hosts.
-- `:Lsscsi` - SCSI device information on Linux hosts.
-- `:Passwd` - User and Group information. This plugin can result in large node sizes if a system connects to Active Directory or LDAP.
-- `:Sessions` - Sessions data from loginctl on Linux hosts.
-- `:Sysctl` - All sysctl values on Linux hosts.
+ `:Grub2`
+: Information from the Linux Grub2 bootloader
+
+ `:IPC`
+: SysV IPC shmem information (New in Chef Infra Client 16)
+
+ `:Interupts`
+: Data from /proc/interrupts and /proc/irq (New in Chef Infra Client 16)
+
+ `:Lspci`
+: PCI device information on Linux hosts.
+
+ `:Lsscsi`
+: SCSI device information on Linux hosts.
+
+ `:Passwd`
+: User and Group information. This plugin can result in large node sizes if a system connects to Active Directory or LDAP.
+
+ `:Sessions`
+: Sessions data from loginctl on Linux hosts.
+
+`:Sysctl`
+
+: All sysctl values on Linux hosts.
 
 ### Enabling Optional Plugins
 

--- a/content/plugin_community.md
+++ b/content/plugin_community.md
@@ -3,7 +3,15 @@ title = "Community Plugins"
 draft = false
 gh_repo = "chef-web-docs"
 aliases = "/plugin_community.html"
+
+[menu]
+  [menu.infra]
+      title = "Community Plugins"
+      identifier = "chef_infra/extension_apis/ohai_plugins/Community Plugins"
+      parent = "chef_infra/extension_apis/ohai_plugins"
+      weight = 20
 +++
+
 <!-- markdownlint-disable-file MD033 -->
 This page lists plugins for Ohai plugins and Chef Infra Client handlers
 that are developed and maintained by the Chef community.


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

For whatever reason we have the menu link for the Ohai Community plugins in the menu config, not in the page's config. So the page's location in the menu doesn't appear when the user is looking at the page. This just moves the menu link to the page.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
