### PR TITLE
Update cookbook_execution.md

### DIFF
--- a/content/infra_language/cookbook_execution.md
+++ b/content/infra_language/cookbook_execution.md
@@ -40,7 +40,7 @@ cookbook_name
 This method is often used as part of a log entry. For example:
 
 ```ruby
-Chef::Log.info('I am a message from the #{recipe_name} recipe in the #{cookbook_name} cookbook.')
+Chef::Log.info("I am a message from the #{recipe_name} recipe in the #{cookbook_name} cookbook.")
 ```
 
 ### recipe_name
@@ -56,7 +56,7 @@ recipe_name
 This method is often used as part of a log entry. For example:
 
 ```ruby
-Chef::Log.info('I am a message from the #{recipe_name} recipe in the #{cookbook_name} cookbook.')
+Chef::Log.info("I am a message from the #{recipe_name} recipe in the #{cookbook_name} cookbook.")
 ```
 
 ### resources


### PR DESCRIPTION
Interpolating `cookbook_name` or `recipe_name` requires double quotes.


## Description

This change fixes incorrect use of single quotes for strings in which interpolation is desired.

## Definition of Done

N/A

## Check List

None of these apply.

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
