### PR TITLE
fixing a tiny spelling error

### DIFF
--- a/layouts/shortcodes/cookbooks_summary.md
+++ b/layouts/shortcodes/cookbooks_summary.md
@@ -3,7 +3,7 @@ A cookbook is the fundamental unit of configuration and policy distribution in C
 A cookbook defines a scenario and contains everything that is required to support that scenario:
 
 - Recipes that specify which Chef Infra built-in resources to use, as well as the order in which they are to be applied
-- Attribute values, which allow environment-based configurations such as `dev` or `prodution`.
+- Attribute values, which allow environment-based configurations such as `dev` or `production`.
 - Custom Resources for extending Chef Infra beyond the built-in resources.
 - Files and Templates for distributing information to systems.
 - Custom Ohai Plugins for extending system configuration collection beyond the Ohai defaults.


### PR DESCRIPTION
## Description
A small spelling error is fixed.

"`prodution`" changed to "`production`"

## Definition of Done


## Issues Resolved

N/A

## Related PRs

N/A

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
