### PR TITLE
Fix GitHub actions error messages

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,9 +60,6 @@ jobs:
           path: tools/vale/chef
           token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: errata-ai/vale-action@reviewdog
-        with:
-          config: https://raw.githubusercontent.com/chef/chef-web-docs/main/.vale.ini
-          files: __onlyModified
-        env: 
+        env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
             

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: carlosperate/download-file-action@v1.0.3
+      - uses: carlosperate/download-file-action@v1.1.2
         id: download-mdl-config
         with:
           file-url: 'https://raw.githubusercontent.com/chef/chef-web-docs/main/.markdownlint.yaml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,11 @@ jobs:
           tag: 'v0.2.4'
           path: tools/vale/chef
           token: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: actions/checkout@v3
+      - uses: carlosperate/download-file-action@v1.1.2
+        id: download-vale-config
+        with:
+          file-url: 'https://raw.githubusercontent.com/chef/chef-web-docs/main/.vale.ini'
+          file-name: '.vale.ini'
       - uses: errata-ai/vale-action@reviewdog
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
   cspell-action:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: streetsidesoftware/cspell-action@v2.1.1
         with:
           files: '**/*.md'
@@ -32,7 +32,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: carlosperate/download-file-action@v1.0.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,7 @@ jobs:
           tag: 'v0.2.4'
           path: tools/vale/chef
           token: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: errata-ai/vale-action@v1
+      - uses: errata-ai/vale-action@reviewdog
         with:
           config: https://raw.githubusercontent.com/chef/chef-web-docs/main/.vale.ini
           files: __onlyModified

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           file-url: 'https://raw.githubusercontent.com/chef/chef-web-docs/main/.markdownlint.yaml'
           file-name: 'markdownlint.yaml'
-      - uses: DavidAnson/markdownlint-cli2-action@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v5
         with:
           globs: |
             *.md

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,7 @@ jobs:
           tag: 'v0.2.4'
           path: tools/vale/chef
           token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/content/custom_resource_glossary.md
+++ b/content/custom_resource_glossary.md
@@ -255,7 +255,7 @@ The following properties are identical to the properties in the execute resource
 - `property :user`
 - `property :sensitive`
 
-Because both the custom properties and the **execute** properties are identical, this
+Because both the custom properties and the __execute__ properties are identical, this
 will result in an error message similar to:
 
 ```ruby
@@ -306,7 +306,7 @@ where:
 - `user new_resource.user`
 - `sensitive new_resource.sensitive`
 
-Correctly use the properties of the **execute** resource and not the identically-named override properties of the custom resource.
+Correctly use the properties of the __execute__ resource and not the identically-named override properties of the custom resource.
 
 ## property
 
@@ -566,7 +566,7 @@ reset_property(:password)
 
 `coerce` is used to transform user input into a canonical form. The
 value is passed in, and the transformed value returned as output. Lazy
-values will **not** be passed to this method until after they are
+values will __not__ be passed to this method until after they are
 evaluated.
 
 `coerce` is run in the context of the instance, which gives it access to


### PR DESCRIPTION
## Description

### Update download-file-action GitHub Action to v1.1.2

Currently the lint GitHub action produces these warnings

Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, carlosperate/download-file-action@v1.0.3, DavidAnson/markdownlint-cli2-action@v4. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This is resolved in download-file-action at v1.1.2

https://github.com/carlosperate/download-file-action/releases/tag/v1.1.2

This commit updates the action to use this new version

### Update markdownlint-cli2-action to version 5

Currently the lint GitHub action produces these warnings

Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, carlosperate/download-file-action@v1.0.3, DavidAnson/markdownlint-cli2-action@v4. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This is resolved for markdownlint-cli2-action by updating to v5.0.0

https://github.com/DavidAnson/markdownlint-cli2-action/releases/tag/v5.0.0

This commit updates the action to use that new version

### Update GitHub actions/checkout to v3

Currently when the linter runs it produces this warning

Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This commit updates the GitHub action to use the actions/checkout action that uses Node.js 16

### Update `vale-action` to recommended branch

Currently when the lint action runs it produces this error

Unable to create annotations; printing Vale alerts instead.

This is caused by https://github.com/errata-ai/vale-action/issues/12

To fix this, the author recommends using the `reviewdog` branch. This commit sets the GitHub Action to that branch.

As part of this change to the `reviewdog` branch

1. There's no need to indicate where the CONFIG file is as .vale.ini is in the correct location by default

2. This new version no longer supports the `__onlyModified` flag so I've removed it. This does mean that the vale check will now check the whole repo. If this is a problem then we'll want to go back to the older version and live with the `Unable to create annotations; printing Vale alerts instead.` error ( https://github.com/errata-ai/vale-action/issues/12 )

### Lint fixes

This also resolves the lint error

```
content/custom_resource_glossary.md:258:44 MD050/strong-style Strong style should be consistent [Expected: underscore; Actual: asterisk]
```

which is newly revealed with these new linter versions.

## Definition of Done

## Issues Resolved

## Related PRs

## Check List

- [x] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
