### PR TITLE
Add macOS ARM Habitat install note to supported platforms

### DIFF
--- a/content/client/19/install/installer/_index.md
+++ b/content/client/19/install/installer/_index.md
@@ -123,6 +123,17 @@ To install Chef Infra Client , follow these steps:
       ```
 
     {{< /accordion-item >}}
+    {{< accordion-item accordion-title="Download tarball" >}}
+
+    For macOS:
+
+    - Using curl:
+
+      ```sh
+      curl -o chef-ice-<VERSION>-macos.tar.gz "https://chefdownload-commercial.chef.io/stable/chef-ice/download?eol=false&license_id=<LICENSE_ID>&m=x86_64&p=macos&pm=tar&v=<VERSION>"
+      ```
+
+    {{< /accordion-item >}}
     {{< /accordion-list >}}
 
 1. Go to the directory with the installer and install the package.
@@ -150,6 +161,15 @@ To install Chef Infra Client , follow these steps:
 
    ```sh
    sudo -E rpm -ivh chef-ice-<VERSION>-linux.rpm
+   ```
+
+   {{< /accordion-item >}}
+   {{< accordion-item accordion-title="Install from tarball" >}}
+
+   For macOS:
+
+   ```sh
+   tar -zxf chef-ice-<VERSION>-macos.tar.gz
    ```
 
    {{< /accordion-item >}}

--- a/content/client/19/install/installer/_index.md
+++ b/content/client/19/install/installer/_index.md
@@ -123,18 +123,13 @@ To install Chef Infra Client , follow these steps:
       ```
 
     {{< /accordion-item >}}
-    {{< accordion-item accordion-title="Download tarball" >}}
-
-    For macOS:
-
-    - Using curl:
-
-      ```sh
-      curl -o chef-ice-<VERSION>-macos.tar.gz "https://chefdownload-commercial.chef.io/stable/chef-ice/download?eol=false&license_id=<LICENSE_ID>&m=x86_64&p=macos&pm=tar&v=<VERSION>"
-      ```
-
-    {{< /accordion-item >}}
     {{< /accordion-list >}}
+
+    {{< note >}}
+
+    For macOS, skip this step. Installing the migration tool and running `migrate-ice apply` downloads and installs Chef Infra Client in one step. See the **Install from tarball** section below.
+
+    {{< /note >}}
 
 1. Go to the directory with the installer and install the package.
 
@@ -166,10 +161,10 @@ To install Chef Infra Client , follow these steps:
    {{< /accordion-item >}}
    {{< accordion-item accordion-title="Install from tarball" >}}
 
