### PR TITLE
[Do not merge ] Add Chef Vault to Deprecated Products List

### DIFF
--- a/_vendor/github.com/chef/chef-workstation/docs-chef-io/content/workstation/chef_vault.md
+++ b/_vendor/github.com/chef/chef-workstation/docs-chef-io/content/workstation/chef_vault.md
@@ -491,7 +491,9 @@ knife vault rotate keys passwords root --clean-unknown-clients
 
 #### `refresh`
 
-This command reads the search_query in the vault item, performs the search, and reapplies the results.
+This command reads the search_query stored in the vault item, re-executes the search, and refreshes access for all nodes that match the updated query results.
+
+Note: This operation does not update or re-encrypt credentials for admin users. To update credentials for admin users, use the knife chef vault update command and explicitly specify the admin user(s).
 
 ``` shell
 knife vault refresh VAULT ITEM

--- a/content/versions.md
+++ b/content/versions.md
@@ -98,6 +98,7 @@ newer versions or products.
 | Chef Infra Server | 14.x    | Deprecated       | TBD            |
 | Chef InSpec       | 5.x     | Deprecated       | TBD            |
 | Chef Manage       | 2.5.x+  | Deprecated       | TBD            |
+| Chef Vault        | All     | Deprecated       | TBD            |
 
 ## End of Life (EOL) products
 


### PR DESCRIPTION
## Description

Chef Vault is marked as deprecated with all versions and no specific EOL date (TBD).


## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
