### PR TITLE
Fix path problems with other repos

### DIFF
--- a/scripts/netlify-deploy-preview.sh
+++ b/scripts/netlify-deploy-preview.sh
@@ -20,7 +20,7 @@ echo Branch deploy URL: $DEPLOY_PRIME_URL
 curl -LJO https://github.com/sass/dart-sass/releases/download/$DART_SASS_VERSION/dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
 tar -xf dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
 rm dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
-export PATH=/opt/build/repo/dart-sass:$PATH
+export PATH=$(pwd)/dart-sass:$PATH
 
 npm install
 hugo --gc --minify --enableGitInfo --buildFuture


### PR DESCRIPTION
## Description

The path that dart-sass is added to is different depending on the repo. This should address issues of adding the correct path to dart sass regardless of repo.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
