### PR TITLE
Update Workstation supported platforms and versions

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -182,6 +182,21 @@ See our policy on [support for derived platforms](#support-for-derived-platforms
 
 The following table lists the commercially supported platforms and versions for the Chef Workstation.
 
+{{< foundation_tabs tabs-id="chef-workstation-commercial-support" >}}
+  {{< foundation_tab active="true" panel-link="chef-workstation-commercial-support-v26" tab-text="Chef Workstation 26">}}
+  {{< foundation_tab panel-link="chef-workstation-commercial-support-v25" tab-text="Chef Workstation 25" >}}
+{{< /foundation_tabs >}}
+
+{{< foundation_tabs_panels tabs-id="chef-workstation-commercial-support" >}}
+{{< foundation_tabs_panel active="true" panel-id="chef-workstation-commercial-support-v26" >}}
+
+- Linux (x86_64)
+- Windows (x86_64)
+
+{{< /foundation_tabs_panel >}}
+
+{{< foundation_tabs_panel panel-id="chef-workstation-commercial-support-v25" >}}
+
 | Platform                          | Architecture                | Version                                                                    |
 |-----------------------------------| ----------------------------| ---------------------------------------------------------------------------|
 | Amazon Linux                      | x86_64, arch64 (2023 only)  | 2.x, 2023                                                                  |
@@ -191,16 +206,20 @@ The following table lists the commercially supported platforms and versions for 
 | Ubuntu                            | x86_64                      | 18.04, 20.04, 22.04                                                        |
 | Windows                           | x64                         | 10, 11, Server 2016, Server 2019, Server 2022                              |
 
+{{< /foundation_tabs_panel >}}
+
+{{< /foundation_tabs_panels >}}
+
 #### Derived platforms
 
-The following table lists supported derived platforms and versions for Chef Workstation.
-
-See our policy on [support for derived platforms](#support-for-derived-platforms) for more information.
+Chef Workstation 25 supports the following derived platforms and versions.
 
 | Platform | Architecture | Version | Parent platform |
 | --- | --- | --- | --- |
 | AlmaLinux | `x86_64` | `8.x` | CentOS |
 | Rocky Linux | `x86_64` | `8.x` | CentOS |
+
+See our policy on [support for derived platforms](#support-for-derived-platforms) for more information.
 
 ## Platform end-of-life policy
 

--- a/content/versions.md
+++ b/content/versions.md
@@ -62,7 +62,7 @@ Additional information is available in [this announcement](https://www.chef.io/b
 | Chef Infra Client | 19.x                     | GA               | n/a            |
 | Chef Habitat      | 0.81+                    | GA               | n/a            |
 | Chef InSpec       | 5+                       | GA               | n/a            |
-| Chef Workstation  | 24.x (2024), 25.x (2025) | GA               | n/a            |
+| Chef Workstation  | 25.x, 26.x               | GA               | n/a            |
 
 {{< note >}}
 
@@ -92,6 +92,7 @@ If you're using one of these products, migrate to a supported version or product
 | Chef Infra Server | 15.x    | Deprecated       | November 2026  | Chef 360 Platform              |
 | Chef InSpec       | 4.x     | Deprecated       | TBD            | Chef Inspec 5.x                |
 | Chef Manage       | 2.5.x+  | Deprecated       | February 2026  | Chef 360 Platform              |
+| Chef Workstation  | 24.x    | Deprecated       | April 2026     | Chef Workstation 25 or above   |
 
 ## End of Life (EOL) products
 


### PR DESCRIPTION
## Description

List supported platforms for Workstation 25 and 26.

Update Workstation supported versions:

- supported: 25 & 26
- deprecated: 24
- EOL: 23 and below

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
