### PR TITLE
Update style guide

### DIFF
--- a/content/style_guide/reuse.md
+++ b/content/style_guide/reuse.md
@@ -14,6 +14,15 @@ product = []
 +++
 <!-- markdownlint-disable-file MD013 MD031 -->
 
+## Reusable Text Files
+
+Store reusable text files in the `content/PRODUCT/reusable` directory within a project. The `reusable` subdirectory must be a [headless bundle](https://gohugo.io/content-management/page-bundles/#headless-bundle) so its contents are not published except when added using the [readfile shortcode](#readfile-shortcode).
+
+All content should be organized by file type. For example:
+
+- `content/server/reusable/md/FILENAME.md`
+- `content/server/reusable/rb/RUBY_EXAMPLE.rb`
+
 ## readfile Shortcode
 
 The readfile shortcode adds text from a file to a page. You can add a Markdown file, HTML file, or code file by specifying the path to the file from the project root directory.
@@ -21,26 +30,28 @@ The readfile shortcode adds text from a file to a page. You can add a Markdown f
 By default it accepts a Markdown file, for example:
 
 ```markdown
-{{</* readfile file="layouts/shortcodes/example.md" */>}}
+{{</* readfile file="content/workstation/reusable/md/example.md" */>}}
 ```
 
 You can also add an HTML file:
 
 ```markdown
-{{</* readfile file="layouts/shortcodes/example.html" html="true" */>}}
+{{</* readfile file="content/workstation/reusable/html/example.html" html="true" */>}}
 ```
 
 And you can pass in a sample code file:
 
 ```markdown
-{{</* readfile file="path/to/file/example.rb" highlight="ruby" */>}}
+{{</* readfile file="content/workstation/reusable/rb/example.rb" highlight="ruby" */>}}
 ```
 
 or:
 
 ```markdown
-{{</* readfile file="path/to/data/file.json" highlight="json" */>}}
+{{</* readfile file="content/workstation/reusable/json/example.json" highlight="json" */>}}
 ```
+
+See the [full list of highlighting languages and aliases](https://gohugo.io/content-management/syntax-highlighting/#list-of-chroma-highlighting-languages) that Hugo accepts.
 
 ## Notes, Warnings, and Admonitions
 
@@ -52,7 +63,7 @@ If you must use notes and warnings, bracket the text of the note or warning in *
 
 ### Notes
 
-```go
+```md
 {{</* note */>}}
 
 This is a note.
@@ -72,7 +83,7 @@ This is a note.
 
 Use sparingly so that when the user sees a warning it registers appropriately:
 
-```go
+```md
 {{</* warning */>}}
 
 This is a warning.
@@ -92,7 +103,7 @@ This is a warning.
 
 Danger should be used when there are serious consequences for the user:
 
-```go
+```md
 {{</* danger */>}}
 
 This is a danger block.
@@ -138,7 +149,7 @@ All `foundation_tab` shortcodes must be contained within opening and closing `fo
 
 For example:
 
-```go
+```md
 {{</* foundation_tabs tabs-id="ruby-python-panel" */>}}
   {{</* foundation_tab active="true" panel-link="ruby-panel" tab-text="Ruby" */>}}
   {{</* foundation_tab panel-link="python-panel" tab-text="Python" */>}}

--- a/content/style_guide/reuse.md
+++ b/content/style_guide/reuse.md
@@ -326,7 +326,7 @@ The following shortcode examples will display these icons: {{< fontawesome class
 
 ## Shortcodes
 
-[Shortcodes](https://gohugo.io/content-management/shortcodes/) add short snippets of code or HTML to a page. For example, the readfile shortcode can add a text file to a page or the notes shortcode can add HTML to a page that places text in an HTML div.
+[Shortcodes](https://gohugo.io/content-management/shortcodes/) add short snippets of Hugo code, Markdown, or HTML to a page. For example, the readfile shortcode can add a text file to a page, the note shortcode puts text inside an HTML div, and the [automate_cli_commands shortcode](https://github.com/chef/automate/blob/main/components/docs-chef-io/layouts/shortcodes/automate/automate_cli_commands.html) reads through YAML files and outputs formatted text from those files.
 
 ### Writing a Shortcode
 

--- a/content/style_guide/reuse.md
+++ b/content/style_guide/reuse.md
@@ -14,71 +14,33 @@ product = []
 +++
 <!-- markdownlint-disable-file MD013 MD031 -->
 
-Chef docs uses [shortcodes](https://gohugo.io/content-management/shortcodes/) to maintain text that appears in more than one location and must be consistent in every location.
+## readfile Shortcode
 
-## Writing a Shortcode
+The readfile shortcode adds text from a file to a page. You can add a Markdown file, HTML file, or code file by specifying the path to the file from the project root directory.
 
-Shortcode files are written in **Markdown** or **HTML** and are stored in [`layouts/shortcodes`](https://github.com/chef/chef-web-docs/tree/main/layouts/shortcodes) or [`themes/docs-new/layouts/shortcodes`](https://github.com/chef/chef-web-docs/tree/main/themes/docs-new/layouts/shortcodes) in the `chef/chef-web-docs` repository.
-
-In repositories other than chef-web-docs, store shortcodes in `layouts/shortcodes/REPOSITORY_NAME/`.
-
-## Adding a Shortcode to a Page
-
-There are two types of shortcodes, **Markdown** and **HTML**. The type of shortcode determines how it is added to a page and how Hugo processes the text when it renders the page into HTML.
-
-{{< note >}}
-If you add a **Markdown** shortcode to a page using **HTML** shortcode delimiters, Hugo will assume that the text is already formatted in HTML and will not run the shortcode file through its Markdown processor, leaving the bare Markdown in the HTML page output.
-{{< /note >}}
-
-### Markdown Shortcodes
-
-To include a Markdown shortcode in a page, wrap the name of the shortcode file, without the file type suffix, in between double curly braces and percent characters, `{{%/* SHORTCODE */%}}`. For example, if you wanted to add the [`chef.md`](https://github.com/chef/chef-web-docs/blob/main/layouts/shortcodes/chef.md) shortcode to a page, add the following text to the Markdown page:
+By default it accepts a Markdown file, for example:
 
 ```markdown
-{{%/* chef */%}}
+{{</* readfile file="layouts/shortcodes/example.md" */>}}
 ```
 
-For shortcodes located in a repository other than chef-web-docs, use `{{%/* REPO_NAME/SHORTCODE */%}}`. For example:
+You can also add an HTML file:
 
 ```markdown
-{{%/* chef-workstation/bento */%}}
+{{</* readfile file="layouts/shortcodes/example.html" html="true" */>}}
 ```
 
-### HTML Shortcodes
-
-To include an HTML shortcode in a page, wrap the name of the shortcode file, without the file type suffix, in between double curly braces and angle brackets, `{{</* SHORTCODE */>}}`. For example, add the following text to a page if you wanted to add the [`chef_automate_mark.html`](https://github.com/chef/chef-web-docs/blob/main/themes/docs-new/layouts/shortcodes/chef_automate_mark.html) shortcode:
-
-```go
-{{</* chef_automate_mark */>}}
-```
-
-For shortcodes located in a repository other than chef-web-docs, use `{{</* REPO_NAME/SHORTCODE */>}}`. For example:
+And you can pass in a sample code file:
 
 ```markdown
-{{</* automate/automate_cli_commands */>}}
+{{</* readfile file="path/to/file/example.rb" highlight="ruby" */>}}
 ```
 
-### Parameters
+or:
 
-Some shortcodes accept positioned or named parameters. For example, the `example_fqdn` shortcode requires a hostname, which is added like this: `{{</* example_fqdn "HOSTNAME" */>}}`, and produces the following output: `{{< example_fqdn "HOSTNAME" >}}`.
-
-The [Fontawesome Shortcode](#fontawesome-shortcode) accepts named parameters. For example, it accepts a class value which is added like this: `{{</* fontawesome class="fas fa-ellipsis-h" */>}}`
-
-See the [Fontawesome Shortcode](#fontawesome-shortcode) section for more examples.
-
-### Nested Content
-
-We have some shortcodes that nest around Markdown content that is included in the text of a page. Those shortcodes are all written in HTML. Note the slash `/` before the name of the closing shortcode.
-
-```md
-{{</* shortcode_name */>}}
-
-Some Markdown text.
-
-{{</* /shortcode_name */>}}
+```markdown
+{{</* readfile file="path/to/data/file.json" highlight="json" */>}}
 ```
-
-See the [Notes and Warnings](#notes-warnings-and-admonitions) and the [Foundation Tabs](#foundation-tabs-container) for examples of nested shortcodes.
 
 ## Notes, Warnings, and Admonitions
 
@@ -351,30 +313,72 @@ The following shortcode examples will display these icons: {{< fontawesome class
 {{</* fontawesome class="far fa-address-book" background-color="DarkBlue" color="rgb(168, 218, 220)" */>}}
 ```
 
-## readfile Shortcode
+## Shortcodes
 
-The readfile shortcode adds text from a file to a page. You can add a Markdown file, HTML file, or code file by specifying the path to the file from the project root directory.
+[Shortcodes](https://gohugo.io/content-management/shortcodes/) add short snippets of code or HTML to a page. For example, the readfile shortcode can add a text file to a page or the notes shortcode can add HTML to a page that places text in an HTML div.
 
-By default it accepts a Markdown file, for example:
+### Writing a Shortcode
+
+Shortcode files are written in **Markdown** or **HTML** and are stored in [`layouts/shortcodes`](https://github.com/chef/chef-web-docs/tree/main/layouts/shortcodes) or [`themes/docs-new/layouts/shortcodes`](https://github.com/chef/chef-web-docs/tree/main/themes/docs-new/layouts/shortcodes) in the `chef/chef-web-docs` repository.
+
+In repositories other than chef-web-docs, store shortcodes in `layouts/shortcodes/REPOSITORY_NAME/`.
+
+### Adding a Shortcode to a Page
+
+There are two types of shortcodes, **Markdown** and **HTML**. The type of shortcode determines how it is added to a page and how Hugo processes the text when it renders the page into HTML.
+
+{{< note >}}
+If you add a **Markdown** shortcode to a page using **HTML** shortcode delimiters, Hugo will assume that the text is already formatted in HTML and will not run the shortcode file through its Markdown processor, leaving the bare Markdown in the HTML page output.
+{{< /note >}}
+
+#### Markdown Shortcodes
+
+A Markdown shortcode must be processed into HTML by Hugo when the site is built.
+
+To include a Markdown shortcode in a page, wrap the name of the shortcode file, without the file type suffix, in between double curly braces and percent characters, `{{%/* SHORTCODE */%}}`. For example, if you wanted to add the [`chef.md`](https://github.com/chef/chef-web-docs/blob/main/layouts/shortcodes/chef.md) shortcode to a page, add the following text to the Markdown page:
 
 ```markdown
-{{</* readfile file="layouts/shortcodes/example.md" */>}}
+{{%/* chef */%}}
 ```
 
-You can also add an HTML file:
+For shortcodes located in a repository other than chef-web-docs, use `{{%/* REPO_NAME/SHORTCODE */%}}`. For example:
 
 ```markdown
-{{</* readfile file="layouts/shortcodes/example.html" html="true" */>}}
+{{%/* chef-workstation/bento */%}}
 ```
 
-And you can pass in a sample code file:
+#### HTML Shortcodes
+
+To include an HTML shortcode in a page, wrap the name of the shortcode file, without the file type suffix, in between double curly braces and angle brackets, `{{</* SHORTCODE */>}}`. For example, add the following text to a page if you wanted to add the [`chef_automate_mark.html`](https://github.com/chef/chef-web-docs/blob/main/themes/docs-new/layouts/shortcodes/chef_automate_mark.html) shortcode:
 
 ```markdown
-{{</* readfile file="path/to/file/example.rb" highlight="ruby" */>}}
+{{</* chef_automate_mark */>}}
 ```
 
-or:
+For shortcodes located in a repository other than chef-web-docs, use `{{</* REPO_NAME/SHORTCODE */>}}`. For example:
 
 ```markdown
-{{</* readfile file="path/to/data/file.json" highlight="json" */>}}
+{{</* automate/automate_cli_commands */>}}
 ```
+
+### Parameters
+
+Some shortcodes accept positioned or named parameters. For example, the `example_fqdn` shortcode requires a hostname, which is added like this: `{{</* example_fqdn "HOSTNAME" */>}}`, and produces the following output: `{{< example_fqdn "HOSTNAME" >}}`.
+
+The [Fontawesome Shortcode](#fontawesome-shortcode) accepts named parameters. For example, it accepts a class value which is added like this: `{{</* fontawesome class="fas fa-ellipsis-h" */>}}`
+
+See the [Fontawesome Shortcode](#fontawesome-shortcode) section for more examples.
+
+### Nested Content
+
+We have some shortcodes that nest around Markdown content that is included in the text of a page. Those shortcodes are all written in HTML. Note the slash `/` before the name of the closing shortcode.
+
+```md
+{{</* shortcode_name */>}}
+
+Some Markdown text.
+
+{{</* /shortcode_name */>}}
+```
+
+See the [Notes and Warnings](#notes-warnings-and-admonitions) and the [Foundation Tabs](#foundation-tabs-container) for examples of nested shortcodes.

--- a/content/style_guide/reuse.md
+++ b/content/style_guide/reuse.md
@@ -16,12 +16,18 @@ product = []
 
 ## Reusable Text Files
 
-Store reusable text files in the `content/PRODUCT/reusable` directory within a project. The `reusable` subdirectory must be a [headless bundle](https://gohugo.io/content-management/page-bundles/#headless-bundle) so its contents are not published except when added using the [readfile shortcode](#readfile-shortcode).
+If there are sections of text or code samples that appear in more than one location in our documentation, create a file with the relevant text and place it in the `content/PRODUCT/reusable/FILE_TYPE/` directory within a project, then use the [readfile shortcode](#readfile-shortcode) to add the text from that file in every location that you want it in the Chef documentation.
 
 All content should be organized by file type. For example:
 
 - `content/server/reusable/md/FILENAME.md`
 - `content/server/reusable/rb/RUBY_EXAMPLE.rb`
+
+{{< note >}}
+
+The `reusable` subdirectory must be a [headless bundle](https://gohugo.io/content-management/page-bundles/#headless-bundle) so its contents are not published unless they're added to a page using the [readfile shortcode](#readfile-shortcode).
+
+{{< /note >}}
 
 ## readfile Shortcode
 
@@ -39,7 +45,7 @@ You can also add an HTML file:
 {{</* readfile file="content/workstation/reusable/html/example.html" html="true" */>}}
 ```
 
-And you can pass in a sample code file:
+You can pass in a sample code file:
 
 ```markdown
 {{</* readfile file="content/workstation/reusable/rb/example.rb" highlight="ruby" */>}}

--- a/content/style_guide/tools.md
+++ b/content/style_guide/tools.md
@@ -104,36 +104,35 @@ Install the extensions:
 
 ### Code Spell Checker
 
-Clone the [Chef Dictionary](https://github.com/chef/chef_dictionary) into your repository directory
-
-```bash
-gh repo clone chef/chef_dictionary
-```
-
-Navigate to your VSCode settings by selecting the gear icon at the bottom left side of the VSCode screen and find the Code Spell settings. Open the setting for "C Spell Dictionaries" and add the following content, adjusting the path for your local workstation
+Navigate to your VSCode settings by selecting the gear icon at the bottom left side of the VSCode screen and find the Code Spell settings. In the left menu nav, select **Language and Dictionaries**, scroll down to **C Spell: Dictionary Definitions**, select **Edit in settings.json**, and add the following content in settings.json file:
 
 ```json
-  "cSpell.dictionaryDefinitions": [
-  { "name": "chef_dictionary",
-    "path": "/Users/<username>/<repodir>/chef_dictionary/chef_dictionary/chef.txt"}
-  ],
-  "cSpell.dictionaries": [
-    "chef_dictionary"
-  ],
+"cSpell.dictionaryDefinitions": [
+    {
+      "name": "chef",
+      "path": "https://raw.githubusercontent.com/chef/chef_dictionary/main/chef.txt",
+      "description": "Custom Chef Dictionary"
+    },
+    {
+      "name": "docs",
+      "path": "https://raw.githubusercontent.com/chef/chef_dictionary/main/docs.txt",
+      "description": "Custom Docs Dictionary"
+    }
+],
 ```
 
 Add this configuration to exclude code blocks from spellcheck:
 
 ```json
-  "cSpell.languageSettings": [
-    {  // use with Markdown files
-      "languageId": "markdown",
-      // Exclude code blocks from spellcheck.
-      "ignoreRegExpList": [
-          "/^\\s*```[\\s\\S]*?^\\s*```/gm"
-      ]
-    }
-  ]
+"cSpell.languageSettings": [
+  {  // use with Markdown files
+    "languageId": "markdown",
+    // Exclude code blocks from spellcheck.
+    "ignoreRegExpList": [
+        "/^\\s*```[\\s\\S]*?^\\s*```/gm"
+    ]
+  }
+],
 ```
 
 ### Markdownlint

--- a/content/style_guide/tools.md
+++ b/content/style_guide/tools.md
@@ -104,35 +104,35 @@ Install the extensions:
 
 ### Code Spell Checker
 
-Navigate to your VSCode settings by selecting the gear icon at the bottom left side of the VSCode screen and find the Code Spell settings. In the left menu nav, select **Language and Dictionaries**, scroll down to **C Spell: Dictionary Definitions**, select **Edit in settings.json**, and add the following content in settings.json file:
+Navigate to your VSCode settings by selecting the gear icon at the bottom left side of the VSCode screen and find the Code Spell settings. In the left menu nav, select **Language and Dictionaries**, scroll down to **C Spell: Dictionary Definitions**, select **Edit in settings.json**, and add the following content in `settings.json` file:
 
 ```json
-"cSpell.dictionaryDefinitions": [
-    {
-      "name": "chef",
-      "path": "https://raw.githubusercontent.com/chef/chef_dictionary/main/chef.txt",
-      "description": "Custom Chef Dictionary"
-    },
-    {
-      "name": "docs",
-      "path": "https://raw.githubusercontent.com/chef/chef_dictionary/main/docs.txt",
-      "description": "Custom Docs Dictionary"
-    }
-],
+  "cSpell.dictionaryDefinitions": [
+      {
+        "name": "chef",
+        "path": "https://raw.githubusercontent.com/chef/chef_dictionary/main/chef.txt",
+        "description": "Custom Chef Dictionary"
+      },
+      {
+        "name": "docs",
+        "path": "https://raw.githubusercontent.com/chef/chef_dictionary/main/docs.txt",
+        "description": "Custom Docs Dictionary"
+      }
+  ]
 ```
 
-Add this configuration to exclude code blocks from spellcheck:
+Add this configuration to the `settings.json` file to exclude code blocks from spellcheck:
 
 ```json
-"cSpell.languageSettings": [
-  {  // use with Markdown files
-    "languageId": "markdown",
-    // Exclude code blocks from spellcheck.
-    "ignoreRegExpList": [
-        "/^\\s*```[\\s\\S]*?^\\s*```/gm"
-    ]
-  }
-],
+  "cSpell.languageSettings": [
+    {  // use with Markdown files
+      "languageId": "markdown",
+      // Exclude code blocks from spellcheck.
+      "ignoreRegExpList": [
+          "/^\\s*```[\\s\\S]*?^\\s*```/gm"
+      ]
+    }
+  ]
 ```
 
 ### Markdownlint


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

Update the C Spell config in the C Spell tool section of the style guide to use a URL to the Chef dictionary.
Update the style guide to emphasize using reusable text files over shortcodes. 

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
