### PR TITLE
Revert AIX.7.3 - not yet released

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -60,7 +60,7 @@ The following table lists the commercially-supported platforms and versions for 
 <tr>
 <td>AIX</td>
 <td><code>powerpc</code></td>
-<td><code>7.1</code> (TL5 SP2 or higher, recommended), <code>7.2</code>,<code>7.3</code></td>
+<td><code>7.1</code> (TL5 SP2 or higher, recommended), <code>7.2</code></td>
 </tr>
 <tr>
 <td>AlmaLinux</td>


### PR DESCRIPTION
Signed-off-by: Poornima <poorndm@progress.com>
Remove  AIX 7.3, this is NOT actually supported yet. It will not be supported until such a time as the client team can cut a release and certify the build

## Description

[Please describe what this change achieves]

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x ] All tests pass
