### PR TITLE
Deindent notes shortcodes

### DIFF
--- a/content/azure_chef_cli.md
+++ b/content/azure_chef_cli.md
@@ -58,7 +58,7 @@ This command has the following options:
 
 `-a`, `--auto-update-client`
 
-: Automatically update Chef Infra Client. Set to `true` to automatically update the version of the Azure Chef Extension when the virtual machine is restarted. For example, if this option is enabled, a virtual machine that has version `1205.12.2.0` will be updated automatically to `1205.12.2.1` when it is published. Default value: `false`.
+: Automatically update Chef Infra Client. Set to `true` to automatically update the version of the Azure Chef Extension when the virtual machine is restarted. For example, if this option is enabled, a virtual machine that has version `1205.12.2.0` will be updated automatically to `1205.12.2.1` when it's published. Default value: `false`.
 
 `-b`, `--disable`
 
@@ -148,13 +148,13 @@ The extension has the following options that can be provided in the
 
   {{< note >}}
 
-  If using the Chef extension in an ARM template, it is recommended that you base64 encode your validation key and set this option to `base64encoded`
+  If using the Chef extension in an ARM template, it's recommended that you base64 encode your validation key and set this option to `base64encoded`
 
   {{< /note >}}
 
 `bootstrap_version`
 
-: The version of Chef Infra Client that will be installed on the system. **linux only**
+: The version of Chef Infra Client that will be installed on the system. **Linux only**
 
   {{< note >}}
   Due to constraints in Azure, the `bootstrap_version` option is only available on the `LinuxChefClient` extension.

--- a/content/azure_chef_cli.md
+++ b/content/azure_chef_cli.md
@@ -146,7 +146,7 @@ The extension has the following options that can be provided in the
 
 : Tells the extension whether the supplied validation key is `plaintext` or `base64encoded`.
 
-  {{< note spaces=4 >}}
+  {{< note >}}
 
   If using the Chef extension in an ARM template, it is recommended that you base64 encode your validation key and set this option to `base64encoded`
 
@@ -156,7 +156,7 @@ The extension has the following options that can be provided in the
 
 : The version of Chef Infra Client that will be installed on the system. **linux only**
 
-  {{< note spaces=4 >}}
+  {{< note >}}
   Due to constraints in Azure, the `bootstrap_version` option is only available on the `LinuxChefClient` extension.
   {{< /note >}}
 
@@ -168,7 +168,7 @@ The extension has the following options that can be provided in the
 
 : Specifies a local path to install Chef Infra Client from. This feature is mainly used for cases where there are restrictions on internet access.
 
