### PR TITLE
Add macOS ARM64 native installer documentation

### DIFF
--- a/content/workstation/26.1/install.md
+++ b/content/workstation/26.1/install.md
@@ -11,8 +11,8 @@ draft = false
 
 {{< readfile file="content/workstation/26.1/reusable/md/workstation_modularize.md" >}}
 
-The Chef Workstation native installers provide an efficient way to install Chef Workstation on Windows, Debian, or RPM-based Linux distributions.
-You can download and install the pre-built `.msi`, `.deb`, or `.rpm` packages using your existing package management tools, simplifying the deployment process for managing system configurations.
+The Chef Workstation native installers provide an efficient way to install Chef Workstation on Windows, Debian, RPM-based Linux distributions, and macOS.
+You can download and install the pre-built `.msi`, `.deb`, `.rpm`, or `.dmg` packages using your existing package management tools, simplifying the deployment process for managing system configurations.
 
 ## Supported platforms
 
@@ -20,6 +20,7 @@ Chef Workstation is supported on:
 
 - Currently supported Linux distributions and versions running Linux kernel 2.6.32 and later on x86-64 (amd64)
 - Currently supported Windows versions greater than or equal to Windows 10 and Windows Server 2016
+- macOS 14 (Sonoma) on Apple Silicon (ARM64/aarch64)
 
 ## Chef Workstation requirements
 
@@ -27,6 +28,7 @@ Chef Workstation is supported on:
 - **Disk space for binaries**:
   - Linux: The Chef Workstation binaries are stored in `/hab` and require a minimum of 2.8 GB of disk space.
   - Windows: The Chef Workstation binaries are stored in `C:\hab` and require a minimum of 3.3 GB of disk space.
+  - macOS: The Chef Workstation binaries are stored in `/opt/hab` and require a minimum of 2.4 GB of disk space.
 
 ## Prerequisites
 
@@ -130,6 +132,42 @@ To install Chef Workstation on Windows, follow these steps:
    - Double-click the `.msi` file and follow the on-screen installation wizard.
 
    Replace `<VERSION>` with the version number of the downloaded package, for example `chef-workstation-enterprise-26.1.0-1_x86_64.msi`.
+
+### Install Chef Workstation on macOS
+
+To install Chef Workstation on macOS (Apple Silicon), follow these steps:
+
+1. Download the installer using one of the following methods:
+
+   - Download using `curl`:
+
+    ```shell
+    curl -o "chef-workstation-enterprise-<VERSION>-darwin.dmg" "https://chefdownload-commercial.chef.io/stable/chef-workstation-enterprise/download?eol=false&license_id=<LICENSE_ID>&m=aarch64&p=mac_os_x&pm=dmg&v=<VERSION>"
+    ```
+
+   - Download using `wget`:
+
+    ```shell
+    wget -O "chef-workstation-enterprise-<VERSION>-darwin.dmg" "https://chefdownload-commercial.chef.io/stable/chef-workstation-enterprise/download?eol=false&license_id=<LICENSE_ID>&m=aarch64&p=mac_os_x&pm=dmg&v=<VERSION>"
+    ```
+
+   Replace:
+   - `<VERSION>` with the version number to install.
+   - `<LICENSE_ID>` with your Chef license ID.
+
+1. Install Chef Workstation using one of the following methods:
+
+   - Double-click the `.dmg` file, then double-click the `.pkg` file inside and follow the on-screen installation wizard.
+
+   - Run the following commands:
+
+    ```shell
+    hdiutil attach chef-workstation-enterprise-<VERSION>-darwin.dmg
+    sudo installer -pkg "/Volumes/Chef Workstation Enterprise <VERSION>/chef-workstation-enterprise-<VERSION>-1_arm64.pkg" -target /
+    hdiutil detach "/Volumes/Chef Workstation Enterprise <VERSION>"
+    ```
+
+   Replace `<VERSION>` with the version number of the downloaded package, for example `chef-workstation-enterprise-26.1.0-1`.
 
 ## Verify the installation
 

--- a/content/workstation/26.1/uninstall.md
+++ b/content/workstation/26.1/uninstall.md
@@ -8,7 +8,7 @@ draft = false
   weight = 70
 +++
 
