### PR TITLE
Correct alt text

### DIFF
--- a/content/chef_client_overview.md
+++ b/content/chef_client_overview.md
@@ -35,7 +35,7 @@ Chef Infra Client's Compliance Phase lets you automatically execute compliance a
 </colgroup>
 <tbody>
 <tr>
-<td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>{{< readfile file="content/reusable/md/chef_client_summary.md" >}}</p>
 <p>{{< readfile file="content/reusable/md/security_key_pairs_chef_client.md" >}}</p></td>
 </tr>

--- a/content/chef_overview.md
+++ b/content/chef_overview.md
@@ -81,7 +81,7 @@ Chef Infra has the following major components:
 <tr>
 <td><p><img src="/images/icon_chef_server.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>The Chef Infra Server acts as a hub of information. Cookbooks and policy settings are uploaded to the Chef Infra Server by users from workstations.</p>
-<p>The Chef Infra Client accesses the Chef Infra Server from the node on which it is installed to get configuration data, performs searches of historical Chef Infra Client run data, and then pulls down the necessary configuration data. After a Chef Infra Client run is finished, the Chef Infra Client uploads updated run data to the Chef Infra Server.</p></td>
+<p>The Chef Infra Client accesses the Chef Infra Server from the node on which it's installed to get configuration data, performs searches of historical Chef Infra Client run data, and then pulls down the necessary configuration data. After a Chef Infra Client run is finished, the Chef Infra Client uploads updated run data to the Chef Infra Server.</p></td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_chef_supermarket.svg" class="align-center" width="130" alt="" /></p></td>

--- a/content/chef_overview.md
+++ b/content/chef_overview.md
@@ -28,7 +28,7 @@ product = ["client", "server", "workstation"]
 - **Chef Infra Server** acts as [a hub for configuration
     data](/server/). Chef Infra Server stores cookbooks,
     the policies that are applied to nodes, and metadata that describes
-    each registered node that is being managed by Chef. Nodes use the
+    each registered node that's being managed by Chef. Nodes use the
     Chef Infra Client to ask the Chef Infra Server for configuration
     details, such as recipes, templates, and file distributions.
 
@@ -68,7 +68,7 @@ Chef Infra has the following major components:
 </tr>
 <tr>
 <td><p><img src="/images/icon_ruby.svg" class="align-center" width="130" alt="" /></p></td>
