### PR TITLE
Make pm as optional

### DIFF
--- a/content/chef_install_script.md
+++ b/content/chef_install_script.md
@@ -167,7 +167,7 @@ In addition to the default install behavior, the Chef Software install script su
 `-P` (`-project` on Windows)
 
 : The product name to install. Supported Chef products are:
-  `chef`, `chef-backend`, `chef-ice`, `chef-server`, `chef-workstation`, `inspec`, `manage`, and `supermarket`. Default value: `chef` (Chef Infra Client 18 and below).
+  `chef`, `chef-backend`, `chef-ice`, `chef-server`, `chef-workstation`, `inspec`, `inspec-enterprise`, `manage`, and `supermarket`. Default value: `chef` (Chef Infra Client 18 and below).
 
 `-s` (`-install_strategy` on Windows)
 

--- a/content/download/commercial.md
+++ b/content/download/commercial.md
@@ -111,7 +111,7 @@ The `metadata` endpoint returns data about a particular package of a Chef produc
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/metadata?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
 ```
 
-For Chef Infra Client Enterprise and Chef Infra Client Legacy Migration, include the `pm` (package manager) query parameter. This value determines the type of package to retrieve (for example: `deb`, `rpm`, `msi`, or `tar`) and is required because these products support multiple packaging formats.
+You can optionally include the `pm` (package manager) query parameter to specify the type of package to retrieve (for example: `deb`, `rpm`, `msi`, or `tar`).
 
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/metadata?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
@@ -125,8 +125,7 @@ The `download` endpoint downloads a particular package of a Chef product.
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
 ```
 
-For Chef Infra Client Enterprise or Chef Infra Client Legacy Migration, include the `pm` (package manager) query parameter in your request.
-This parameter specifies the package format to download---for example, `deb`, `rpm`, `msi`, or `tar`.
+You can optionally include the `pm` (package manager) query parameter to specify the package format to download---for example, `deb`, `rpm`, `msi`, or `tar`.
 
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
@@ -140,8 +139,7 @@ The `fileName` endpoint returns the file name.
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/fileName?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
 ```
 
-For Chef Infra Client Enterprise or Chef Infra Client Legacy Migration, include the `pm` (package manager) query parameter in your request.
-This parameter specifies the package format---for example, `deb`, `rpm`, `msi`, or `tar`.
+You can optionally include the `pm` (package manager) query parameter to specify the package format---for example, `deb`, `rpm`, `msi`, or `tar`.
 
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/fileName?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
@@ -207,9 +205,7 @@ The API accepts the following parameters in a query string.
   Default value: `latest`.
 
 `pm`
-: The package manager.
-
-  Use this parameter only for Chef Infra Client Enterprise and Chef Infra Client Legacy Migration.
+: The package manager. This parameter is optional.
 
   Possible values:
 
@@ -285,11 +281,7 @@ To use curl to download a package, enter the following:
 curl -LOJ 'https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>'
 ```
 
-To use curl to download a Chef Infra Client Enterprise or Chef Infra Client Legacy Migration package, include the `pm` (package manager) parameter as shown:
-
-```bash
-curl -LOJ 'https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>'
-```
+To download a specific package format, add the optional `pm=<PACKAGE_MANAGER>` parameter to the URL.
 
 To use GNU Wget to download a package, enter the following:
 
@@ -297,8 +289,4 @@ To use GNU Wget to download a package, enter the following:
 wget --content-disposition https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>
 ```
 
-To use GNU Wget to download a Chef Infra Client Enterprise or Chef Infra Client Legacy Migration package, enter the following:
-
-```bash
-wget --content-disposition https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>
-```
+To download a specific package format, add the optional `pm=<PACKAGE_MANAGER>` parameter to the URL.

--- a/content/download/commercial.md
+++ b/content/download/commercial.md
@@ -105,15 +105,22 @@ https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/versions/latest?lice
 
 ### metadata
 
-The `metadata` endpoint returns data about a particular package of a Chef product.
+The `metadata` endpoint returns data about a particular Chef product package.
+
+The endpoint determines the package type (for example, `rpm` or `deb`) from the `pm` or `p` query parameter:
+
+- `p`: (required) The platform that the package is installed on.
+  - If you also specify `pm`, you can use a generic value such as `linux`.
+  - If you omit `pm`, specify the exact platform name (for example, `ubuntu`, `amazon`, or `redhat`) so the API can derive the package type from the platform.
+- `pm`: (optional) The package type to retrieve (for example: `deb`, `rpm`, `msi`, or `tar`). If provided, the API uses `pm` to determine the package type directly.
+
+Retrieve metadata by specifying the platform:
 
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/metadata?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
 ```
 
