### PR TITLE
CHEF-34732: Update docs to include Workstation 26 product

### DIFF
--- a/content/chef_install_script.md
+++ b/content/chef_install_script.md
@@ -167,7 +167,7 @@ In addition to the default install behavior, the Chef Software install script su
 `-P` (`-project` on Windows)
 
 : The product name to install. Supported Chef products are:
-  `chef`, `chef-backend`, `chef-ice`, `chef-server`, `chef-workstation`, `inspec`, `inspec-enterprise`, `manage`, and `supermarket`. Default value: `chef` (Chef Infra Client 18 and below).
+  `chef`, `chef-backend`, `chef-ice`, `chef-server`, `chef-workstation`, `chef-workstation-enterprise`, `inspec`, `inspec-enterprise`, `manage`, and `supermarket`. Default value: `chef` (Chef Infra Client 18 and below).
 
 `-s` (`-install_strategy` on Windows)
 

--- a/content/chef_install_script.md
+++ b/content/chef_install_script.md
@@ -239,10 +239,18 @@ To install a specific version of Chef Infra Client 19 or above on Windows, speci
 . { iwr -useb https://chefdownload-commercial.chef.io/install.ps1?license_id=<LICENSE_ID> } | iex; install -project chef-ice -version <VERSION>
 ```
 
-### Install the latest version of Chef Workstation
+### Install Chef Workstation up to version 25
 
-To install the latest version of Chef Workstation on Windows from the `current` channel:
+To install the latest version of Chef Workstation 25 on Windows from the `current` channel, specify the `chef-workstation` project:
 
 ```powershell
 . { iwr -useb https://chefdownload-commercial.chef.io/install.ps1?license_id=<LICENSE_ID> } | iex; install -channel current -project chef-workstation
+```
+
+### Install Chef Workstation 26 and above
+
+To install the latest version of Chef Workstation Enterprise (version 26 and above) on Windows from the `current` channel, specify the `chef-workstation-enterprise` project:
+
+```powershell
+. { iwr -useb https://chefdownload-commercial.chef.io/install.ps1?license_id=<LICENSE_ID> } | iex; install -channel current -project chef-workstation-enterprise
 ```

--- a/content/download/commercial.md
+++ b/content/download/commercial.md
@@ -268,6 +268,7 @@ You can also use the [products endpoint](#products)
 | Chef InSpec Enterprise             | `inspec-enterprise` |
 | Chef Supermarket                   | `supermarket`       |
 | Chef Workstation                   | `chef-workstation`  |
+| Chef Workstation Enterprise        | `chef-workstation-enterprise` |
 
 See the [supported versions]({{< relref "versions" >}}) documentation for information about the support status of individual products.
 
@@ -307,6 +308,21 @@ sha1	"dcf75b37bb80128af4657501bfd41eac52820191"
 sha256	"2c501d02b16d67e9d5a28578b95f8d3155bed940ee4946229213f41a2e8b798e"
 url	"https://chefdownload-commercial.chef.io/stable/chef-ice/download?license_id=<LICENSE_ID>&eol=false&m=x86_64&p=linux&pm=deb&v=19.1.8"
 version	"19.1.8"
+```
+
+To get the latest supported build of Chef Workstation Enterprise for Debian Linux 26.04, enter the following:
+
+```sh
+https://chefdownload-commercial.chef.io/stable/chef-workstation-enterprise/metadata?pv=26.04&m=x86_64&p=linux&pm=deb&license_id=<LICENSE_ID>
+```
+
+which returns something like:
+
+```json
+sha1	"593b60c0f1266267d0dae2921e89a0b3a7c53615"
+sha256	"f27c4ad2fc92f540b3508043af7012023c16a013b3caa3603d93e6ac735bed61"
+url	"https://chefdownload-commercial.chef.io/stable/chef-workstation-enterprise/download?license_id=<LICENSE_ID>&eol=false&m=x86_64&p=linux&pm=deb&v=26.0.23"
+version	"26.0.23"
 ```
 
 ### Download directly

--- a/content/download/commercial.md
+++ b/content/download/commercial.md
@@ -255,20 +255,20 @@ The API accepts the following parameters in a query string.
 Use the following product keys to download packages or retrieve data for different Chef products.
 You can also use the [products endpoint](#products)
 
-| Product                            | Product key         |
-| ---------------------------------- | ------------------- |
-| Chef Automate                      | `automate`          |
-| Chef Backend                       | `chef-backend`      |
-| Chef Habitat                       | `habitat`           |
-| Chef Infra Client                  | `chef`              |
-| Chef Infra Client Enterprise       | `chef-ice`          |
-| Chef Infra Client Legacy Migration | `migrate-ice`       |
-| Chef Infra Server                  | `chef-server`       |
-| Chef InSpec                        | `inspec`            |
-| Chef InSpec Enterprise             | `inspec-enterprise` |
-| Chef Supermarket                   | `supermarket`       |
-| Chef Workstation                   | `chef-workstation`  |
-| Chef Workstation Enterprise        | `chef-workstation-enterprise` |
+| Product                            | Product key                   | Notes                   |
+| ---------------------------------- | ----------------------------- | ----------------------- |
+| Chef Automate                      | `automate`                    |                         |
+| Chef Backend                       | `chef-backend`                |                         |
+| Chef Habitat                       | `habitat`                     |                         |
+| Chef Infra Client                  | `chef`                        | Versions 18 and earlier |
+| Chef Infra Client Enterprise       | `chef-ice`                    | Versions 19 and later   |
+| Chef Infra Client Legacy Migration | `migrate-ice`                 |                         |
+| Chef Infra Server                  | `chef-server`                 |                         |
+| Chef InSpec                        | `inspec`                      |                         |
+| Chef InSpec Enterprise             | `inspec-enterprise`           |                         |
+| Chef Supermarket                   | `supermarket`                 |                         |
+| Chef Workstation                   | `chef-workstation`            | Versions 25 and earlier |
+| Chef Workstation Enterprise        | `chef-workstation-enterprise` | Versions 26 and later   |
 
 See the [supported versions]({{< relref "versions" >}}) documentation for information about the support status of individual products.
 


### PR DESCRIPTION
Jira :[Link](https://progresssoftware.atlassian.net/browse/CHEF-34732)

Preview links for changes: 
https://deploy-preview-4679--chef-web-docs.netlify.app/chef_install_script/
https://deploy-preview-4679--chef-web-docs.netlify.app/download/commercial/

This pull request updates the documentation to add support and installation instructions for Chef Workstation Enterprise. The changes include updating product lists, adding new installation instructions, and providing download metadata examples for the new product.

**Documentation updates for Chef Workstation Enterprise:**

* Added `chef-workstation-enterprise` to the list of supported products for the install script, reflecting its availability as a distinct installable product.
* Updated the product table in the commercial downloads documentation to include `chef-workstation-enterprise` and its identifier.

**Installation and download instructions:**

* Added detailed instructions for installing Chef Workstation Enterprise on both Linux and Windows, including how to specify the product and version using the install script.
* Provided an example API request and response for obtaining the latest supported build metadata for Chef Workstation Enterprise, similar to other products.## Description

[Please describe what this change achieves]

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
