### PR TITLE
docs: add no-animal-violence Vale package for inclusive language checking

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -8,11 +8,11 @@
 StylesPath = tools/vale/
 MinAlertLevel = suggestion
 SkippedScopes = code
-Packages = Microsoft, write-good, Hugo
+Packages = Microsoft, write-good, Hugo, NoAnimalViolence
 Vocab = Chef
 
 [*.{md,yaml,yml}]
-BasedOnStyles = chef, Microsoft, vale, write-good
+BasedOnStyles = chef, Microsoft, vale, write-good, NoAnimalViolence
 
 # Ignore SVG markup
 TokenIgnores = (\*\*\{\w*\}\*\*), (Master License and Services Agreement)

--- a/.vale.ini
+++ b/.vale.ini
@@ -8,7 +8,7 @@
 StylesPath = tools/vale/
 MinAlertLevel = suggestion
 SkippedScopes = code
-Packages = Microsoft, write-good, Hugo, NoAnimalViolence
+Packages = Microsoft, write-good, Hugo, https://github.com/Open-Paws/vale-no-animal-violence/releases/latest/download/NoAnimalViolence.zip
 Vocab = Chef
 
 [*.{md,yaml,yml}]


### PR DESCRIPTION
Adds the [no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) Vale package to the existing Vale configuration.

Chef's docs already use `Microsoft` and `write-good` for quality checks. The `NoAnimalViolence` package extends this by flagging phrases that normalize violence toward animals and suggesting clearer, more professional alternatives:

- "kill two birds with one stone" → "accomplish two things at once"
- "guinea pig" → "test subject"
- "sacred cow" → "unquestioned belief"
- "cattle vs. pets" → "ephemeral vs. persistent"
- "beat a dead horse" → "belabor the point"

These alternatives are typically shorter and clearer for international readers.

**Package source**: https://github.com/Open-Paws/vale-no-animal-violence

**Change**: `.vale.ini` — add `NoAnimalViolence` to `Packages` and `BasedOnStyles`