-  {{< note spaces=4 >}}
+  {{< note >}}
   Azure extensions have network access limitations. See the [Azure documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/features-linux#network-access) for more information.
   {{< /note >}}
 
@@ -188,7 +188,7 @@ The extension has the following options that can be provided in the
 
 : A hash of the following options: `chef_node_name`, `chef_server_url`, `environment`, `secret`, and `validation_client_name`.
 
-  {{< note spaces=4 >}}
+  {{< note >}}
 
   Options that are supplied in the bootstrap items will take precedence over any conflicts found in the `client.rb` file.
 

--- a/content/config_rb_client.md
+++ b/content/config_rb_client.md
@@ -52,7 +52,7 @@ This configuration file has the following settings:
     knife[:authentication_protocol_version] = '1.3'
     ```
 
-    {{< note spaces=4 >}}
+    {{< note >}}
 
     Authentication protocol 1.3 is only supported on Chef Server versions 12.4.0 and above.
 
@@ -128,7 +128,7 @@ This configuration file has the following settings:
 
   Default value: `true`. Set to `false` to disable running Chef Infra Client in fork node.
 
-    {{< note spaces=4 >}}
+    {{< note >}}
 
     Must be set to `false` up to Chef Infra Client 13.11.3 to gather the standard return code offered by `exit_status true`. Later versions run as expected without changes to the configuration file.
 
@@ -250,7 +250,7 @@ This configuration file has the following settings:
 
   Default value: `true`.
 
-    {{< warning spaces=4 >}}
+    {{< warning >}}
 
     Changing this setting to `false` may cause file corruption, data loss, or instability. Use the `atomic_update` property on the **cookbook_file**, **file**, **remote_file**, and **template** resources to tune this behavior at the recipe level.
 

--- a/content/config_rb_metadata.md
+++ b/content/config_rb_metadata.md
@@ -139,7 +139,7 @@ This configuration file has the following settings:
   gem 'chef-sugar'
   ```
 
-  {{< warning spaces=4 >}}
+  {{< warning >}}
 
   Use the `gem` setting only for making external chef libraries shipped as gems accessible in a Chef Infra Client run for libraries and attribute files. The `gem` setting in `metadata.rb` allows for the early installation of this specific type of gem, with the fundamental limitation that it cannot install native gems.
 
@@ -227,7 +227,7 @@ This configuration file has the following settings:
     ohai_version '~> 8'
     ```
 
-    {{< note spaces=4 >}}
+    {{< note >}}
 
     This setting is not visible in Chef Supermarket.
 

--- a/content/config_rb_metadata.md
+++ b/content/config_rb_metadata.md
@@ -25,7 +25,7 @@ aliases = ["/config_rb_metadata.html"]
 
 ## Error Messages
 
-The Chef Infra Server will only try to distribute the cookbooks that are needed to configure an individual node. This is determined by identifying the roles and recipes that are assigned directly to that system, and then to expand the list of dependencies, and then to deliver that entire set to the node. In some cases, if the dependency is not specified in the cookbook's metadata, the Chef Infra Server may not treat that dependency as a requirement, which will result in an error message. If an error message is received from the Chef Infra Server about cookbook distribution, verify the `depends` entries in the `metadata.rb` file, and then try again.
+The Chef Infra Server will only try to distribute the cookbooks that are needed to configure an individual node. This is determined by identifying the roles and recipes that are assigned directly to that system, and then to expand the list of dependencies, and then to deliver that entire set to the node. In some cases, if the dependency isn't specified in the cookbook's metadata, the Chef Infra Server may not treat that dependency as a requirement, which will result in an error message. If an error message is received from the Chef Infra Server about cookbook distribution, verify the `depends` entries in the `metadata.rb` file, and then try again.
 
 {{< note >}}
 
@@ -35,7 +35,7 @@ A metadata.json file can be edited directly, should temporary changes be require
 
 ## Version Constraints
 
-Many fields in a cookbook's metadata allow the user to constrain versions. There are a set of operators common to all fields:
+Many fields in a cookbook's metadata allow the user to constrain versions. The following operators are common to all fields:
 
 <!-- markdownlint-disable MD033 -->
 <table>
@@ -106,7 +106,7 @@ This configuration file has the following settings:
 
 `depends`
 
-: This field requires that a cookbook with a matching name and version exists on the Chef Infra Server. When the match exists, the Chef Infra Server includes the dependency as part of the set of cookbooks that are sent to the node during a Chef Infra Client run. It is important that the `depends` field contain accurate data. If a dependency statement is inaccurate, Chef Infra Client may not be able to complete the configuration of the system. All [version constraint operators](#version-constraints) are applicable to this field.
+: This field requires that a cookbook with a matching name and version exists on the Chef Infra Server. When the match exists, the Chef Infra Server includes the dependency as part of the set of cookbooks that are sent to the node during a Chef Infra Client run. It's important that the `depends` field contain accurate data. If a dependency statement is inaccurate, Chef Infra Client may not be able to complete the configuration of the system. All [version constraint operators](#version-constraints) are applicable to this field.
 
   For example, to set a dependency a cookbook named `cats`:
 
@@ -143,7 +143,7 @@ This configuration file has the following settings:
 
   Use the `gem` setting only for making external chef libraries shipped as gems accessible in a Chef Infra Client run for libraries and attribute files. The `gem` setting in `metadata.rb` allows for the early installation of this specific type of gem, with the fundamental limitation that it can't install native gems.
 
-  Don't install native gems with the `gem` setting in `metadata.rb`. The `gem` setting is not a general purpose replacement for the [chef_gem resource](/resources/chef_gem/), and does not internally re-use the `chef_gem` resource. Native gems require C compilation and must not be installed with `metadata.rb` because `metadata.rb` runs before any recipe code runs. Consequently, Chef Infra Client Linux install the C compilers before the gem installation occurs. Instead, install native gems with the `chef_gem` resource called from the recipe code. You'll also need to use the `build_essential` resource in the recipe code to install the prerequisite compilers onto the system.
+  Don't install native gems with the `gem` setting in `metadata.rb`. The `gem` setting isn't a general purpose replacement for the [chef_gem resource](/resources/chef_gem/), and doesn't internally re-use the `chef_gem` resource. Native gems require C compilation and must not be installed with `metadata.rb` because `metadata.rb` runs before any recipe code runs. Consequently, Chef Infra Client Linux install the C compilers before the gem installation occurs. Instead, install native gems with the `chef_gem` resource called from the recipe code. You'll also need to use the `build_essential` resource in the recipe code to install the prerequisite compilers onto the system.
 
   Pure ruby gems can also be installed with `metadata.rb`.
 
@@ -151,7 +151,7 @@ This configuration file has the following settings:
 
 `issues_url`
 
-: The URL for the location in which a cookbook's issue tracking is maintained. This setting is also used by Chef Supermarket. In Chef Supermarket, this value is used to define the destination for the "View Issues" link.
+: The URL of the location in which a cookbook's issue tracking is maintained. This setting is also used by Chef Supermarket. In Chef Supermarket, this value is used to define the destination for the "View Issues" link.
 
   For example:
 
@@ -199,7 +199,7 @@ This configuration file has the following settings:
 
 `maintainer_email`
 
-: The email address for the person responsible for maintaining a cookbook. Only one email can be listed here, so if this needs to be forwarded to multiple people consider using an email address that is already setup for mail forwarding.
+: The email address for the person responsible for maintaining a cookbook. Only one email can be listed here, so if this needs to be forwarded to multiple people consider using an email address that's already setup for mail forwarding.
 
     For example:
 
@@ -229,7 +229,7 @@ This configuration file has the following settings:
 
     {{< note >}}
 
-    This setting is not visible in Chef Supermarket.
+    This setting isn't visible in Chef Supermarket.
 
     {{< /note >}}
 
@@ -245,7 +245,7 @@ This configuration file has the following settings:
 
 `source_url`
 
-: The URL for the location in which a cookbook's source code is maintained. This setting is also used by Chef Supermarket. In Chef Supermarket, this value is used to define the destination for the "View Source" link.
+: The URL of the location in which a cookbook's source code is maintained. This setting is also used by Chef Supermarket. In Chef Supermarket, this value is used to define the destination for the "View Source" link.
 
     For example:
 

--- a/content/config_rb_metadata.md
+++ b/content/config_rb_metadata.md
@@ -141,9 +141,9 @@ This configuration file has the following settings:
 
   {{< warning >}}
 
-  Use the `gem` setting only for making external chef libraries shipped as gems accessible in a Chef Infra Client run for libraries and attribute files. The `gem` setting in `metadata.rb` allows for the early installation of this specific type of gem, with the fundamental limitation that it cannot install native gems.
+  Use the `gem` setting only for making external chef libraries shipped as gems accessible in a Chef Infra Client run for libraries and attribute files. The `gem` setting in `metadata.rb` allows for the early installation of this specific type of gem, with the fundamental limitation that it can't install native gems.
 
-  Do not install native gems with the `gem` setting in `metadata.rb` . The `gem` setting is not a general purpose replacement for the [chef_gem resource](/resources/chef_gem/), and does not internally re-use the `chef_gem` resource. Native gems require C compilation and must not be installed with `metadata.rb` because `metadata.rb` runs before any recipe code runs. Consequently, Chef Infra Client cannot install the C compilers before the gem installation occurs. Instead, install native gems with the `chef_gem` resource called from the recipe code. You'll also need to use the `build_essential` resource in the recipe code to install the prerequisite compilers onto the system.
+  Don't install native gems with the `gem` setting in `metadata.rb`. The `gem` setting is not a general purpose replacement for the [chef_gem resource](/resources/chef_gem/), and does not internally re-use the `chef_gem` resource. Native gems require C compilation and must not be installed with `metadata.rb` because `metadata.rb` runs before any recipe code runs. Consequently, Chef Infra Client Linux install the C compilers before the gem installation occurs. Instead, install native gems with the `chef_gem` resource called from the recipe code. You'll also need to use the `build_essential` resource in the recipe code to install the prerequisite compilers onto the system.
 
   Pure ruby gems can also be installed with `metadata.rb`.
 

--- a/content/ctl_chef_client.md
+++ b/content/ctl_chef_client.md
@@ -122,7 +122,7 @@ This command has the following options:
 
     Use this option to set the `chef_environment` value for a node.
 
-    {{< note spaces=4 >}}
+    {{< note >}}
 
     Any environment specified for `chef_environment` by a JSON file will take precedence over an environment specified by the `--environment` option when both options are part of the same command.
 
@@ -148,7 +148,7 @@ This command has the following options:
 
     {{< readfile file="content/reusable/md/node_ctl_attribute.md" >}}
 
-    {{< note spaces=4 >}}
+    {{< note >}}
 
     This has set the `normal` attribute
     `node['override_attributes']['apptastic']`.
@@ -707,7 +707,7 @@ threads. To increase the system process limits:
     chsec -f /etc/security/limits -s default -a "nofiles=50000"
     ```
 
-    {{< note spaces="4" >}}
+    {{< note >}}
 
     The previous commands may be run against the root user, instead of
     default. For example:

--- a/content/ctl_chef_solo.md
+++ b/content/ctl_chef_solo.md
@@ -72,7 +72,7 @@ This command has the following options:
 
     {{< readfile file="content/reusable/md/node_ctl_run_list.md" spaces=4 >}}
 
-    {{< warning spaces=4 >}}
+    {{< warning >}}
 
     {{< readfile file="content/reusable/md/node_ctl_attribute.md">}}
 

--- a/content/environments.md
+++ b/content/environments.md
@@ -384,7 +384,7 @@ using the following methods:
     file, and then using `knife bootstrap -e environment_name` to
     bootstrap the changes to the specified environment
 
-    {{< note spaces=4 >}}
+    {{< note >}}
 
     After the environment has been set using bootstrap, the environment is
     set in the client.rb file and may not be modified using the `edit` argument of the `knife node`

--- a/content/server_ldap.md
+++ b/content/server_ldap.md
@@ -53,7 +53,7 @@ the following:
     Availability installation as well as on Chef servers in a standalone
     installation.
 
-    {{< warning spaces=4 >}}
+    {{< warning >}}
 
     The following settings **MUST** be in the config file for LDAP
     authentication to Active Directory to work:
@@ -99,7 +99,7 @@ the following:
       'CN=user,OU=Employees,OU=Domainuser,DC=example,DC=com'
       ```
 
-      {{< note spaces=6 >}}
+      {{< note >}}
 
       If you need to escape characters in a distinguished name, such as
       when using Active Directory, they must be [escaped with a backslash
@@ -176,13 +176,13 @@ the following:
       Default value: `false`. Must be `false` when `ldap['tls_enabled']`
       is `true`.
 
-      {{< note spaces=6 >}}
+      {{< note >}}
 
       Enable SSL for Active Directory.
 
       {{< /note >}}
 
-      {{< note spaces=6 >}}
+      {{< note >}}
 
       Previous versions of the Chef Infra Server used the
       `ldap['ssl_enabled']` setting to first enable SSL, and then the
@@ -199,7 +199,7 @@ the following:
       will display strings like "the corporate login server," "corporate
       login," or "corporate password." Default value: `AD/LDAP`.
 
-      {{< warning spaces=6 >}}
+      {{< warning >}}
 
       This setting **isn't** used by the Chef Infra Server. It's used only by the Chef management console.
 
@@ -217,7 +217,7 @@ the following:
       `ldap['port']` is also set to `636`. Default value: `false`. Must be
       `false` when `ldap['ssl_enabled']` is `true`.
 
-      {{< note spaces=6 >}}
+      {{< note >}}
 
       Previous versions of the Chef Infra Server used the
       `ldap['ssl_enabled']` setting to first enable SSL, and then the
@@ -226,7 +226,7 @@ the following:
 
       {{< /note >}}
 
-    {{< note spaces=4 >}}
+    {{< note >}}
 
     If the `chef-server.rb` file doesn't exist, create a file called
     `chef-server.rb` and put it in the `/etc/opscode/` directory.

--- a/content/style/test.md
+++ b/content/style/test.md
@@ -99,10 +99,17 @@ mind:
 Indent ordered sub-list items **3 spaces**.
 
 1. This is a list item
-2. This is another list item in the same list. The number you use in Markdown
+1. This is another list item in the same list. The number you use in Markdown
    does not necessarily correlate to the number in the final output. By
    convention, we keep them in sync.
-3. {{< note >}}
+1. {{< note >}}
+   For single-digit numbered lists, using two spaces after the period makes
+   interior block-level content line up better along tab-stops.
+   {{< /note >}}
+
+1. Some text before a note. Then the note:
+
+   {{< note >}}
    For single-digit numbered lists, using two spaces after the period makes
    interior block-level content line up better along tab-stops.
    {{< /note >}}
@@ -111,7 +118,10 @@ Indent ordered sub-list items **3 spaces**.
 
 1. This is a new list. With Hugo, you need to use a HTML comment to separate
    two consecutive lists. **The HTML comment needs to be at the left margin.**
-2. Numbered lists can have paragraphs or block elements within them.
+
+   The HTML comment `<!-- separate lists -->` is between this list item and the previous one.
+
+1. Numbered lists can have paragraphs or block elements within them.
 
    Indent the content to be the same as the first line of the bullet
    point. **This paragraph and the code block line up with the `N` in
@@ -153,6 +163,11 @@ This is some text that introduces an ordered list.
         - item 1
         - item 2
         - code in item3 `chef-backend-ctl cleanse`
+        - A note as part of a list item:
+
+          {{< note >}}
+          Some text in the note.
+          {{< /note >}}
 
         1. another ordered list item
         1. Ea excepteur duis eiusmod duis laboris anim eiusmod. Est officia dolore veniam exercitation. Do cupidatat ea duis minim labore proident dolore sit dolore et. Elit Lorem aliqua incididunt sint.
@@ -216,6 +231,12 @@ A plain unordered list with additional paragraphs in list items:
   A long paragraph in item 3. Duis quis minim anim reprehenderit id in velit ut commodo deserunt Lorem qui aliqua. Sint duis dolore commodo et irure sunt. Labore ut reprehenderit excepteur eiusmod id ea dolore consectetur laborum sint magna. Qui aliqua consectetur tempor deserunt aliquip. Eiusmod deserunt dolore deserunt ea aliquip non fugiat. Duis tempor exercitation laborum aute ut sit do occaecat proident. Adipisicing qui ex do nulla pariatur ullamco pariatur magna proident.
 
 - item 4
+
+  {{< note >}}
+
+  Some text in a note related to item 4.
+
+  {{< /note >}}
 
 Note that the text of each list item is now enclosed in a paragraph tag while the items in the plain list just had a list item tag.
 
@@ -353,6 +374,7 @@ Checklists are an unordered list with a checkbox.
   {{< foundation_tab active="true" panel-link="ruby-panel" tab-text="Ruby">}}
   {{< foundation_tab panel-link="python-panel" tab-text="Python" >}}
   {{< foundation_tab panel-link="golang-panel" tab-text="Go" >}}
+  {{< foundation_tab panel-link="note-panel" tab-text="Notes" >}}
 {{< /foundation_tabs >}}
 
 {{< foundation_tabs_panels tabs-id="ruby-python-go-panel" >}}
@@ -377,6 +399,19 @@ Checklists are an unordered list with a checkbox.
       fmt.Println("Hello, world!")
   }
   ```
+  {{< /foundation_tabs_panel >}}
+  {{< foundation_tabs_panel panel-id="note-panel" >}}
+  This tests how notes function in a panel.
+
+  {{< note >}}
+
+  Some words in a note.
+
+  ```ruby
+  puts 'Hello, world!'
+  ```
+
+  {{< /note >}}
   {{< /foundation_tabs_panel >}}
 {{< /foundation_tabs_panels >}}
 
@@ -479,7 +514,7 @@ tables, use HTML instead.
   <tr>
     <td>Body cell 1</td>
     <td>Body cell with a note in it:
-      {{< note spaces=6 >}}
+      {{< note >}}
         Some text in a note.
       {{< /note >}}
     </td>

--- a/content/style/test.md
+++ b/content/style/test.md
@@ -359,6 +359,35 @@ plain text _(term in italics)_
 
 : Adding square brackets and the `(@)` symbol around the term (`[another term](@)`) adds a [linkable ID to the term](#another-term).
 
+Foundation panel in a description list.
+
+some_term
+: A bunch of text defining the term.
+
+  More info:
+
+  {{< foundation_tabs tabs-id="bash-powershell-panel1" >}}
+  {{< foundation_tab active="true" panel-link="bash-panel1" tab-text="A panel">}}
+  {{< foundation_tab panel-link="powershell-panel1" tab-text="Another panel" >}}
+  {{< /foundation_tabs >}}
+
+  {{< foundation_tabs_panels tabs-id="bash-powershell-panel1" >}}
+  {{< foundation_tabs_panel active="true" panel-id="bash-panel1" >}}
+  Text in a panel.
+
+  ```ruby
+  puts 'Hello, world!'
+  ```
+  {{< /foundation_tabs_panel >}}
+
+  {{< foundation_tabs_panel panel-id="powershell-panel1" >}}
+  Text in another panel.
+  {{< /foundation_tabs_panel >}}
+  {{< /foundation_tabs_panels >}}
+
+another_term
+: A bunch of text defining the term.
+
 ### Checklists
 
 Checklists are an unordered list with a checkbox.
@@ -620,6 +649,22 @@ You should back up the server.
 {{< recommend >}}
 Back up the server.
 {{< /recommend >}}
+
+Recommend inside a list:
+
+- item 1
+- item 2
+
+  {{< recommend not >}}
+  You should back up the server.
+  {{< /recommend >}}
+
+  - subitem 1
+
+    {{< recommend >}}
+    Back up the server.
+    {{< /recommend >}}
+
 
 ## Notices
 

--- a/content/style/test.md
+++ b/content/style/test.md
@@ -100,7 +100,7 @@ Indent ordered sub-list items **3 spaces**.
 
 1. This is a list item
 1. This is another list item in the same list. The number you use in Markdown
-   does not necessarily correlate to the number in the final output. By
+   doesn't necessarily correlate to the number in the final output. By
    convention, we keep them in sync.
 1. {{< note >}}
    For single-digit numbered lists, using two spaces after the period makes

--- a/content/style/test.md
+++ b/content/style/test.md
@@ -378,6 +378,7 @@ some_term
   ```ruby
   puts 'Hello, world!'
   ```
+
   {{< /foundation_tabs_panel >}}
 
   {{< foundation_tabs_panel panel-id="powershell-panel1" >}}
@@ -664,7 +665,6 @@ Recommend inside a list:
     {{< recommend >}}
     Back up the server.
     {{< /recommend >}}
-
 
 ## Notices
 

--- a/themes/docs-new/layouts/shortcodes/beta.html
+++ b/themes/docs-new/layouts/shortcodes/beta.html
@@ -1,6 +1,6 @@
 <div class="admonition-beta">
   <div class="admonition-beta-text">
     <div class="beta-tag">Beta</div>
-    {{- .Inner | markdownify -}}
+    {{- trim .InnerDeindent "\r\n" | .Page.RenderString -}}
   </div>
 </div>

--- a/themes/docs-new/layouts/shortcodes/codeblock.html
+++ b/themes/docs-new/layouts/shortcodes/codeblock.html
@@ -1,8 +1,0 @@
-<div class="codeblock">
-  {{- with .Get "title" -}}
-  <div class="title">{{. | markdownify}}</div>
-  {{- end -}}
-
-  {{- highlight (trim .Inner "\n") (.Get "lang" | default "") (.Get "options" | default "") -}}
-</div>
-

--- a/themes/docs-new/layouts/shortcodes/cta.html
+++ b/themes/docs-new/layouts/shortcodes/cta.html
@@ -1,5 +1,0 @@
-{{ if eq (.Get "button") "true" }}
-<a href="{{ .Get "href" }}" class="button white arrow-right">{{ .Get "text" }}</a>
-{{ else }}
-<a href="{{ .Get "href" }}" class="cta">{{ .Get "text" }}</a>
-{{ end }}

--- a/themes/docs-new/layouts/shortcodes/danger.html
+++ b/themes/docs-new/layouts/shortcodes/danger.html
@@ -1,11 +1,6 @@
 <div class="admonition-danger">
-    <p class="admonition-danger-title">Danger</p>
-    <div class="admonition-danger-text">
-      {{ if .Get "spaces" }}
-        {{  $regex := delimit (slice `(?m)^\s{` ( .Get "spaces") `}`) "" }}
-        {{- markdownify (replaceRE $regex `` .Inner) -}}
-      {{ else }}
-        {{- .Inner | markdownify -}}
-      {{ end }}
-    </div>
+  <p class="admonition-danger-title">Danger</p>
+  <div class="admonition-danger-text">
+    {{- trim .InnerDeindent "\r\n" | .Page.RenderString -}}
+  </div>
 </div>

--- a/themes/docs-new/layouts/shortcodes/foundation_tabs.html
+++ b/themes/docs-new/layouts/shortcodes/foundation_tabs.html
@@ -1,3 +1,3 @@
 <ul class="tabs" data-tabs id="{{ .Get "tabs-id"}}">
-  {{ .Inner }}
+{{ .Inner }}
 </ul>

--- a/themes/docs-new/layouts/shortcodes/foundation_tabs_panel.html
+++ b/themes/docs-new/layouts/shortcodes/foundation_tabs_panel.html
@@ -1,3 +1,3 @@
 <div class="tabs-panel {{ if .Get "active" }}is-active{{ end }}" id="{{.Get "panel-id"}}">
-  {{- .Inner | markdownify -}}
+{{- trim .InnerDeindent "\r\n" | .Page.RenderString -}}
 </div>

--- a/themes/docs-new/layouts/shortcodes/foundation_tabs_panels.html
+++ b/themes/docs-new/layouts/shortcodes/foundation_tabs_panels.html
@@ -1,3 +1,3 @@
 <div class="tabs-content" data-tabs-content="{{ .Get "tabs-id"}}">
-  {{- .Inner -}}
+{{- trim .InnerDeindent "\r\n" | .Page.RenderString -}}
 </div>

--- a/themes/docs-new/layouts/shortcodes/important.html
+++ b/themes/docs-new/layouts/shortcodes/important.html
@@ -1,4 +1,6 @@
 <div class="admonition-important">
-    <p class="admonition-important-title">Important</p>
-    <div class="admonition-important-text">{{- .Inner | markdownify -}}</div>
+  <p class="admonition-important-title">Important</p>
+  <div class="admonition-important-text">
+    {{- trim .InnerDeindent "\r\n" | .Page.RenderString -}}
+  </div>
 </div>

--- a/themes/docs-new/layouts/shortcodes/note.html
+++ b/themes/docs-new/layouts/shortcodes/note.html
@@ -1,11 +1,6 @@
 <div class="admonition-note">
-    <p class="admonition-note-title">Note</p>
-    <div class="admonition-note-text">
-      {{ if .Get "spaces" }}
-        {{  $regex := delimit (slice `(?m)^\s{` ( .Get "spaces") `}`) "" }}
-        {{- markdownify (replaceRE $regex `` .Inner) -}}
-      {{ else }}
-        {{- .Inner | markdownify -}}
-      {{ end }}
-    </div>
+  <p class="admonition-note-title">Note</p>
+  <div class="admonition-note-text">
+    {{- trim .InnerDeindent "\r\n" | .Page.RenderString -}}
+  </div>
 </div>

--- a/themes/docs-new/layouts/shortcodes/recommend.html
+++ b/themes/docs-new/layouts/shortcodes/recommend.html
@@ -1,11 +1,11 @@
 {{- if eq (.Get 0) "not" -}}
 <div class="text-recommend">
   <div class="recommend-text"><i class="fa-solid fa-square-xmark"></i>Not Recommended</div>
-  <div class="recommended-text">{{ .Inner | markdownify }}</div>
+  <div class="recommended-text">{{- trim .InnerDeindent "\r\n" | .Page.RenderString -}}</div>
 </div>
 {{- else -}}
 <div class="text-recommend">
   <div class="recommend-text"><i class="fa-regular fa-square-check"></i>Recommend</div>
-  <div class="recommended-text">{{ .Inner | markdownify }}</div>
+  <div class="recommended-text">{{- trim .InnerDeindent "\r\n" | .Page.RenderString -}}</div>
 </div>
 {{- end -}}

--- a/themes/docs-new/layouts/shortcodes/warning.html
+++ b/themes/docs-new/layouts/shortcodes/warning.html
@@ -1,11 +1,6 @@
 <div class="admonition-warning">
-    <p class="admonition-warning-title">Warning</p>
-    <div class="admonition-warning-text">
-      {{ if .Get "spaces" }}
-        {{  $regex := delimit (slice `(?m)^\s{` ( .Get "spaces") `}`) "" }}
-        {{- markdownify (replaceRE $regex `` .Inner) -}}
-      {{ else }}
-        {{- .Inner | markdownify -}}
-      {{ end }}
-    </div>
+  <p class="admonition-warning-title">Warning</p>
+  <div class="admonition-warning-text">
+    {{- trim .InnerDeindent "\r\n" | .Page.RenderString -}}
+  </div>
 </div>


### PR DESCRIPTION
## Description

The [`.InnerDeindent` method](https://gohugo.io/methods/shortcode/innerdeindent/) handles indented text in a markdown page so that it renders properly.

The previous method (`.Inner`) could lead to weird HTML rendering when a shortcode is indented in a markdown page and the text it wraps is also indented.

See the relevant [discussion on Hugo Discourse](https://discourse.gohugo.io/t/making-highlight-shortcode-indentation-aware-for-code-blocks-within-list/18462).

This also cleans up the foundation_tab shortcodes and deletes two shortcodes we don't use.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
