### PR TITLE
Remove extraneous backtick from find command in Mac uninstall documentation

### DIFF
--- a/content/uninstall.md
+++ b/content/uninstall.md
@@ -55,7 +55,7 @@ sudo pkgutil --forget com.getchef.pkg.chef-workstation
 To remove symlinks:
 
 > ```bash
-> sudo find /usr/local/bin -lname '`/opt/chef-workstation/*' -delete
+> sudo find /usr/local/bin -lname '/opt/chef-workstation/*' -delete
 > ```
 
 ### Red Hat Enterprise Linux


### PR DESCRIPTION
## Description

Remove unnecessary backtick in `find` command in uninstall documentation for Mac. Its presence stops the command finding any of the chef symlinks in /usr/local/bin, leaving them all present.

## Definition of Done

## Issues Resolved

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
