### PR TITLE
cspell ignore _vendor dir

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -32,7 +32,8 @@
     ".expeditor/**/*",
     "**/*.yml",
     "**/*.toml",
-    "archetypes/*.md"
+    "archetypes/*.md",
+    "_vendor/**/*"
   ],
   "ignoreRegExpList": [
     "/'s\\b/",


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

Make cspell ignore the vendor directory. Some of the projects (most of them) that are vendored don't have cspell set up in those repos, so this returns a bunch of errors when content is updated in chef-web-docs. Really, if we're using cspell to check the content from other repos, then it should be checking those repos when PRs are made there and not after it gets pulled into chef-web-docs.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