-<td><p>Ruby is the programming language that is the authoring syntax for cookbooks. Most recipes are simple patterns (blocks that define properties and values that map to specific configuration items like packages, files, services, templates, and users. The full power of Ruby is available for when you need a programming language.</p></td>
+<td><p>Ruby is the programming language that's the authoring syntax for cookbooks. Most recipes are simple patterns (blocks that define properties and values that map to specific configuration items like packages, files, services, templates, and users. The full power of Ruby is available for when you need a programming language.</p></td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_node.svg" class="align-center" width="130" alt="" /></p></td>
@@ -76,7 +76,7 @@ Chef Infra has the following major components:
 </tr>
 <tr>
 <td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="" /></p></td>
-<td><p>Chef Infra Client is installed on each node that is managed with Chef Infra. Chef Infra Client configures the node locally by performing the tasks specified in the run-list. Chef Infra Client will also pull down any required configuration data from the Chef Infra Server during a Chef Infra Client run.</p></td>
+<td><p>Chef Infra Client is installed on each node that's managed with Chef Infra. Chef Infra Client configures the node locally by performing the tasks specified in the run-list. Chef Infra Client will also pull down any required configuration data from the Chef Infra Server during a Chef Infra Client run.</p></td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_chef_server.svg" class="align-center" width="130" alt="" /></p></td>
@@ -210,13 +210,13 @@ Cookbooks are comprised of the following components:
 <tr>
 <td><p><img src="/images/icon_cookbook_recipes.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>{{< readfile file="content/reusable/md/cookbooks_recipe.md" >}}</p>
-<p>The Chef Infra Client will run a recipe only when asked. When the Chef Infra Client runs the same recipe more than once, the results will be the same system state each time. When a recipe is run against a system, but nothing has changed on either the system or in the recipe, the Chef Infra Client will not change anything.</p>
+<p>The Chef Infra Client will run a recipe only when asked. When the Chef Infra Client runs the same recipe more than once, the results will be the same system state each time. When a recipe is run against a system, but nothing has changed on either the system or in the recipe, the Chef Infra Client won't change anything.</p>
 <p>{{< readfile file="content/reusable/md/infra_lang_summary.md" >}}</p></td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_cookbook_resources.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>{{< readfile file="content/reusable/md/resources_common.md" >}}</p>
-<p>Chef has <a href="/resources/">many built-in resources</a> that cover all of the most common actions across all of the most common platforms. You can <a href="/custom_resources/">build your own resources</a> to handle any situation that is not covered by a built-in resource.</p></td>
+<p>Chef has <a href="/resources/">many built-in resources</a> that cover all of the most common actions across all of the most common platforms. You can <a href="/custom_resources/">build your own resources</a> to handle any situation that's not covered by a built-in resource.</p></td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_cookbook_templates.svg" class="align-center" width="130" alt="" /></p></td>
@@ -224,7 +224,7 @@ Cookbooks are comprised of the following components:
 </tr>
 <tr>
 <td><p><img src="/images/icon_cookbook_tests.svg" class="align-center" width="130" alt="" /></p></td>
-<td>Testing cookbooks improves the quality of those cookbooks by ensuring they are doing what they are supposed to do and that they are authored in a consistent manner. Unit and integration testing validates the recipes in cookbooks. Syntax testing---often called linting---validates the quality of the code itself. The following tools are popular tools used for testing Chef recipes: Test Kitchen, ChefSpec, and Cookstyle.</td>
+<td>Testing cookbooks improves the quality of those cookbooks by ensuring they're doing what they're supposed to do and that they're authored in a consistent manner. Unit and integration testing validates the recipes in cookbooks. Syntax testing---often called linting---validates the quality of the code itself. The following tools are popular tools used for testing Chef recipes: Test Kitchen, ChefSpec, and Cookstyle.</td>
 </tr>
 </tbody>
 </table>

--- a/content/chef_overview.md
+++ b/content/chef_overview.md
@@ -58,33 +58,33 @@ Chef Infra has the following major components:
 </thead>
 <tbody>
 <tr>
-<td><p><img src="/images/icon_workstation.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_workstation.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>One (or more) workstations are configured to allow users to author, test, and maintain cookbooks.</p>
 <p>Workstation systems run the Chef Workstation package which includes tools such as Chef Infra Client, Chef InSpec, Test Kitchen, ChefSpec, Cookstyle, and other tools necessary for developing and testing your infrastructure with Chef products.</p></td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_cookbook.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_cookbook.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>Cookbooks are uploaded to the Chef Infra Server from these workstations. Some cookbooks are custom to the organization and others are based on community cookbooks available from the Chef Supermarket.</p></td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_ruby.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_ruby.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>Ruby is the programming language that is the authoring syntax for cookbooks. Most recipes are simple patterns (blocks that define properties and values that map to specific configuration items like packages, files, services, templates, and users. The full power of Ruby is available for when you need a programming language.</p></td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_node.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_node.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>{{< readfile file="content/reusable/md/node.md" >}}</p></td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>Chef Infra Client is installed on each node that is managed with Chef Infra. Chef Infra Client configures the node locally by performing the tasks specified in the run-list. Chef Infra Client will also pull down any required configuration data from the Chef Infra Server during a Chef Infra Client run.</p></td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_chef_server.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_chef_server.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>The Chef Infra Server acts as a hub of information. Cookbooks and policy settings are uploaded to the Chef Infra Server by users from workstations.</p>
 <p>The Chef Infra Client accesses the Chef Infra Server from the node on which it is installed to get configuration data, performs searches of historical Chef Infra Client run data, and then pulls down the necessary configuration data. After a Chef Infra Client run is finished, the Chef Infra Client uploads updated run data to the Chef Infra Server.</p></td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_chef_supermarket.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_chef_supermarket.svg" class="align-center" width="130" alt="" /></p></td>
 <td>Chef Supermarket is the location in which community cookbooks are shared and managed. Cookbooks that are part of the Chef Supermarket may be used by any Chef user. How community cookbooks are used varies from organization to organization.</td>
 </tr>
 </tbody>
@@ -127,12 +127,12 @@ Some important tools and components of Chef Workstation include:
 </thead>
 <tbody>
 <tr>
-<td><p><img src="/images/icon_workstation.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_workstation.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/workstation/reusable/md/chef_workstation.md" >}}</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_ctl_chef.svg" class="align-center" width="130" alt="image" /></p>
-<p><img src="/images/icon_ctl_knife.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_ctl_chef.svg" class="align-center" width="130" alt="" /></p>
+<p><img src="/images/icon_ctl_knife.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>Chef Workstation includes important command-line tools:</p>
 <ul>
 <li>Chef Infra: Use the chef command-line tool to work with items in a chef-repo, which is the primary location in which cookbooks are authored, tested, and maintained, and from which policy is uploaded to the Chef Infra Server</li>
