### PR TITLE
Fix release notes order

### DIFF
--- a/themes/docs-new/layouts/_default/release_notes.html
+++ b/themes/docs-new/layouts/_default/release_notes.html
@@ -28,21 +28,28 @@
           {{/* We have a current version of Infra Client that they want release notes for on the Client release notes page. */}}
           {{/* This allows us to add current release version numbers of Client to the list of version numbers */}}
           {{/* that we want to include in the Client release notes. */}}
-          {{- $current_versions := slice -}}
           {{- if eq $product "chef" -}}
-            {{- $current_versions = $.Site.Data.releases.chef.current -}}
+            {{- $current_versions := $.Site.Data.releases.chef.current -}}
+            {{- $versions = append $current_versions $versions -}}
           {{- end -}}
-          {{- $versions := append $versions $current_versions -}}
 
           {{- $versionsCorrectOrder := slice -}}
 
           {{- if eq $product "automate" -}}
             {{- $len := len $versions -}}
             {{- range seq $len -}}
-                {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) -}}
+              {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) -}}
             {{- end -}}
-          {{- else -}}
-            {{- $versionsCorrectOrder = sort $versions "value" "desc" -}}
+          {{- else if ne $product "chef" -}}
+            {{ $len := len $versions }}
+            {{- range seq $len -}}
+              {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) }}
+            {{ end }}
+          {{ else }}
+            {{ $len := len $versions }}
+            {{- range seq $len -}}
+              {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) }}
+            {{ end }}
           {{- end -}}
 
 

--- a/themes/docs-new/layouts/partials/release_notes_toc.html
+++ b/themes/docs-new/layouts/partials/release_notes_toc.html
@@ -28,18 +28,27 @@
         {{/* that we want to include in the Client release notes. */}}
         {{- $current_versions := slice -}}
         {{- if eq $product "chef" -}}
-          {{- $current_versions = $.Site.Data.releases.chef.current -}}
+          {{- $current_versions := $.Site.Data.releases.chef.current -}}
+          {{- $versions = append $current_versions $versions -}}
         {{- end -}}
-        {{- $versions := append $versions $current_versions -}}
 
         {{- $versionsCorrectOrder := slice -}}
+
         {{- if eq $product "automate" -}}
           {{- $len := len $versions -}}
           {{- range seq $len -}}
-            {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) }}
+            {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) -}}
           {{- end -}}
+        {{- else if ne $product "chef" -}}
+          {{ $len := len $versions }}
+          {{- range seq $len -}}
+            {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) }}
+          {{ end }}
         {{ else }}
-          {{- $versionsCorrectOrder = sort $versions "value" "desc" -}}
+          {{ $len := len $versions }}
+          {{- range seq $len -}}
+            {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) }}
+          {{ end }}
         {{- end -}}
 
         {{ $lastDate := ""}}


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

This is a bit of a temp fix, but at least it will get the release notes back in the correct order.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
