### PR TITLE
MetadataGems: Document the gems field in the metadata cookbook structure

### DIFF
--- a/_vendor/github.com/chef/chef-server/docs-chef-io/content/server/api_chef_server.md
+++ b/_vendor/github.com/chef/chef-server/docs-chef-io/content/server/api_chef_server.md
@@ -3134,6 +3134,7 @@ The response contains the record of the deleted resource and is similar to:
     "ohai_versions": [
     ],
     "gems": [
+      ["foo"]
     ]
   }
 }
@@ -3376,6 +3377,7 @@ The response is similar to:
     "ohai_versions": [
     ],
     "gems": [
+      ["foo"]
     ]
   }
 }
@@ -3458,7 +3460,11 @@ The request body is similar to:
     "groupings": {},
     "replacing": {},
     "description": "Installs/Configures unicorn",
-    "providing": {}
+    "providing": {},
+    "gems": [
+       ["foo"],
+       ["bar", "~1.0.0"]
+    ],
   },
   "libraries": [],
   "templates": [
@@ -3978,6 +3984,10 @@ The response is similar to:
     "platforms": { },
     "groupings": { },
     "recommendations": { },
+    "gems": [
+       ["foo"],
+       ["bar", "~1.0.0"]
+    ],
     "name": "getting-started",
     "description": "description",
     "version": "0.4.0",
@@ -4068,7 +4078,11 @@ with a request body similar to:
     "groupings": {},
     "replacing": {},
     "description": "Installs/Configures unicorn",
-    "providing": {}
+    "providing": {},
+    "gems": [
+       ["foo"],
+       ["bar", "~1.0.0"]
+    ],
   },
   "libraries": [],
   "templates": [
@@ -5398,6 +5412,10 @@ The response is similar to:
       },
       "providing": {
       },
+      "gems": [
+         ["foo"],
+         ["bar", "~1.0.0"]
+      ],
       "replacing": {
       },
       "attributes": {


### PR DESCRIPTION
## Description

The gems field of the cookbook metadata is not defined in the api documentation. This adds examples to the doc.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
