### PR TITLE
Add unified resources catalog page at /resources

### DIFF
--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -1,0 +1,35 @@
++++
+title = "Resources"
+draft = false
+description = "Unified reference of every resource available in Chef Infra Client and Chef InSpec, with a compatibility matrix and links to each product's documentation."
+gh_repo = "chef-web-docs"
+layout = "resources_matrix"
+data_path = ["client", "19", "resources"]
+
+swiftype_search_products = ["client", "inspec"]
+
+[menu]
+  [menu.overview]
+    title = "Resources"
+    identifier = "overview/resources.md Resources"
+    parent = "overview"
+    weight = 15
++++
+
+Chef Infra Client and Chef InSpec both use _resources_ as their core building block, but for
+different purposes. A Chef Infra Client resource declares the desired state of part of a system---a
+package, service, file, or user---and Chef Infra Client configures the system to match.
+A Chef InSpec resource inspects part of a system so you can write compliance and security tests
+for its actual state.
+
+This page is the single catalog of every resource across both products. Use it to discover which
+resources exist, see at a glance whether a resource is available in Chef Infra Client,
+Chef InSpec, or both, and go to each product's authoritative documentation.
+
+For the resources introduced in a specific release, see that version's documentation. This page
+lists the complete catalog and doesn't replace the version-specific resource references:
+
+- [Chef Infra Client resources](/client/19/resources/)
+- [Chef InSpec resources](/inspec/latest/resources/)
+
+The following sections list the resources supported by both products and then the complete catalog.

