### PR TITLE
Bump EOL and deprecated versions of Client -- Do Not Merge Until Nov 30

### DIFF
--- a/content/versions.md
+++ b/content/versions.md
@@ -98,7 +98,7 @@ newer versions or products.
 | Product           | Version | Lifecycle Status | EOL Date          |
 |-------------------|---------|------------------|-------------------|
 | Chef Backend      | 2.x     | Deprecated       | TBD               |
-| Chef Infra Client | 17.x    | Deprecated       | April 30, 2024    |
+| Chef Infra Client | 17.x    | Deprecated       | TBD               |
 | Chef Manage       | 2.5.x+  | Deprecated       | TBD               |
 
 ## End of Life (EOL) Products

--- a/content/versions.md
+++ b/content/versions.md
@@ -98,7 +98,7 @@ newer versions or products.
 | Product           | Version | Lifecycle Status | EOL Date          |
 |-------------------|---------|------------------|-------------------|
 | Chef Backend      | 2.x     | Deprecated       | TBD               |
-| Chef Infra Client | 16.x    | Deprecated       | November 30, 2022 |
+| Chef Infra Client | 17.x    | Deprecated       | April 30, 2024    |
 | Chef Manage       | 2.5.x+  | Deprecated       | TBD               |
 
 ## End of Life (EOL) Products
@@ -107,7 +107,7 @@ newer versions or products.
 |--------------------------|---------------------|------------------|-------------------|
 | Analytics                | All                 | EOL              | December 31, 2018 |
 | Chef Automate            | 1.x                 | EOL              | December 31, 2019 |
-| Chef Infra Client        | 15 and under        | EOL              | April 30, 2021    |
+| Chef Infra Client        | 16 and under        | EOL              | November 30, 2022 |
 | Chef Compliance Server   | All                 | EOL              | December 31, 2018 |
 | ChefDK                   | ALL                 | EOL              | December 31, 2020 |
 | Chef Infra Server        | 13.x                | EOL              | June 30, 2021     |


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

Client 17 becomes deprecated, EOL date for 17 is TBD. Client 16 becomes EOL.

**DO NOT MERGE UNTIL Nov 30.**

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
