### PR TITLE
Added New relic integration monitoring

### DIFF
--- a/layouts/shortcodes/handler_community_handlers.md
+++ b/layouts/shortcodes/handler_community_handlers.md
@@ -62,6 +62,10 @@ community:
 <td>A handler that reports the status of a Chef run to any API using net/HTTP.</td>
 </tr>
 <tr>
+<td><a href="https://newrelic.com/instant-observability/chef/ad40ccc2-f7ef-44bf-b961-07813088fce0">New Relic</a></td>
+<td>A handler that collects Chef Infra Client stats and sends them into a New Relic newsfeed.</td>
+</tr>
+<tr>
 <td><a href="https://rubygems.org/gems/chef-handler-mail">Simple Email</a></td>
 <td>A handler that collects exception and report handler data and then uses pony to send email reports that are based on `.erb` (Embedded Ruby ) templates.</td>
 </tr>


### PR DESCRIPTION
## Description
Hey, 
We have many users on our platform who are using [Chef] and would like to instrument it.  We’d love to provide a smooth experience for [Chef] users who need to use commercial monitoring solutions.  Please see our documentation here (https://newrelic.com/instant-observability/chef/ad40ccc2-f7ef-44bf-b961-07813088fce0).

Please consider adding a link for your direct users to provide an option for New Relic.  We propose the content submitted in this PR.
<img width="1014" alt="Screenshot 2022-08-05 at 2 12 48 PM" src="https://user-images.githubusercontent.com/110660709/183564199-fcac94c9-c838-434b-8b7c-8cf4d97798fe.png">