--- a/data/resources/inspec.yaml
+++ b/data/resources/inspec.yaml
@@ -1,0 +1,1638 @@
+# InSpec resource catalog snapshot for the unified /resources page.
+#
+# Source: inspec/inspec repo, docs-chef-io/content/inspec/resources/*.md (main branch).
+# Each entry mirrors a resource page's `platform` front matter and lead description.
+# This is a point-in-time snapshot; InSpec docs are deployed as a separate site and are
+# not built from this repository. To regenerate: re-read the resource pages from
+# inspec/inspec and rebuild this map (name -> platform, description, deprecated).
+#
+# Keyed by resource name so the resources_matrix layout can look up InSpec support.
+
+aide_conf:
+  platform: "linux"
+  description: "Use the `aide_conf` Chef InSpec audit resource to test the rules established for the file integrity tool AIDE."
+  deprecated: false
+apache:
+  platform: "linux"
+  description: "Use the `apache` Chef InSpec audit resource to test the state of the Apache server on Linux/Unix systems."
+  deprecated: true
+apache_conf:
+  platform: "linux"
+  description: "Use the `apache_conf` Chef InSpec audit resource to test the configuration settings for Apache."
+  deprecated: false
+apt:
+  platform: "linux"
+  description: "Use the `apt` Chef InSpec audit resource to verify Apt repositories on the Debian and Ubuntu platforms, and also PPA repositories on the Ubuntu platform."
+  deprecated: false
+audit_policy:
+  platform: "linux"
+  description: "Use the `audit_policy` Chef InSpec audit resource to test auditing policies on the Windows platform."
+  deprecated: false
+auditd:
+  platform: "linux"
+  description: "Use the `auditd` Chef InSpec audit resource to test the rules for logging that exist on the system."
+  deprecated: false
+auditd_conf:
+  platform: "linux"
+  description: "Use the `auditd_conf` Chef InSpec audit resource to test the configuration settings for the audit daemon."
+  deprecated: false
+azurerm_ad_user:
+  platform: "azure"
+  description: "Use the `azurerm_ad_user` InSpec audit resource to test properties of an Azure Active Directory user within a Tenant."
+  deprecated: true
+azurerm_ad_users:
+  platform: "azure"
+  description: "Use the `azurerm_ad_users` InSpec audit resource to test properties of some or all Azure Active Directory users within a Tenant."
+  deprecated: true
+azurerm_aks_cluster:
+  platform: "azure"
+  description: "Use the `azurerm_aks_cluster` InSpec audit resource to test properties of an Azure AKS Cluster."
+  deprecated: false
+azurerm_aks_clusters:
+  platform: "azure"
+  description: "Use the `azurerm_aks_clusters` InSpec audit resource to enumerate AKS Clusters."
+  deprecated: false
+azurerm_cosmosdb_database_account:
+  platform: "azure"
+  description: "Use the `azurerm_cosmosdb_database_account` InSpec audit resource to test properties and configuration of an Azure CosmosDb Database Account within a Resource Group."
+  deprecated: false
+azurerm_event_hub_authorization_rule:
+  platform: "azure"
+  description: "Use the `azurerm_event_hub_authorization_rule` InSpec audit resource to test properties and configuration of an Azure Event Hub Authorization Rule within a Resource Group."
+  deprecated: false
+azurerm_event_hub_event_hub:
+  platform: "azure"
+  description: "Use the `azurerm_event_hub_event_hub` InSpec audit resource to test properties and configuration of an Azure Event Hub Event Hub within a Resource Group."
+  deprecated: false
+azurerm_event_hub_namespace:
+  platform: "azure"
+  description: "Use the `azurerm_event_hub_namespace` InSpec audit resource to test properties and configuration of an Azure Event Hub Namespace within a Resource Group."
+  deprecated: false
+azurerm_iothub:
+  platform: "azure"
+  description: "Use the `azurerm_iothub` InSpec audit resource to test properties and configuration of an Azure Event Hub Namespace within a Resource Group."
+  deprecated: false
+azurerm_iothub_event_hub_consumer_group:
+  platform: "azure"
+  description: "Use the `azurerm_iothub_event_hub_consumer_group` InSpec audit resource to test properties and configuration of an Azure IoT Hub Event Hub Consumer Group within a Resource Group."
+  deprecated: false
+azurerm_iothub_event_hub_consumer_groups:
+  platform: "azure"
+  description: "Use the `azurerm_iothub_event_hub_consumer_groups` InSpec audit resource to test properties and configuration of an Azure IoT Hub Event Hub Consumer Groups within a Resource Group."
+  deprecated: false
+azurerm_key_vault:
+  platform: "azure"
+  description: "Use the `azurerm_key_vault` InSpec audit resource to test properties and configuration of an Azure Key Vault."
+  deprecated: false
+azurerm_key_vault_key:
+  platform: "azure"
+  description: "Use the `azurerm_key_vault_key` InSpec audit resource to test properties and configuration of an Azure Key within a Vault."
+  deprecated: false
+azurerm_key_vault_keys:
+  platform: "azure"
+  description: "Use the `azurerm_key_vault_keys` InSpec audit resource to test properties and configuration of Azure Keys within Vaults."
+  deprecated: false
+azurerm_key_vault_secret:
+  platform: "azure"
+  description: "Use the `azurerm_key_vault_secret` InSpec audit resource to test properties and configuration of an Azure Secret within a Vault."
+  deprecated: false
+azurerm_key_vault_secrets:
+  platform: "azure"
+  description: "Use the `azurerm_key_vault_secrets` InSpec audit resource to test properties and configuration of Azure Secrets within Vaults."
+  deprecated: false
+azurerm_key_vaults:
+  platform: "azure"
+  description: "Use the `azurerm_key_vaults` InSpec audit resource to test properties and configuration of Azure Key Vaults."
+  deprecated: false
+azurerm_load_balancer:
+  platform: "azure"
+  description: "Use the `azurerm_load_balancer` InSpec audit resource to test properties and configuration of an Azure Load Balancer."
+  deprecated: false
+azurerm_load_balancers:
+  platform: "azure"
+  description: "Use the `azurerm_load_balancers` InSpec audit resource to test properties and configuration of Azure Load Balancers."
+  deprecated: false
+azurerm_locks:
+  platform: "azure"
+  description: "Use the `azurerm_locks` InSpec audit resource to test properties of some or all Azure Resource Locks."
+  deprecated: false
+azurerm_management_group:
+  platform: "azure"
+  description: "Use the `azurerm_management_group` InSpec audit resource to test properties related to a management group."
+  deprecated: false
+azurerm_management_groups:
+  platform: "azure"
+  description: "Use the `azurerm_management_groups` InSpec audit resource to test properties related to management groups."
+  deprecated: false
+azurerm_monitor_activity_log_alert:
+  platform: "azure"
+  description: "Use the `azurerm_monitor_activity_log_alert` InSpec audit resource to test properties of an Azure Monitor Activity Log Alert."
+  deprecated: false
+azurerm_monitor_activity_log_alerts:
+  platform: "azure"
+  description: "Use the `azurerm_monitor_activity_log_alerts` InSpec audit resource to verify that an Activity Log Alert exists."
+  deprecated: false
+azurerm_monitor_log_profile:
+  platform: "azure"
+  description: "Use the `azurerm_monitor_log_profile` InSpec audit resource to test properties of an Azure Monitor Log Profile."
+  deprecated: false
+azurerm_monitor_log_profiles:
+  platform: "azure"
+  description: "Use the `azurerm_monitor_log_profiles` InSpec audit resource to verify that a Log Profile exists."
+  deprecated: false
+azurerm_mysql_database:
+  platform: "azure"
+  description: "Use the `azurerm_mysql_database` InSpec audit resource to test properties and configuration of an Azure MySQL Database on a MySQL Server."
+  deprecated: false
+azurerm_mysql_databases:
+  platform: "azure"
+  description: "Use the `azurerm_mysql_databases` InSpec audit resource to test properties and configuration of Azure MySQL Databases."
+  deprecated: false
+azurerm_mysql_server:
+  platform: "azure"
+  description: "Use the `azurerm_mysql_server` InSpec audit resource to test properties and configuration of an Azure MySQL Server."
+  deprecated: false
+azurerm_mysql_servers:
+  platform: "azure"
+  description: "Use the `azurerm_mysql_servers` InSpec audit resource to test properties and configuration of multiple Azure MySQL Servers."
+  deprecated: false
+azurerm_network_interface:
+  platform: "azure"
+  description: "Use the `azurerm_network_interface` InSpec audit resource to test properties and configuration of Azure Network Interface."
+  deprecated: false
+azurerm_network_interfaces:
+  platform: "azure"
+  description: "Use the `azurerm_network_interfaces` InSpec audit resource to test properties and configuration of Azure Network interfaces."
+  deprecated: false
+azurerm_network_security_group:
+  platform: "azure"
+  description: "Use the `azurerm_network_security_group` InSpec audit resource to test properties of an Azure Network Security Group."
+  deprecated: false
+azurerm_network_security_groups:
+  platform: "azure"
+  description: "Use the `azurerm_network_security_groups` InSpec audit resource to enumerate Network Security Groups."
+  deprecated: false
+azurerm_network_watcher:
+  platform: "azure"
+  description: "Use the `azurerm_network_watcher` InSpec audit resource to test properties of an Azure Network Watcher."
+  deprecated: false
+azurerm_network_watchers:
+  platform: "azure"
+  description: "Use the `azurerm_network_watchers` InSpec audit resource to verify that a Network Watcher exists."
+  deprecated: false
+azurerm_postgresql_database:
+  platform: "azure"
+  description: "Use the `azurerm_postgresql_database` InSpec audit resource to test properties and configuration of an Azure PostgreSQL Database on a PostgreSQL Server."
+  deprecated: false
+azurerm_postgresql_databases:
+  platform: "azure"
+  description: "Use the `azurerm_postgresql_databases` InSpec audit resource to test properties and configuration of Azure PostgreSQL Databases."
+  deprecated: false
+azurerm_postgresql_server:
+  platform: "azure"
+  description: "Use the `azurerm_postgresql_server` InSpec audit resource to test properties and configuration of an Azure PostgreSQL Server."
+  deprecated: false
+azurerm_postgresql_servers:
+  platform: "azure"
+  description: "Use the `azurerm_postgresql_servers` InSpec audit resource to test properties and configuration of multiple Azure PostgreSQL Servers."
+  deprecated: false
+azurerm_resource_groups:
+  platform: "azure"
+  description: "Use the `azurerm_resource_groups` InSpec audit resource to test properties of some or all Azure Resource Groups"
+  deprecated: false
+azurerm_role_definition:
+  platform: "azure"
+  description: "Use the `azurerm_role_definition` InSpec audit resource to test properties of an Azure Role Definition."
+  deprecated: false
+azurerm_role_definitions:
+  platform: "azure"
+  description: "Use the `azurerm_role_definitions` InSpec audit resource to test properties of some or all Azure Role Definitions."
+  deprecated: false
+azurerm_security_center_policies:
+  platform: "azure"
+  description: "Use the `azurerm_security_center_policies` InSpec audit resource to test properties of some or all Azure Security Center Policies."
+  deprecated: false
+azurerm_security_center_policy:
+  platform: "azure"
+  description: "Use the `azurerm_security_center_policy` InSpec audit resource to test properties of the `default` Security Center Policy."
+  deprecated: false
+azurerm_sql_database:
+  platform: "azure"
+  description: "Use the `azurerm_sql_database` InSpec audit resource to test properties and configuration of an Azure SQL Database on a SQL Server."
+  deprecated: false
+azurerm_sql_databases:
+  platform: "azure"
+  description: "Use the `azurerm_sql_databases` InSpec audit resource to test properties and configuration of Azure SQL Databases."
+  deprecated: false
+azurerm_sql_server:
+  platform: "azure"
+  description: "Use the `azurerm_sql_server` InSpec audit resource to test properties and configuration of an Azure SQL Server within a Resource Group."
+  deprecated: false
+azurerm_sql_servers:
+  platform: "azure"
+  description: "Use the `azurerm_sql_servers` InSpec audit resource to test properties and configuration of Azure SQL Servers."
+  deprecated: false
+azurerm_storage_account_blob_container:
+  platform: "azure"
+  description: "Use the `azurerm_storage_account_blob_container` InSpec audit resource to test properties related to a Blob Container in an Azure Storage Account."
+  deprecated: false
+azurerm_storage_account_blob_containers:
+  platform: "azure"
+  description: "Use the `azurerm_storage_account_blob_containers` InSpec audit resource to test properties and configuration of Blob Containers within an Azure Storage Account."
+  deprecated: false
+azurerm_subnet:
+  platform: "azure"
+  description: "Use the `azurerm_subnet` InSpec audit resource to test properties related to a subnet for a given virtual network."
+  deprecated: false
+azurerm_subnets:
+  platform: "azure"
+  description: "Use the `azurerm_subnets` InSpec audit resource to test properties related to subnets for a resource group."
+  deprecated: false
+azurerm_subscription:
+  platform: "azure"
+  description: "Use the `azurerm_subscription` InSpec audit resource to test properties related to the current subscription subscription."
+  deprecated: false
+azurerm_virtual_machine:
+  platform: "azure"
+  description: "Use the `azurerm_virtual_machine` InSpec audit resource to test properties related to a virtual machine."
+  deprecated: false
+azurerm_virtual_machine_disk:
+  platform: "azure"
+  description: "Use the `azurerm_virtual_machine_disk` InSpec audit resource to test properties related to a virtual machine's disk."
+  deprecated: false
+azurerm_virtual_machine_disks:
+  platform: "azure"
+  description: "Use the `azurerm_virtual_machine_disks` InSpec audit resource to test properties of some or all Azure Disks within a subscription."
+  deprecated: false
+azurerm_virtual_machines:
+  platform: "azure"
+  description: "Use the `azurerm_virtual_machines` InSpec audit resource to test properties related to virtual machines for a resource group."
+  deprecated: false
+azurerm_virtual_network:
+  platform: "azure"
+  description: "Use the `azurerm_virtual_network` InSpec audit resource to test properties related to a virtual network."
+  deprecated: false
+azurerm_virtual_networks:
+  platform: "azure"
+  description: "Use the `azurerm_virtual_networks` InSpec audit resource to test properties related to virtual networks for a resource group."
+  deprecated: false
+azurerm_webapp:
+  platform: "azure"
+  description: "Use the `azurerm_webapp` InSpec audit resource to test properties of an Azure Webapp."
+  deprecated: false
+azurerm_webapps:
+  platform: "azure"
+  description: "Use the `azurerm_webapps` InSpec audit resource to enumerate Webapps."
+  deprecated: false
+bash:
+  platform: "linux"
+  description: "Use the `bash` Chef InSpec audit resource to test an arbitrary command that is run on the system using a Bash script."
+  deprecated: false
+bond:
+  platform: "linux"
+  description: "Use the `bond` Chef InSpec audit resource to test a logical, bonded network interface (i.e."
+  deprecated: false
+bridge:
+  platform: "linux"
+  description: "Use the `bridge` Chef InSpec audit resource to test basic network bridge properties, such as `name`, if an interface is defined, and the associations for any defined interface."
+  deprecated: false
+bsd_service:
+  platform: "linux"
+  description: "Use the `bsd_service` Chef InSpec audit resource to test a service using a Berkeley OS-style `init` on the FreeBSD platform."
+  deprecated: false
+cassandradb_conf:
+  platform: "os"
+  description: "Use the `cassandradb_conf` Chef InSpec audit resource to test the configuration of a Cassandra database, which is typically located at `$CASSANDRA_HOME/cassandra.yaml` or `$CASSANDRA_HOME\\conf\\cassandra.yaml` depending upon the platform."
+  deprecated: false
+cassandradb_session:
+  platform: "os"
+  description: "Use the `cassandradb_session` Chef InSpec audit resource to test Cassandra Query Language (CQL) commands run against a Cassandra database."
+  deprecated: false
+cgroup:
+  platform: "linux"
+  description: "Use the `cgroup` Chef InSpec audit resource to test the different parameters values of the control group (cgroup) resource controllers."
+  deprecated: false
+chocolatey_package:
+  platform: "windows"
+  description: "Use the `chocolatey_package` Chef InSpec audit resource to test if the named [Chocolatey](https://chocolatey.org/) package and/or package version is installed on the system."
+  deprecated: false
+chrony_conf:
+  platform: "linux"
+  description: "Use the `chrony_conf` Chef InSpec audit resource to test the synchronization settings defined in the `chrony.conf` file."
+  deprecated: false
+command:
+  platform: "os"
+  description: "Use the `command` Chef InSpec audit resource to test an arbitrary command that is run on the system."
+  deprecated: false
+cpan:
+  platform: "linux"
+  description: "Use the `cpan` Chef InSpec audit resource to test Perl modules that are installed by system packages or the CPAN installer."
+  deprecated: false
+cran:
+  platform: "linux"
+  description: "Use the `cran` Chef InSpec audit resource to test R modules that are installed from CRAN package repository."
+  deprecated: false
+cron:
+  platform: "linux"
+  description: "Use the `cron` Chef InSpec audit resource to test the Crontab entries of a particular user on the system."
+  deprecated: false
+crontab:
+  platform: "linux"
+  description: "Use the `crontab` Chef InSpec audit resource to test the crontab entries for a particular user on the system."
+  deprecated: false
+csv:
+  platform: "os"
+  description: "Use the `csv` Chef InSpec audit resource to test configuration data in a CSV file."
+  deprecated: false
+default_gateway:
+  platform: "unix"
+  description: "Use the **default_gateway** Chef InSpec audit resource to test the assigned IP address and interface for the default route."
+  deprecated: false
+dh_params:
+  platform: "linux"
+  description: "Use the `dh_params` Chef InSpec audit resource to test Diffie-Hellman (DH) parameters."
+  deprecated: false
+directory:
+  platform: "os"
+  description: "Use the `directory` Chef InSpec audit resource to test if the file type is a directory."
+  deprecated: false
+etc_fstab:
+  platform: "linux"
+  description: "Use the `etc_fstab` Chef InSpec audit resource to test information about all partitions and storage devices on a Linux system."
+  deprecated: false
+etc_group:
+  platform: "linux"
+  description: "Use the `etc_group` Chef InSpec audit resource to test groups that are defined on Linux and Unix platforms."
+  deprecated: false
+etc_hosts:
+  platform: "linux"
+  description: "Use the `etc_hosts` Chef InSpec audit resource to test rules set to match IP addresses with hostnames."
+  deprecated: false
+etc_hosts_allow:
+  platform: "linux"
+  description: "Use the `etc_hosts_allow` Chef InSpec audit resource to test rules defined for accepting daemon and client traffic in the `'/etc/hosts.allow'` file."
+  deprecated: false
+etc_hosts_deny:
+  platform: "linux"
+  description: "Use the `etc_hosts_deny` Chef InSpec audit resource to test rules for rejecting daemon and client traffic defined in /etc/hosts.deny."
+  deprecated: false
+file:
+  platform: "os"
+  description: "Use the `file` Chef InSpec audit resource to test system file types, including directories, symbolic links, named pipes, sockets, character devices, block devices, and doors."
+  deprecated: false
+filesystem:
+  platform: "linux"
+  description: "Use the `filesystem` Chef InSpec resource to audit filesystem disk space usage."
+  deprecated: false
+firewalld:
+  platform: "linux"
+  description: "Use the `firewalld` Chef InSpec audit resource to test that firewalld is configured to allow and deny access to specific hosts, services and ports on a system."
+  deprecated: false
+gem:
+  platform: "os"
+  description: "Use the `gem` Chef InSpec audit resource to test if a global Gem package is installed."
+  deprecated: false
+google_access_context_manager_access_policies:
+  platform: "gcp"
+  description: "A `google_access_context_manager_access_policies` is used to test a Google AccessPolicy resource"
+  deprecated: false
+google_access_context_manager_access_policy:
+  platform: "gcp"
+  description: "A `google_access_context_manager_access_policy` is used to test a Google AccessPolicy resource"
+  deprecated: false
+google_access_context_manager_service_perimeter:
+  platform: "gcp"
+  description: "A `google_access_context_manager_service_perimeter` is used to test a Google ServicePerimeter resource"
+  deprecated: false
+google_access_context_manager_service_perimeters:
+  platform: "gcp"
+  description: "A `google_access_context_manager_service_perimeters` is used to test a Google ServicePerimeter resource"
+  deprecated: false
+google_appengine_standard_app_version:
+  platform: "gcp"
+  description: "A `google_appengine_standard_app_version` is used to test a Google StandardAppVersion resource"
+  deprecated: false
+google_appengine_standard_app_versions:
+  platform: "gcp"
+  description: "A `google_appengine_standard_app_versions` is used to test a Google StandardAppVersion resource"
+  deprecated: false
+google_bigquery_dataset:
+  platform: "gcp"
+  description: "A `google_bigquery_dataset` is used to test a Google Dataset resource"
+  deprecated: false
+google_bigquery_datasets:
+  platform: "gcp"
+  description: "A `google_bigquery_datasets` is used to test a Google Dataset resource"
+  deprecated: false
+google_bigquery_table:
+  platform: "gcp"
+  description: "A `google_bigquery_table` is used to test a Google Table resource"
+  deprecated: false
+google_bigquery_tables:
+  platform: "gcp"
+  description: "A `google_bigquery_tables` is used to test a Google Table resource"
+  deprecated: false
+google_billing_project_billing_info:
+  platform: "gcp"
+  description: "A `google_billing_project_billing_info` is used to test a Google ProjectBillingInfo resource"
+  deprecated: false
+google_cloud_scheduler_job:
+  platform: "gcp"
+  description: "A `google_cloud_scheduler_job` is used to test a Google Job resource"
+  deprecated: false
+google_cloud_scheduler_jobs:
+  platform: "gcp"
+  description: "A `google_cloud_scheduler_jobs` is used to test a Google Job resource"
+  deprecated: false
+google_cloudbuild_trigger:
+  platform: "gcp"
+  description: "A `google_cloudbuild_trigger` is used to test a Google Trigger resource"
+  deprecated: false
+google_cloudbuild_triggers:
+  platform: "gcp"
+  description: "A `google_cloudbuild_triggers` is used to test a Google Trigger resource"
+  deprecated: false
+google_cloudfunctions_cloud_function:
+  platform: "gcp"
+  description: "A `google_cloudfunctions_cloud_function` is used to test a Google CloudFunction resource"
+  deprecated: false
+google_cloudfunctions_cloud_functions:
+  platform: "gcp"
+  description: "A `google_cloudfunctions_cloud_functions` is used to test a Google CloudFunction resource"
+  deprecated: false
+google_compute_address:
+  platform: "gcp"
+  description: "A `google_compute_address` is used to test a Google Address resource"
+  deprecated: false
+google_compute_addresses:
+  platform: "gcp"
+  description: "A `google_compute_addresses` is used to test a Google Address resource"
+  deprecated: false
+google_compute_autoscaler:
+  platform: "gcp"
+  description: "A `google_compute_autoscaler` is used to test a Google Autoscaler resource"
+  deprecated: false
+google_compute_autoscalers:
+  platform: "gcp"
+  description: "A `google_compute_autoscalers` is used to test a Google Autoscaler resource"
+  deprecated: false
+google_compute_backend_bucket:
+  platform: "gcp"
+  description: "A `google_compute_backend_bucket` is used to test a Google BackendBucket resource"
+  deprecated: false
+google_compute_backend_buckets:
+  platform: "gcp"
+  description: "A `google_compute_backend_buckets` is used to test a Google BackendBucket resource"
+  deprecated: false
+google_compute_backend_service:
+  platform: "gcp"
+  description: "A `google_compute_backend_service` is used to test a Google BackendService resource"
+  deprecated: false
+google_compute_backend_services:
+  platform: "gcp"
+  description: "A `google_compute_backend_services` is used to test a Google BackendService resource"
+  deprecated: false
+google_compute_disk:
+  platform: "gcp"
+  description: "A `google_compute_disk` is used to test a Google Disk resource"
+  deprecated: false
+google_compute_disks:
+  platform: "gcp"
+  description: "A `google_compute_disks` is used to test a Google Disk resource"
+  deprecated: false
+google_compute_firewall:
+  platform: "gcp"
+  description: "A `google_compute_firewall` is used to test a Google Firewall resource"
+  deprecated: false
+google_compute_firewalls:
+  platform: "gcp"
+  description: "A `google_compute_firewalls` is used to test a Google Firewall resource"
+  deprecated: false
+google_compute_forwarding_rule:
+  platform: "gcp"
+  description: "A `google_compute_forwarding_rule` is used to test a Google ForwardingRule resource"
+  deprecated: false
+google_compute_forwarding_rules:
+  platform: "gcp"
+  description: "A `google_compute_forwarding_rules` is used to test a Google ForwardingRule resource"
+  deprecated: false
+google_compute_global_address:
+  platform: "gcp"
+  description: "A `google_compute_global_address` is used to test a Google GlobalAddress resource"
+  deprecated: false
+google_compute_global_addresses:
+  platform: "gcp"
+  description: "A `google_compute_global_addresses` is used to test a Google GlobalAddress resource"
+  deprecated: false
+google_compute_global_forwarding_rule:
+  platform: "gcp"
+  description: "A `google_compute_global_forwarding_rule` is used to test a Google GlobalForwardingRule resource"
+  deprecated: false
+google_compute_global_forwarding_rules:
+  platform: "gcp"
+  description: "A `google_compute_global_forwarding_rules` is used to test a Google GlobalForwardingRule resource"
+  deprecated: false
+google_compute_health_check:
+  platform: "gcp"
+  description: "A `google_compute_health_check` is used to test a Google HealthCheck resource"
+  deprecated: false
+google_compute_health_checks:
+  platform: "gcp"
+  description: "A `google_compute_health_checks` is used to test a Google HealthCheck resource"
+  deprecated: false
+google_compute_http_health_check:
+  platform: "gcp"
+  description: "A `google_compute_http_health_check` is used to test a Google HttpHealthCheck resource"
+  deprecated: false
+google_compute_http_health_checks:
+  platform: "gcp"
+  description: "A `google_compute_http_health_checks` is used to test a Google HttpHealthCheck resource"
+  deprecated: false
+google_compute_https_health_check:
+  platform: "gcp"
+  description: "A `google_compute_https_health_check` is used to test a Google HttpsHealthCheck resource"
+  deprecated: false
+google_compute_https_health_checks:
+  platform: "gcp"
+  description: "A `google_compute_https_health_checks` is used to test a Google HttpsHealthCheck resource"
+  deprecated: false
+google_compute_image:
+  platform: "gcp"
+  description: "A `google_compute_image` is used to test a Google Image resource"
+  deprecated: false
+google_compute_instance:
+  platform: "gcp"
+  description: "A `google_compute_instance` is used to test a Google Instance resource"
+  deprecated: false
+google_compute_instance_group:
+  platform: "gcp"
+  description: "A `google_compute_instance_group` is used to test a Google InstanceGroup resource"
+  deprecated: false
+google_compute_instance_group_manager:
+  platform: "gcp"
+  description: "A `google_compute_instance_group_manager` is used to test a Google InstanceGroupManager resource"
+  deprecated: false
+google_compute_instance_group_managers:
+  platform: "gcp"
+  description: "A `google_compute_instance_group_managers` is used to test a Google InstanceGroupManager resource"
+  deprecated: false
+google_compute_instance_groups:
+  platform: "gcp"
+  description: "A `google_compute_instance_groups` is used to test a Google InstanceGroup resource"
+  deprecated: false
+google_compute_instance_template:
+  platform: "gcp"
+  description: "A `google_compute_instance_template` is used to test a Google InstanceTemplate resource"
+  deprecated: false
+google_compute_instance_templates:
+  platform: "gcp"
+  description: "A `google_compute_instance_templates` is used to test a Google InstanceTemplate resource"
+  deprecated: false
+google_compute_instances:
+  platform: "gcp"
+  description: "A `google_compute_instances` is used to test a Google Instance resource"
+  deprecated: false
+google_compute_network:
+  platform: "gcp"
+  description: "A `google_compute_network` is used to test a Google Network resource"
+  deprecated: false
+google_compute_network_endpoint_group:
+  platform: "gcp"
+  description: "A `google_compute_network_endpoint_group` is used to test a Google NetworkEndpointGroup resource"
+  deprecated: false
+google_compute_network_endpoint_groups:
+  platform: "gcp"
+  description: "A `google_compute_network_endpoint_groups` is used to test a Google NetworkEndpointGroup resource"
+  deprecated: false
+google_compute_networks:
+  platform: "gcp"
+  description: "A `google_compute_networks` is used to test a Google Network resource"
+  deprecated: false
+google_compute_node_group:
+  platform: "gcp"
+  description: "A `google_compute_node_group` is used to test a Google NodeGroup resource"
+  deprecated: false
+google_compute_node_groups:
+  platform: "gcp"
+  description: "A `google_compute_node_groups` is used to test a Google NodeGroup resource"
+  deprecated: false
+google_compute_node_template:
+  platform: "gcp"
+  description: "A `google_compute_node_template` is used to test a Google NodeTemplate resource"
+  deprecated: false
+google_compute_node_templates:
+  platform: "gcp"
+  description: "A `google_compute_node_templates` is used to test a Google NodeTemplate resource"
+  deprecated: false
+google_compute_project_info:
+  platform: "gcp"
+  description: "A `google_compute_project_info` is used to test a Google ProjectInfo resource"
+  deprecated: false
+google_compute_region:
+  platform: "gcp"
+  description: "A `google_compute_region` is used to test a Google Region resource"
+  deprecated: false
+google_compute_region_backend_service:
+  platform: "gcp"
+  description: "A `google_compute_region_backend_service` is used to test a Google RegionBackendService resource"
+  deprecated: false
+google_compute_region_backend_services:
+  platform: "gcp"
+  description: "A `google_compute_region_backend_services` is used to test a Google RegionBackendService resource"
+  deprecated: false
+google_compute_region_instance_group_manager:
+  platform: "gcp"
+  description: "A `google_compute_region_instance_group_manager` is used to test a Google RegionInstanceGroupManager resource"
+  deprecated: false
+google_compute_region_instance_group_managers:
+  platform: "gcp"
+  description: "A `google_compute_region_instance_group_managers` is used to test a Google RegionInstanceGroupManager resource"
+  deprecated: false
+google_compute_regional_disk:
+  platform: "gcp"
+  description: "A `google_compute_regional_disk` is used to test a Google Regional Disk resource"
+  deprecated: false
+google_compute_regions:
+  platform: "gcp"
+  description: "A `google_compute_regions` is used to test a Google Region resource"
+  deprecated: false
+google_compute_route:
+  platform: "gcp"
+  description: "A `google_compute_route` is used to test a Google Route resource"
+  deprecated: false
+google_compute_router:
+  platform: "gcp"
+  description: "A `google_compute_router` is used to test a Google Router resource"
+  deprecated: false
+google_compute_router_nat:
+  platform: "gcp"
+  description: "A `google_compute_router_nat` is used to test a Google RouterNat resource"
+  deprecated: false
+google_compute_router_nats:
+  platform: "gcp"
+  description: "A `google_compute_router_nats` is used to test a Google RouterNat resource"
+  deprecated: false
+google_compute_routers:
+  platform: "gcp"
+  description: "A `google_compute_routers` is used to test a Google Router resource"
+  deprecated: false
+google_compute_routes:
+  platform: "gcp"
+  description: "A `google_compute_routes` is used to test a Google Route resource"
+  deprecated: false
+google_compute_security_policies:
+  platform: "gcp"
+  description: "A `google_compute_security_policies` is used to test a Google SecurityPolicy resource"
+  deprecated: false
+google_compute_security_policy:
+  platform: "gcp"
+  description: "A `google_compute_security_policy` is used to test a Google SecurityPolicy resource"
+  deprecated: false
+google_compute_snapshot:
+  platform: "gcp"
+  description: "A `google_compute_snapshot` is used to test a Google Snapshot resource"
+  deprecated: false
+google_compute_snapshots:
+  platform: "gcp"
+  description: "A `google_compute_snapshots` is used to test a Google Snapshot resource"
+  deprecated: false
+google_compute_ssl_certificate:
+  platform: "gcp"
+  description: "A `google_compute_ssl_certificate` is used to test a Google SslCertificate resource"
+  deprecated: false
+google_compute_ssl_certificates:
+  platform: "gcp"
+  description: "A `google_compute_ssl_certificates` is used to test a Google SslCertificate resource"
+  deprecated: false
+google_compute_ssl_policies:
+  platform: "gcp"
+  description: "A `google_compute_ssl_policies` is used to test a Google SslPolicy resource"
+  deprecated: false
+google_compute_ssl_policy:
+  platform: "gcp"
+  description: "A `google_compute_ssl_policy` is used to test a Google SslPolicy resource"
+  deprecated: false
+google_compute_subnetwork:
+  platform: "gcp"
+  description: "A `google_compute_subnetwork` is used to test a Google Subnetwork resource"
+  deprecated: false
+google_compute_subnetwork_iam_binding:
+  platform: "gcp"
+  description: "A `google_compute_subnetwork_iam_binding` is used to test a Google Subnetwork Iam Bindings"
+  deprecated: false
+google_compute_subnetwork_iam_policy:
+  platform: "gcp"
+  description: "A `google_compute_subnetwork_iam_policy` is used to test a Google Subnetwork Iam Policy resource"
+  deprecated: false
+google_compute_subnetworks:
+  platform: "gcp"
+  description: "A `google_compute_subnetworks` is used to test a Google Subnetwork resource"
+  deprecated: false
+google_compute_target_http_proxies:
+  platform: "gcp"
+  description: "A `google_compute_target_http_proxies` is used to test a Google TargetHttpProxy resource"
+  deprecated: false
+google_compute_target_http_proxy:
+  platform: "gcp"
+  description: "A `google_compute_target_http_proxy` is used to test a Google TargetHttpProxy resource"
+  deprecated: false
+google_compute_target_https_proxies:
+  platform: "gcp"
+  description: "A `google_compute_target_https_proxies` is used to test a Google TargetHttpsProxy resource"
+  deprecated: false
+google_compute_target_https_proxy:
+  platform: "gcp"
+  description: "A `google_compute_target_https_proxy` is used to test a Google TargetHttpsProxy resource"
+  deprecated: false
+google_compute_target_pool:
+  platform: "gcp"
+  description: "A `google_compute_target_pool` is used to test a Google TargetPool resource"
+  deprecated: false
+google_compute_target_pools:
+  platform: "gcp"
+  description: "A `google_compute_target_pools` is used to test a Google TargetPool resource"
+  deprecated: false
+google_compute_target_tcp_proxies:
+  platform: "gcp"
+  description: "A `google_compute_target_tcp_proxies` is used to test a Google TargetTcpProxy resource"
+  deprecated: false
+google_compute_target_tcp_proxy:
+  platform: "gcp"
+  description: "A `google_compute_target_tcp_proxy` is used to test a Google TargetTcpProxy resource"
+  deprecated: false
+google_compute_url_map:
+  platform: "gcp"
+  description: "A `google_compute_url_map` is used to test a Google UrlMap resource"
+  deprecated: false
+google_compute_url_maps:
+  platform: "gcp"
+  description: "A `google_compute_url_maps` is used to test a Google UrlMap resource"
+  deprecated: false
+google_compute_vpn_tunnel:
+  platform: "gcp"
+  description: "A `google_compute_vpn_tunnel` is used to test a Google VpnTunnel resource"
+  deprecated: false
+google_compute_vpn_tunnels:
+  platform: "gcp"
+  description: "A `google_compute_vpn_tunnels` is used to test a Google VpnTunnel resource"
+  deprecated: false
+google_compute_zone:
+  platform: "gcp"
+  description: "A `google_compute_zone` is used to test a Google Zone resource"
+  deprecated: false
+google_compute_zones:
+  platform: "gcp"
+  description: "A `google_compute_zones` is used to test a Google Zone resource"
+  deprecated: false
+google_container_cluster:
+  platform: "gcp"
+  description: "A `google_container_cluster` is used to test a Google Cluster resource"
+  deprecated: false
+google_container_clusters:
+  platform: "gcp"
+  description: "A `google_container_clusters` is used to test a Google Cluster resource."
+  deprecated: false
+google_container_node_pool:
+  platform: "gcp"
+  description: "A `google_container_node_pool` is used to test a Google NodePool resource"
+  deprecated: false
+google_container_node_pools:
+  platform: "gcp"
+  description: "A `google_container_node_pools` is used to test a Google NodePool resource"
+  deprecated: false
+google_container_regional_cluster:
+  platform: "gcp"
+  description: "A `google_container_regional_cluster` is used to test a Google RegionalCluster resource"
+  deprecated: false
+google_container_regional_clusters:
+  platform: "gcp"
+  description: "A `google_container_regional_clusters` is used to test a Google RegionalCluster resource"
+  deprecated: false
+google_container_regional_node_pool:
+  platform: "gcp"
+  description: "A `google_container_regional_node_pool` is used to test a Google RegionalNodePool resource"
+  deprecated: false
+google_container_regional_node_pools:
+  platform: "gcp"
+  description: "A `google_container_regional_node_pools` is used to test a Google RegionalNodePool resource"
+  deprecated: false
+google_dataproc_cluster:
+  platform: "gcp"
+  description: "A `google_dataproc_cluster` is used to test a Google Cluster resource"
+  deprecated: false
+google_dataproc_clusters:
+  platform: "gcp"
+  description: "A `google_dataproc_clusters` is used to test a Google Cluster resource"
+  deprecated: false
+google_dns_managed_zone:
+  platform: "gcp"
+  description: "A `google_dns_managed_zone` is used to test a Google ManagedZone resource"
+  deprecated: false
+google_dns_managed_zones:
+  platform: "gcp"
+  description: "A `google_dns_managed_zones` is used to test a Google ManagedZone resource"
+  deprecated: false
+google_dns_resource_record_set:
+  platform: "gcp"
+  description: "A `google_dns_resource_record_set` is used to test a Google ResourceRecordSet resource"
+  deprecated: false
+google_dns_resource_record_sets:
+  platform: "gcp"
+  description: "A `google_dns_resource_record_sets` is used to test a Google ResourceRecordSet resource"
+  deprecated: false
+google_filestore_instance:
+  platform: "gcp"
+  description: "A `google_filestore_instance` is used to test a Google Instance resource"
+  deprecated: false
+google_filestore_instances:
+  platform: "gcp"
+  description: "A `google_filestore_instances` is used to test a Google Instance resource"
+  deprecated: false
+google_iam_custom_role:
+  platform: "gcp"
+  description: "A `google_iam_custom_role` is used to test a Google CustomRole resource"
+  deprecated: false
+google_iam_custom_roles:
+  platform: "gcp"
+  description: "A `google_iam_custom_roles` is used to test a Google CustomRole resource"
+  deprecated: false
+google_iam_organization_custom_role:
+  platform: "gcp"
+  description: "A `google_iam_organization_custom_role` is used to test a Google OrganizationCustomRole resource"
+  deprecated: false
+google_iam_organization_custom_roles:
+  platform: "gcp"
+  description: "A `google_iam_organization_custom_roles` is used to test a Google OrganizationCustomRole resource"
+  deprecated: false
+google_iam_service_account:
+  platform: "gcp"
+  description: "A `google_iam_service_account` is used to test a Google ServiceAccount resource"
+  deprecated: false
+google_iam_service_account_key:
+  platform: "gcp"
+  description: "A `google_iam_service_account_key` is used to test a Google ServiceAccountKey resource"
+  deprecated: false
+google_iam_service_account_keys:
+  platform: "gcp"
+  description: "A `google_iam_service_account_keys` is used to test a Google ServiceAccountKey resource"
+  deprecated: false
+google_iam_service_accounts:
+  platform: "gcp"
+  description: "A `google_iam_service_accounts` is used to test a Google ServiceAccount resource"
+  deprecated: false
+google_kms_crypto_key:
+  platform: "gcp"
+  description: "A `google_kms_crypto_key` is used to test a Google CryptoKey resource"
+  deprecated: false
+google_kms_crypto_key_iam_binding:
+  platform: "gcp"
+  description: "A `google_kms_crypto_key_iam_binding` is used to test a Google CryptoKey Iam Bindings"
+  deprecated: false
+google_kms_crypto_key_iam_bindings:
+  platform: "gcp"
+  description: "Use the `google_kms_crypto_key_iam_bindings` InSpec audit resource to test properties of all, or a filtered group of, GCP KMS Crypto Key IAM Bindings."
+  deprecated: false
+google_kms_crypto_key_iam_policy:
+  platform: "gcp"
+  description: "A `google_kms_crypto_key_iam_policy` is used to test a Google CryptoKey Iam Policy resource"
+  deprecated: false
+google_kms_crypto_keys:
+  platform: "gcp"
+  description: "A `google_kms_crypto_keys` is used to test a Google CryptoKey resource"
+  deprecated: false
+google_kms_key_ring:
+  platform: "gcp"
+  description: "A `google_kms_key_ring` is used to test a Google KeyRing resource"
+  deprecated: false
+google_kms_key_ring_iam_binding:
+  platform: "gcp"
+  description: "A `google_kms_key_ring_iam_binding` is used to test a Google KeyRing Iam Bindings"
+  deprecated: false
+google_kms_key_ring_iam_bindings:
+  platform: "gcp"
+  description: "Use the `google_kms_key_ring_iam_bindings` InSpec audit resource to test properties of all, or a filtered group of, GCP KMS key ring IAM bindings."
+  deprecated: false
+google_kms_key_ring_iam_policy:
+  platform: "gcp"
+  description: "A `google_kms_key_ring_iam_policy` is used to test a Google KeyRing Iam Policy resource"
+  deprecated: false
+google_kms_key_rings:
+  platform: "gcp"
+  description: "A `google_kms_key_rings` is used to test a Google KeyRing resource"
+  deprecated: false
+google_logging_folder_exclusion:
+  platform: "gcp"
+  description: "A `google_logging_folder_exclusion` is used to test a Google FolderExclusion resource"
+  deprecated: false
+google_logging_folder_exclusions:
+  platform: "gcp"
+  description: "A `google_logging_folder_exclusions` is used to test a Google FolderExclusion resource"
+  deprecated: false
+google_logging_folder_log_sink:
+  platform: "gcp"
+  description: "A `google_logging_folder_log_sink` is used to test a Google FolderLogSink resource"
+  deprecated: false
+google_logging_folder_log_sinks:
+  platform: "gcp"
+  description: "A `google_logging_folder_log_sinks` is used to test a Google FolderLogSink resource"
+  deprecated: false
+google_logging_organization_log_sink:
+  platform: "gcp"
+  description: "A `google_logging_organization_log_sink` is used to test a Google OrganizationLogSink resource"
+  deprecated: false
+google_logging_organization_log_sinks:
+  platform: "gcp"
+  description: "A `google_logging_organization_log_sinks` is used to test a Google OrganizationLogSink resource"
+  deprecated: false
+google_logging_project_exclusion:
+  platform: "gcp"
+  description: "A `google_logging_project_exclusion` is used to test a Google ProjectExclusion resource"
+  deprecated: false
+google_logging_project_exclusions:
+  platform: "gcp"
+  description: "A `google_logging_project_exclusions` is used to test a Google ProjectExclusion resource"
+  deprecated: false
+google_logging_project_sink:
+  platform: "gcp"
+  description: "A `google_logging_project_sink` is used to test a Google ProjectSink resource"
+  deprecated: false
+google_logging_project_sinks:
+  platform: "gcp"
+  description: "A `google_logging_project_sinks` is used to test a Google ProjectSink resource"
+  deprecated: false
+google_ml_engine_model:
+  platform: "gcp"
+  description: "A `google_ml_engine_model` is used to test a Google Model resource"
+  deprecated: false
+google_ml_engine_models:
+  platform: "gcp"
+  description: "A `google_ml_engine_models` is used to test a Google Model resource"
+  deprecated: false
+google_organization:
+  platform: "gcp"
+  description: "A `google_organization` is used to test a Google Organization resource"
+  deprecated: false
+google_organization_iam_binding:
+  platform: "gcp"
+  description: "A `google_organization_iam_binding` is used to test a Google Organization Iam Bindings"
+  deprecated: false
+google_organization_iam_policy:
+  platform: "gcp"
+  description: "A `google_organization_iam_policy` is used to test a Google Organization Iam Policy resource"
+  deprecated: false
+google_organization_policy:
+  platform: "gcp"
+  description: "Use the `google_organization_policy` InSpec audit resource to test constraints set on a GCP organization."
+  deprecated: false
+google_organizations:
+  platform: "gcp"
+  description: "A `google_organizations` is used to test a Google Organization resource"
+  deprecated: false
+google_project:
+  platform: "gcp"
+  description: "A `google_project` is used to test a Google Project resource"
+  deprecated: false
+google_project_alert_policies:
+  platform: "gcp"
+  description: "A `google_project_alert_policies` is used to test a Google AlertPolicy resource"
+  deprecated: false
+google_project_alert_policy:
+  platform: "gcp"
+  description: "A `google_project_alert_policy` is used to test a Google AlertPolicy resource"
+  deprecated: false
+google_project_alert_policy_condition:
+  platform: "gcp"
+  description: "Use the `google_project_alert_policy_condition` InSpec audit resource to test properties of a single GCP project alert policy condition."
+  deprecated: false
+google_project_iam_binding:
+  platform: "gcp"
+  description: "A `google_project_iam_binding` is used to test a Google Project Iam Bindings"
+  deprecated: false
+google_project_iam_bindings:
+  platform: "gcp"
+  description: "Use the `google_project_iam_bindings` InSpec audit resource to test properties of all, or a filtered group of, GCP project IAM bindings."
+  deprecated: false
+google_project_iam_custom_role:
+  platform: "gcp"
+  description: "A `google_project_iam_custom_role` is used to test a Google CustomRole resource"
+  deprecated: false
+google_project_iam_custom_roles:
+  platform: "gcp"
+  description: "A `google_project_iam_custom_roles` is used to test a Google CustomRole resource"
+  deprecated: false
+google_project_iam_policy:
+  platform: "gcp"
+  description: "A `google_project_iam_policy` is used to test a Google Project Iam Policy resource"
+  deprecated: false
+google_project_logging_audit_config:
+  platform: "gcp"
+  description: "Use the `google_compute_zone` InSpec audit resource to test properties of a single GCP compute zone."
+  deprecated: false
+google_project_metric:
+  platform: "gcp"
+  description: "A `google_project_metric` is used to test a Google Metric resource"
+  deprecated: false
+google_project_metrics:
+  platform: "gcp"
+  description: "A `google_project_metrics` is used to test a Google Metric resource"
+  deprecated: false
+google_project_service:
+  platform: "gcp"
+  description: "A `google_project_service` is used to test a Google Service resource"
+  deprecated: false
+google_project_services:
+  platform: "gcp"
+  description: "A `google_project_services` is used to test a Google Service resource"
+  deprecated: false
+google_projects:
+  platform: "gcp"
+  description: "A `google_projects` is used to test a Google Project resource"
+  deprecated: false
+google_pubsub_subscription:
+  platform: "gcp"
+  description: "A `google_pubsub_subscription` is used to test a Google Subscription resource"
+  deprecated: false
+google_pubsub_subscription_iam_binding:
+  platform: "gcp"
+  description: "A `google_pubsub_subscription_iam_binding` is used to test a Google Subscription Iam Bindings"
+  deprecated: false
+google_pubsub_subscription_iam_policy:
+  platform: "gcp"
+  description: "A `google_pubsub_subscription_iam_policy` is used to test a Google Subscription Iam Policy resource"
+  deprecated: false
+google_pubsub_subscriptions:
+  platform: "gcp"
+  description: "A `google_pubsub_subscriptions` is used to test a Google Subscription resource"
+  deprecated: false
+google_pubsub_topic:
+  platform: "gcp"
+  description: "A `google_pubsub_topic` is used to test a Google Topic resource"
+  deprecated: false
+google_pubsub_topic_iam_binding:
+  platform: "gcp"
+  description: "A `google_pubsub_topic_iam_binding` is used to test a Google Topic Iam Bindings"
+  deprecated: false
+google_pubsub_topic_iam_policy:
+  platform: "gcp"
+  description: "A `google_pubsub_topic_iam_policy` is used to test a Google Topic Iam Policy resource"
+  deprecated: false
+google_pubsub_topics:
+  platform: "gcp"
+  description: "A `google_pubsub_topics` is used to test a Google Topic resource"
+  deprecated: false
+google_redis_instance:
+  platform: "gcp"
+  description: "A `google_redis_instance` is used to test a Google Instance resource"
+  deprecated: false
+google_redis_instances:
+  platform: "gcp"
+  description: "A `google_redis_instances` is used to test a Google Instance resource"
+  deprecated: false
+google_resourcemanager_folder:
+  platform: "gcp"
+  description: "A `google_resourcemanager_folder` is used to test a Google Folder resource"
+  deprecated: false
+google_resourcemanager_folder_iam_binding:
+  platform: "gcp"
+  description: "A `google_resourcemanager_folder_iam_binding` is used to test a Google Folder Iam Bindings"
+  deprecated: false
+google_resourcemanager_folder_iam_policy:
+  platform: "gcp"
+  description: "A `google_resourcemanager_folder_iam_policy` is used to test a Google Folder Iam Policy resource"
+  deprecated: false
+google_resourcemanager_folders:
+  platform: "gcp"
+  description: "A `google_resourcemanager_folders` is used to test a Google Folder resource"
+  deprecated: false
+google_resourcemanager_organization_policy:
+  platform: "gcp"
+  description: "A `google_resourcemanager_organization_policy` is used to test organization policy constraints."
+  deprecated: false
+google_resourcemanager_project_iam_binding:
+  platform: "gcp"
+  description: "A `google_resourcemanager_project_iam_binding` is used to test a Google Project Iam Bindings"
+  deprecated: false
+google_resourcemanager_project_iam_policy:
+  platform: "gcp"
+  description: "A `google_resourcemanager_project_iam_policy` is used to test a Google Project Iam Policy resource"
+  deprecated: false
+google_runtime_config_config:
+  platform: "gcp"
+  description: "A `google_runtime_config_config` is used to test a Google Config resource"
+  deprecated: false
+google_runtime_config_config_iam_binding:
+  platform: "gcp"
+  description: "A `google_runtime_config_config_iam_binding` is used to test a Google Config Iam Bindings"
+  deprecated: false
+google_runtime_config_config_iam_policy:
+  platform: "gcp"
+  description: "A `google_runtime_config_config_iam_policy` is used to test a Google Config IAM Policy resource"
+  deprecated: false
+google_runtime_config_configs:
+  platform: "gcp"
+  description: "A `google_runtime_config_configs` is used to test a Google Config resource"
+  deprecated: false
+google_runtime_config_variable:
+  platform: "gcp"
+  description: "A `google_runtime_config_variable` is used to test a Google Variable resource"
+  deprecated: false
+google_runtime_config_variables:
+  platform: "gcp"
+  description: "A `google_runtime_config_variables` is used to test a Google Variable resource"
+  deprecated: false
+google_service_account:
+  platform: "gcp"
+  description: "A `google_service_account` is used to test a Google ServiceAccount resource"
+  deprecated: false
+google_service_account_key:
+  platform: "gcp"
+  description: "A `google_service_account_key` is used to test a Google ServiceAccountKey resource"
+  deprecated: false
+google_service_account_keys:
+  platform: "gcp"
+  description: "A `google_service_account_keys` is used to test a Google ServiceAccountKey resource"
+  deprecated: false
+google_service_accounts:
+  platform: "gcp"
+  description: "A `google_service_accounts` is used to test a Google ServiceAccount resource"
+  deprecated: false
+google_sourcerepo_repositories:
+  platform: "gcp"
+  description: "A `google_sourcerepo_repositories` is used to test a Google Repository resource"
+  deprecated: false
+google_sourcerepo_repository:
+  platform: "gcp"
+  description: "A `google_sourcerepo_repository` is used to test a Google Repository resource"
+  deprecated: false
+google_spanner_database:
+  platform: "gcp"
+  description: "A `google_spanner_database` is used to test a Google Database resource"
+  deprecated: false
+google_spanner_databases:
+  platform: "gcp"
+  description: "A `google_spanner_databases` is used to test a Google Database resource"
+  deprecated: false
+google_spanner_instance:
+  platform: "gcp"
+  description: "A `google_spanner_instance` is used to test a Google Instance resource"
+  deprecated: false
+google_spanner_instance_iam_binding:
+  platform: "gcp"
+  description: "A `google_spanner_instance_iam_binding` is used to test a Google Instance Iam Bindings"
+  deprecated: false
+google_spanner_instance_iam_policy:
+  platform: "gcp"
+  description: "A `google_spanner_instance_iam_policy` is used to test a Google Instance Iam Policy resource"
+  deprecated: false
+google_spanner_instances:
+  platform: "gcp"
+  description: "A `google_spanner_instances` is used to test a Google Instance resource"
+  deprecated: false
+google_sql_database_instance:
+  platform: "gcp"
+  description: "A `google_sql_database_instance` is used to test a Google DatabaseInstance resource"
+  deprecated: false
+google_sql_database_instances:
+  platform: "gcp"
+  description: "A `google_sql_database_instances` is used to test a Google DatabaseInstance resource"
+  deprecated: false
+google_sql_user:
+  platform: "gcp"
+  description: "A `google_sql_user` is used to test a Google User resource"
+  deprecated: false
+google_sql_users:
+  platform: "gcp"
+  description: "A `google_sql_users` is used to test a Google User resource"
+  deprecated: false
+google_storage_bucket:
+  platform: "gcp"
+  description: "A `google_storage_bucket` is used to test a Google Bucket resource"
+  deprecated: false
+google_storage_bucket_acl:
+  platform: "gcp"
+  description: "A `google_storage_bucket_acl` is used to test a Google BucketACL resource"
+  deprecated: false
+google_storage_bucket_iam_binding:
+  platform: "gcp"
+  description: "A `google_storage_bucket_iam_binding` is used to test a Google Bucket Iam Bindings"
+  deprecated: false
+google_storage_bucket_iam_bindings:
+  platform: "gcp"
+  description: "Use the `google_storage_bucket_iam_bindings` InSpec audit resource to test properties of all, or a filtered group of, GCP storage bucket IAM bindings."
+  deprecated: false
+google_storage_bucket_iam_policy:
+  platform: "gcp"
+  description: "A `google_storage_bucket_iam_policy` is used to test a Google Bucket Iam Policy resource"
+  deprecated: false
+google_storage_bucket_object:
+  platform: "gcp"
+  description: "A `google_storage_bucket_object` is used to test a Google BucketObject resource"
+  deprecated: false
+google_storage_bucket_objects:
+  platform: "gcp"
+  description: "A `google_storage_bucket_objects` is used to test a Google BucketObject resource"
+  deprecated: false
+google_storage_buckets:
+  platform: "gcp"
+  description: "A `google_storage_buckets` is used to test a Google Bucket resource"
+  deprecated: false
+google_storage_default_object_acl:
+  platform: "gcp"
+  description: "A `google_storage_default_object_acl` is used to test a Google DefaultObjectACL resource"
+  deprecated: false
+google_storage_object_acl:
+  platform: "gcp"
+  description: "A `google_storage_object_acl` is used to test a Google ObjectACL resource"
+  deprecated: false
+google_user:
+  platform: "gcp"
+  description: "Use the `google_user` InSpec audit resource to test properties of a single GCP user."
+  deprecated: false
+google_users:
+  platform: "gcp"
+  description: "Use the `google_users` InSpec audit resource to test properties of all, or a filtered group of, GCP users."
+  deprecated: false
+group:
+  platform: "os"
+  description: "Use the `group` Chef InSpec audit resource to test a single group on the system."
+  deprecated: false
+groups:
+  platform: "os"
+  description: "Use the `groups` Chef InSpec audit resource to test multiple groups on the system."
+  deprecated: false
+grub_conf:
+  platform: "linux"
+  description: "Grub is a boot loader on the Linux platform used to load and then transfer control to an operating system kernel, after which that kernel initializes the rest of the operating system."
+  deprecated: false
+host:
+  platform: "os"
+  description: "Use the `host` Chef InSpec audit resource to test the specific host name and its availability."
+  deprecated: false
+http:
+  platform: "linux"
+  description: "Use the `http` Chef InSpec audit resource to test an http endpoint."
+  deprecated: false
+iis_app:
+  platform: "windows"
+  description: "Use the `iis_app` Chef InSpec audit resource to test the state of IIS on Windows Server 2012 (and later)."
+  deprecated: false
+iis_site:
+  platform: "windows"
+  description: "Use the `iis_site` Chef InSpec audit resource to test the state of IIS on Windows Server 2012 (and later)."
+  deprecated: false
+inetd_conf:
+  platform: "linux"
+  description: "Use the `inetd_conf` Chef InSpec audit resource to test if a service is listed in the `inetd.conf` file on Linux and Unix platforms."
+  deprecated: false
+ini:
+  platform: "os"
+  description: "Use the `ini` Chef InSpec audit resource to test settings in an INI file."
+  deprecated: false
+interface:
+  platform: "os"
+  description: "Use the `interface` Chef InSpec audit resource to test basic network adapter properties, such as name, status, IP addresses, and link speed (in MB/sec)."
+  deprecated: false
+interfaces:
+  platform: "os"
+  description: "Use the `interfaces` Chef InSpec audit resource to test the properties of multiple network interfaces on the system."
+  deprecated: false
+ip6tables:
+  platform: "linux"
+  description: "Use the `ip6tables` Chef InSpec audit resource to test rules that are defined in `ip6tables`, which maintains tables of IP packet filtering rules for IPv6."
+  deprecated: false
+ipfilter:
+  platform: "bsd"
+  description: "Use the `ipfilter` Chef InSpec audit resource to test rules defined for `ipfilter`."
+  deprecated: false
+ipnat:
+  platform: "bsd"
+  description: "Use the `ipnat` Chef InSpec audit resource to test rules that are defined for `IP NAT`."
+  deprecated: false
+iptables:
+  platform: "linux"
+  description: "Use the `iptables` Chef InSpec audit resource to test rules that are defined in `iptables`, which maintains tables of IP packet filtering rules."
+  deprecated: false
+json:
+  platform: "os"
+  description: "Use the `json` Chef InSpec audit resource to test data in a JSON file."
+  deprecated: false
+kernel_module:
+  platform: "linux"
+  description: "Use the `kernel_module` Chef InSpec audit resource to test kernel modules on Linux platforms."
+  deprecated: false
+kernel_parameter:
+  platform: "linux"
+  description: "Use the `kernel_parameter` Chef InSpec audit resource to test kernel parameters on Linux platforms."
+  deprecated: false
+kernel_parameters:
+  platform: "linux"
+  description: "Use the `kernel_parameters` Chef InSpec audit resource to test multiple kernel parameters on Linux platforms."
+  deprecated: false
+key_rsa:
+  platform: "os"
+  description: "Use the `key_rsa` Chef InSpec audit resource to test RSA public/private keypairs."
+  deprecated: false
+launchd_service:
+  platform: "linux"
+  description: "Use the `launchd_service` Chef InSpec audit resource to test a service using Launchd."
+  deprecated: false
+limits_conf:
+  platform: "linux"
+  description: "Use the `limits_conf` Chef InSpec audit resource to test configuration settings in the `/etc/security/limits.conf` file."
+  deprecated: false
+linux_audit_system:
+  platform: "linux"
+  description: "Use the `linux_audit_system` Chef InSpec audit resource to test the configuration of Linux audit system."
+  deprecated: false
+login_defs:
+  platform: "linux"
+  description: "Use the `login_defs` Chef InSpec audit resource to test configuration settings in the `/etc/login.defs` file."
+  deprecated: false
+lxc:
+  platform: "linux"
+  description: "Use the `lxc` Chef InSpec audit resource to test the information about Linux containers."
+  deprecated: false
+mail_alias:
+  platform: "unix"
+  description: "Use the `mail_alias` Chef InSpec audit resource to test the mail alias present in the aliases file."
+  deprecated: false
+mount:
+  platform: "linux"
+  description: "Use the `mount` Chef InSpec audit resource to test the mount points on FreeBSD and Linux systems."
+  deprecated: false
+mssql_session:
+  platform: "windows"
+  description: "Use the `mssql_session` Chef InSpec audit resource to test SQL commands run against a Microsoft SQL database."
+  deprecated: false
+mssql_sys_conf:
+  platform: "os"
+  description: "Use the `mssql_sys_conf` Chef InSpec audit resource to test the configuration of a Microsoft SQL Server database."
+  deprecated: false
+mysql_conf:
+  platform: "os"
+  description: "Use the `mysql_conf` Chef InSpec audit resource to test the contents of the configuration file for MySQL, typically located at `/etc/mysql/my.cnf` or `/etc/my.cnf`."
+  deprecated: false
+mysql_session:
+  platform: "os"
+  description: "Use the `mysql_session` Chef InSpec audit resource to test SQL commands run against a MySQL database."
+  deprecated: false
+nftables:
+  platform: "linux"
+  description: "Use the `nftables` Chef InSpec audit resource to test rules and sets that are defined using `nftables`, which maintains tables of IP packet filtering rules."
+  deprecated: false
+nginx:
+  platform: "linux"
+  description: "Use the `nginx` Chef InSpec audit resource to test the fields and validity of nginx."
+  deprecated: false
+nginx_conf:
+  platform: "linux"
+  description: "Use the `nginx_conf` Chef InSpec resource to test configuration data for the NGINX server located at `/etc/nginx/nginx.conf` on Linux and Unix platforms."
+  deprecated: false
+npm:
+  platform: "os"
+  description: "Use the `npm` Chef InSpec audit resource to test if a global NPM package is installed."
+  deprecated: false
+ntp_conf:
+  platform: "linux"
+  description: "Use the `ntp_conf` Chef InSpec audit resource to test the synchronization settings defined in the `ntp.conf` file."
+  deprecated: false
+oneget:
+  platform: "windows"
+  description: "Use the `oneget` Chef InSpec audit resource to test if the named package and/or package version is installed on the system."
+  deprecated: false
+oracledb_conf:
+  platform: "os"
+  description: "Use the `oracledb_conf` Chef InSpec audit resource to test the Oracle system parameters."
+  deprecated: false
+oracledb_listener_conf:
+  platform: "os"
+  description: "Use the `oracledb_listener_conf` Chef InSpec audit resource to test the listeners settings of Oracle DB, typically located at `$ORACLE_HOME/network/admin/listener.ora` or `$ORACLE_HOME\\network\\admin\\listener.ora` depending upon the platform."
+  deprecated: false
+oracledb_session:
+  platform: "os"
+  description: "Use the `oracledb_session` Chef InSpec audit resource to test SQL commands run against a Oracle database."
+  deprecated: false
+os:
+  platform: "os"
+  description: "Use the `os` Chef InSpec audit resource to test the platform on which the system is running."
+  deprecated: false
+os_env:
+  platform: "os"
+  description: "Use the `os_env` Chef InSpec audit resource to test the environment variables for the platform on which the system is running."
+  deprecated: false
+package:
+  platform: "os"
+  description: "Use the `package` Chef InSpec audit resource to test if the named package and/or package version is installed on the system."
+  deprecated: false
+packages:
+  platform: "linux"
+  description: "Use the `packages` Chef InSpec audit resource to test the properties of multiple packages on the system."
+  deprecated: false
+parse_config:
+  platform: "os"
+  description: "Use the `parse_config` Chef InSpec audit resource to test arbitrary configuration files."
+  deprecated: false
+parse_config_file:
+  platform: "os"
+  description: "Use the `parse_config_file` Chef InSpec audit resource to test arbitrary configuration files."
+  deprecated: false
+passwd:
+  platform: "linux"
+  description: "Use the `passwd` Chef InSpec audit resource to test the contents of `/etc/passwd`, which contains the following information for users that may log into the system and/or as users that own running processes."
+  deprecated: false
+php_config:
+  platform: "os"
+  description: "Use the `php_config` Chef InSpec audit resource to test the PHP configuration parameters from the default `php.ini` file or a custom *php* file."
+  deprecated: false
+pip:
+  platform: "os"
+  description: "Use the `pip` Chef InSpec audit resource to test packages that are installed using the Python PIP installer."
+  deprecated: false
+port:
+  platform: "os"
+  description: "Use the `port` Chef InSpec audit resource to test basic port properties, such as port, process, if it's listening."
+  deprecated: false
+postfix_conf:
+  platform: "os"
+  description: "Use the `postfix_conf` Chef InSpec audit resource to test the main configuration of the Postfix Mail Transfer Agent."
+  deprecated: false
+postgres_conf:
+  platform: "os"
+  description: "Use the `postgres_conf` Chef InSpec audit resource to test the contents of the configuration file for PostgreSQL, typically located at `/etc/postgresql/<version>/main/postgresql.conf` or `/var/lib/postgres/data/postgresql.conf`, depending on the platform."
+  deprecated: false
+postgres_hba_conf:
+  platform: "linux"
+  description: "Use the `postgres_hba_conf` Chef InSpec audit resource to test the client authentication data defined in the pg_hba.conf file."
+  deprecated: false
+postgres_ident_conf:
+  platform: "linux"
+  description: "Use the `postgres_ident_conf` Chef InSpec audit resource to test the client authentication data defined in the pg_ident.conf file."
+  deprecated: false
+postgres_session:
+  platform: "os"
+  description: "Use the `postgres_session` Chef InSpec audit resource to test SQL commands run against a PostgreSQL database."
+  deprecated: false
+powershell:
+  platform: "windows"
+  description: "Use the `powershell` Chef InSpec audit resource to test a Powershell script on the Windows platform."
+  deprecated: false
+ppa:
+  platform: "linux"
+  description: "Use the `ppa` Chef InSpec audit resource to verify the PPA repositories on Debian-based Linux distributions."
+  deprecated: false
+processes:
+  platform: "os"
+  description: "Use the `processes` Chef InSpec audit resource to test the properties of system programs."
+  deprecated: false
+registry_key:
+  platform: "windows"
+  description: "Use the `registry_key` Chef InSpec audit resource to test key values in the Windows registry."
+  deprecated: false
+routing_table:
+  platform: "linux"
+  description: "Use the `routing_table` Chef InSpec audit resource to test the routing information parameters, destination, gateway, and interface present in the routing table."
+  deprecated: false
+runit_service:
+  platform: "linux"
+  description: "Use the `runit_service` Chef InSpec audit resource to test a service using runit."
+  deprecated: false
+security_identifier:
+  platform: "windows"
+  description: "Use the `security_identifier` Chef InSpec resource to test the [Security Identifier (SID)](https://docs.microsoft.com/en-us/windows/desktop/secauthz/security-identifiers) for user and group trustees on Windows."
+  deprecated: false
+security_policy:
+  platform: "windows"
+  description: "Use the `security_policy` Chef InSpec audit resource to test security policies on the Windows platform."
+  deprecated: false
+selinux:
+  platform: "linux"
+  description: "Use the `selinux` Chef InSpec audit resource to test the configuration data of the SELinux policy, SELinux modules and SELinux booleans."
+  deprecated: false
+service:
+  platform: "os"
+  description: "Use the `service` Chef InSpec audit resource to test whether the installation of the named service is successful and enabled."
+  deprecated: false
+shadow:
+  platform: "linux"
+  description: "Use the `shadow` Chef InSpec audit resource to test the contents of `/etc/shadow`, which contains password details that are readable only by the `root` user."
+  deprecated: false
+ssh_config:
+  platform: "linux"
+  description: "Use the `ssh_config` Chef InSpec audit resource to test OpenSSH client configuration data located at `/etc/ssh/ssh_config` on Linux and Unix platforms."
+  deprecated: false
+ssh_key:
+  platform: "os"
+  description: "Use the `ssh_key` Chef InSpec audit resource to test ssh keys."
+  deprecated: false
+sshd_active_config:
+  platform: "linux"
+  description: "Use the `sshd_active_config` Chef InSpec audit resource to find and test configuration data for the OpenSSH daemon."
+  deprecated: false
+sshd_config:
+  platform: "linux"
+  description: "Use the `sshd_config` Chef InSpec audit resource to test configuration data for the OpenSSH daemon located at `/etc/ssh/sshd_config` on Linux and Unix platforms."
+  deprecated: false
+ssl:
+  platform: "os"
+  description: "Use the `ssl` Chef InSpec audit resource to test SSL settings for the named port."
+  deprecated: false
+sys_info:
+  platform: "os"
+  description: "Use the `sys_info` Chef InSpec audit resource to test for operating system properties for the named host, and then returns that info as standard output."
+  deprecated: false
+systemd_service:
+  platform: "linux"
+  description: "Use the `systemd_service` Chef InSpec audit resource to test a service using SystemD."
+  deprecated: false
+sysv_service:
+  platform: "linux"
+  description: "Use the `sysv_service` Chef InSpec audit resource to test a service using SystemV."
+  deprecated: false
+timezone:
+  platform: "linux"
+  description: "Use the `timezone` Chef InSpec audit resource to test timezone configurations of the system."
+  deprecated: false
+toml:
+  platform: "os"
+  description: "Use the `toml` Chef InSpec audit resource to test settings in a TOML file."
+  deprecated: false
+upstart_service:
+  platform: "linux"
+  description: "Use the `upstart_service` Chef InSpec audit resource to test a service using Upstart."
+  deprecated: false
+user:
+  platform: "os"
+  description: "Use the `user` Chef InSpec audit resource to test user profiles of a single, known or expected local user, including the groups to which the user belongs, the frequency of password changes, and the directory paths to home and shell."
+  deprecated: false
+users:
+  platform: "os"
+  description: "Use the `users` Chef InSpec audit resource to look up all local users available on the system, and then test specific properties of those users."
+  deprecated: false
+vbscript:
+  platform: "windows"
+  description: "Use the `vbscript` Chef InSpec audit resource to test a VBScript on the Windows platform."
+  deprecated: false
+virtualization:
+  platform: "linux"
+  description: "Use the `virtualization` Chef InSpec audit resource to test the virtualization platform on which the system is running."
+  deprecated: false
+windows_feature:
+  platform: "windows"
+  description: "Use the `windows_feature` Chef InSpec audit resource to test features on Windows via the `Get-WindowsFeature` cmdlet."
+  deprecated: false
+windows_firewall:
+  platform: "windows"
+  description: "Use the `windows_firewall` Chef InSpec audit resource to test if a firewall profile is correctly configured on a Windows system."
+  deprecated: false
+windows_firewall_rule:
+  platform: "windows"
+  description: "Use the `windows_firewall_rule` Chef InSpec audit resource to test if a firewall rule is correctly configured on a Windows system."
+  deprecated: false
+windows_hotfix:
+  platform: "windows"
+  description: "Use the `windows_hotfix` Chef InSpec audit resource to test if the hotfix has been installed on a Windows system."
+  deprecated: false
+windows_task:
+  platform: "windows"
+  description: "Use the `windows_task` Chef InSpec audit resource to test a scheduled tasks configuration on a Windows platform."
+  deprecated: false
+wmi:
+  platform: "windows"
+  description: "Use the `wmi` Chef InSpec audit resource to test WMI settings on the Windows platform."
+  deprecated: false
+x509_certificate:
+  platform: "os"
+  description: "Use the `x509_certificate` Chef InSpec audit resource to test the fields and validity of an x.509 certificate."
+  deprecated: false
+x509_private_key:
+  platform: "unix"
+  description: "Use the `x509_private_key` Chef InSpec audit resource to test the x509 private key."
+  deprecated: false
+xinetd_conf:
+  platform: "linux"
+  description: "Use the `xinetd_conf` Chef InSpec audit resource to test services under `/etc/xinet.d` on Linux and Unix platforms."
+  deprecated: false
+xml:
+  platform: "os"
+  description: "Use the `xml` Chef InSpec audit resource to test data in an XML file."
+  deprecated: false
+yaml:
+  platform: "os"
+  description: "Use the `yaml` Chef InSpec audit resource to test configuration data in a Yaml file."
+  deprecated: false
+yum:
+  platform: "linux"
+  description: "Use the `yum` Chef InSpec audit resource to test packages in the Yum repository."
+  deprecated: false
+zfs:
+  platform: "linux"
+  description: "Use the `zfs` Chef InSpec audit resource to test the named ZFS Pool file system and its respective properties."
+  deprecated: false
+zfs_dataset:
+  platform: "linux"
+  description: "Use the `zfs_dataset` Chef InSpec audit resource to test the ZFS datasets on FreeBSD & Linux (Check [OS Family Details](https://docs.chef.io/inspec/resources/os/#osfamily-helpers) for more details)."
+  deprecated: false
+zfs_pool:
+  platform: "linux"
+  description: "Use the `zfs_pool` Chef InSpec audit resource to test the ZFS pools on FreeBSD & Linux (Centos, RHEL, Ubuntu, CloudLinux, Debian) systems."
+  deprecated: false

