### PR TITLE
Updating to remove support for Windows Server 2012 and 2012R2

### DIFF
--- a/content/api_omnitruck.md
+++ b/content/api_omnitruck.md
@@ -130,7 +130,7 @@ Omnitruck accepts the following platforms:
 <td>Windows</td>
 <td><code>windows</code></td>
 <td><code>x86_64</code>, <code>i386</code></td>
-<td><code>7</code>, <code>8</code>, <code>10</code>, <span class="title-ref">2008r2</span>, <code>2012</code>, <code>2012r2</code>, <code>2016</code>, <code>2019</code>, <code>11</code>, <code>2022</code></td>
+<td><code>10</code>, <span class="title-ref">2016</span>, <code>2019</code>, <code>11</code>, <code>2022</code></td>
 </tr>
 </tbody>
 </table>

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -104,7 +104,7 @@ The following table lists the commercially supported platforms and versions for 
 | Solaris | `sparc`, `i86pc` | `11.3` (16.17.4 and later only), `11.4`  |
 | SUSE Linux Enterprise Server | `x86_64`, `aarch64` (15.x only), `s390x` | `12`, `15` |
 | Ubuntu (LTS releases) | `x86_64`,`aarch64` (18.x and above) | `16.04`, `18.04`, `20.04`, `22.04` |
-| Windows | `x86_64` | `2012`, `2012 R2`, `2016`, `10` (all channels except "insider" builds), `2019` (Long-term servicing channel (LTSC), both Desktop Experience and Server Core), `11`, `2022` |
+| Windows | `x86_64` | `2016`, `10` (all channels except "insider" builds), `2019` (Long-term servicing channel (LTSC), both Desktop Experience and Server Core), `11`, `2022` |
 
 #### Derived platforms
 


### PR DESCRIPTION
## Description

Windows Server 2012 and is out of support and we're updating the platforms list here to reflect that. 

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
