### PR TITLE
CHEF-3469 Replace downloads links

### DIFF
--- a/_vendor/github.com/chef/chef-server/docs-chef-io/content/server/install_server.md
+++ b/_vendor/github.com/chef/chef-server/docs-chef-io/content/server/install_server.md
@@ -70,7 +70,7 @@ loop.
 
 To install Chef Infra Server:
 
-1.  Download the package from <https://www.chef.io/downloads/tools/infra-server/>.
+1.  Download the package from [Chef Downloads](https://www.chef.io/downloads).
 
 2.  Upload the package to the machine that will run the Chef Infra
     Server, and then record its location on the file system. The rest of

--- a/_vendor/github.com/chef/chef-server/docs-chef-io/content/server/install_server_ha.md
+++ b/_vendor/github.com/chef/chef-server/docs-chef-io/content/server/install_server_ha.md
@@ -120,8 +120,7 @@ These instructions assume you are using the minimum versions:
 -   Chef Server : 12.5.0
 -   Chef Backend : 0.8.0
 
-Download [Chef Infra Server](https://www.chef.io/downloads/tools/infra-server) and
-[Chef Backend (chef-backend)](https://www.chef.io/downloads/tools/backend)
+Download Chef Infra Server and Chef Backend from [Chef Downloads](https://www.chef.io/downloads)
 if you do not have them already.
 
 Before creating the backend HA cluster and building at least one Chef
@@ -149,7 +148,7 @@ different from any other back-end node.
 1.  Install the Chef Backend package on the first backend node **as root**.
 
     -   Download [Chef Backend
-        (chef-backend)](https://www.chef.io/downloads/tools/backend)
+        (chef-backend)](https://www.chef.io/downloads)
     -   In Red Hat/CentOS: `yum install PATH_TO_RPM`
     -   In Debian/Ubuntu: `dpkg -i PATH_TO_DEB`
 
@@ -200,7 +199,7 @@ join nodes in parallel the cluster may fail to become available):
 1.  Install the Chef Backend package on the node.
 
     -   Download [Chef Backend
-        (chef-backend)](https://www.chef.io/downloads/tools/backend)
+        (chef-backend)](https://www.chef.io/downloads)
     -   In Red Hat/CentOS: `yum install PATH_TO_RPM`
     -   In Debian/Ubuntu: `dpkg -i PATH_TO_DEB`
 

--- a/_vendor/github.com/chef/chef-server/docs-chef-io/content/server/install_server_tiered.md
+++ b/_vendor/github.com/chef/chef-server/docs-chef-io/content/server/install_server_tiered.md
@@ -128,7 +128,7 @@ following:
 
 Use the following steps to set up the backend Chef Infra Server:
 
-1.  Download the packages from <https://www.chef.io/downloads/tools/infra-server>.
+1.  Download the packages from [Chef Downloads](https://www.chef.io/downloads).
     For Red Hat and CentOS 6:
 
     ```bash

--- a/_vendor/github.com/chef/chef-server/docs-chef-io/content/server/upgrades.md
+++ b/_vendor/github.com/chef/chef-server/docs-chef-io/content/server/upgrades.md
@@ -88,7 +88,7 @@ See the [Release-Specific Steps](#release-specific-steps) for information about 
 
    After performing the stepped upgrade to 12.17.15, continue with the next step.
 
-1. Download the desired Chef Infra Server version from the [Chef Infra Server Downloads](https://www.chef.io/downloads/tools/infra-server).
+1. Download the desired Chef Infra Server version from the [Chef Infra Server Downloads](https://www.chef.io/downloads).
 
 1. Stop the Chef Infra Server:
 
@@ -248,7 +248,7 @@ The following External PostgreSQL upgrade steps are provided as a courtesy only.
 
    After performing the stepped upgrade, return here and continue with the next step below.
 
-1. [Download](https://www.chef.io/downloads/tools/infra-server) the desired version of Chef Infra Server.
+1. [Download](https://www.chef.io/downloads) the desired version of Chef Infra Server.
 
 1. Stop the Chef Infra Server:
 
@@ -480,7 +480,7 @@ To upgrade to Chef Infra Server on a tiered Chef Infra Server configuration, do 
     chef-server-ctl reconfigure
     ```
 
-3. Download the desired Chef Infra Server version from the [Chef Infra Server Downloads](https://www.chef.io/downloads/tools/infra-server) page, then copy it to each server.
+3. Download the desired Chef Infra Server version from [Chef Downloads](https://www.chef.io/downloads), then copy it to each server.
 
 4. Stop all front end servers:
 

--- a/_vendor/github.com/chef/chef-server/docs-chef-io/layouts/shortcodes/chef-server/ctl_chef_server_restore.md
+++ b/_vendor/github.com/chef/chef-server/docs-chef-io/layouts/shortcodes/chef-server/ctl_chef_server_restore.md
@@ -14,4 +14,4 @@ Ideally, the restore server will have the same FQDN as the server that you backe
 4. If you use a CA-issued certificate instead of a self-signed certificate, copy the CA-issued certificate and key into `/var/opt/opscode/nginx/ca`.
 5. Update the `/etc/chef/client.rb` file on each client to point to the new server FQDN.
 6. Run `chef-server-ctl reconfigure`.
-7. Run ``chef-server-ctl restore`.
+7. Run `chef-server-ctl restore`.

--- a/_vendor/github.com/chef/supermarket/docs-chef-io/content/supermarket/install_supermarket.md
+++ b/_vendor/github.com/chef/supermarket/docs-chef-io/content/supermarket/install_supermarket.md
@@ -300,7 +300,7 @@ While there are many benefits to using the cookbook method to install Supermarke
 
 Before following these steps, be sure to complete the OAuth setup process detailed in the [Chef Identity](/install_supermarket/#chef-identity) section of this guide.
 
-1. [Download](https://www.chef.io/downloads/tools/supermarket) the correct package for your operating system from `chef.io/downloads`.
+1. Download the correct package of Chef Supermarket for your operating system from [Chef Downloads](https://www.chef.io/downloads).
 
 2. Install Supermarket using the appropriate package manager for your distribution:
 
@@ -411,7 +411,7 @@ Encrypted S3 buckets are currently not supported.
 1. Shut down the server running Private Supermarket.
 1. Backup the `/var/opt/supermarket` directory.
 
-1. Download the [Chef Supermarket](https://www.chef.io/downloads/tools/supermarket) package.
+1. Download the correct package of Chef Supermarket for your operating system from [Chef Downloads](https://www.chef.io/downloads).
 1. Upgrade your system with the new package using the appropriate package manager for your distribution:
 
     - For Ubuntu:

--- a/_vendor/github.com/chef/supermarket/docs-chef-io/content/supermarket/supermarket_upgrade.md
+++ b/_vendor/github.com/chef/supermarket/docs-chef-io/content/supermarket/supermarket_upgrade.md
@@ -23,7 +23,7 @@ Running Version | Upgrade Version | Supported Version
 
 ## Supported Release
 
-Chef Supermarket uses the PostgreSQL database. [PostgreSQL 9.3 is EOL](https://endoflife.date/postgresql) and Private Supermarket users should upgrade to [Supermarket 5.0](https://www.chef.io/downloads/tools/supermarket) or above and migrate to [PostgreSQL 13](https://www.postgresql.org/about/news/postgresql-13-released-2077/).
+Chef Supermarket uses the PostgreSQL database. [PostgreSQL 9.3 is EOL](https://endoflife.date/postgresql) and Private Supermarket users should upgrade to [Supermarket 5.0](https://www.chef.io/downloads) or above and migrate to [PostgreSQL 13](https://www.postgresql.org/about/news/postgresql-13-released-2077/).
 
 Chef Software supports Supermarket 5.0 release and later. Earlier releases are not supported. For more information about supported Chef Software see the [Supported Versions](https://docs.chef.io/versions/#supported-commercial-distributions) documentation.
 
@@ -38,7 +38,7 @@ Every Private Supermarket installation is unique. These are general steps for up
         ```
 
   1. Backup the `/var/opt/supermarket` directory.
-  1. Download the [Chef Supermarket](https://www.chef.io/downloads/tools/supermarket) package.
+  1. Download the Chef Supermarket package from [Chef Downloads](https://www.chef.io/downloads).
   1. Upgrade your system by installing the new package using the appropriate package manager for your distribution:
      - For Ubuntu:
 

--- a/_vendor/github.com/habitat-sh/habitat/components/docs-chef-io/content/habitat/_index.md
+++ b/_vendor/github.com/habitat-sh/habitat/components/docs-chef-io/content/habitat/_index.md
@@ -81,7 +81,7 @@ You can also develop your application if you are unsure of the infrastructure yo
 
 ### Download
 
-- [Download Chef Habitat](https://www.chef.io/downloads/tools/habitat)
+- [Download Chef Habitat](https://www.chef.io/downloads)
 - [Install documentation]({{< relref "/habitat/install_habitat" >}})
 
 ### Learning

--- a/_vendor/github.com/habitat-sh/habitat/components/docs-chef-io/content/habitat/install_habitat.md
+++ b/_vendor/github.com/habitat-sh/habitat/components/docs-chef-io/content/habitat/install_habitat.md
@@ -23,7 +23,7 @@ Chef Habitat for Linux requires a 64-bit processor with kernel 2.6.32 or later. 
 
 Once you have downloaded the package, extract the hab binary with tar to `/usr/local/bin` or add its location to your `PATH` (e.g. `tar -xvzf hab.tgz -C /usr/local/bin --strip-components 1`).
 
-[Download Chef Habitat for Linux](https://www.chef.io/downloads/tools/habitat)
+[Download Chef Habitat for Linux](https://www.chef.io/downloads)
 
 ### Install Chef Habitat from the Command Line
 
@@ -47,7 +47,7 @@ Requires 64-bit processor running 10.9 or later
 
 Once you have downloaded the `hab` CLI, unzip it onto your machine. Unzipping to `/usr/local/bin` should place it on your `PATH`. In order to use the Chef Habitat Studio, you'll also need to install Docker for Mac.
 
-[Download Chef Habitat for Mac](https://www.chef.io/downloads/tools/habitat)
+[Download Chef Habitat for Mac](https://www.chef.io/downloads)
 
 [Download Docker for Mac](https://store.docker.com/editions/community/docker-ce-desktop-mac)
 
@@ -93,6 +93,6 @@ To use a Docker Chef Habitat Studio as an isolated environment, you'll also need
 
 Docker for Windows requires 64-bit Windows 10 Pro, Enterprise, or Education editions (1607 Anniversary Update, Build 14393 or later) with Hyper-V enabled
 
-[Download Chef Habitat for Windows](https://www.chef.io/downloads/tools/habitat)
+[Download Chef Habitat for Windows](https://www.chef.io/downloads)
 
 [Download Docker for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows)

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/chef/automate/components/docs-chef-io v0.0.0-20230608113604-7816d5bb2fb8
 # github.com/chef/desktop-config/docs-chef-io v0.0.0-20220405052948-5947f844edff
-# github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20230523193340-3c2aa8a1cffe
-# github.com/chef/chef-server/docs-chef-io v0.0.0-20230621131704-389da5d3e3f8
+# github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20230710140513-c5d5a2448261
+# github.com/chef/chef-server/docs-chef-io v0.0.0-20230706194022-b91aa30b4c99
 # github.com/inspec/inspec/docs-chef-io v0.0.0-20230518135327-870c69937dc2
 # github.com/inspec/inspec-alicloud/docs-chef-io v0.0.0-20220614123852-e453ba687370
 # github.com/inspec/inspec-aws/docs-chef-io v0.0.0-20220228151600-69aa036b1527
@@ -9,7 +9,7 @@
 # github.com/inspec/inspec-habitat/docs-chef-io v0.0.0-20220218210405-bfd542da49fd
 # github.com/inspec/inspec-k8s/docs-chef-io v0.0.0-20230522203306-c23ca61f913f
 # github.com/chef/chef-workstation/docs-chef-io v0.0.0-20230710100518-6ac024bfa49e
-# github.com/chef/supermarket/docs-chef-io v0.0.0-20230317105755-1f3d273b3f82
+# github.com/chef/supermarket/docs-chef-io v0.0.0-20230707131947-d0b3d65ae7a6
 # github.com/chef/effortless/docs-chef-io v0.0.0-20211119164252-4ff3d53886be
 # github.com/chef/compliance-profiles/docs-chef-io v0.0.0-20230623103238-3e312f1c2da0
 # github.com/chef/compliance-remediation-2022/docs-chef-io v0.0.0-20230509164248-bb54d1e7fbc3

--- a/content/glossary.md
+++ b/content/glossary.md
@@ -42,7 +42,7 @@ Chef Infra Server
 
 Chef Workstation
 
-: A collection of tools to aide in development of Chef Infra cookbooks. It uses the full stack installer to give you everything you need to get going in one package. You can download it at [Chef Workstation](https://www.chef.io/downloads/tools/workstation).
+: A collection of tools to aide in development of Chef Infra cookbooks. It uses the full stack installer to give you everything you need to get going in one package. You can download it at [Chef Downloads](https://www.chef.io/downloads).
 
 chef-client
 

--- a/content/install_chef_air_gap.md
+++ b/content/install_chef_air_gap.md
@@ -75,7 +75,7 @@ organization and user. Note that to configure Supermarket later
 in this guide, you will need a user that is a member of the `admins`
 group.
 
-1. Download the package from <https://www.chef.io/downloads/tools/infra-server>.
+1. Download the package from [Chef Downloads](https://www.chef.io/downloads).
 
 2. Upload the package to the machine that will run the Chef Infra Server, and then record its location on the file system. The rest of these steps assume this location is in the `/tmp` directory.
 
@@ -100,7 +100,7 @@ group.
 ### Install Chef Workstation
 
 1. First, install the Chef Workstation [installer
-    package](https://www.chef.io/downloads/tools/workstation). Use the
+    package](https://www.chef.io/downloads). Use the
     appropriate tool to run the installer:
 
     ```bash

--- a/content/install_windows.md
+++ b/content/install_windows.md
@@ -30,7 +30,7 @@ There are several methods available to install Chef Infra Client depending on th
 
 ### Use MSI Installer
 
-A Microsoft Installer Package (MSI) is available for installing Chef Infra Client on a Windows machine at [Chef Downloads](https://www.chef.io/downloads/tools/infra-client?os=windows).
+A Microsoft Installer Package (MSI) is available for installing Chef Infra Client on a Windows machine at [Chef Downloads](https://www.chef.io/downloads).
 
 {{< readfile file="content/reusable/md/windows_msiexec.md" >}}
 

--- a/content/quick_start.md
+++ b/content/quick_start.md
@@ -15,8 +15,7 @@ product = ["client", "server"]
 
 The quickest way to get started using Chef Infra is to install Chef Workstation and create your first Chef Infra Cookbook:
 
-1. Install Chef Workstation:
-    <https://www.chef.io/downloads/tools/workstation>.
+1. Install Chef Workstation from [Chef Downloads](https://www.chef.io/downloads).
 
 2. Generate a Chef Infra repository with an example cookbook:
 

--- a/content/release_notes_chefdk.md
+++ b/content/release_notes_chefdk.md
@@ -284,7 +284,7 @@ Sample kitchen.yml config:
 
 ### New Platforms
 
-ChefDK packages are now created for Ubuntu 20.04 and Debian 10! Additionally, we have increased package validation for our Windows 10 packages to ensure compatibility. See the [Chef Downloads Page](https://www.chef.io/downloads) for a complete list of platforms.
+ChefDK packages are now created for Ubuntu 20.04 and Debian 10! Additionally, we have increased package validation for our Windows 10 packages to ensure compatibility. See the Chef Downloads Page for a complete list of platforms.
 
 ### macOS Binary Signing
 
@@ -1754,18 +1754,18 @@ hosts in nested directories.
 #### macOS 10.15 Support
 
 ChefDK is now validated against macOS 10.15 (Catalina) with packages
-available at [Chef Downloads](https://www.chef.io/downloads).
+available at Chef Downloads.
 Additionally, ChefDK will no longer be validated against macOS 10.12.
 
 #### RHEL 8 Support
 
 ChefDK is now validated against RHEL 8 with packages available at
-[Chef Downloads](https://www.chef.io/downloads).
+Chef Downloads.
 
 #### Windows 2019 Support
 
 ChefDK is now validated against Windows 2019 with packages available at
-[Chef Downloads](https://www.chef.io/downloads).
+Chef Downloads.
 
 #### SLES 11 EOL
 
@@ -2204,7 +2204,7 @@ measurements in megabytes):
 ### Platform Support Updates
 
 macOS 10.14 (Mojave) is now fully tested and packages are available on
-[Chef Downloads](https://www.chef.io/downloads).
+Chef Downloads.
 
 ### Security Updates
 

--- a/content/release_notes_chefdk.md
+++ b/content/release_notes_chefdk.md
@@ -284,7 +284,7 @@ Sample kitchen.yml config:
 
 ### New Platforms
 
-ChefDK packages are now created for Ubuntu 20.04 and Debian 10! Additionally, we have increased package validation for our Windows 10 packages to ensure compatibility. See the [ChefDK Downloads Page](https://downloads.chef.io/chefdk) for a complete list of platforms.
+ChefDK packages are now created for Ubuntu 20.04 and Debian 10! Additionally, we have increased package validation for our Windows 10 packages to ensure compatibility. See the [Chef Downloads Page](https://www.chef.io/downloads) for a complete list of platforms.
 
 ### macOS Binary Signing
 
@@ -1754,18 +1754,18 @@ hosts in nested directories.
 #### macOS 10.15 Support
 
 ChefDK is now validated against macOS 10.15 (Catalina) with packages
-available at [downloads.chef.io](https://downloads.chef.io/chefdk/).
+available at [Chef Downloads](https://www.chef.io/downloads).
 Additionally, ChefDK will no longer be validated against macOS 10.12.
 
 #### RHEL 8 Support
 
 ChefDK is now validated against RHEL 8 with packages available at
-[downloads.chef.io](https://downloads.chef.io/chefdk/).
+[Chef Downloads](https://www.chef.io/downloads).
 
 #### Windows 2019 Support
 
 ChefDK is now validated against Windows 2019 with packages available at
-[downloads.chef.io](https://downloads.chef.io/chefdk/).
+[Chef Downloads](https://www.chef.io/downloads).
 
 #### SLES 11 EOL
 
@@ -2204,7 +2204,7 @@ measurements in megabytes):
 ### Platform Support Updates
 
 macOS 10.14 (Mojave) is now fully tested and packages are available on
-downloads.chef.io.
+[Chef Downloads](https://www.chef.io/downloads).
 
 ### Security Updates
 

--- a/content/release_notes_manage.md
+++ b/content/release_notes_manage.md
@@ -22,7 +22,7 @@ Chef Manage is [deprecated](/versions/#deprecated) and users should plan to migr
 
 ## Upgrading
 
-Download the latest version of the chef-manage package for your platform from [Chef Downloads](https://www.chef.io/downloads/tools/manage) to your Chef Infra Server, then run:
+Download the latest version of the chef-manage package for your platform from [Chef Downloads](https://www.chef.io/downloads) to your Chef Infra Server, then run:
 
 ```bash
 rpm -Uvh /path/to/chef-manage-*.rpm

--- a/content/windows.md
+++ b/content/windows.md
@@ -115,8 +115,7 @@ Se the [knife windows](/workstation/knife_windows/) for more information.
 ### Install Chef Infra Client using the MSI Installer
 
 A Microsoft Installer Package (MSI) is available for installing Chef
-Infra Client on a Windows machine from [Chef
-Downloads](https://www.chef.io/downloads/tools/infra-client?os=windows).
+Infra Client on a Windows machine from [Chef Downloads](https://www.chef.io/downloads).
 
 #### Msiexec.exe
 

--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,15 @@ go 1.16
 
 require (
 	github.com/chef/automate/components/docs-chef-io v0.0.0-20230608113604-7816d5bb2fb8 // indirect
-	github.com/chef/chef-server/docs-chef-io v0.0.0-20230621131704-389da5d3e3f8 // indirect
+	github.com/chef/chef-server/docs-chef-io v0.0.0-20230706194022-b91aa30b4c99 // indirect
 	github.com/chef/chef-workstation/docs-chef-io v0.0.0-20230710100518-6ac024bfa49e // indirect
 	github.com/chef/compliance-profiles/docs-chef-io v0.0.0-20230623103238-3e312f1c2da0 // indirect
 	github.com/chef/compliance-remediation-2022/docs-chef-io v0.0.0-20230509164248-bb54d1e7fbc3 // indirect
 	github.com/chef/desktop-config/docs-chef-io v0.0.0-20220405052948-5947f844edff // indirect
 	github.com/chef/effortless/docs-chef-io v0.0.0-20211119164252-4ff3d53886be // indirect
-	github.com/chef/supermarket/docs-chef-io v0.0.0-20230317105755-1f3d273b3f82 // indirect
+	github.com/chef/supermarket/docs-chef-io v0.0.0-20230707131947-d0b3d65ae7a6 // indirect
 	github.com/cowboy/jquery-hashchange v0.0.0-20100902193700-0310f3847f90 // indirect
-	github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20230523193340-3c2aa8a1cffe // indirect
+	github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20230710140513-c5d5a2448261 // indirect
 	github.com/inspec/inspec-alicloud/docs-chef-io v0.0.0-20220614123852-e453ba687370 // indirect
 	github.com/inspec/inspec-aws/docs-chef-io v0.0.0-20220228151600-69aa036b1527 // indirect
 	github.com/inspec/inspec-azure/docs-chef-io v0.0.0-20220228040450-e1b23e65979a // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chef/automate/components/docs-chef-io v0.0.0-20230608113604-7816d5bb2fb8 h1:O+VDcPLzHfVRVaSvWZTPywwli7n4sI1HYrco56pK7ME=
 github.com/chef/automate/components/docs-chef-io v0.0.0-20230608113604-7816d5bb2fb8/go.mod h1:juvLC7Rt33YOCgJ5nnfl4rWZRAbSwqjTbWmcAoA0LtU=
-github.com/chef/chef-server/docs-chef-io v0.0.0-20230621131704-389da5d3e3f8 h1:YeAvgC+Ox/IJkwpUV/J5tirmuSSjlTh7anlKqPT4L20=
-github.com/chef/chef-server/docs-chef-io v0.0.0-20230621131704-389da5d3e3f8/go.mod h1:gMSa25GUHmLimA0gjvRd3hs1buOBqkKPrdHzHvaJauY=
+github.com/chef/chef-server/docs-chef-io v0.0.0-20230706194022-b91aa30b4c99 h1:9Y95JNXbpkYxz7efwxBfNdhbD2IF4yiIHnUWBmVuUtQ=
+github.com/chef/chef-server/docs-chef-io v0.0.0-20230706194022-b91aa30b4c99/go.mod h1:gMSa25GUHmLimA0gjvRd3hs1buOBqkKPrdHzHvaJauY=
 github.com/chef/chef-workstation/docs-chef-io v0.0.0-20230710100518-6ac024bfa49e h1:FsMQ5T9GPtzgC5XozFn7kQyOLKNEOFk/wtaY4MNDinY=
 github.com/chef/chef-workstation/docs-chef-io v0.0.0-20230710100518-6ac024bfa49e/go.mod h1:gvoh6ov1YU98CVzBEWzEZeCLTRunfQ6r1VO7M3LFE9U=
 github.com/chef/compliance-profiles/docs-chef-io v0.0.0-20230623103238-3e312f1c2da0 h1:ZBQb0WcQ3TSZOHsW7ElaUlJQJvo3xWogNd8tON/ZLxc=
@@ -15,8 +15,8 @@ github.com/chef/desktop-config/docs-chef-io v0.0.0-20220405052948-5947f844edff h
 github.com/chef/desktop-config/docs-chef-io v0.0.0-20220405052948-5947f844edff/go.mod h1:90xAx6sIfgSL50M2KzeBmx7V7s7dlhQU3xpUkJO0qW0=
 github.com/chef/effortless/docs-chef-io v0.0.0-20211119164252-4ff3d53886be h1:QeeHFnUaNVQmTlxX3MT06Dgz8omORr5ZATVH7yLc96A=
 github.com/chef/effortless/docs-chef-io v0.0.0-20211119164252-4ff3d53886be/go.mod h1:Lfq+HjwAQwUJ41EPTO/8qbI1oJb2i415fR28d2Ig9kc=
-github.com/chef/supermarket/docs-chef-io v0.0.0-20230317105755-1f3d273b3f82 h1:Nhv0puii4R+Cr8tFkORHhavOxXSp2ATIlg6tHmiw/5k=
-github.com/chef/supermarket/docs-chef-io v0.0.0-20230317105755-1f3d273b3f82/go.mod h1:L0DhIJHTKsPYhAr9TrhAIg3KXtrS9BJF0XNHfGDDGGg=
+github.com/chef/supermarket/docs-chef-io v0.0.0-20230707131947-d0b3d65ae7a6 h1:+cr06FvS0yJskPAroKEc9kzxegSD8J4+SWu0QmBItkg=
+github.com/chef/supermarket/docs-chef-io v0.0.0-20230707131947-d0b3d65ae7a6/go.mod h1:L0DhIJHTKsPYhAr9TrhAIg3KXtrS9BJF0XNHfGDDGGg=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cowboy/jquery-hashchange v0.0.0-20100902193700-0310f3847f90 h1:p/a5iSATj0OjrqJLX/YKxYdGXhZzW58yyyNIC4JY4S0=
 github.com/cowboy/jquery-hashchange v0.0.0-20100902193700-0310f3847f90/go.mod h1:N/6F0+wmdvL6k0AjqyKIncMRClKAN92atjZdTLtYMaw=
@@ -37,8 +37,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20230523193340-3c2aa8a1cffe h1:6NiuwBPL1mSt5Arxw/Yjs+9i8W3gWhJb1EOo01w77yY=
-github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20230523193340-3c2aa8a1cffe/go.mod h1:luAy42opPrAM/T6hsqDyW3CNBaAMgy+a6l0+oi8sw8U=
+github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20230710140513-c5d5a2448261 h1:DzcLym6E7p6Xr7c5lfzCM+0HjeUULkN7j/DYvFLwRf4=
+github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20230710140513-c5d5a2448261/go.mod h1:luAy42opPrAM/T6hsqDyW3CNBaAMgy+a6l0+oi8sw8U=
 github.com/inspec/inspec-alicloud/docs-chef-io v0.0.0-20220614123852-e453ba687370 h1:ExM/pqpJgy8gtu2gK6E8EiuolMy7BvcHSSvTzkf/Sm4=
 github.com/inspec/inspec-alicloud/docs-chef-io v0.0.0-20220614123852-e453ba687370/go.mod h1:tAazDDBtR5yCl/FNWHnrmkxpfxnOo9B99DyfRE7JH1c=
 github.com/inspec/inspec-aws/docs-chef-io v0.0.0-20220228151600-69aa036b1527 h1:uUaij/nZVKcjxg6wiyKdHZjUESGAXrnUPyFL8+YhfaU=


### PR DESCRIPTION
## Description

Replace links to chef.io/downloads/tools/<something> with just links to chef.io/downloads.

## Definition of Done

## Issues Resolved

https://chefio.atlassian.net/browse/CHEF-3469

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
