### PR TITLE
Updated Chef Infra Client platform support to include Debian 13 and Ubuntu 26.04.

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -95,7 +95,7 @@ The following table lists the commercially supported platforms and versions for 
 | AIX | `powerpc` | `7.1` (TL5 SP2 or higher, recommended), `7.2`, `7.3` |
 | Amazon Linux | `x86_64`, `aarch64` | `2.x`, `2023` |
 | CentOS | `x86_64`, `ppc64le`, `ppc64`, `aarch64` | `7.x` |
-| Debian | `x86_64`, `aarch64` | `10`, `11` |
+| Debian | `x86_64`, `aarch64` | `10`, `11`, `13` |
 | FreeBSD | `amd64` | `13.x` |
 | macOS | `aarch64` | `13.x`, `14.x` |
 | Oracle Enterprise Linux | `x86_64`, `aarch64` | `7.x`, `8.x` |
@@ -103,7 +103,7 @@ The following table lists the commercially supported platforms and versions for 
 | Rocky Linux | `x86_64`, `aarch64` | `8.x`, `9.x` |
 | Solaris | `sparc`, `i86pc` | `11.3` (16.17.4 and later only), `11.4`  |
 | SUSE Linux Enterprise Server | `x86_64`, `aarch64` (15.x only), `s390x` | `12`, `15` |
-| Ubuntu (LTS releases) | `x86_64`,`aarch64` (18.x and above) | `18.04`, `20.04`, `22.04`, `24.04` |
+| Ubuntu (LTS releases) | `x86_64`,`aarch64` (18.x and above) | `18.04`, `20.04`, `22.04`, `24.04`, `26.04` |
 | Windows | `x86_64` | `2016`, `10` (all channels except "insider" builds), `2019` (Long-term servicing channel (LTSC), both Desktop Experience and Server Core), `11`, `2022`, `2025` |
 
 #### Derived platforms


### PR DESCRIPTION
## Description

Just a small addition to the Supported Platforms list to add Deb 13 and Ubuntu 26.04 support.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