@@ -145,7 +145,7 @@ Some important tools and components of Chef Workstation include:
 </ul></td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_repository.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_repository.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>The chef-repo is the repository structure in which cookbooks are authored, tested, and maintained:</p>
 <ul>
 <li>Cookbooks contain recipes, attributes, custom resources, libraries, files, templates, tests, and metadata</li>
@@ -154,11 +154,11 @@ Some important tools and components of Chef Workstation include:
 <p>The directory structure within the chef-repo varies. Some organizations prefer to keep all of their cookbooks in a single chef-repo, while other organizations prefer to use a chef-repo for every cookbook.</p></td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_kitchen.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_kitchen.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/workstation/reusable/md/test_kitchen.md" >}}</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_chefspec.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_chefspec.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/chefspec_summary.md" >}}</td>
 </tr>
 </tbody>
@@ -192,38 +192,38 @@ Cookbooks are comprised of the following components:
 </thead>
 <tbody>
 <tr>
-<td><p><img src="/images/icon_cookbook_attributes.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_cookbook_attributes.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/cookbooks_attribute.md" >}}</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_cookbook_files.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_cookbook_files.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/resource_cookbook_file_summary.md" >}}</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_cookbook_libraries.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_cookbook_libraries.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/libraries_summary.md" >}}</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_cookbook_metadata.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_cookbook_metadata.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/cookbooks_metadata.md" >}}</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_cookbook_recipes.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_cookbook_recipes.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>{{< readfile file="content/reusable/md/cookbooks_recipe.md" >}}</p>
 <p>The Chef Infra Client will run a recipe only when asked. When the Chef Infra Client runs the same recipe more than once, the results will be the same system state each time. When a recipe is run against a system, but nothing has changed on either the system or in the recipe, the Chef Infra Client will not change anything.</p>
 <p>{{< readfile file="content/reusable/md/infra_lang_summary.md" >}}</p></td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_cookbook_resources.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_cookbook_resources.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>{{< readfile file="content/reusable/md/resources_common.md" >}}</p>
 <p>Chef has <a href="/resources/">many built-in resources</a> that cover all of the most common actions across all of the most common platforms. You can <a href="/custom_resources/">build your own resources</a> to handle any situation that is not covered by a built-in resource.</p></td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_cookbook_templates.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_cookbook_templates.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/template.md" >}}</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_cookbook_tests.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_cookbook_tests.svg" class="align-center" width="130" alt="" /></p></td>
 <td>Testing cookbooks improves the quality of those cookbooks by ensuring they are doing what they are supposed to do and that they are authored in a consistent manner. Unit and integration testing validates the recipes in cookbooks. Syntax testing---often called linting---validates the quality of the code itself. The following tools are popular tools used for testing Chef recipes: Test Kitchen, ChefSpec, and Cookstyle.</td>
 </tr>
 </tbody>
@@ -254,12 +254,12 @@ The key components of nodes that are under management by Chef include:
 </thead>
 <tbody>
 <tr>
-<td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>{{< readfile file="content/reusable/md/chef_client_summary.md" >}}</p>
 <p>{{< readfile file="content/reusable/md/security_key_pairs_chef_client.md" >}}</p></td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_ohai.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_ohai.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/ohai_summary.md" >}}</td>
 </tr>
 </tbody>
@@ -282,19 +282,19 @@ The key components of nodes that are under management by Chef include:
 </thead>
 <tbody>
 <tr>
-<td><p><img src="/images/icon_search.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_search.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/search.md" >}}</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_manage.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_manage.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/chef_manager.md" >}}</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_data_bags.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_data_bags.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/data_bag.md" >}}</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_policy.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_policy.svg" class="align-center" width="130" alt="" /></p></td>
 <td>Policy defines how business and operational requirements, processes, and production workflows map to objects that are stored on the Chef Infra Server. Policy objects on the Chef Infra Server include roles, environments, and cookbook versions.</td>
 </tr>
 </tbody>
@@ -319,19 +319,19 @@ Some important aspects of policy include:
 </thead>
 <tbody>
 <tr>
