### PR TITLE
Re-added eol date to Client 17 which got missed during changes

### DIFF
--- a/content/versions.md
+++ b/content/versions.md
@@ -98,7 +98,7 @@ newer versions or products.
 | Product           | Version | Lifecycle Status | EOL Date          |
 |-------------------|---------|------------------|-------------------|
 | Chef Backend      | 2.x     | Deprecated       | TBD               |
-| Chef Infra Client | 17.x    | Deprecated       | TBD               |
+| Chef Infra Client | 17.x    | Deprecated       | April 30, 2024    |
 | Chef Infra Server | 14.x    | Deprecated       | TBD               |
 | Chef Manage       | 2.5.x+  | Deprecated       | TBD               |
 


### PR DESCRIPTION
Signed-off-by: Sudharshan Kaushik Kannan <skk@progress.com>


## Description

Original EOL date mentioned in https://github.com/chef/chef-web-docs/pull/3923/ got missed when moving 17 to different tables on the page (https://github.com/chef/chef-web-docs/pull/4001/files and https://github.com/chef/chef-web-docs/commit/2bae696b13cf33e1464ae2858ffa4405c6299cb5) . Re-adding the actual date

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