-Use these steps to remove Chef Workstation from Debian-based, RPM-based, or Windows systems.
+Use these steps to remove Chef Workstation from Debian-based, RPM-based, Windows, or macOS systems.
 
 ## Uninstall Chef Workstation on Debian-based distributions
 
@@ -61,6 +61,22 @@ msiexec /x chef-workstation-enterprise-<VERSION>_x86_64.msi
 ```
 
 Replace `<VERSION>` with the version number of the currently installed package.
+
+## Uninstall Chef Workstation on macOS
+
+To uninstall Chef Workstation on macOS, run the uninstaller script:
+
+```shell
+sudo /opt/hab/chef-workstation/uninstall.sh
+```
+
+This script will:
+
+- Remove all Chef Workstation binaries from `/usr/local/bin/`
+- Remove the installation directory `/opt/hab/`
+- Remove the PATH configuration from `/etc/paths.d/chef-workstation-enterprise`
+- Remove the installation metadata from `/Library/Application Support/chef-workstation-enterprise/`
+- Forget the package receipt using `pkgutil`
 
 ## See also
 

--- a/content/workstation/26.1/upgrade.md
+++ b/content/workstation/26.1/upgrade.md
@@ -7,7 +7,7 @@ title = "Upgrade Chef Workstation and its components"
   weight = 30
 +++
 
-Chef Workstation 26.1 and later uses native installers for Debian, RPM, and Windows.
+Chef Workstation 26.1 and later uses native installers for Debian, RPM, Windows, and macOS.
 To upgrade, install the latest version for your operating system.
 
 ## Upgrade on Debian-based systems
@@ -95,6 +95,36 @@ To upgrade Chef Workstation on Windows, follow these steps:
    ```powershell
    msiexec /i chef-workstation-enterprise-<VERSION>_x86_64.msi
    ```
+
+   Replace `<VERSION>` with the version number of the downloaded package.
+
+## Upgrade on macOS
+
+To upgrade Chef Workstation on macOS, follow these steps:
+
+1. Download the latest installer:
+
+   ```shell
+   curl -o "chef-workstation-enterprise-<VERSION>-darwin.dmg" "https://chefdownload-commercial.chef.io/stable/chef-workstation-enterprise/download?eol=false&license_id=<LICENSE_ID>&m=aarch64&p=mac_os_x&pm=dmg&v=<VERSION>"
+   ```
+
+   Replace:
+   - `<VERSION>` with the version number to upgrade to.
+   - `<LICENSE_ID>` with your Chef license ID.
+
+1. Install the new version using one of the following methods:
+
+   - Double-click the `.dmg` file, then double-click the `.pkg` file inside and follow the on-screen installation wizard.
+
+   - Run the following commands:
+
+     ```shell
+     hdiutil attach chef-workstation-enterprise-<VERSION>-darwin.dmg
+     sudo installer -pkg "/Volumes/Chef Workstation Enterprise <VERSION>/chef-workstation-enterprise-<VERSION>-1_arm64.pkg" -target /
+     hdiutil detach "/Volumes/Chef Workstation Enterprise <VERSION>"
+     ```
+
+   The installer will automatically detect and upgrade your existing installation.
 
    Replace `<VERSION>` with the version number of the downloaded package.
 


### PR DESCRIPTION
## Summary
This PR adds documentation for the new macOS ARM64 (Apple Silicon) native installer support in Chef Workstation 26.1+.

## Changes
- **install.md**: Added macOS ARM64 to supported platforms, documented DMG installation steps
- **uninstall.md**: Added macOS uninstall section using the uninstall.sh script
- **upgrade.md**: Added macOS upgrade process

## Details
- macOS installer uses DMG format with PKG inside
- Binaries installed to `/opt/hab/` (2.4 GB disk space)
- Symlinks created in `/usr/local/bin/` (not `/usr/bin/` due to macOS SIP)
- PATH configured via `/etc/paths.d/chef-workstation-enterprise`
- Uninstall via dedicated script at `/opt/hab/chef-workstation/uninstall.sh`
- Supports clean install and upgrade scenarios

## Testing
- [ ] Documentation builds successfully
- [ ] Installation steps verified on macOS 14+ ARM64
- [ ] Upgrade process verified
- [ ] Uninstall process verified

## Related
- chef/chef-workstation-docs#33 (original PR)
- chef/chef-workstation-installer-scripts#12 (macOS native installer implementation)
- CHEF-34644