### PR TITLE
CHEF-27171 - Replace CONTRIBUTING.md file with standard template for non-product

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to a Chef Project
+
+Thank you for your interest in contributing to this project! It is part of the larger Progress ecosystem of projects but is governed by the Chef Client contribution guidelines, which may be found at [Contributing to Progress Chef Infra Client](https://chef.github.io/chef-oss-practices/projects/chef/contributing/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 # Contributing to a Chef Project
 
-Thank you for your interest in contributing to this project! It is part of the larger Progress ecosystem of projects but is governed by the Chef Client contribution guidelines, which may be found at [Contributing to Progress Chef Infra Client](https://chef.github.io/chef-oss-practices/projects/chef/contributing/).
+Thank you for your interest in contributing to this project! It's part of the larger Progress ecosystem of projects but is governed by the Chef Client contribution guidelines, which may be found at [Contributing to Progress Chef Infra Client](https://chef.github.io/chef-oss-practices/projects/chef/contributing/).


### PR DESCRIPTION
Replace CONTRIBUTING.md file with standard template for non-product
This pull request replaces the existing CONTRIBUTING.md file with the standard template for the non-product project. As part of the [repo standardization effort](https://github.com/chef-boneyard/oss-repo-standardization-2025) we are replacing all the different contributing guides with a standard template that links to a published version of the chef-oss-practices repo.
This PR is intended to be a mere mechanical change, not a change in policy. Watch chef/chef-oss-practices for changes in policy.
The link provided in the template may not function at the time this PR is opened, in which case this PR is intended to remain in Draft status if the repo permits; in any case it should not be merged until the link is live.