### PR TITLE
Add svg shortcode

### DIFF
--- a/content/reusable/README.md
+++ b/content/reusable/README.md
@@ -1,0 +1,9 @@
+<!-- markdownlint-disable MD002 -->
+# Directory for Reusable Content
+<!-- markdownlint-enable MD002 -->
+
+Files in this directory are used in *more than one place* within the Chef docs.
+
+Store all files in subdirectories organized by file type. For example, all Markdown files should be in `content/reusable/md/` and all Ruby files are stored in `content/reusable/rb/`.
+
+Call these files using the [`readfile` shortcode](https://docs.chef.io/style_guide/reuse/#readfile-shortcode).

--- a/content/reusable/index.md
+++ b/content/reusable/index.md
@@ -1,0 +1,5 @@
++++
+headless = true
+## headless = true makes this a headless bundle.
+## See https://gohugo.io/content-management/page-bundles/#headless-bundle
++++

--- a/content/reusable/md/fontawesome_shortcode.md
+++ b/content/reusable/md/fontawesome_shortcode.md
@@ -1,0 +1,23 @@
+The Fontawesome shortcode will display any free [Font Awesome icon](https://fontawesome.com/icons) in a page.
+
+It accepts the following parameters:
+
+- `background-color`
+- `border`
+- `border-radius`
+- `class`
+- `color`
+- `font-size`
+- `margin`
+- `padding`
+
+The only required parameter is `class`, which is the same as the class name of the icon.
+
+The following shortcode examples will display these icons: {{< fontawesome class="fas fa-ellipsis-h">}} {{< fontawesome class="fas fa-anchor" font-size="3rem" border="2px dashed" padding="1px" border-radius="5px">}} {{< fontawesome class="fas fa-archive" color="#cc814b" margin="0 0 0 12px">}} {{< fontawesome class="far fa-address-book" background-color="DarkBlue" color="rgb(168, 218, 220)">}}
+
+```markdown
+{{</* fontawesome class="fas fa-ellipsis-h" */>}}
+{{</* fontawesome class="fas fa-anchor" font-size="3rem" border="2px dashed" padding="1px" border-radius="5px" */>}}
+{{</* fontawesome class="fas fa-archive" color="#cc814b" margin="0 0 0 12px"*/>}}
+{{</* fontawesome class="far fa-address-book" background-color="DarkBlue" color="rgb(168, 218, 220)" */>}}
+```

--- a/content/style_guide/markdown.md
+++ b/content/style_guide/markdown.md
@@ -304,6 +304,24 @@ Which looks like this:
 
 Raster images should be 96 dpi and no larger than 600 pixels wide. This helps ensure that the image can be printed and/or built into other output formats; in some cases, separate 300 dpi files should be maintained for images that require inclusion in formats designed for printing and/or presentations.
 
+### Fontawesome Shortcode
+
+{{< readfile file="content/reusable/md/fontawesome_shortcode.md" >}}
+
+### SVG Shortcode
+
+You can also add an inline SVG image into a line of text using the svg shortcode. Use this for adding SVG icons that Fontawesome doesn't include in their free tier.
+
+For example, this will add an SVG icon to a string of text:
+
+```md
+Click on the web asset icon ({{</* svg src="themes/docs-new/static/images/web-asset.svg" */>}}).
+```
+
+which produces this output:
+
+Click on the web asset icon ({{< svg file="themes/docs-new/static/images/web-asset.svg" >}}).
+
 ## Markdownlint
 
 We use [Markdownlint](https://github.com/DavidAnson/markdownlint) in a [GitHub action](https://github.com/DavidAnson/markdownlint-cli2-action) to lint the

--- a/content/style_guide/reuse.md
+++ b/content/style_guide/reuse.md
@@ -27,6 +27,8 @@ All content should be organized by file type. For example:
 
 The `reusable` subdirectory must be a [headless bundle](https://gohugo.io/content-management/page-bundles/#headless-bundle) so its contents are not published unless they're added to a page using the [readfile shortcode](#readfile-shortcode).
 
+See the [`content/reusable/index.md` file](https://github.com/chef/chef-web-docs/blob/main/content/reusable/index.md) to see how a headless bundle is created.
+
 {{< /note >}}
 
 ## readfile Shortcode
@@ -306,29 +308,7 @@ and `panel-id`/`panel-link` values must be unique HTML IDs on the page.
 
 ## Fontawesome Shortcode
 
-The Fontawesome shortcode will display any free [Font Awesome icon](https://fontawesome.com/icons) in a page.
-
-It accepts the following parameters:
-
-- `background-color`
-- `border`
-- `border-radius`
-- `class`
-- `color`
-- `font-size`
-- `margin`
-- `padding`
-
-The only required parameter is `class`, which is the same as the class name of the icon.
-
-The following shortcode examples will display these icons: {{< fontawesome class="fas fa-ellipsis-h">}} {{< fontawesome class="fas fa-anchor" font-size="3rem" border="2px dashed" padding="1px" border-radius="5px">}} {{< fontawesome class="fas fa-archive" color="#cc814b" margin="0 0 0 12px">}} {{< fontawesome class="far fa-address-book" background-color="DarkBlue" color="rgb(168, 218, 220)">}}
-
-```markdown
-{{</* fontawesome class="fas fa-ellipsis-h" */>}}
-{{</* fontawesome class="fas fa-anchor" font-size="3rem" border="2px dashed" padding="1px" border-radius="5px" */>}}
-{{</* fontawesome class="fas fa-archive" color="#cc814b" margin="0 0 0 12px"*/>}}
-{{</* fontawesome class="far fa-address-book" background-color="DarkBlue" color="rgb(168, 218, 220)" */>}}
-```
+{{< readfile file="content/reusable/md/fontawesome_shortcode.md" >}}
 
 ## Shortcodes
 

--- a/content/test.md
+++ b/content/test.md
@@ -348,3 +348,9 @@ Warnings point out something that could cause harm if ignored.
 {{< danger >}}
 The reader should proceed with caution.
 {{< /danger >}}
+
+## SVG Shortcode
+
+The SVG shortcode will add an inline SVG icon to a string of text:
+
+Click on the web asset icon ({{< svg file="themes/docs-new/static/images/web-asset.svg" >}}).

--- a/themes/docs-new/layouts/shortcodes/svg.html
+++ b/themes/docs-new/layouts/shortcodes/svg.html
@@ -1,0 +1,1 @@
+{{ readFile (.Get "file") | safeHTML }}

--- a/themes/docs-new/static/images/web-asset.svg
+++ b/themes/docs-new/static/images/web-asset.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" fit="" height="1.75em" viewBox="0 0 24 24" style="top: .35em; position: relative; " preserveAspectRatio="xMidYMid meet" focusable="false">
+  <g>
+    <!-- https://material.io/icons/#web_asset -->
+    <path d="M19 4H5c-1.11 0-2 .9-2 2v12c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.89-2-2-2zm0 14H5V8h14v10z"></path>
+  </g>
+</svg>


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

This adds an SVG shortcode which allows us to add inline SVG files to text. Useful if there are SVG icons in the web UI of certain products we release and those icons aren't in the free tier of Fontawesome.

Also this does a minor reorganization of our style guide 

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
