### PR TITLE
Added current equivalent product information for deprecated products

### DIFF
--- a/content/versions.md
+++ b/content/versions.md
@@ -82,16 +82,16 @@ version 2.0.
 
 ## Deprecated products and versions
 
-The following products are deprecated. Users are advised to move to
-newer versions or products.
+Progress Chef has deprecated the following products.
+If you're using one of these products, migrate to a supported version or product.
 
-| Product           | Version | Lifecycle Status | EOL Date       | Current equivalent product    |
-|-------------------|---------|------------------|----------------|-------------------------------|
-| Chef Backend      | 3.x     | Deprecated       | TBD            | Chef 360 Platform             |
-| Chef Infra Client | 18.x    | Deprecated       | TBD            | Chef Infra Client 19.x        |
-| Chef Infra Server | 15.x    | Deprecated       | November 2026  | Chef 360 Platform             |
-| Chef InSpec       | 4.x     | Deprecated       | TBD            | Chef Inspec 5.x               |
-| Chef Manage       | 2.5.x+  | Deprecated       | February 2026  | Chef 360 Platform             |
+| Product           | Version | Lifecycle Status | EOL Date       | Replacement product or version |
+|-------------------|---------|------------------|----------------|--------------------------------|
+| Chef Backend      | 3.x     | Deprecated       | TBD            | Chef 360 Platform              |
+| Chef Infra Client | 18.x    | Deprecated       | TBD            | Chef Infra Client 19.x         |
+| Chef Infra Server | 15.x    | Deprecated       | November 2026  | Chef 360 Platform              |
+| Chef InSpec       | 4.x     | Deprecated       | TBD            | Chef Inspec 5.x                |
+| Chef Manage       | 2.5.x+  | Deprecated       | February 2026  | Chef 360 Platform              |
 
 ## End of Life (EOL) products
 

--- a/content/versions.md
+++ b/content/versions.md
@@ -85,13 +85,13 @@ version 2.0.
 The following products are deprecated. Users are advised to move to
 newer versions or products.
 
-| Product           | Version | Lifecycle Status | EOL Date       |
-|-------------------|---------|------------------|----------------|
-| Chef Backend      | 3.x     | Deprecated       | TBD            |
-| Chef Infra Client | 18.x    | Deprecated       | TBD            |
-| Chef Infra Server | 15.x    | Deprecated       | November 2026  |
-| Chef InSpec       | 4.x     | Deprecated       | TBD            |
-| Chef Manage       | 2.5.x+  | Deprecated       | February 2026  |
+| Product           | Version | Lifecycle Status | EOL Date       | Current equivalent product    |
+|-------------------|---------|------------------|----------------|-------------------------------|
+| Chef Backend      | 3.x     | Deprecated       | TBD            | Chef 360 Platform             |
+| Chef Infra Client | 18.x    | Deprecated       | TBD            | Chef Infra Client 19.x        |
+| Chef Infra Server | 15.x    | Deprecated       | November 2026  | Chef 360 Platform             |
+| Chef InSpec       | 4.x     | Deprecated       | TBD            | Chef Inspec 5.x               |
+| Chef Manage       | 2.5.x+  | Deprecated       | February 2026  | Chef 360 Platform             |
 
 ## End of Life (EOL) products
 


### PR DESCRIPTION
## Description

The deprecated products list was not making it apparent what current equivalent product the users must transition over to. Now there is a column added with this information to make it clear to the users and they can plan their transition accordingly

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
