### PR TITLE
Set age for cached remote resources

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -60,3 +60,24 @@ notAlternative = true
     endLevel = 4
     ordered = false
     startLevel = 2
+
+[caches]
+  [caches.assets]
+    dir = ':resourceDir/_gen'
+    maxAge = -1
+  [caches.getcsv]
+    dir = ':cacheDir/:project'
+    maxAge = -1
+  [caches.getjson]
+    dir = ':cacheDir/:project'
+    maxAge = "1h"
+  [caches.getresource]
+    dir = ':cacheDir/:project'
+    maxAge = "1h"
+  [caches.images]
+    dir = ':resourceDir/_gen'
+    maxAge = -1
+  [caches.modules]
+    dir = ':cacheDir/modules'
+    maxAge = -1
+

--- a/themes/docs-new/layouts/_default/release_notes.html
+++ b/themes/docs-new/layouts/_default/release_notes.html
@@ -11,7 +11,6 @@
       {{ if or (hugo.IsProduction) ( eq hugo.Environment "staging") ( eq hugo.Environment "branch-deploy")}}
         {{ with $product := $.Param "release_notes" }}
 
-
           {{- $versionsUrl := "" -}}
           {{- if eq $product "automate" -}}
             {{- $versionsUrl = "https://packages.chef.io/releases/current/automate.json"}}
@@ -23,7 +22,26 @@
             {{- $versionsUrl = (print "https://omnitruck.chef.io/stable/" $product "/versions/all") -}}
           {{- end -}}
 
-          {{- $versions := getJSON $versionsUrl -}}
+          {{ $versions := "" }}
+
+          {{ $headers := dict "Cache-Control" "no-cache" "Connection" "keep-alive" }}
+          {{ $cacheKey := print $versionsUrl (now.Format "20060102") (div now.Hour 6) | md5 }}
+          {{ $opts :=  dict "headers" $headers "key" $cacheKey }}
+
+          {{- if hasPrefix $versionsUrl "https://" -}}
+            {{- with resources.GetRemote $versionsUrl $opts -}}
+              {{ with .Err }}
+                {{ errorf "%s" . }}
+              {{ else }}
+                {{ $unmarshalOpts := dict "delimiter" "," }}
+                {{ $versions = . | transform.Unmarshal $unmarshalOpts }}
+              {{ end }}
+            {{ else }}
+              {{ errorf "Unable to get remote resource %q" $versionsUrl }}
+            {{ end }}
+          {{ else }}
+            {{ $versions = getJSON $versionsUrl }}
+          {{ end }}
 
           {{/* We have a "current" version of Infra Client that they want release notes for on the Client release notes page. */}}
           {{/* This allows us to add current release version numbers of Client to the list of version numbers */}}
@@ -102,7 +120,12 @@
               <p><i>Released on {{ time.Format "January 2, 2006" .release_date }}</i></p>
             {{- end -}}
 
-            {{- $remoteResponse := resources.GetRemote $mdUrl (dict "headers" (dict "Cache-Control" "no-cache" "Connection" "keep-alive")) -}}
+            {{/* Define GetRemote options */}}
+            {{ $headers := dict "Cache-Control" "no-cache" "Connection" "keep-alive" }}
+            {{ $cacheKey := print $mdUrl (now.Format "20060102") (div now.Hour 6) | md5 }}
+            {{ $opts :=  dict "headers" $headers "key" $cacheKey }}
+
+            {{- $remoteResponse := resources.GetRemote $mdUrl $opts -}}
 
             {{- if eq $remoteResponse nil -}}
               <p>This release does not have any release notes.</p>

--- a/themes/docs-new/layouts/_default/release_notes.html
+++ b/themes/docs-new/layouts/_default/release_notes.html
@@ -11,68 +11,10 @@
       {{ if or (hugo.IsProduction) ( eq hugo.Environment "staging") ( eq hugo.Environment "branch-deploy")}}
         {{ with $product := $.Param "release_notes" }}
 
