### PR TITLE
Remove nav section from Desktop

### DIFF
--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -276,12 +276,6 @@ identifier = "desktop"
   parent = "desktop"
   weight = 30
 
-  [[desktop]]
-  title = "Configure"
-  identifier = "desktop/configure"
-  parent = "desktop"
-  weight = 40
-
  [[desktop]]
   title = "Zero Touch Deployment"
   identifier = "desktop/zero_touch"


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description
There aren't any pages that use this section of the desktop nav.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
