### PR TITLE
Disaster Recovery Section in TOC

### DIFF
--- a/_vendor/github.com/chef/automate/components/docs-chef-io/content/automate/opensearch.md
+++ b/_vendor/github.com/chef/automate/components/docs-chef-io/content/automate/opensearch.md
@@ -27,6 +27,8 @@ These configuration directions are intended for the initial deployment of Chef A
 
 Add the following to your `config.toml` for HTTPS connection:
 
+{{< note >}} Special characters like **‘ ` " ' \ ; $** are not allowed in the password. {{< /note >}}
+
 ```toml
 [global.v1.external.opensearch]
   enable = true
@@ -54,6 +56,9 @@ Add the following to your `config.toml` for HTTPS connection:
 ```
 
 Add the following to your `config.toml` for HTTP connection:
+
+{{< note >}} Special characters like **‘ ` " ' \ ; $** are not allowed in the password. {{< /note >}}
+
 ```toml
 [global.v1.external.opensearch]
   enable = true

--- a/_vendor/github.com/chef/automate/components/docs-chef-io/content/automate/opensearch.md
+++ b/_vendor/github.com/chef/automate/components/docs-chef-io/content/automate/opensearch.md
@@ -27,8 +27,6 @@ These configuration directions are intended for the initial deployment of Chef A
 
 Add the following to your `config.toml` for HTTPS connection:
 
-{{< note >}} Special characters like **‘ ` " ' \ ; $** are not allowed in the password. {{< /note >}}
-
 ```toml
 [global.v1.external.opensearch]
   enable = true
@@ -56,9 +54,6 @@ Add the following to your `config.toml` for HTTPS connection:
 ```
 
 Add the following to your `config.toml` for HTTP connection:
-
-{{< note >}} Special characters like **‘ ` " ' \ ; $** are not allowed in the password. {{< /note >}}
-
 ```toml
 [global.v1.external.opensearch]
   enable = true

--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -124,6 +124,12 @@ identifier = "automate"
     weight = 40
 
     [[automate]]
+    title = "Disaster Recovery"
+    identifier = "automate/deploy_high_availability/disaster_recovery"
+    parent = "automate/deploy_high_availability"
+    weight = 50
+
+    [[automate]]
     title = "Backup and Restore"
     identifier = "automate/deploy_high_availability/backup_and_restore"
     parent = "automate/deploy_high_availability"


### PR DESCRIPTION
Signed-off-by: Dishank Tiwari <dtiwari@progress.com>


## Description

A new section has been added to the HA section named Disaster Recovery.

## Related PRs

Reference PR: https://github.com/chef/automate/pull/7425

## Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
