### PR TITLE
Fix paludis package data

### DIFF
--- a/data/infra/resources/paludis_package.yaml
+++ b/data/infra/resources/paludis_package.yaml
@@ -18,16 +18,6 @@ syntax_description: 'A **paludis_package** resource block manages a package on a
   which will install the named package using all of the default options
   and the default action (`:install`).'
 resource_new_in: '12.1'
-syntax_description: |
-  A **paludis_package** resource block manages a package on a node,
-  typically by installing it. The simplest use of the **paludis_package**
-  resource is:
-
-  ```ruby
-  paludis_package 'package_name'
-  ```
-
-  which will install the named package using all of the default options.
 syntax_full_code_block: |-
   paludis_package 'name' do
     options           String, Array


### PR DESCRIPTION
## Description

The `syntax_description` block is in there twice.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