-You can optionally include the `pm` (package manager) query parameter to specify the type of package to retrieve (for example: `deb`, `rpm`, `msi`, or `tar`).
-If you don't include `pm`, include `p` (platform) so the API can derive the package format from `p`.
-Include `pm` when you want to request a specific package format explicitly.
+Retrieve metadata by specifying the platform and package type:
 
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/metadata?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
@@ -123,13 +130,20 @@ https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/metadata?p=<PLATFORM
 
 The `download` endpoint downloads a particular package of a Chef product.
 
+The endpoint determines the package type (for example, `rpm` or `deb`) from the `pm` or `p` query parameter:
+
+- `p`: (required) The platform that the package is installed on.
+  - If you also specify `pm`, you can use a generic value such as `linux`.
+  - If you omit `pm`, specify the exact platform name (for example, `ubuntu`, `amazon`, or `redhat`) so the API can derive the package type from the platform.
+- `pm`: (optional) The package type to retrieve (for example: `deb`, `rpm`, `msi`, or `tar`). If provided, the API uses `pm` to determine the package type directly.
+
+Download a package by specifying the platform:
+
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
 ```
 
-You can optionally include the `pm` (package manager) query parameter to specify the package format to download---for example, `deb`, `rpm`, `msi`, or `tar`.
-If you don't include `pm`, include `p` (platform) so the API can derive the package format from `p`.
-Include `pm` when you want to request a specific package format explicitly.
+Download a package by specifying the platform and package type:
 
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
@@ -139,13 +153,20 @@ https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM
 
 The `fileName` endpoint returns the file name.
 
+The endpoint determines the package type (for example, `rpm` or `deb`) from the `pm` or `p` query parameter:
+
+- `p`: (required) The platform that the package is installed on.
+  - If you also specify `pm`, you can use a generic value such as `linux`.
+  - If you omit `pm`, specify the exact platform name (for example, `ubuntu`, `amazon`, or `redhat`) so the API can derive the package type from the platform.
+- `pm`: (optional) The package type to retrieve (for example: `deb`, `rpm`, `msi`, or `tar`). If provided, the API uses `pm` to determine the package type directly.
+
+Retrieve a file name by specifying the platform:
+
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/fileName?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
 ```
 
-You can optionally include the `pm` (package manager) query parameter to specify the package format---for example, `deb`, `rpm`, `msi`, or `tar`.
-If you don't include `pm`, include `p` (platform) so the API can derive the package format from `p`.
-Include `pm` when you want to request a specific package format explicitly.
+Retrieve a file name by specifying the platform and package type:
 
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/fileName?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
@@ -153,7 +174,7 @@ https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/fileName?p=<PLATFORM
 
 ### package-managers
 
-The `package-managers` endpoint lists the available package managers.
+The `package-managers` endpoint lists the available package types.
 
 ```plain
 https://chefdownload-commercial.chef.io/package-managers
@@ -188,9 +209,25 @@ The API accepts the following parameters in a query string.
 `p`
 : The platform.
 
-  Common values include `debian`, `el` (for RHEL derivatives), `linux`, `linux-kernel2`, `mac_os_x`, `sles`, `ubuntu`, and `windows`.
+  Possible values include: `debian`, `el` (for RHEL derivatives), `linux`, `linux-kernel2`, `mac_os_x`, `sles`, `ubuntu` or `windows`.
 
-  For the complete and current list, use the [`platforms`](#platforms) endpoint.
+  For a complete list, use the [`platforms`](#platforms) endpoint.
+
+`pm`
+: The package type.
+
+  This parameter is optional.
+  If not provided, the API automatically detects the platform and derives the package format from it.
+  Include `pm` when you want to request a specific package format explicitly.
+
+  Values include:
+
+  - `deb` for Debian-based systems, for example, Ubuntu
+  - `rpm` for Red Hat-based systems, for example, CentOS or Fedora
+  - `tar` for generic Unix-like systems
+  - `msi` for Windows systems
+
+  For a complete list, use the [`package-managers`](#package-managers) endpoint.
 
 `pv`
 : The platform version.
@@ -213,36 +250,24 @@ The API accepts the following parameters in a query string.
 
   Default value: `latest`.
 
-`pm`
-: This parameter is optional.
-  If not provided, the API automatically detects the platform and derives the package format from it.
-  Include `pm` when you want to request a specific package format explicitly.
-
-  Possible values:
-
-  - `deb` for Debian-based systems, for example, Ubuntu
-  - `rpm` for Red Hat-based systems, for example, CentOS or Fedora
-  - `tar` for generic Unix-like systems
-  - `msi` for Windows systems
-
 ## Chef product names
 
 Use the following product keys to download packages or retrieve data for different Chef products.
 You can also use the [products endpoint](#products)
 
-| Product                            | Product key        |
-| ---------------------------------- | ------------------ |
-| Chef Automate                      | `automate`         |
-| Chef Backend                       | `chef-backend`     |
-| Chef Habitat                       | `habitat`          |
-| Chef Infra Client                  | `chef`             |
-| Chef Infra Client Enterprise       | `chef-ice`         |
-| Chef Infra Client Legacy Migration | `migrate-ice`      |
-| Chef Infra Server                  | `chef-server`      |
-| Chef InSpec                        | `inspec`           |
+| Product                            | Product key         |
+| ---------------------------------- | ------------------- |
+| Chef Automate                      | `automate`          |
+| Chef Backend                       | `chef-backend`      |
+| Chef Habitat                       | `habitat`           |
+| Chef Infra Client                  | `chef`              |
+| Chef Infra Client Enterprise       | `chef-ice`          |
+| Chef Infra Client Legacy Migration | `migrate-ice`       |
+| Chef Infra Server                  | `chef-server`       |
+| Chef InSpec                        | `inspec`            |
 | Chef InSpec Enterprise             | `inspec-enterprise` |
-| Chef Supermarket                   | `supermarket`      |
-| Chef Workstation                   | `chef-workstation` |
+| Chef Supermarket                   | `supermarket`       |
+| Chef Workstation                   | `chef-workstation`  |
 
 See the [supported versions]({{< relref "versions" >}}) documentation for information about the support status of individual products.
 
@@ -292,7 +317,11 @@ To use curl to download a package, enter the following:
 curl -LOJ 'https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>'
 ```
 
