### PR TITLE
fix typos for "don'thing"

### DIFF
--- a/content/ctl_chef_client.md
+++ b/content/ctl_chef_client.md
@@ -440,7 +440,7 @@ made:
 
 For example, the **service** resource can be used to start a service. If
 the action is `:start`, then the service will start if it's not running
-and don'thing if it's running. If a service is installed from a
+and do nothing if it's running. If a service is installed from a
 package, then Chef Infra Client can't check to see if the service is
 running until after the package is installed. In that case, why-run mode
 will indicate what Chef Infra Client would do about the state of the

--- a/content/resource_common.md
+++ b/content/resource_common.md
@@ -98,7 +98,7 @@ end
 
 The following example shows how to use a custom block of Ruby code to
 ensure that a node can resolve the host. If the node can resolve the
-host, Chef Infra Client will don'thing. If the node can't resolve the
+host, Chef Infra Client will do nothing. If the node can't resolve the
 host, Chef Infra Client will configure the host:
 
 ```ruby
@@ -154,7 +154,7 @@ necessary. In this case, three attributes exist in the
 The `only_if` attributes are used to test for the presence of these
 packages on the target node before then asking Chef Infra Client to
 complete the process of installing these packages. If the packages are
-already present, Chef Infra Client will don'thing.
+already present, Chef Infra Client will do nothing.
 
 ```ruby
 package 'libpcre3-dev' do

--- a/content/reusable/md/resources_common_guards.md
+++ b/content/reusable/md/resources_common_guards.md
@@ -16,4 +16,4 @@ a string value or a Ruby block value:
 A guard property is useful for ensuring that a resource is idempotent by
 allowing that resource to test for the desired state as it's being
 executed, and then if the desired state is present, for Chef Infra
-Client to don'thing.
+Client to do nothing.


### PR DESCRIPTION
## Description

This change fixes a simple and obvious typo.  This is a high confidence change.

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
