### PR TITLE
correct most likely fetcher used with specified reporter

### DIFF
--- a/content/chef_compliance_phase.md
+++ b/content/chef_compliance_phase.md
@@ -225,7 +225,7 @@ The following examples:
   'supermarket': 'hardening/ssh-hardening'
   }
   # Fetch additional profiles
-  default['audit']['fetcher'] = 'chef-automate'
+  default['audit']['fetcher'] = 'chef-server'
   # Set reporter
   default['audit']['reporter'] = 'chef-server-automate'
   ```


### PR DESCRIPTION
so, if a customer is using the reporter 'chef-server-automate' then the info is flowing to automate via chef infra server.

with this the most likely route for getting profiles will be from the automate via the chef-server so the correct fetcher is 'chef-server'

Signed-off-by: James McCormick <James.McCormick>


## Description

correct most likely fetcher used with specified reporter

## Definition of Done

## Issues Resolved

correct most likely fetcher used with specified reporter

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass


Signed-off-by: James McCormick <James.McCormick@progress.com>