-<td><p><img src="/images/icon_roles.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_roles.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/role.md" >}}</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_environments.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_environments.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/environment.md" >}}</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_cookbook_versions.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_cookbook_versions.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/cookbooks_version.md" >}}</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_run_lists.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_run_lists.svg" class="align-center" width="130" alt="" /></p></td>
 <td>{{< readfile file="content/reusable/md/node_run_list.md" >}}</td>
 </tr>
 </tbody>

--- a/content/platform_overview.md
+++ b/content/platform_overview.md
@@ -149,7 +149,7 @@ There is a query language available through the UI and customizable dashboards.
 
 Here is an example of the Chef Automate dashboard.
 
-{{< figure src="/images/automate-dashboard.png" width=700 alt="Image of Chef Automate dashboard showing the status of nodes under management with Chef Automate." >}}
+{{< figure src="/images/automate-dashboard.png" width=700 alt="Chef Automate dashboard showing the status of nodes monitored with Chef Automate." >}}
 
 ### Compliance
 

--- a/content/reusable/md/node_types.md
+++ b/content/reusable/md/node_types.md
@@ -17,7 +17,7 @@ limited to, the following:
 <tbody>
 <tr class="odd">
 <td><p><img src="/images/icon_node_type_server.svg" class="align-center" width="130" alt="" /></p></td>
-<td>A physical node is typically a server or a virtual machine, but it can be any active device attached to a network that is capable of sending, receiving, and forwarding information over a communications channel. In other words, a physical node is any active device attached to a network that can run a Chef Infra Client and also allow that Chef Infra Client to communicate with a Chef Infra Server.</td>
+<td>A physical node is typically a server or a virtual machine, but it can be any active device attached to a network that's capable of sending, receiving, and forwarding information over a communications channel. In other words, a physical node is any active device attached to a network that can run a Chef Infra Client and also allow that Chef Infra Client to communicate with a Chef Infra Server.</td>
 </tr>
 <tr class="even">
 <td><p><img src="/images/icon_node_type_cloud_public.svg" class="align-center" width="130" alt="" /></p></td>
@@ -29,11 +29,11 @@ limited to, the following:
 </tr>
 <tr class="even">
 <td><p><img src="/images/icon_node_type_network_device.svg" class="align-center" width="130" alt="" /></p></td>
-<td>A network node is any networking device---a switch, a router---that is being managed by a Chef Infra Client, such as networking devices by Juniper Networks, Arista, Cisco, and F5. Use Chef to automate common network configurations, such as physical and logical Ethernet link properties and VLANs, on these devices.</td>
+<td>A network node is any networking device---a switch, a router---that's being managed by a Chef Infra Client, such as networking devices by Juniper Networks, Arista, Cisco, and F5. Use Chef to automate common network configurations, such as physical and logical Ethernet link properties and VLANs, on these devices.</td>
 </tr>
 <tr class="odd">
 <td><p><img src="/images/icon_node_type_container.svg" class="align-center" width="130" alt="" /></p></td>
-<td>Containers are an approach to virtualization that allows a single operating system to host many working configurations, where each working configuration---a container---is assigned a single responsibility that is isolated from all other responsibilities. Containers are popular as a way to manage distributed and scalable applications and services.</td>
+<td>Containers are an approach to virtualization that allows a single operating system to host many working configurations, where each working configuration---a container---is assigned a single responsibility that's isolated from all other responsibilities. Containers are popular as a way to manage distributed and scalable applications and services.</td>
 </tr>
 </tbody>
 </table>

--- a/content/reusable/md/node_types.md
+++ b/content/reusable/md/node_types.md
@@ -16,23 +16,23 @@ limited to, the following:
 </thead>
 <tbody>
 <tr class="odd">
-<td><p><img src="/images/icon_node_type_server.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_node_type_server.svg" class="align-center" width="130" alt="" /></p></td>
 <td>A physical node is typically a server or a virtual machine, but it can be any active device attached to a network that is capable of sending, receiving, and forwarding information over a communications channel. In other words, a physical node is any active device attached to a network that can run a Chef Infra Client and also allow that Chef Infra Client to communicate with a Chef Infra Server.</td>
 </tr>
 <tr class="even">
