### PR TITLE
Fix vale lint error

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog
         with:
-          files: '["archetypes", "assets", "content", "data", "layouts", "static"]'
+          files: '["assets", "content", "data", "layouts", "static"]'
           vale_flags: "--config=tools/vale/.vale-github-action.ini"
           filter_mode: diff_context
           fail_on_error: true


### PR DESCRIPTION
## Description

The release of Vale 3.11 includes frontmatter linting and produces an error in the Hugo archetypes. 

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