-          {{- $versionsUrl := "" -}}
-          {{- if eq $product "automate" -}}
-            {{- $versionsUrl = "https://packages.chef.io/releases/current/automate.json"}}
-          {{- else if (eq $product "habitat") -}}
-            {{- $versionsUrl = "assets/release-notes/habitat/release-versions.json" -}}
-          {{- else if (hasPrefix $product "inspec-") -}}
-            {{- $versionsUrl = print "_vendor/github.com/inspec/"  $product "/docs-chef-io/assets/release-notes/" $product "/release-dates.json" -}}
-          {{- else -}}
-            {{- $versionsUrl = (print "https://omnitruck.chef.io/stable/" $product "/versions/all") -}}
-          {{- end -}}
+          {{ $partialData := dict "product" $product "chefVersions" $.Site.Data.releases.chef.current }}
+          {{ $versionsCorrectOrder := partial "version_numbers.html" $partialData }}
 
-          {{ $versions := "" }}
-
-          {{ $headers := dict "Cache-Control" "no-cache" "Connection" "keep-alive" }}
-          {{ $cacheKey := print $versionsUrl (now.Format "20060102") (div now.Hour 6) | md5 }}
-          {{ $opts :=  dict "headers" $headers "key" $cacheKey }}
-
-          {{- if hasPrefix $versionsUrl "https://" -}}
-            {{- with resources.GetRemote $versionsUrl $opts -}}
-              {{ with .Err }}
-                {{ errorf "%s" . }}
-              {{ else }}
-                {{ $unmarshalOpts := dict "delimiter" "," }}
-                {{ $versions = . | transform.Unmarshal $unmarshalOpts }}
-              {{ end }}
-            {{ else }}
-              {{ errorf "Unable to get remote resource %q" $versionsUrl }}
-            {{ end }}
-          {{ else }}
-            {{ $versions = getJSON $versionsUrl }}
-          {{ end }}
-
-          {{/* We have a "current" version of Infra Client that they want release notes for on the Client release notes page. */}}
-          {{/* This allows us to add current release version numbers of Client to the list of version numbers */}}
-          {{/* that we want to include in the Client release notes. */}}
-          {{- if eq $product "chef" -}}
-            {{- $current_versions := $.Site.Data.releases.chef.current -}}
-            {{- $versions = append $current_versions $versions -}}
-            {{- $paddedVersions := apply $versions "partial" "zero_prefix_pad" "." }}
-            {{- $sortedVersions := (sort $paddedVersions "value" "desc") }}
-            {{- $versions = apply $sortedVersions "partial" "zero_prefix_trim" "." }}
-          {{- end -}}
-
-          {{- $versionsCorrectOrder := slice -}}
-
-          {{- if eq $product "automate" -}}
-            {{- $len := len $versions -}}
-            {{- range seq $len -}}
-              {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) -}}
-            {{- end -}}
-          {{- else if eq $product "chef" -}}
-            {{- $versionsCorrectOrder = $versions -}}
-          {{ else }}
-            {{ $len := len $versions }}
-            {{- range seq $len -}}
-              {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) }}
-            {{ end }}
-          {{- end -}}
-
-
-
-          {{- range $versionsCorrectOrder}}
+          {{- range $versionsCorrectOrder }}
 
             {{- $version := "" -}}
 

--- a/themes/docs-new/layouts/partials/release_notes_toc.html
+++ b/themes/docs-new/layouts/partials/release_notes_toc.html
@@ -10,65 +10,8 @@
 
       {{ with $product := $.Param "release_notes" }}
 