--- a/layouts/_default/resources_matrix.html
+++ b/layouts/_default/resources_matrix.html
@@ -1,0 +1,130 @@
+{{/*
+  Unified resources compatibility matrix.
+  Adapted from layouts/_default/infra_resources_all.html.
+
+  Merges two data sources into a single 4-column matrix:
+    - Chef Infra Client: data/client/19/resources/*.yaml (this repo, canonical).
+    - Chef InSpec:       data/resources/inspec.yaml (committed snapshot; InSpec docs
+                         are deployed as a separate site and aren't built here).
+
+  Rows link out to each product's authoritative resource page; this page never
+  duplicates resource documentation.
+*/}}
+
+{{ define "main" }}
+  {{ .Content }}
+
+  {{/* --- Build the Chef Infra Client resource map: name -> {description, new_in} --- */}}
+  {{ $infra := dict }}
+  {{ range $yaml_file := index $.Site.Data ( .Params.data_path ) }}
+    {{ if index $yaml_file "resource_reference" }}
+      {{ $name := index $yaml_file "resource" }}
+      {{ $desc := "" }}
+      {{ with index $yaml_file "resource_description_list" }}
+        {{ range . }}
+          {{ if and (eq $desc "") (isset . "markdown") }}
+            {{ $desc = index . "markdown" }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+      {{ $new_in := "" }}
+      {{ with index $yaml_file "resource_new_in" }}{{ $new_in = . }}{{ end }}
+      {{ $infra = merge $infra (dict $name (dict "description" $desc "new_in" $new_in)) }}
+    {{ end }}
+  {{ end }}
+
+  {{/* --- Chef InSpec snapshot: name -> {platform, description, deprecated} --- */}}
+  {{ $inspec := $.Site.Data.resources.inspec }}
+
+  {{/* --- Union of resource names, sorted --- */}}
+  {{ $names := slice }}
+  {{ range $k, $_ := $infra }}{{ $names = $names | append $k }}{{ end }}
+  {{ range $k, $_ := $inspec }}{{ $names = $names | append $k }}{{ end }}
+  {{ $names = $names | uniq | sort }}
+
+  {{/* --- Resources supported by both products (the compatibility core) --- */}}
+  {{ $both := slice }}
+  {{ range $names }}
+    {{ if and (isset $infra .) (isset $inspec .) }}{{ $both = $both | append . }}{{ end }}
+  {{ end }}
+
+  {{ $infra_base := "/client/19/resources/bundled" }}
+  {{ $inspec_base := "/inspec/latest/resources" }}
+
+  <h2 id="resources-supported-by-both-products">Resources supported by both products</h2>
+
+  <p>The following {{ len $both }} resources are available in both Chef Infra Client and
+  Chef InSpec. Chef Infra Client resources configure system state; Chef InSpec resources
+  audit it. Select a checkmark to open that product's resource documentation.</p>
+
+  <div class="responsive-table">
+    <table>
+      <thead>
+        <tr>
+          <th>Resource</th>
+          <th>Chef Infra Client</th>
+          <th>Chef InSpec</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range $both }}
+          {{ $name := . }}
+          {{ $id := $name }}
+          <tr id="both-{{ $id }}">
+            <td><code>{{ $name }}</code></td>
+            <td><a href="{{ $infra_base }}/{{ $name }}/" aria-label="{{ $name }} in Chef Infra Client">&#10003;</a></td>
+            <td><a href="{{ $inspec_base }}/{{ $name }}/" aria-label="{{ $name }} in Chef InSpec">&#10003;</a></td>
+            <td>{{ partial "resource_short_desc" (index $infra $name).description | markdownify }}</td>
+          </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  </div>
+
+  <h2 id="all-resources">All resources</h2>
+
+  <p>The complete catalog of Chef Infra Client and Chef InSpec resources.
+  A checkmark links to that product's authoritative resource documentation.</p>
+
+  <div class="responsive-table">
+    <table>
+      <thead>
+        <tr>
+          <th>Resource</th>
+          <th>Chef Infra Client</th>
+          <th>Chef InSpec</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range $names }}
+          {{ $name := . }}
+          {{ $in_infra := isset $infra $name }}
+          {{ $in_inspec := isset $inspec $name }}
+          {{ $desc := "" }}
+          {{ if $in_infra }}
+            {{ $desc = (index $infra $name).description }}
+          {{ else }}
+            {{ $desc = (index $inspec $name).description }}
+          {{ end }}
+          <tr id="resource-{{ $name }}">
+            <td><code>{{ $name }}</code></td>
+            <td>
+              {{ if $in_infra }}
+                <a href="{{ $infra_base }}/{{ $name }}/" aria-label="{{ $name }} in Chef Infra Client">&#10003;</a>
+                {{ with (index $infra $name).new_in }}<span class="resource-new-in">{{ . }}</span>{{ end }}
+              {{ else }}&#8212;{{ end }}
+            </td>
+            <td>
+              {{ if $in_inspec }}
+                <a href="{{ $inspec_base }}/{{ $name }}/" aria-label="{{ $name }} in Chef InSpec">&#10003;</a>
+              {{ else }}&#8212;{{ end }}
+            </td>
+            <td>{{ partial "resource_short_desc" $desc | markdownify }}</td>
+          </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  </div>
+{{ end }}

