### PR TITLE
CHEF-34794 docs: Add release notes for InSpec 7.2.1

### DIFF
--- a/content/release_notes/inspec.md
+++ b/content/release_notes/inspec.md
@@ -33,6 +33,7 @@ Release date: July 20th, 2026
 
 ### Packaging
 
+- We now release Chef InSpec Habitat packages for Linux ARM.
 - Added support for aarch64-linux (ARM64) Habitat packages for Linux systems. ([#7968](https://github.com/inspec/inspec/pull/7968))
 - Added support for aarch64-darwin Habitat packages for Apple Silicon Macs. ([#7987](https://github.com/inspec/inspec/pull/7987))
 
@@ -40,6 +41,7 @@ Release date: July 20th, 2026
 
 - Updated `train` and `train-core` from 3.16.1 to 3.16.5. ([#7980](https://github.com/inspec/inspec/pull/7980))
 - Updated `chef-licensing` from 1.4.0 to 1.4.1. ([#7983](https://github.com/inspec/inspec/pull/7983))
+- Updated gems to support the latest `train-kubernetes` requirements, including `excon` (1.6.0) and `k8s-ruby` (0.18.0). ([#7995](https://github.com/inspec/inspec/pull/7995))
 
 ## Chef InSpec 7.1.7
 

--- a/content/release_notes/inspec.md
+++ b/content/release_notes/inspec.md
@@ -17,9 +17,9 @@ summary = "Chef InSpec release notes"
 <!-- cSpell:disable  -->
 <!-- vale off -->
 
-## Chef InSpec 7.1.16
+## Chef InSpec 7.2.0
 
-Release date: July 20th, 2026
+Release date: August 13th, 2026
 
 ### Enhancements
 

--- a/content/release_notes/inspec.md
+++ b/content/release_notes/inspec.md
@@ -33,9 +33,9 @@ Release date: August 13th, 2026
 
 ### Packaging
 
-- We now release Chef InSpec Habitat packages for Linux ARM.
-- Added support for aarch64-linux (ARM64) Habitat packages for Linux systems. ([#7968](https://github.com/inspec/inspec/pull/7968))
-- Added support for aarch64-darwin Habitat packages for Apple Silicon Macs. ([#7987](https://github.com/inspec/inspec/pull/7987))
+- We now provide OS-native Habitat-based Chef InSpec packages for Linux ARM.
+- We now release Chef InSpec Habitat packages for Linux ARM. ([#7968](https://github.com/inspec/inspec/pull/7968))
+- We now release Chef InSpec Habitat packages for Apple Silicon Macs. ([#7987](https://github.com/inspec/inspec/pull/7987))
 
 ### Dependency updates
 

--- a/content/release_notes/inspec.md
+++ b/content/release_notes/inspec.md
@@ -17,6 +17,30 @@ summary = "Chef InSpec release notes"
 <!-- cSpell:disable  -->
 <!-- vale off -->
 
+## Chef InSpec 7.1.16
+
+Release date: July 20th, 2026
+
+### Enhancements
+
+- Added deprecation warning for the `--overwrite` flag in the `inspec compliance upload` command. This option does not work as expected when uploading to Automate and will be removed in a future release. ([#7974](https://github.com/inspec/inspec/pull/7974))
+
+### Bug fixes
+
+- Fixed Docker and Podman resource fallback when using the `--auto-install-gems` flag. The regex patterns now correctly match bare resource names (e.g., `docker` and `podman`) in addition to their sub-resources (e.g., `docker_container`, `podman_volume`). ([#7976](https://github.com/inspec/inspec/pull/7976))
+- Fixed an issue where vendored InSpec profiles with gemspec files in the vendor/ directory were incorrectly identified as gem profiles instead of regular InSpec profiles, which prevented controls from loading. ([#7962](https://github.com/inspec/inspec/pull/7962))
+- Fixed an issue on Windows where the system architecture could not be determined when using Test Kitchen with WinRM. InSpec now includes WOW6432Node registry paths for all architectures except 32-bit (i386) systems, ensuring that 32-bit applications are correctly detected. ([#7942](https://github.com/inspec/inspec/pull/7942))
+
+### Packaging
+
+- Added support for aarch64-linux (ARM64) Habitat packages for Linux systems. ([#7968](https://github.com/inspec/inspec/pull/7968))
+- Added support for aarch64-darwin Habitat packages for Apple Silicon Macs. ([#7987](https://github.com/inspec/inspec/pull/7987))
+
+### Dependency updates
+
+- Updated `train` and `train-core` from 3.16.1 to 3.16.5. ([#7980](https://github.com/inspec/inspec/pull/7980))
+- Updated `chef-licensing` from 1.4.0 to 1.4.1. ([#7983](https://github.com/inspec/inspec/pull/7983))
+
 ## Chef InSpec 7.1.7
 
 Release date: May 11th, 2026

--- a/content/release_notes/inspec.md
+++ b/content/release_notes/inspec.md
@@ -21,21 +21,22 @@ summary = "Chef InSpec release notes"
 
 Release date: August 13th, 2026
 
-### Enhancements
-
-- Added deprecation warning for the `--overwrite` flag in the `inspec compliance upload` command. This option does not work as expected when uploading to Automate and will be removed in a future release. ([#7974](https://github.com/inspec/inspec/pull/7974))
-
 ### Bug fixes
 
-- Fixed Docker and Podman resource fallback when using the `--auto-install-gems` flag. The regex patterns now correctly match bare resource names (e.g., `docker` and `podman`) in addition to their sub-resources (e.g., `docker_container`, `podman_volume`). ([#7976](https://github.com/inspec/inspec/pull/7976))
-- Fixed an issue where vendored InSpec profiles with gemspec files in the vendor/ directory were incorrectly identified as gem profiles instead of regular InSpec profiles, which prevented controls from loading. ([#7962](https://github.com/inspec/inspec/pull/7962))
-- Fixed an issue on Windows where the system architecture could not be determined when using Test Kitchen with WinRM. InSpec now includes WOW6432Node registry paths for all architectures except 32-bit (i386) systems, ensuring that 32-bit applications are correctly detected. ([#7942](https://github.com/inspec/inspec/pull/7942))
+- The `--auto-install-gems` flag now correctly falls back to install the Docker and Podman resource pack gems for bare resource names, such as `docker` and `podman`, in addition to sub-resources such as `docker_container` and `podman_volume`. Previously, running a profile with a bare `docker` or `podman` resource and `--auto-install-gems` raised an undefined method error, because the fallback pattern matching required at least one character after the resource name and so skipped bare resource names. ([#7976](https://github.com/inspec/inspec/pull/7976))
+- Chef InSpec now correctly loads controls from vendored profiles that include gemspec files in the `vendor/` directory. Previously, InSpec identified these as gem profiles instead of regular InSpec profiles, so controls failed to load. ([#7962](https://github.com/inspec/inspec/pull/7962))
+- Chef InSpec now correctly detects 32-bit applications on Windows by querying `WOW6432Node` registry paths for all architectures except 32-bit (i386) systems. Previously, when using Test Kitchen with WinRM, InSpec couldn't determine the system architecture, so it skipped `WOW6432Node` paths and 32-bit applications appeared as not installed. ([#7942](https://github.com/inspec/inspec/pull/7942))
+- Chef InSpec Habitat packages on Linux now bundle the build toolchain required to compile native gem extensions, such as those used by the MongoDB resource pack. Previously, these packages couldn't compile native extensions on hosts without system `gcc` and `make` installed. ([#7979](https://github.com/inspec/inspec/pull/7979))
+
+### Deprecated features
+
+- The `--overwrite` flag in the `inspec compliance upload` command is deprecated and will be removed in a future release. This option doesn't work as expected when uploading to Chef Automate. ([#7974](https://github.com/inspec/inspec/pull/7974))
 
 ### Packaging
 
 - We now provide OS-native Habitat-based Chef InSpec packages for Linux ARM.
-- We now release Chef InSpec Habitat packages for Linux ARM. ([#7968](https://github.com/inspec/inspec/pull/7968))
-- We now release Chef InSpec Habitat packages for Apple Silicon Macs. ([#7987](https://github.com/inspec/inspec/pull/7987))
+- We now release Chef InSpec Habitat packages for Linux ARM (`aarch64-linux`). ([#7968](https://github.com/inspec/inspec/pull/7968))
+- We now release Chef InSpec Habitat packages for Apple Silicon Macs (`aarch64-darwin`). ([#7987](https://github.com/inspec/inspec/pull/7987))
 
 ### Dependency updates
 

--- a/content/release_notes/inspec.md
+++ b/content/release_notes/inspec.md
@@ -17,7 +17,7 @@ summary = "Chef InSpec release notes"
 <!-- cSpell:disable  -->
 <!-- vale off -->
 
-## Chef InSpec 7.2.0
+## Chef InSpec 7.2.1
 
 Release date: August 13th, 2026
 

--- a/content/release_notes/inspec.md
+++ b/content/release_notes/inspec.md
@@ -19,7 +19,7 @@ summary = "Chef InSpec release notes"
 
 ## Chef InSpec 7.2.1
 
-Release date: August 13th, 2026
+Release date: September 1, 2026
 
 ### Bug fixes
 

--- a/content/release_notes/inspec.md
+++ b/content/release_notes/inspec.md
@@ -19,7 +19,7 @@ summary = "Chef InSpec release notes"
 
 ## Chef InSpec 7.2.1
 
-Release date: September 1, 2026
+Release date: September 2, 2026
 
 ### Bug fixes
 

--- a/content/release_notes/inspec.md
+++ b/content/release_notes/inspec.md
@@ -41,7 +41,7 @@ Release date: July 20th, 2026
 
 - Updated `train` and `train-core` from 3.16.1 to 3.16.5. ([#7980](https://github.com/inspec/inspec/pull/7980))
 - Updated `chef-licensing` from 1.4.0 to 1.4.1. ([#7983](https://github.com/inspec/inspec/pull/7983))
-- Updated gems to support the latest `train-kubernetes` requirements, including `excon` (1.6.0) and `k8s-ruby` (0.18.0). ([#7995](https://github.com/inspec/inspec/pull/7995))
+- Updated gems to support the latest `train-kubernetes` requirements, including `excon` (1.6.0) and `k8s-ruby` (0.18.0). ([#7995](https://github.com/inspec/inspec/pull/7995), [k8s-ruby #19](https://github.com/inspec/k8s-ruby/pull/19))
 
 ## Chef InSpec 7.1.7
 


### PR DESCRIPTION
## Changes Made

### Updated InSpec Release Notes
This pull request updates the Chef InSpec release notes to include details for version 7.2.1, released on August 13th, 2026. The changes summarize new enhancements, bug fixes, packaging improvements, and dependency updates.

Most important changes:

**Enhancements**
* Added a deprecation warning for the `--overwrite` flag in the `inspec compliance upload` command, noting its future removal.

**Bug fixes**
* Fixed Docker and Podman resource fallback with the `--auto-install-gems` flag, ensuring regex patterns match both bare resource names and sub-resources.
* Corrected profile detection to avoid misidentifying vendored InSpec profiles with gemspec files as gem profiles, restoring proper control loading.
* Resolved a Windows issue where system architecture could not be determined with Test Kitchen and WinRM by including WOW6432Node registry paths for all architectures except i386.

**Packaging**
* Added support for Chef InSpec Habitat packages for aarch64-linux (ARM64), and aarch64-darwin (Apple Silicon Macs).
* Added support for OS-native Habitat-based Chef InSpec packages for Linux ARM platform.

**Dependency updates**
* Updated `train`, `train-core`, `chef-
### Files Modified
- `content/release_notes/inspec.md` - Updated version and date for the latest release

### Related Issue
CHEF-34794