-   For macOS:
+   For macOS, [install the migration tool](https://docs.chef.io/client/19/install/migration_tool/install/#download-migration-tool-with-curl-windows), then download and install Chef Infra Client in one step:
 
    ```sh
-   tar -zxf chef-ice-<VERSION>-macos.tar.gz
+   .\migrate-ice apply online --fresh-install --download-url "<CHEF_TAR_DOWNLOAD_URL>"
    ```
 
    {{< /accordion-item >}}

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -106,6 +106,12 @@ The following table lists the commercially supported platforms and versions for 
 | Ubuntu (LTS releases) | `x86_64`,`aarch64` (18.x and above) | `18.04`, `20.04`, `22.04`, `24.04`, `26.04` |
 | Windows | `x86_64` | `2016`, `10` (all channels except "insider" builds), `2019` (Long-term servicing channel (LTSC), both Desktop Experience and Server Core), `11`, `2022`, `2025` |
 
+{{< note >}}
+
+There's no native installer for macOS on `aarch64` (Apple Silicon / M-series). Use [Chef Habitat](/habitat/) to install Chef Infra Client on this platform.
+
+{{< /note >}}
+
 #### Derived platforms
 
 The following table lists supported derived platforms and versions for Chef Infra Client.

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -90,27 +90,21 @@ See our policy on [support for derived platforms](#support-for-derived-platforms
 
 The following table lists the commercially supported platforms and versions for Chef Infra Client.
 
-| Platform | Architecture | Version |
-| --- | --- | --- |
-| AIX | `powerpc` | `7.1` (TL5 SP2 or higher, recommended), `7.2`, `7.3` |
-| Amazon Linux | `x86_64`, `aarch64` | `2.x`, `2023` |
-| CentOS | `x86_64`, `ppc64le`, `ppc64`, `aarch64` | `7.x` |
-| Debian | `x86_64`, `aarch64` | `10`, `11`, `13` |
-| FreeBSD | `amd64` | `13.x` |
-| macOS | `aarch64` | `13.x`, `14.x` |
-| Oracle Enterprise Linux | `x86_64`, `aarch64` | `7.x`, `8.x` |
-| Red Hat Enterprise Linux | `x86_64`, `ppc64le` (7.x only), `ppc64` (7.x only), `aarch64`, `s390x` (7.x / 8.x only) | `7.x`, `8.x`, `9.x`, `10.x` |
-| Rocky Linux | `x86_64`, `aarch64` | `8.x`, `9.x` |
-| Solaris | `sparc`, `i86pc` | `11.3` (16.17.4 and later only), `11.4`  |
-| SUSE Linux Enterprise Server | `x86_64`, `aarch64` (15.x only), `s390x` | `12`, `15` |
-| Ubuntu (LTS releases) | `x86_64`,`aarch64` (18.x and above) | `18.04`, `20.04`, `22.04`, `24.04`, `26.04` |
-| Windows | `x86_64` | `2016`, `10` (all channels except "insider" builds), `2019` (Long-term servicing channel (LTSC), both Desktop Experience and Server Core), `11`, `2022`, `2025` |
-
-{{< note >}}
-
-There's no native installer for macOS on `aarch64` (Apple Silicon / M-series). Use [Chef Habitat](/habitat/) to install Chef Infra Client on this platform.
-
-{{< /note >}}
+| Platform | Architecture | Version | Notes |
+| --- | --- | --- | --- |
+| AIX | `powerpc` | `7.1` (TL5 SP2 or higher, recommended), `7.2`, `7.3` | |
+| Amazon Linux | `x86_64`, `aarch64` | `2.x`, `2023` | |
+| CentOS | `x86_64`, `ppc64le`, `ppc64`, `aarch64` | `7.x` | |
+| Debian | `x86_64`, `aarch64` | `10`, `11`, `13` | |
+| FreeBSD | `amd64` | `13.x` | |
+| macOS | `aarch64` | `13.x`, `14.x` | Only a [Habitat](/habitat/) package is available. No native `.pkg` or `.dmg` installer is produced. |
+| Oracle Enterprise Linux | `x86_64`, `aarch64` | `7.x`, `8.x` | |
+| Red Hat Enterprise Linux | `x86_64`, `ppc64le` (7.x only), `ppc64` (7.x only), `aarch64`, `s390x` (7.x / 8.x only) | `7.x`, `8.x`, `9.x`, `10.x` | |
+| Rocky Linux | `x86_64`, `aarch64` | `8.x`, `9.x` | |
+| Solaris | `sparc`, `i86pc` | `11.3` (16.17.4 and later only), `11.4`  | |
+| SUSE Linux Enterprise Server | `x86_64`, `aarch64` (15.x only), `s390x` | `12`, `15` | |
+| Ubuntu (LTS releases) | `x86_64`,`aarch64` (18.x and above) | `18.04`, `20.04`, `22.04`, `24.04`, `26.04` | |
+| Windows | `x86_64` | `2016`, `10` (all channels except "insider" builds), `2019` (Long-term servicing channel (LTSC), both Desktop Experience and Server Core), `11`, `2022`, `2025` | |
 
 #### Derived platforms
 


### PR DESCRIPTION
## Summary

macOS on `aarch64` (Apple Silicon) is already listed as a supported platform for Chef Infra Client, but there is no native installer for it. Added a note under the Chef Infra Client supported platforms table clarifying that [Chef Habitat](/habitat/) must be used to install on this platform.

Also updated the macOS tarball install instructions to use the migration tool (`migrate-ice apply`) to download and install Chef Infra Client in one step, instead of separate `curl`/`tar` commands.

This work was completed with AI assistance following Progress AI policies