-<td><p><img src="/images/icon_node_type_cloud_public.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_node_type_cloud_public.svg" class="align-center" width="130" alt="" /></p></td>
 <td>A cloud-based node is hosted in an external cloud-based service, such as Amazon Web Services (AWS), OpenStack, Rackspace, Google Compute Engine, or Microsoft Azure. Plugins are available for knife that provide support for external cloud-based services. knife can use these plugins to create instances on cloud-based services. Once created, Chef Infra Client can be used to deploy, configure, and maintain those instances.</td>
 </tr>
 <tr class="odd">
-<td><p><img src="/images/icon_node_virtual_machine.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_node_virtual_machine.svg" class="align-center" width="130" alt="" /></p></td>
 <td>A virtual node is a machine that runs only as a software implementation, but otherwise behaves much like a physical machine.</td>
 </tr>
 <tr class="even">
-<td><p><img src="/images/icon_node_type_network_device.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_node_type_network_device.svg" class="align-center" width="130" alt="" /></p></td>
 <td>A network node is any networking device---a switch, a router---that is being managed by a Chef Infra Client, such as networking devices by Juniper Networks, Arista, Cisco, and F5. Use Chef to automate common network configurations, such as physical and logical Ethernet link properties and VLANs, on these devices.</td>
 </tr>
 <tr class="odd">
-<td><p><img src="/images/icon_node_type_container.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_node_type_container.svg" class="align-center" width="130" alt="" /></p></td>
 <td>Containers are an approach to virtualization that allows a single operating system to host many working configurations, where each working configuration---a container---is assigned a single responsibility that is isolated from all other responsibilities. Containers are popular as a way to manage distributed and scalable applications and services.</td>
 </tr>
 </tbody>

--- a/content/server_orgs.md
+++ b/content/server_orgs.md
@@ -31,7 +31,7 @@ role-based access control:
 <tbody>
 <tr>
 <td><p><img src="/images/icon_server_organization.svg" class="align-center" width="130" alt="" /></p></td>
-<td>An organization is the top-level entity for role-based access control in the Chef Infra Server. Each organization contains the default groups (<code>admins</code>, <code>clients</code>, and <code>users</code>, plus <code>billing_admins</code> for the hosted Chef Infra Server), at least one user and at least one node (on which the Chef Infra Client is installed). The Chef Infra Server supports multiple organizations. The Chef Infra Server includes a single default organization that is defined during setup. Additional organizations can be created after the initial setup and configuration of the Chef Infra Server.</td>
+<td>An organization is the top-level entity for role-based access control in the Chef Infra Server. Each organization contains the default groups (<code>admins</code>, <code>clients</code>, and <code>users</code>, plus <code>billing_admins</code> for the hosted Chef Infra Server), at least one user and at least one node (on which the Chef Infra Client is installed). The Chef Infra Server supports multiple organizations. The Chef Infra Server includes a single default organization that's defined during setup. Additional organizations can be created after the initial setup and configuration of the Chef Infra Server.</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_server_groups.svg" class="align-center" width="130" alt="" /></p></td>
@@ -40,11 +40,11 @@ role-based access control:
 </tr>
 <tr>
 <td><p><img src="/images/icon_server_users.svg" class="align-center" width="130" alt="" /></p></td>
-<td>A user is any non-administrator human being who will manage data that is uploaded to the Chef Infra Server from a workstation or who will log on to the Chef management console web user interface. The Chef Infra Server includes a single default user that is defined during setup and is automatically assigned to the <code>admins</code> group.</td>
+<td>A user is any non-administrator human being who will manage data that's uploaded to the Chef Infra Server from a workstation or who will log on to the Chef management console web user interface. The Chef Infra Server includes a single default user that's defined during setup and is automatically assigned to the <code>admins</code> group.</td>
 </tr>
 <tr>
 <td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="" /></p></td>
-<td>A client is an actor that has permission to access the Chef Infra Server. A client is most often a node (on which the Chef Infra Client runs), but is also a workstation (on which knife runs), or some other machine that is configured to use the Chef Infra Server API. Each request to the Chef Infra Server that is made by a client uses a private key for authentication that must be authorized by the public key on the Chef Infra Server.</td>
+<td>A client is an actor that has permission to access the Chef Infra Server. A client is most often a node (on which the Chef Infra Client runs), but is also a workstation (on which knife runs), or some other machine that's configured to use the Chef Infra Server API. Each request to the Chef Infra Server that's made by a client uses a private key for authentication that must be authorized by the public key on the Chef Infra Server.</td>
 </tr>
 </tbody>
 </table>
@@ -223,7 +223,7 @@ The Chef Infra Server includes the following default groups:
 </tr>
 <tr>
 <td><code>users</code></td>
