### PR TITLE
Automate HA has limited platform support

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -408,10 +408,10 @@ for platforms that use:
 
 ### Chef Automate HA
 
-### Commercial Support
+#### Commercial Support
 
-Commercially supported platforms for Automate HA can be found at
-[Chef Automate HA supported platforms](/automate/ha_platform_support/#software-requirements)
+See the [Chef Automate HA supported platforms](/automate/ha_platform_support/#software-requirements)
+documentation for a list of supported platforms for Chef Automate HA.
 
 ### Chef Backend
 

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -406,6 +406,13 @@ for platforms that use:
 - `useradd`
 - `curl` or `wget`
 
+### Chef Automate HA
+
+### Commercial Support
+
+Commercially supported platforms for Automate HA can be found at
+[Chef Automate HA supported platforms](/automate/ha_platform_support/#software-requirements)
+
 ### Chef Backend
 
 #### Commercial Support


### PR DESCRIPTION
Automate HA's first release supports many fewer platforms than standalone Automate.

Signed-off-by: Sean Horn <sean_horn@opscode.com>


## Description

Clarification of platform support for Automate HA's first release

## Definition of Done

Clarification is made

## Issues Resolved

The platfom section of our docs site didn't mention Automate HA alongside the other projects

## Related PRs

## Check List

- [X] Spell Check
- [X] Local build
- [X] Examine the local build
- [X] All tests pass
