### PR TITLE
Update Chef Workstation supported platforms

### DIFF
--- a/_vendor/github.com/chef/chef-workstation/docs-chef-io/content/workstation/install_workstation.md
+++ b/_vendor/github.com/chef/chef-workstation/docs-chef-io/content/workstation/install_workstation.md
@@ -47,7 +47,7 @@ Supported Host Operating Systems:
 </tr>
 <tr class="odd">
 <td>Red Hat Enterprise Linux / CentOS</td>
-<td>7.x, 8.x, 9.x</td>
+<td>7.x, 8.x</td>
 </tr>
 <tr class="even">
 <td>Ubuntu</td>

--- a/_vendor/github.com/chef/chef-workstation/docs-chef-io/content/workstation/install_workstation.md
+++ b/_vendor/github.com/chef/chef-workstation/docs-chef-io/content/workstation/install_workstation.md
@@ -47,7 +47,7 @@ Supported Host Operating Systems:
 </tr>
 <tr class="odd">
 <td>Red Hat Enterprise Linux / CentOS</td>
-<td>7.x, 8.x</td>
+<td>7.x, 8.x, 9.x</td>
 </tr>
 <tr class="even">
 <td>Ubuntu</td>

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -305,17 +305,17 @@ versions for the Chef Workstation:
 <tr>
 <td>Debian</td>
 <td><code>x86_64</code></td>
-<td><code>9</code>, <code>10</code>, <code>11</code></td>
+<td><code>10</code>, <code>11</code></td>
 </tr>
 <tr>
 <td>Red Hat Enterprise Linux</td>
 <td><code>x86_64</code></td>
-<td><code>7.x</code>, <code>8.x</code></td>
+<td><code>7.x</code>, <code>8.x</code>, <code>9.x</code></td>
 </tr>
 <tr>
 <td>Ubuntu</td>
 <td><code>x86_64</code></td>
-<td><code>16.04</code>, <code>18.04</code>, <code>20.04</code></td>
+<td><code>18.04</code>, <code>20.04</code>, <code>22.04</code></td>
 </tr>
 <tr>
 <td>Windows</td>

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -299,7 +299,7 @@ versions for the Chef Workstation:
 </tr>
 <tr>
 <td>macOS</td>
-<td><code>x86_64</code></td>
+<td><code>x86_64</code>, <code>aarch64</code></td>
 <td><code>10.15</code>, <code>11.x</code>, <code>12.x</code></td>
 </tr>
 <tr>

--- a/content/versions.md
+++ b/content/versions.md
@@ -70,7 +70,7 @@ commercial agreement with Chef. Additional information is available in
 | Chef Infra Server | 15.x                     | GA               | n/a            |
 | Chef Habitat      | 0.81+                    | GA               | n/a            |
 | Chef InSpec       | 5.x                      | GA               | n/a            |
-| Chef Workstation  | 21.x (2021), 22.x (2022) | GA               | n/a            |
+| Chef Workstation  | 22.x (2022), 23.x (2023) | GA               | n/a            |
 
 {{< note >}}
 


### PR DESCRIPTION
## Description
New OS versions in Ubuntu & RHEL are now supported. ARM architecture based systems are supported in macOS.

## Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
