### PR TITLE
Added Infra Server 14.x to deprecated list

### DIFF
--- a/content/versions.md
+++ b/content/versions.md
@@ -99,6 +99,7 @@ newer versions or products.
 |-------------------|---------|------------------|-------------------|
 | Chef Backend      | 2.x     | Deprecated       | TBD               |
 | Chef Infra Client | 17.x    | Deprecated       | TBD               |
+| Chef Infra Server | 14.x    | Deprecated       | TBD               |
 | Chef Manage       | 2.5.x+  | Deprecated       | TBD               |
 
 ## End of Life (EOL) Products


### PR DESCRIPTION


Signed-off-by: Sudharshan Kaushik Kannan <skk@progress.com>


## Description

With Infra Server 15 being shipped into Automate (https://docs.chef.io/release_notes_automate/#improvements) , version 14.x can be added into list of deprecated product versions

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
