### PR TITLE
Add sorting for semver version numbers in RN

### DIFF
--- a/themes/docs-new/layouts/_default/release_notes.html
+++ b/themes/docs-new/layouts/_default/release_notes.html
@@ -31,6 +31,9 @@
           {{- if eq $product "chef" -}}
             {{- $current_versions := $.Site.Data.releases.chef.current -}}
             {{- $versions = append $current_versions $versions -}}
+            {{- $paddedVersions := apply $versions "partial" "zero_prefix_pad" "." }}
+            {{- $sortedVersions := (sort $paddedVersions "value" "desc") }}
+            {{- $versions = apply $sortedVersions "partial" "zero_prefix_trim" "." }}
           {{- end -}}
 
           {{- $versionsCorrectOrder := slice -}}
@@ -40,11 +43,8 @@
             {{- range seq $len -}}
               {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) -}}
             {{- end -}}
-          {{- else if ne $product "chef" -}}
-            {{ $len := len $versions }}
-            {{- range seq $len -}}
-              {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) }}
-            {{ end }}
+          {{- else if eq $product "chef" -}}
+            {{- $versionsCorrectOrder = $versions -}}
           {{ else }}
             {{ $len := len $versions }}
             {{- range seq $len -}}

--- a/themes/docs-new/layouts/partials/release_notes_toc.html
+++ b/themes/docs-new/layouts/partials/release_notes_toc.html
@@ -30,6 +30,9 @@
         {{- if eq $product "chef" -}}
           {{- $current_versions := $.Site.Data.releases.chef.current -}}
           {{- $versions = append $current_versions $versions -}}
+          {{- $paddedVersions := apply $versions "partial" "zero_prefix_pad" "." }}
+          {{- $sortedVersions := (sort $paddedVersions "value" "desc") }}
+          {{- $versions = apply $sortedVersions "partial" "zero_prefix_trim" "." }}
         {{- end -}}
 
         {{- $versionsCorrectOrder := slice -}}
@@ -39,11 +42,8 @@
           {{- range seq $len -}}
             {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) -}}
           {{- end -}}
-        {{- else if ne $product "chef" -}}
-          {{ $len := len $versions }}
-          {{- range seq $len -}}
-            {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) }}
-          {{ end }}
+        {{- else if eq $product "chef" -}}
+            {{- $versionsCorrectOrder = $versions -}}
         {{ else }}
           {{ $len := len $versions }}
           {{- range seq $len -}}

--- a/themes/docs-new/layouts/partials/zero_prefix_pad.html
+++ b/themes/docs-new/layouts/partials/zero_prefix_pad.html
@@ -1,0 +1,6 @@
+{{/* useful for sorting semver version numbers in order. */}}
+{{/* See also the release_notes page layout, release_notes_toc partial, and zero_prefix_trim partial */}}
+{{- $padSize := 6 }}
+{{- $paddedString := replaceRE "(\\d+)" (print (strings.Repeat (sub $padSize 1) "0") "$1") . }}
+{{- $trimmedString := replaceRE (print "0+(\\d{" $padSize "})") "$1" $paddedString }}
+{{- return $trimmedString }}

--- a/themes/docs-new/layouts/partials/zero_prefix_trim.html
+++ b/themes/docs-new/layouts/partials/zero_prefix_trim.html
@@ -1,0 +1,3 @@
+{{/* useful for sorting semver version numbers in order. */}}
+{{/* See also the release_notes page layout, release_notes_toc partial, and zero_prefix_pad partial */}}
+{{- return replaceRE "0+(\\d+)" "$1" . }}


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

This will properly sort SemVer version numbers in order. We need this because I had to manually add an RC version number for Client and initially this just placed that new version number as the newest number in a list, but at some point we're going to have more numbers on omnitruck and the numbers will be out of order. This will sort numbers correctly regardless of the place that they're added. 

See my other previous hacky attempts at this: #3982, #3968, #3967


## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
