### PR TITLE
Remove actions from snap_package resource

### DIFF
--- a/data/infra/resources/snap_package.yaml
+++ b/data/infra/resources/snap_package.yaml
@@ -31,17 +31,11 @@ actions_list:
   :install:
     markdown: Default. Install a package. If a version is specified, install the specified
       version of the package.
-  :lock:
-    markdown: Locks the apt package to a specific version.
   :purge:
     markdown: Purge a package. This action typically removes the configuration files
       as well as the package.
-  :reconfig:
-    markdown: Reconfigure a package. This action requires a response file.
   :remove:
     markdown: Remove a package.
-  :unlock:
-    markdown: Unlocks the apt package so that it can be upgraded to a newer version.
   :upgrade:
     markdown: Install a package and/or ensure that a package is the latest version.
   :nothing:


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

Removes three actions from the snap_package docs page that the resource doesn't actually have.

## Definition of Done

## Issues Resolved

chef/chef#13123

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