-<td>The <code>users</code> group defines the list of users who use knife and the Chef management console to interact with objects and object types. In general, think of this permission as "all of the non-admin human actors who work with data that is uploaded to and/or downloaded from the Chef server".</td>
+<td>The <code>users</code> group defines the list of users who use knife and the Chef management console to interact with objects and object types. In general, think of this permission as "all of the non-admin human actors who work with data that's uploaded to and/or downloaded from the Chef server".</td>
 </tr>
 </tbody>
 </table>

--- a/content/server_orgs.md
+++ b/content/server_orgs.md
@@ -30,20 +30,20 @@ role-based access control:
 </thead>
 <tbody>
 <tr>
-<td><p><img src="/images/icon_server_organization.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_server_organization.svg" class="align-center" width="130" alt="" /></p></td>
 <td>An organization is the top-level entity for role-based access control in the Chef Infra Server. Each organization contains the default groups (<code>admins</code>, <code>clients</code>, and <code>users</code>, plus <code>billing_admins</code> for the hosted Chef Infra Server), at least one user and at least one node (on which the Chef Infra Client is installed). The Chef Infra Server supports multiple organizations. The Chef Infra Server includes a single default organization that is defined during setup. Additional organizations can be created after the initial setup and configuration of the Chef Infra Server.</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_server_groups.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_server_groups.svg" class="align-center" width="130" alt="" /></p></td>
 <td><p>A group is used to define access to object types and objects in the Chef Infra Server and also to assign permissions that determine what types of tasks are available to members of that group who are authorized to perform them. Groups are configured by organization.</p>
 <p>Individual users who are members of a group will inherit the permissions assigned to the group. The Chef Infra Server includes the following default groups: <code>admins</code>, <code>clients</code>, and <code>users</code>. For users of the hosted Chef Infra Server, an additional default group is provided: <code>billing_admins</code>.</p></td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_server_users.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_server_users.svg" class="align-center" width="130" alt="" /></p></td>
 <td>A user is any non-administrator human being who will manage data that is uploaded to the Chef Infra Server from a workstation or who will log on to the Chef management console web user interface. The Chef Infra Server includes a single default user that is defined during setup and is automatically assigned to the <code>admins</code> group.</td>
 </tr>
 <tr>
-<td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="image" /></p></td>
+<td><p><img src="/images/icon_chef_client.svg" class="align-center" width="130" alt="" /></p></td>
 <td>A client is an actor that has permission to access the Chef Infra Server. A client is most often a node (on which the Chef Infra Client runs), but is also a workstation (on which knife runs), or some other machine that is configured to use the Chef Infra Server API. Each request to the Chef Infra Server that is made by a client uses a private key for authentication that must be authorized by the public key on the Chef Infra Server.</td>
 </tr>
 </tbody>

--- a/content/server_orgs.md
+++ b/content/server_orgs.md
@@ -215,7 +215,7 @@ The Chef Infra Server includes the following default groups:
 </tr>
 <tr>
 <td><code>clients</code></td>
-<td>The <code>clients</code> group defines the list of nodes on which a Chef Infra Client is installed and under management by Chef. In general, think of this permission as "all of the non-human actors---Chef Infra Client, in almost every case---that get data from, and/or upload data to, the Chef server". Newly-created Chef Infra Client instances are added to this group automatically.</td>
+<td>The <code>clients</code> group defines the list of nodes on which a Chef Infra Client is installed and under management by Chef. In general, think of this permission as "all of the non-human actors---Chef Infra Client, in almost every case---that get data from, and/or upload data to, Chef Infra Server." Newly-created Chef Infra Client instances are added to this group automatically.</td>
 </tr>
 <tr>
 <td><code>public_key_read_access</code></td>
@@ -223,7 +223,7 @@ The Chef Infra Server includes the following default groups:
 </tr>
 <tr>
 <td><code>users</code></td>
-<td>The <code>users</code> group defines the list of users who use knife and the Chef management console to interact with objects and object types. In general, think of this permission as "all of the non-admin human actors who work with data that's uploaded to and/or downloaded from the Chef server".</td>
+<td>The <code>users</code> group defines the list of users who use knife and the Chef management console to interact with objects and object types. In general, think of this permission as "all of the non-admin human actors who work with data that's uploaded to and/or downloaded from Chef Infra Server."</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
## Description

Decorative icons should have empty alt text string.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