--- a/layouts/partials/resource_short_desc.html
+++ b/layouts/partials/resource_short_desc.html
@@ -1,0 +1,12 @@
+{{/*
+  Returns the first sentence of a resource description for use in the matrix.
+  Input: the raw description string (may be multi-paragraph Markdown).
+  Keeps the table scannable and the description SEO-friendly.
+*/}}
+{{ $d := . }}
+{{ $d = index (split $d "\n\n") 0 }}
+{{ $d = replaceRE `\s+` " " $d }}
+{{ $d = trim $d " " }}
+{{ $match := findRE `^.*?[.!?](\s|$)` $d 1 }}
+{{ with $match }}{{ $d = trim (index . 0) " " }}{{ end }}
+{{ return $d }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -126,6 +126,10 @@
 # Chef Infra Client redirects
 ####
 
+# The unified resources catalog is a real page at /resources/ (content/resources/_index.md).
+# This rule is non-forced (status 301), so Netlify serves the generated /resources/index.html
+# for the bare path and only applies this redirect to legacy per-resource deep links
+# (for example, /resources/apt_package/), sending them to the Chef Infra Client resource page.
 [[redirects]]
   from = "/resources/*"
   to = "/client/19/resources/bundled/:splat"


### PR DESCRIPTION
## Summary

Introduces a single, authoritative **Resources** discovery page at `docs.chef.io/resources` that lists every resource across **Chef Infra Client** and **Chef InSpec**, with a compatibility matrix, SEO-friendly descriptions, and links to each product's documentation.

Today, `/resources` is only a redirect to the Infra bundled pages, and resources are documented per product and per release with no unified view. This page provides that unified catalog **without replacing** the existing version-specific documentation — release pages continue to list only the resources introduced in each version.

## What's included

- **New page** `content/resources/_index.md` — top-level hub, registered in the Overview nav via page front matter (same pattern as `platforms.md` / `versions.md`; no `menu.toml` change).
- **New layout** `layouts/_default/resources_matrix.html` — adapted from the existing `infra_resources_all.html`. Merges the canonical Infra resource YAML (`data/client/19/resources`) with a committed InSpec snapshot into one **4-column compatibility matrix** (`Resource | Chef Infra Client | Chef InSpec | Description`). Checkmark cells link to each product's authoritative page.
- **New partial** `layouts/partials/resource_short_desc.html` — trims descriptions to the first sentence so cells stay scannable and SEO-friendly.
- **New data** `data/resources/inspec.yaml` — a committed snapshot of the InSpec resource catalog (name → platform, description, deprecated), generated once from `inspec/inspec`. InSpec docs are deployed as a separate site and aren't built from this repo, so a snapshot is the least-coupled way to include them.
- **`netlify.toml`** — documents the `/resources/*` redirect. It's non-forced (301), so Netlify serves the generated `/resources/index.html` for the hub while legacy per-resource deep links (for example `/resources/apt_package/`) still redirect to the Infra resource page.

## Data of record

Chef Infra Client resources: **181** · Chef InSpec resources: **407** · Supported by both: **16** · Total catalog: **572**.

## Design rationale

- **Reuse over new infrastructure.** The Infra half reads existing canonical YAML at build time (no duplication, auto-syncs). The new layout is a clone of the repo's existing all-resources generator.
- **No re-coupling of InSpec.** Re-importing InSpec as a Hugo module would drag ~407 pages and shortcodes into this build and undo the deliberate separate-site deployment. A thin committed snapshot mirrors the existing "resource data generated from a source repo, committed here" pattern.
- **No duplication of resource docs.** Rows link out to authoritative pages; the page is a discovery/index layer.

## Validation

- Isolated Hugo build against real data: no errors, no `raw HTML omitted` / `ZgotmplZ`.
- Matrix verified: 16 both-rows, 572 total rows, 181 Infra links, 407 InSpec links, no list bloat in cells.
- `markdownlint-cli2`: 0 issues. `vale --minAlertLevel warning`: 0 errors/warnings.
- `hugo_lint.sh` ASCII rule: new content and data files are ASCII-clean.

## Reviewer notes

- **Highest-attention item:** the `netlify.toml` redirect. Behavior relies on Netlify's file-precedence for non-forced redirects. Please confirm on a deploy preview that `/resources/` renders the new page and `/resources/apt_package/` still redirects.
- **InSpec snapshot** is a point-in-time capture; see the header comment in `data/resources/inspec.yaml` for the source and how to regenerate.

## Intentionally out of scope (follow-ups)

- A committed refresh script and CI wiring to auto-update the InSpec snapshot.
- Per-resource unified detail pages (currently link-out only).
- A filter/search UI on the matrix if the flat table proves large.
