### PR TITLE
Added license id to community api docs

### DIFF
--- a/content/chef_install_script.md
+++ b/content/chef_install_script.md
@@ -92,16 +92,19 @@ Use the Chef install script to install packages on UNIX, Linux, and macOS system
 By default the script installs the latest available version of Chef Infra Client:
 
 ```bash
-curl -L https://chefdownload-community.chef.io/install.sh | sudo bash
+curl -L https://chefdownload-community.chef.io/install.sh?license_id=<LICENSE_ID> | sudo bash
 ```
 
 Use the `-P` option to specify a Chef application to install:
 
 ```bash
-curl -L https://chefdownload-community.chef.io/install.sh | sudo bash -s -- -P <PROJECT>
+curl -L https://chefdownload-community.chef.io/install.sh?license_id=<LICENSE_ID> | sudo bash -s -- -P <PROJECT>
 ```
 
-Replace `<PROJECT>` with the application you want to install.
+Replace:
+
+- `<LICENSE_ID>` with your license ID
+- `<PROJECT>` with the application you want to install
 
 For additional script install options, see the [script options](#script-options).
 
@@ -112,14 +115,18 @@ On Windows systems, you can install Chef software using the Powershell install s
 By default the script installs the latest available version of Chef Infra Client:
 
 ```powershell
-. { iwr -useb https://chefdownload-community.chef.io/install.ps1 } | iex; install
+. { iwr -useb https://chefdownload-community.chef.io/install.ps1?license_id=<LICENSE_ID> } | iex; install
 ```
+
+Replace `<LICENSE_ID>` with your license ID.
 
 Use the `-project` option to specify a Chef application to install:
 
 ```powershell
-. { iwr -useb https://chefdownload-community.chef.io/install.ps1 } | iex; install -project <PROJECT>
+. { iwr -useb https://chefdownload-community.chef.io/install.ps1?license_id=<LICENSE_ID> } | iex; install -project <PROJECT>
 ```
+
+Replace `<LICENSE_ID>` with your license ID.
 
 For additional script install options, see the [script options](#script-options).
 

--- a/content/chef_install_script.md
+++ b/content/chef_install_script.md
@@ -85,6 +85,10 @@ For additional script install options, see the [script options](#script-options)
 
 Community users can use the install script from the [Chef Community API](/download/community/) to install Chef software.
 
+### Prerequisites
+
+You must have a license ID to use the install script from the Chef Community API. Only free licenses can be used for community downloads.
+
 ### UNIX, Linux, and macOS
 
 Use the Chef install script to install packages on UNIX, Linux, and macOS systems.

--- a/content/download/commercial.md
+++ b/content/download/commercial.md
@@ -132,7 +132,7 @@ The API accepts the following parameters in a query string.
 `license_id`
 : Your license ID.
 
-  A license is required to download packages and retrieve package metadata with this API.
+  A license is required to download packages and retrieve package metadata with this API. Only commercial and free licenses can be used for commercial downloads.
 
 `eol`
 : Whether to include EOL versions of a product or EOL products in the response.

--- a/content/download/commercial.md
+++ b/content/download/commercial.md
@@ -18,7 +18,7 @@ You can use an install script from the API to download and install Chef packages
 
 ## License
 
-To download packages and review metadata with this API, you need a license ID. Only commercial and free licenses can be used for commercial downloads.
+To download packages and review metadata with this API, you need a license ID.
 
 You can get your license ID from the [Chef Downloads portal](https://chef.io/downloads), or [contact Chef](https://www.chef.io/contact-us) if you don't have one.
 
@@ -132,7 +132,7 @@ The API accepts the following parameters in a query string.
 `license_id`
 : Your license ID.
 
-  A license is required to download packages and retrieve package metadata with this API. Only commercial and free licenses can be used for commercial downloads.
+  A license is required to download packages and retrieve package metadata with this API.
 
 `eol`
 : Whether to include EOL versions of a product or EOL products in the response.

--- a/content/download/commercial.md
+++ b/content/download/commercial.md
@@ -18,7 +18,7 @@ You can use an install script from the API to download and install Chef packages
 
 ## License
 
-To download packages and review metadata with this API, you need a license ID.
+To download packages and review metadata with this API, you need a license ID. Only commercial and free licenses can be used for commercial downloads.
 
 You can get your license ID from the [Chef Downloads portal](https://chef.io/downloads), or [contact Chef](https://www.chef.io/contact-us) if you don't have one.
 

--- a/content/download/community.md
+++ b/content/download/community.md
@@ -15,6 +15,8 @@ Chef community members can use Chef's Community API to download Chef software pa
 
 ## License
 
+To download packages and review metadata with this API, you need a license ID.  Only free licenses can be used for community downloads.
+
 See [Chef's licensing documentation]({{< relref "chef_license" >}}) for more information on the Chef license.
 
 ## Endpoints

--- a/content/download/community.md
+++ b/content/download/community.md
@@ -70,13 +70,13 @@ Use `packages` to get a list of all packages for a particular product.
 By default, it returns packages for the latest version.
 
 ```plain
-https://chefdownload-community.chef.io/stable/<PRODUCT>/packages
+https://chefdownload-community.chef.io/stable/<PRODUCT>/packages?license_id=<LICENSE_ID>
 ```
 
 You can specify a version number with the `v` query string to get packages for a particular product version.
 
 ```plain
-https://chefdownload-community.chef.io/stable/<PRODUCT>/packages?v=<VERSION_NUMBER>
+https://chefdownload-community.chef.io/stable/<PRODUCT>/packages?v=<VERSION_NUMBER>&license_id=<LICENSE_ID>
 ```
 
 ### versions/all
@@ -84,7 +84,7 @@ https://chefdownload-community.chef.io/stable/<PRODUCT>/packages?v=<VERSION_NUMB
 Use `versions/all` to return a list of versions of a product.
 
 ```plain
-https://chefdownload-community.chef.io/stable/<PRODUCT>/versions/all
+https://chefdownload-community.chef.io/stable/<PRODUCT>/versions/all?license_id=<LICENSE_ID>
 ```
 
 ### versions/latest
@@ -92,7 +92,7 @@ https://chefdownload-community.chef.io/stable/<PRODUCT>/versions/all
 Use `versions/latest` to return the latest version of a product.
 
 ```plain
-https://chefdownload-community.chef.io/stable/<PRODUCT>/versions/latest
+https://chefdownload-community.chef.io/stable/<PRODUCT>/versions/latest?license_id=<LICENSE_ID>
 ```
 
 ### metadata
@@ -100,7 +100,7 @@ https://chefdownload-community.chef.io/stable/<PRODUCT>/versions/latest
 The `metadata` endpoint returns data about a particular package of a Chef product.
 
 ```plain
-https://chefdownload-community.chef.io/stable/<PRODUCT>/metadata?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>
+https://chefdownload-community.chef.io/stable/<PRODUCT>/metadata?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
 ```
 
 ### download
@@ -108,7 +108,7 @@ https://chefdownload-community.chef.io/stable/<PRODUCT>/metadata?p=<PLATFORM>&pv
 The `download` endpoint downloads a particular package of a Chef product.
 
 ```plain
-https://chefdownload-community.chef.io/stable/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>
+https://chefdownload-community.chef.io/stable/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
 ```
 
 ## Parameters
@@ -119,6 +119,11 @@ The API accepts the following parameters in a query string.
 : The Chef Software product to install.
 
   A list of valid product keys can be found in the [Chef product matrix](https://github.com/chef/mixlib-install/blob/main/PRODUCT_MATRIX.md) or by using the [`products`](#products) endpoint.
+
+`license_id`
+: Your license ID.
+
+  A license is required to download packages and retrieve package metadata with this API.
 
 `eol`
 : Whether to include EOL versions of a product or EOL products in the response.
@@ -174,7 +179,7 @@ This is a list of currently supported products that you can install with this AP
 To get the latest supported build of Chef Infra Client for Ubuntu 20.04, enter the following:
 
 ```plain
-https://chefdownload-community.chef.io/stable/chef/metadata?p=ubuntu&pv=20.04&m=x86_64
+https://chefdownload-community.chef.io/stable/chef/metadata?p=ubuntu&pv=20.04&m=x86_64&license_id=<LICENSE_ID>
 ```
 
 which will return something like:
@@ -191,11 +196,11 @@ version	"14.15.6"
 To use cURL to download a package directly, enter the following:
 
 ```bash
-curl -LOJ 'https://chefdownload-community.chef.io/stable/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>'
+curl -LOJ 'https://chefdownload-community.chef.io/stable/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>'
 ```
 
 To use GNU Wget to download a package directly, enter the following:
 
 ```bash
-wget --content-disposition https://chefdownload-community.chef.io/stable/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>
+wget --content-disposition https://chefdownload-community.chef.io/stable/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>
 ```

--- a/content/download/community.md
+++ b/content/download/community.md
@@ -123,7 +123,7 @@ The API accepts the following parameters in a query string.
 `license_id`
 : Your license ID.
 
-  A license is required to download packages and retrieve package metadata with this API.
+  A license is required to download packages and retrieve package metadata with this API. Only free licenses can be used for community downloads.
 
 `eol`
 : Whether to include EOL versions of a product or EOL products in the response.


### PR DESCRIPTION
## Description
Mandate license id for downloads apis. 

- Only Free licenses are valid in opensource mode.
- Only Free or Trial licenses are valid in trial mode.
- Only commercial and free license can be used in commercial mode.


[Please describe what this change achieves]

## Definition of Done

## Issues Resolved
https://progresssoftware.atlassian.net/browse/CHEF-28434

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