-To download a specific package format, add the optional `pm=<PACKAGE_MANAGER>` parameter to the URL.
+To download a specific package format, add the optional `pm=<PACKAGE_MANAGER>` parameter to the URL, for example:
+
+```bash
+curl -LOJ 'https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>'
+```
 
 To use GNU Wget to download a package, enter the following:
 
@@ -300,4 +329,8 @@ To use GNU Wget to download a package, enter the following:
 wget --content-disposition https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>
 ```
 
-To download a specific package format, add the optional `pm=<PACKAGE_MANAGER>` parameter to the URL.
+To download a specific package format, add the optional `pm=<PACKAGE_MANAGER>` parameter to the URL. For example:
+
+```bash
+wget --content-disposition https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>
+```

--- a/content/download/commercial.md
+++ b/content/download/commercial.md
@@ -111,7 +111,7 @@ The `metadata` endpoint returns data about a particular package of a Chef produc
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/metadata?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
 ```
 
-For Chef Infra Client Enterprise and Chef Infra Client Legacy Migration, include the `pm` (package manager) query parameter. This value determines the type of package to retrieve (for example: `deb`, `rpm`, `msi`, or `tar`) and is required because these products support multiple packaging formats.
+You can optionally include the `pm` (package manager) query parameter to specify the type of package to retrieve (for example: `deb`, `rpm`, `msi`, or `tar`).
 
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/metadata?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
@@ -125,8 +125,7 @@ The `download` endpoint downloads a particular package of a Chef product.
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
 ```
 
-For Chef Infra Client Enterprise or Chef Infra Client Legacy Migration, include the `pm` (package manager) query parameter in your request.
-This parameter specifies the package format to download---for example, `deb`, `rpm`, `msi`, or `tar`.
+You can optionally include the `pm` (package manager) query parameter to specify the package format to download---for example, `deb`, `rpm`, `msi`, or `tar`.
 
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
@@ -140,8 +139,7 @@ The `fileName` endpoint returns the file name.
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/fileName?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
 ```
 
-For Chef Infra Client Enterprise or Chef Infra Client Legacy Migration, include the `pm` (package manager) query parameter in your request.
-This parameter specifies the package format---for example, `deb`, `rpm`, `msi`, or `tar`.
+You can optionally include the `pm` (package manager) query parameter to specify the package format---for example, `deb`, `rpm`, `msi`, or `tar`.
 
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/fileName?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
@@ -207,9 +205,8 @@ The API accepts the following parameters in a query string.
   Default value: `latest`.
 
 `pm`
-: The package manager.
-
-  Use this parameter only for Chef Infra Client Enterprise and Chef Infra Client Legacy Migration.
+: This parameter is optional.
+  If not provided, the API automatically detects the platform and derives the package format from it.
 
   Possible values:
 
@@ -284,11 +281,7 @@ To use curl to download a package, enter the following:
 curl -LOJ 'https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>'
 ```
 
-To use curl to download a Chef Infra Client Enterprise or Chef Infra Client Legacy Migration package, include the `pm` (package manager) parameter as shown:
-
-```bash
-curl -LOJ 'https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>'
-```
+To download a specific package format, add the optional `pm=<PACKAGE_MANAGER>` parameter to the URL.
 
 To use GNU Wget to download a package, enter the following:
 
@@ -296,8 +289,4 @@ To use GNU Wget to download a package, enter the following:
 wget --content-disposition https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pv=<PLATFORM_VERSION>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>
 ```
 
