### PR TITLE
Clarify required location of .d directories for each tool

### DIFF
--- a/content/reusable/md/config_rb_client_dot_d_directories.md
+++ b/content/reusable/md/config_rb_client_dot_d_directories.md
@@ -3,11 +3,13 @@ putting them inside a `.d` configuration directory. For example:
 `/etc/chef/client.d`. All files that end in `.rb` in the `.d` directory
 are loaded; other non-`.rb` files are ignored.
 
-`.d` directories may exist in any location where the `client.rb`,
-`config.rb`, or `solo.rb` files are present, such as:
-
+Chef Infra Client itself requires that .rb files are stored in a directory named `client.d`, such as
 - `/etc/chef/client.d`
-- `/etc/chef/config.d`
+
+Chef development tooling such as knife requires that .rb files are stored in a directory named `config.d`, such as
+- `~/.chef/config.d`
+
+Chef Solo requires that .rb files are stored in a directory named `solo.d`, such as
 - `~/chef/solo.d`
 
 (There is no support for a `knife.d` directory; use `config.d` instead.)

--- a/content/reusable/md/config_rb_client_dot_d_directories.md
+++ b/content/reusable/md/config_rb_client_dot_d_directories.md
@@ -4,12 +4,15 @@ putting them inside a `.d` configuration directory. For example:
 are loaded; other non-`.rb` files are ignored.
 
 Chef Infra Client itself requires that .rb files are stored in a directory named `client.d`, such as
+
 - `/etc/chef/client.d`
 
 Chef development tooling such as knife requires that .rb files are stored in a directory named `config.d`, such as
+
 - `~/.chef/config.d`
 
 Chef Solo requires that .rb files are stored in a directory named `solo.d`, such as
+
 - `~/chef/solo.d`
 
 (There is no support for a `knife.d` directory; use `config.d` instead.)


### PR DESCRIPTION
## Description

The current documentation around the use of .d directories does not make it clear that different Chef tools require a specific directory name and will ignore any other .d directories not named correctly.

This PR clarifies the requirements of each tool.

## Check List

- [X] Spell Check
- [X] Local build
- [X] Examine the local build
- [X] All tests pass