-        {{ $versionsUrl := ""}}
-        {{ if eq $product "automate" }}
-          {{ $versionsUrl = "https://packages.chef.io/releases/current/automate.json"}}
-        {{ else if (eq $product "habitat") }}
-          {{ $versionsUrl = "assets/release-notes/habitat/release-versions.json" }}
-        {{ else if (hasPrefix $product "inspec-") }}
-          {{ $versionsUrl = print "_vendor/github.com/inspec/"  $product "/docs-chef-io/assets/release-notes/" $product "/release-dates.json" }}
-        {{ else }}
-          {{ $versionsUrl = (print "https://omnitruck.chef.io/stable/" $product "/versions/all") }}
-        {{ end }}
-
-        {{ $versions := "" }}
-
-        {{ $headers := dict "Cache-Control" "no-cache" "Connection" "keep-alive" }}
-        {{ $cacheKey := print $versionsUrl (now.Format "20060102") (div now.Hour 6) | md5 }}
-        {{ $opts :=  dict "headers" $headers "key" $cacheKey }}
-
-        {{- if hasPrefix $versionsUrl "https://" -}}
-          {{- with resources.GetRemote $versionsUrl $opts -}}
-            {{ with .Err }}
-              {{ errorf "%s" . }}
-            {{ else }}
-              {{ $unmarshalOpts := dict "delimiter" "," }}
-              {{ $versions = . | transform.Unmarshal $unmarshalOpts }}
-            {{ end }}
-          {{ else }}
-            {{ errorf "Unable to get remote resource %q" $versionsUrl }}
-          {{ end }}
-        {{ else }}
-          {{ $versions = getJSON $versionsUrl }}
-        {{ end }}
-
-        {{/* We have a current version of Infra Client that they want release notes for on the Client release notes page. */}}
-        {{/* This allows us to add current release version numbers of Client to the list of version numbers */}}
-        {{/* that we want to include in the Client release notes. */}}
-        {{- $current_versions := slice -}}
-        {{- if eq $product "chef" -}}
-          {{- $current_versions := $.Site.Data.releases.chef.current -}}
-          {{- $versions = append $current_versions $versions -}}
-          {{- $paddedVersions := apply $versions "partial" "zero_prefix_pad" "." }}
-          {{- $sortedVersions := (sort $paddedVersions "value" "desc") }}
-          {{- $versions = apply $sortedVersions "partial" "zero_prefix_trim" "." }}
-        {{- end -}}
-
-        {{- $versionsCorrectOrder := slice -}}
-
-        {{- if eq $product "automate" -}}
-          {{- $len := len $versions -}}
-          {{- range seq $len -}}
-            {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) -}}
-          {{- end -}}
-        {{- else if eq $product "chef" -}}
-            {{- $versionsCorrectOrder = $versions -}}
-        {{ else }}
-          {{ $len := len $versions }}
-          {{- range seq $len -}}
-            {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) }}
-          {{ end }}
-        {{- end -}}
+        {{ $partialData := dict "product" $product "chefVersions" $.Site.Data.releases.chef.current }}
+        {{ $versionsCorrectOrder := partial "version_numbers.html" $partialData }}
 
         {{ $lastDate := ""}}
         {{ if eq $product "automate" }}

--- a/themes/docs-new/layouts/partials/release_notes_toc.html
+++ b/themes/docs-new/layouts/partials/release_notes_toc.html
@@ -21,7 +21,26 @@
           {{ $versionsUrl = (print "https://omnitruck.chef.io/stable/" $product "/versions/all") }}
         {{ end }}
 
-        {{ $versions := getJSON $versionsUrl }}
+        {{ $versions := "" }}
+
+        {{ $headers := dict "Cache-Control" "no-cache" "Connection" "keep-alive" }}
+        {{ $cacheKey := print $versionsUrl (now.Format "20060102") (div now.Hour 6) | md5 }}
+        {{ $opts :=  dict "headers" $headers "key" $cacheKey }}
+
+        {{- if hasPrefix $versionsUrl "https://" -}}
+          {{- with resources.GetRemote $versionsUrl $opts -}}
+            {{ with .Err }}
+              {{ errorf "%s" . }}
+            {{ else }}
+              {{ $unmarshalOpts := dict "delimiter" "," }}
+              {{ $versions = . | transform.Unmarshal $unmarshalOpts }}
+            {{ end }}
+          {{ else }}
+            {{ errorf "Unable to get remote resource %q" $versionsUrl }}
+          {{ end }}
+        {{ else }}
+          {{ $versions = getJSON $versionsUrl }}
+        {{ end }}
 
         {{/* We have a current version of Infra Client that they want release notes for on the Client release notes page. */}}
         {{/* This allows us to add current release version numbers of Client to the list of version numbers */}}

