### PR TITLE
URL typo fixes

### DIFF
--- a/content/download/commercial.md
+++ b/content/download/commercial.md
@@ -40,7 +40,7 @@ The `architectures` endpoint returns a valid list of architecture that Chef prod
 Any of these architectures can be used in the `m` [query string](#parameters) value in various endpoints below.
 
 ```plain
-https://chefdownload-commerical.chef.io/architectures
+https://chefdownload-commercial.chef.io/architectures
 ```
 
 ### platforms
@@ -48,7 +48,7 @@ https://chefdownload-commerical.chef.io/architectures
 The `platforms` endpoint returns a list of valid platform keys along with full friendly names. Any of these platform keys can be used in the `p` [query string](#parameters) value in various endpoints below.
 
 ```plain
-https://chefdownload-commerical.chef.io/platforms
+https://chefdownload-commercial.chef.io/platforms
 ```
 
 ### products
@@ -56,13 +56,13 @@ https://chefdownload-commerical.chef.io/platforms
 The `products` endpoint returns a list of valid product keys. In the following endpoints, you can replace the `<PRODUCT>` string with a product key in the response of this endpoint.
 
 ```plain
-https://chefdownload-commerical.chef.io/products
+https://chefdownload-commercial.chef.io/products
 ```
 
 Use `eol=true` to return EOL products.
 
 ```plain
-https://chefdownload-commerical.chef.io/products?eol=true
+https://chefdownload-commercial.chef.io/products?eol=true
 ```
 
 ### packages
@@ -72,13 +72,13 @@ Use `packages` to get a full list of all packages for a particular release chann
 By default, it returns packages for the latest version.
 
 ```plain
-https://chefdownload-commerical.chef.io/<CHANNEL>/<PRODUCT>/packages?license_id=<LICENSE_ID>
+https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/packages?license_id=<LICENSE_ID>
 ```
 
 You can specify a version number with the `v` query string to get packages for a particular product version.
 
 ```plain
-https://chefdownload-commerical.chef.io/<CHANNEL>/<PRODUCT>/packages?v=<VERSION_NUMBER>&license_id=<LICENSE_ID>
+https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/packages?v=<VERSION_NUMBER>&license_id=<LICENSE_ID>
 ```
 
 ### versions/all
@@ -86,7 +86,7 @@ https://chefdownload-commerical.chef.io/<CHANNEL>/<PRODUCT>/packages?v=<VERSION_
 Use `versions/all` to return a list of versions of a product from a particular release channel.
 
 ```plain
-https://chefdownload-commerical.chef.io/<CHANNEL>/<PRODUCT>/versions/all?license_id=<LICENSE_ID>
+https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/versions/all?license_id=<LICENSE_ID>
 ```
 
 ### versions/latest
@@ -94,7 +94,7 @@ https://chefdownload-commerical.chef.io/<CHANNEL>/<PRODUCT>/versions/all?license
 Use `versions/latest` to return the latest version of a product from a particular release channel.
 
 ```plain
-https://chefdownload-commerical.chef.io/<CHANNEL>/<PRODUCT>/versions/latest?license_id=<LICENSE_ID>
+https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/versions/latest?license_id=<LICENSE_ID>
 ```
 
 ### metadata
@@ -102,7 +102,7 @@ https://chefdownload-commerical.chef.io/<CHANNEL>/<PRODUCT>/versions/latest?lice
 The `metadata` endpoint returns data about a particular package of a Chef product.
 
 ```plain
-https://chefdownload-commerical.chef.io/<CHANNEL>/<PRODUCT>/metadata?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
+https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/metadata?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
 ```
 
 ### download
@@ -110,7 +110,7 @@ https://chefdownload-commerical.chef.io/<CHANNEL>/<PRODUCT>/metadata?p=<PLATFORM
 The `download` endpoint downloads a particular package of a Chef product.
 
 ```plain
-https://chefdownload-commerical.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
+https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
 ```
 
 ## Parameters
@@ -187,7 +187,7 @@ This is a list of currently supported products that you can install with this AP
 To get the latest supported build of Chef Infra Client for Ubuntu 20.04, enter the following:
 
 ```plain
-https://chefdownload-commerical.chef.io/stable/chef/metadata?p=ubuntu&pv=20.04&m=x86_64&license_id=<LICENSE_ID>
+https://chefdownload-commercial.chef.io/stable/chef/metadata?p=ubuntu&pv=20.04&m=x86_64&license_id=<LICENSE_ID>
 ```
 
 which will return something like:
@@ -195,7 +195,7 @@ which will return something like:
 ```json
 sha1	"8e8ae315d4695f9c95efc0a1437d2d453f7ab116"
 sha256	"86f14ae08237b4e24201436ecb83c08c29b68aed1d6ede0953a1b4547a920e36"
-url	"https://chefdownload-commerical.chef.io/stable/chef/download?license_id=<LICENSE_ID>&m=x86_64&p=ubuntu&pv=20.04"
+url	"https://chefdownload-commercial.chef.io/stable/chef/download?license_id=<LICENSE_ID>&m=x86_64&p=ubuntu&pv=20.04"
 version	"18.2.7"
 ```
 
@@ -204,11 +204,11 @@ version	"18.2.7"
 To use cURL to download a package directly, enter the following:
 
 ```bash
-curl -LOJ 'https://chefdownload-commerical.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>'
+curl -LOJ 'https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>'
 ```
 
 To use GNU Wget to download a package directly, enter the following:
 
 ```bash
-wget --content-disposition https://chefdownload-commerical.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>
+wget --content-disposition https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>
 ```


### PR DESCRIPTION
## Description

[Please describe what this change achieves]
Fixed the URL typo for the Downloads API
Jira: https://progresssoftware.atlassian.net/browse/CHEF-15765

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

chef/chef-server#3908

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