-To use GNU Wget to download a Chef Infra Client Enterprise or Chef Infra Client Legacy Migration package, enter the following:
-
-```bash
-wget --content-disposition https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&license_id=<LICENSE_ID>
-```
+To download a specific package format, add the optional `pm=<PACKAGE_MANAGER>` parameter to the URL.

--- a/content/download/commercial.md
+++ b/content/download/commercial.md
@@ -112,6 +112,8 @@ https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/metadata?p=<PLATFORM
 ```
 
 You can optionally include the `pm` (package manager) query parameter to specify the type of package to retrieve (for example: `deb`, `rpm`, `msi`, or `tar`).
+If you don't include `pm`, include `p` (platform) so the API can derive the package format from `p`.
+Include `pm` when you want to request a specific package format explicitly.
 
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/metadata?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
@@ -126,6 +128,8 @@ https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM
 ```
 
 You can optionally include the `pm` (package manager) query parameter to specify the package format to download---for example, `deb`, `rpm`, `msi`, or `tar`.
+If you don't include `pm`, include `p` (platform) so the API can derive the package format from `p`.
+Include `pm` when you want to request a specific package format explicitly.
 
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/download?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
@@ -140,6 +144,8 @@ https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/fileName?p=<PLATFORM
 ```
 
 You can optionally include the `pm` (package manager) query parameter to specify the package format---for example, `deb`, `rpm`, `msi`, or `tar`.
+If you don't include `pm`, include `p` (platform) so the API can derive the package format from `p`.
+Include `pm` when you want to request a specific package format explicitly.
 
 ```plain
 https://chefdownload-commercial.chef.io/<CHANNEL>/<PRODUCT>/fileName?p=<PLATFORM>&pm=<PACKAGE_MANAGER>&m=<ARCHITECTURE>&v=<PRODUCT_VERSION>&license_id=<LICENSE_ID>
@@ -182,8 +188,9 @@ The API accepts the following parameters in a query string.
 `p`
 : The platform.
 
-  Possible values: `debian`, `el` (for RHEL derivatives), `freebsd`, `mac_os_x`, `solaris2`, `sles`, `suse`, `ubuntu` or
-  `windows`.
+  Common values include `debian`, `el` (for RHEL derivatives), `linux`, `linux-kernel2`, `mac_os_x`, `sles`, `ubuntu`, and `windows`.
+
+  For the complete and current list, use the [`platforms`](#platforms) endpoint.
 
 `pv`
 : The platform version.
@@ -207,6 +214,7 @@ The API accepts the following parameters in a query string.
 `pm`
 : This parameter is optional.
   If not provided, the API automatically detects the platform and derives the package format from it.
+  Include `pm` when you want to request a specific package format explicitly.
 
   Possible values:
 

--- a/content/download/commercial.md
+++ b/content/download/commercial.md
@@ -203,6 +203,8 @@ The API accepts the following parameters in a query string.
   Possible values depend on the platform. For example, for
   Ubuntu or Debian: `i386` or `x86_64`, or for macOS: `x86_64`.
 
+  To get the supported architecture values, use the [`architectures`](#architectures) endpoint.
+
 `v`
 : The version of the product to be installed.
 
@@ -238,6 +240,7 @@ You can also use the [products endpoint](#products)
 | Chef Infra Client Legacy Migration | `migrate-ice`      |
 | Chef Infra Server                  | `chef-server`      |
 | Chef InSpec                        | `inspec`           |
+| Chef InSpec Enterprise             | `inspec-enterprise` |
 | Chef Supermarket                   | `supermarket`      |
 | Chef Workstation                   | `chef-workstation` |
 


### PR DESCRIPTION
## Description
Updates the Commercial API documentation to reflect that the pm (package manager) query parameter is now optional for all products, not restricted to Chef Infra Client Enterprise and Chef Infra Client Legacy Migration.

## Issues Resolved
https://progresssoftware.atlassian.net/browse/CHEF-30749
<img width="1512" height="857" alt="Screenshot 2026-05-08 at 2 56 38 PM" src="https://github.com/user-attachments/assets/b56d3e59-0880-4d6b-ac5f-2a8e15bed4ca" />
<img width="1512" height="857" alt="Screenshot 2026-05-08 at 2 56 50 PM" src="https://github.com/user-attachments/assets/f6b7ce14-18f5-49ef-90ac-dba0489929f1" />



## Check List

- [x] Spell Check
- [x] Local build
- [x] Examine the local build
- [x] All tests pass
