### PR TITLE
Fix resources new in text

### DIFF
--- a/themes/docs-new/layouts/_default/infra_resource.html
+++ b/themes/docs-new/layouts/_default/infra_resource.html
@@ -94,7 +94,11 @@
         {{ end }}
 
         {{ if and ( ne (index $yaml_file "resource_new_in") "" ) ( index $yaml_file "resource_new_in" )}}
-          <p><strong>New in Chef Infra Client {{ index $yaml_file "resource_new_in" }}.</strong></p>
+          {{ if eq $product "infra" }}
+            <p><strong>New in Chef Infra Client {{ index $yaml_file "resource_new_in" }}.</strong></p>
+          {{ else if ( eq $product "desktop") }}
+            <p><strong>New in Chef Desktop {{ index $yaml_file "resource_new_in" }}.</strong></p>
+          {{ end }}
         {{ end }}
 
         <!-------------- Handler Types ------------------->

--- a/themes/docs-new/layouts/_default/infra_resources_all.html
+++ b/themes/docs-new/layouts/_default/infra_resources_all.html
@@ -90,7 +90,11 @@
             {{ end }}
 
             {{ if and ( ne (index $yaml_file "resource_new_in") "" ) ( index $yaml_file "resource_new_in" )}}
-              <p><strong>New in Chef Infra Client {{ index $yaml_file "resource_new_in" }}.</strong></p>
+              {{ if eq $product "infra" }}
+                <p><strong>New in Chef Infra Client {{ index $yaml_file "resource_new_in" }}.</strong></p>
+              {{ else if ( eq $product "desktop") }}
+                <p><strong>New in Chef Desktop {{ index $yaml_file "resource_new_in" }}.</strong></p>
+              {{ end }}
             {{ end }}
 
             <!-------------- Handler Types ------------------->


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

The "New in" text is only formatted for Infra Client resources, but this field is in Desktop resources as well, so the Desktop resources all say "New in Chef Infra Client x.y" when they should say "New in Chef Desktop x.y". This updates the resources layout so that Desktop and Infra resources say the correct thing.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