--- a/themes/docs-new/layouts/partials/version_numbers.html
+++ b/themes/docs-new/layouts/partials/version_numbers.html
@@ -1,0 +1,64 @@
+{{ $product := .product }}
+{{ $chefVersions := .chefVersions }}
+
+{{ $versionsUrl := ""}}
+{{ if eq $product "automate" }}
+  {{ $versionsUrl = "https://packages.chef.io/releases/current/automate.json"}}
+{{ else if (eq $product "habitat") }}
+  {{ $versionsUrl = "assets/release-notes/habitat/release-versions.json" }}
+{{ else if (hasPrefix $product "inspec-") }}
+  {{ $versionsUrl = print "_vendor/github.com/inspec/"  $product "/docs-chef-io/assets/release-notes/" $product "/release-dates.json" }}
+{{ else }}
+  {{ $versionsUrl = (print "https://omnitruck.chef.io/stable/" $product "/versions/all") }}
+{{ end }}
+
+{{ $versions := "" }}
+
+{{ $headers := dict "Cache-Control" "no-cache" "Connection" "keep-alive" }}
+{{ $cacheKey := print $versionsUrl (now.Format "20060102") (div now.Hour 6) | md5 }}
+{{ $opts :=  dict "headers" $headers "key" $cacheKey }}
+
+{{- if hasPrefix $versionsUrl "https://" -}}
+  {{- with resources.GetRemote $versionsUrl $opts -}}
+    {{ with .Err }}
+      {{ errorf "%s" . }}
+    {{ else }}
+      {{ $unmarshalOpts := dict "delimiter" "," }}
+      {{ $versions = . | transform.Unmarshal $unmarshalOpts }}
+    {{ end }}
+  {{ else }}
+    {{ errorf "Unable to get remote resource %q" $versionsUrl }}
+  {{ end }}
+{{ else }}
+  {{ $versions = getJSON $versionsUrl }}
+{{ end }}
+
+
+{{/* We have a current version of Infra Client that they want release notes for on the Client release notes page. */}}
+{{/* This allows us to add current release version numbers of Client to the list of version numbers */}}
+{{/* that we want to include in the Client release notes. */}}
+{{- $current_versions := slice -}}
+{{- if eq $product "chef" -}}
+  {{- $versions = append $chefVersions $versions -}}
+  {{- $paddedVersions := apply $versions "partial" "zero_prefix_pad" "." }}
+  {{- $sortedVersions := (sort $paddedVersions "value" "desc") }}
+  {{- $versions = apply $sortedVersions "partial" "zero_prefix_trim" "." }}
+{{- end -}}
+
+{{- $versionsCorrectOrder := slice -}}
+
+{{- if eq $product "automate" -}}
+  {{- $len := len $versions -}}
+  {{- range seq $len -}}
+    {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) -}}
+  {{- end -}}
+{{- else if eq $product "chef" -}}
+    {{- $versionsCorrectOrder = $versions -}}
+{{ else }}
+  {{ $len := len $versions }}
+  {{- range seq $len -}}
+    {{- $versionsCorrectOrder = $versionsCorrectOrder | append (index $versions (sub $len .)) }}
+  {{ end }}
+{{- end -}}
+
+{{ return $versionsCorrectOrder }}

--- a/themes/docs-new/layouts/partials/version_numbers.html
+++ b/themes/docs-new/layouts/partials/version_numbers.html
@@ -15,7 +15,7 @@
 {{ $versions := "" }}
 
 {{ $headers := dict "Cache-Control" "no-cache" "Connection" "keep-alive" }}
-{{ $cacheKey := print $versionsUrl (now.Format "20060102") (div now.Hour 6) | md5 }}
+{{ $cacheKey := print $versionsUrl (now.Format "20060102") (now.Hour) | md5 }}
 {{ $opts :=  dict "headers" $headers "key" $cacheKey }}
 
 {{- if hasPrefix $versionsUrl "https://" -}}


### PR DESCRIPTION
## Description

This sets the maxage of remote resources, JSON or other file types, to 1 hour. That should save us from issues where an existing file is updated remotely but Hugo doesn't update the cached file locally.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
