### PR TITLE
No Auto-upgrade Chef Server and Manage

### DIFF
--- a/content/packages.md
+++ b/content/packages.md
@@ -116,7 +116,7 @@ To set up a Yum package repository for Enterprise Linux platforms:
     name=chef-<CHANNEL>
     baseurl=https://packages.chef.io/repos/yum/<CHANNEL>/el/<VERSION>/\$basearch/
     gpgcheck=1
-    # No auto-upgrade, as there are manual steps needed for Chef Server upgrades
+    # No auto-upgrade, as there are manual steps needed for Chef Infra Server upgrades
     enabled=0
     EOL
     ```

--- a/content/packages.md
+++ b/content/packages.md
@@ -116,7 +116,8 @@ To set up a Yum package repository for Enterprise Linux platforms:
     name=chef-<CHANNEL>
     baseurl=https://packages.chef.io/repos/yum/<CHANNEL>/el/<VERSION>/\$basearch/
     gpgcheck=1
-    enabled=1
+    # No auto-upgrade, as there are manual steps needed for Chef Server upgrades
+    enabled=0
     EOL
     ```
 


### PR DESCRIPTION
## Description

Automatic upgrades do not automatically run chef-server-ctl upgrade or reconfigure. This is not correct.

Chef Server/Manage repos should have `enabled=0` set and the person responsible for Chef Server will manually run the Chef Server/Manage upgrade.

Signed-off-by: Sean Horn <sean_horn@opscode.com>

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [X] Spell Check
- [X] Local build
- [X] Examine the local build
- [X] All tests pass
