### PR TITLE
Update habitat-sh/on-prem-builder module

### DIFF
--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/chef/automate/components/docs-chef-io v0.0.0-20250617123043-e9e3b2463824
 # github.com/chef/desktop-config/docs-chef-io v0.0.0-20240814044820-5af667d41a43
 # github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20250703193412-93daafc684a8
-# github.com/habitat-sh/on-prem-builder/docs-chef-io v0.0.0-20250703193242-204bceb9833e
+# github.com/habitat-sh/on-prem-builder/docs-chef-io v0.0.0-20250805192817-f8b1dae05d5e
 # github.com/chef/chef-server/docs-chef-io v0.0.0-20250414141619-a0fb7ff68e94
 # github.com/inspec/inspec/docs-chef-io v0.0.0-20250123110211-42364d842e34
 # github.com/inspec/inspec-alicloud/docs-chef-io v0.0.0-20240122032124-a1d2a214e170

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chef/chef-web-docs
 
-go 1.24.2
+go 1.23
 
 require (
 	github.com/chef/automate/components/docs-chef-io v0.0.0-20250617123043-e9e3b2463824 // indirect
@@ -16,7 +16,7 @@ require (
 	github.com/chef/supermarket/docs-chef-io v0.0.0-20250602140848-cded623a3f5c // indirect
 	github.com/cowboy/jquery-hashchange v0.0.0-20100902193700-0310f3847f90 // indirect
 	github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20250703193412-93daafc684a8 // indirect
-	github.com/habitat-sh/on-prem-builder/docs-chef-io v0.0.0-20250703193242-204bceb9833e // indirect
+	github.com/habitat-sh/on-prem-builder/docs-chef-io v0.0.0-20250805192817-f8b1dae05d5e // indirect
 	github.com/inspec/inspec-alicloud/docs-chef-io v0.0.0-20240122032124-a1d2a214e170 // indirect
 	github.com/inspec/inspec-aws/docs-chef-io v0.0.0-20240122032232-049dcf822eef // indirect
 	github.com/inspec/inspec-azure/docs-chef-io v0.0.0-20250728075256-c374c23637d3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/cowboy/jquery-hashchange v0.0.0-20100902193700-0310f3847f90 h1:p/a5iS
 github.com/cowboy/jquery-hashchange v0.0.0-20100902193700-0310f3847f90/go.mod h1:N/6F0+wmdvL6k0AjqyKIncMRClKAN92atjZdTLtYMaw=
 github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20250703193412-93daafc684a8 h1:euxH1nuHIWgo6hr6Z/CkHOGik+JIghtkrFXUj01hB+4=
 github.com/habitat-sh/habitat/components/docs-chef-io v0.0.0-20250703193412-93daafc684a8/go.mod h1:5GKz/BtTWeTr8vdVQPkvGDQkQ+xiGWLkDsPOXhu2Ps4=
-github.com/habitat-sh/on-prem-builder/docs-chef-io v0.0.0-20250703193242-204bceb9833e h1:Rqg0DsHGRpQNUuH8ewyZR5cGf8g1xIr2f+zRqe04JDY=
-github.com/habitat-sh/on-prem-builder/docs-chef-io v0.0.0-20250703193242-204bceb9833e/go.mod h1:qrPLVomtsigVjzB+Q0hhZJx/0RVzs8GQPOzovYflc5k=
+github.com/habitat-sh/on-prem-builder/docs-chef-io v0.0.0-20250805192817-f8b1dae05d5e h1:qHs6EaygFn8iNJgqeGHI6Bd1jMSynG4TijKKWfqR8N8=
+github.com/habitat-sh/on-prem-builder/docs-chef-io v0.0.0-20250805192817-f8b1dae05d5e/go.mod h1:8gmm7JyOiJAbZHIpZNCP4XqgZ8RtUHaEwEi0X0AsJ4M=
 github.com/inspec/inspec-alicloud/docs-chef-io v0.0.0-20240122032124-a1d2a214e170 h1:Q9jEEyv8nZAN5NgJXwMoqjngSz6Bc5ruNc9V72Hk4b4=
 github.com/inspec/inspec-alicloud/docs-chef-io v0.0.0-20240122032124-a1d2a214e170/go.mod h1:tAazDDBtR5yCl/FNWHnrmkxpfxnOo9B99DyfRE7JH1c=
 github.com/inspec/inspec-aws/docs-chef-io v0.0.0-20240122032232-049dcf822eef h1:r+GoVO6zbIAtusZ2w6MwUhtDAJicQkYbX0iWwZmuXfQ=


### PR DESCRIPTION
## Description
I've been getting errors in Expeditor when it tries to update modules due to the go version number in this go.mod file.
This is due to the version in the habitat-sh/on-prem-builder repo. This sets the version 1.23.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

- https://github.com/habitat-sh/on-prem-builder/pull/285

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
