### PR TITLE
Add Chef Infra Server 15.10.122 release notes

### DIFF
--- a/content/release_notes/server.md
+++ b/content/release_notes/server.md
@@ -16,9 +16,10 @@ summary = "Chef Infra Server release notes"
 <!-- markdownlint-disable-file -->
 <!-- cSpell:disable  -->
 <!-- vale off -->
+
 ## Chef Infra Server 15.10.119
 
-Released on August 26, 2026
+Release date: August 27, 2026
 
 ### Security
 
@@ -44,7 +45,7 @@ This release uses:
 
 ## Chef Infra Server 15.10.114
 
-Released on June 25, 2026
+Release date: June 25, 2026
 
 ### Security
 
@@ -93,7 +94,7 @@ This release uses:
 
 ## Chef Infra Server 15.10.91
 
-Released on February 10, 2026
+Release date: February 10, 2026
 
 ### Security improvements
 
@@ -128,6 +129,8 @@ This release uses:
 - Valkey 7.2.11
 
 ## Chef Infra Server 15.10.83
+
+Release date: November 4, 2025
 
 ### Improvements
 
@@ -185,6 +188,8 @@ This release uses:
 
 ## Chef Infra Server 15.10.66
 
+Release date: September 15, 2025
+
 ### Bug Fixes
 
 - Chef Infra Server now allows and properly validates extended validation certificates when it connects to external databases.
@@ -200,6 +205,8 @@ This release uses:
 - OpenResty 1.25.3.1
 
 ## Chef Infra Server 15.10.63
+
+Release date: August 29, 2025
 
 ### Improvements
 
@@ -228,6 +235,8 @@ This release uses:
 
 ## Chef Infra Server 15.10.33
 
+Release date: March 3, 2025
+
 ### Security
 
 - Updated REXML to 3.3.9 to resolve the following CVE:
@@ -244,6 +253,8 @@ This release uses:
 - OpenResty 1.25.3.1
 
 ## Chef Infra Server 15.10.27
+
+Release date: January 9, 2025
 
 ### Improvements
 

--- a/content/release_notes/server.md
+++ b/content/release_notes/server.md
@@ -17,6 +17,39 @@ summary = "Chef Infra Server release notes"
 <!-- cSpell:disable  -->
 <!-- vale off -->
 
+## Chef Infra Server 15.10.119
+
+Released on August 25, 2026
+
+### Security
+
+- Removed stale Rack and rexml gem directories left on disk by the package manager during upgrades.
+  `chef-server-ctl reconfigure` now cleans up gem versions below the required minimums, resolving the following CVEs that were flagged on disk even though they were not actively loaded:
+  - CVE-2025-61772 (Rack multipart denial-of-service, fixed in Rack 3.2.2 and later)
+  - CVE-2026-22860 (Rack::Directory path traversal, fixed in Rack 3.2.5 and later)
+  - CVE-2026-25500 (Rack::Directory cross-site scripting, fixed in Rack 3.2.5 and later)
+- Added minimum version floors for `net-imap`, `rack`, and `rexml` in the `oc-id`, `chef-server-ctl`, and `oc-chef-pedant` Gemfiles.
+  These floors are sourced from a shared `safe_versions.rb` constant, making the safety boundary a single source of truth and preventing vulnerable gem versions from being resolved during package installs or bundle updates.
+  ([#4227](https://github.com/chef/chef-server/pull/4227))
+
+### Improvements
+
+- Chef Infra Server now accepts external PostgreSQL 14 databases during preflight validation, in addition to the default embedded PostgreSQL 13.
+  Users running an external PostgreSQL 14 database are no longer blocked by a CSPG014 preflight failure during `chef-server-ctl reconfigure`.
+  The embedded PostgreSQL shipped with Chef Infra Server remains at version 13 and is unaffected by this change.
+  ([#4225](https://github.com/chef/chef-server/pull/4225))
+
+### Service versions
+
+This release uses:
+
+- OpenResty 1.29.2.5
+- OpenJRE 17.0.9+9
+- PostgreSQL 13.23.tuxcare.1.0.0
+- OpenSearch 1.3.20-tuxcare-1.0.3
+- Rack 3.2.6
+- Valkey 7.2.11
+
 ## Chef Infra Server 15.10.114
 
 Released on June 25, 2026

--- a/content/release_notes/server.md
+++ b/content/release_notes/server.md
@@ -16,28 +16,27 @@ summary = "Chef Infra Server release notes"
 <!-- markdownlint-disable-file -->
 <!-- cSpell:disable  -->
 <!-- vale off -->
-
 ## Chef Infra Server 15.10.119
 
-Released on August 25, 2026
-
-### Security
-
-- Removed stale Rack and rexml gem directories left on disk by the package manager during upgrades.
-  `chef-server-ctl reconfigure` now cleans up gem versions below the required minimums, resolving the following CVEs that were flagged on disk even though they were not actively loaded:
-  - CVE-2025-61772 (Rack multipart denial-of-service, fixed in Rack 3.2.2 and later)
-  - CVE-2026-22860 (Rack::Directory path traversal, fixed in Rack 3.2.5 and later)
-  - CVE-2026-25500 (Rack::Directory cross-site scripting, fixed in Rack 3.2.5 and later)
-- Added minimum version floors for `net-imap`, `rack`, and `rexml` in the `oc-id`, `chef-server-ctl`, and `oc-chef-pedant` Gemfiles.
-  These floors are sourced from a shared `safe_versions.rb` constant, making the safety boundary a single source of truth and preventing vulnerable gem versions from being resolved during package installs or bundle updates.
-  ([#4227](https://github.com/chef/chef-server/pull/4227))
+Released on August 26, 2026
 
 ### Improvements
 
-- Chef Infra Server now accepts external PostgreSQL 14 databases during preflight validation, in addition to the default embedded PostgreSQL 13.
-  Users running an external PostgreSQL 14 database are no longer blocked by a CSPG014 preflight failure during `chef-server-ctl reconfigure`.
-  The embedded PostgreSQL shipped with Chef Infra Server remains at version 13 and is unaffected by this change.
+- Chef Infra Server now accepts external PostgreSQL 14 databases during preflight validation, in addition to the default embedded PostgreSQL 13 database.
+  Users running an external PostgreSQL 14 database are no longer blocked by a CSPG014 preflight validation failure during `chef-server-ctl reconfigure`.
+  Chef Infra Server is still embedded with PostgreSQL version 13. If you're using the default embedded PostgreSQL, this change doesn't affect your deployment.
   ([#4225](https://github.com/chef/chef-server/pull/4225))
+
+### Security
+
+- Removed stale Rack and REXML gem directories that could be left on disk by the package manager during upgrades.
+  `chef-server-ctl reconfigure` now removes gem versions below the required minimum versions. This addresses the following CVEs, which could be flagged during vulnerability scans even though the affected gems were not actively loaded:
+  - CVE-2025-61772 (Rack multipart denial-of-service, fixed in Rack 3.2.2 and later)
+  - CVE-2026-22860 (Rack::Directory path traversal, fixed in Rack 3.2.5 and later)
+  - CVE-2026-25500 (Rack::Directory cross-site scripting, fixed in Rack 3.2.5 and later)
+- Defined minimum versions for `net-imap`, `rack`, and `rexml` in the `oc-id`, `chef-server-ctl`, and `oc-chef-pedant` Gemfiles.
+  These minimum versions are defined in a shared `safe_versions.rb` constant, creating a single source of truth and preventing vulnerable gem versions from being included in package installations or bundle updates.
+  ([#4227](https://github.com/chef/chef-server/pull/4227))
 
 ### Service versions
 

--- a/content/release_notes/server.md
+++ b/content/release_notes/server.md
@@ -20,13 +20,6 @@ summary = "Chef Infra Server release notes"
 
 Released on August 26, 2026
 
-### Improvements
-
-- Chef Infra Server now accepts external PostgreSQL 14 databases during preflight validation, in addition to the default embedded PostgreSQL 13 database.
-  Users running an external PostgreSQL 14 database are no longer blocked by a CSPG014 preflight validation failure during `chef-server-ctl reconfigure`.
-  Chef Infra Server is still embedded with PostgreSQL version 13. If you're using the default embedded PostgreSQL, this change doesn't affect your deployment.
-  ([#4225](https://github.com/chef/chef-server/pull/4225))
-
 ### Security
 
 - Removed stale Rack and REXML gem directories that could be left on disk by the package manager during upgrades.

--- a/content/release_notes/server.md
+++ b/content/release_notes/server.md
@@ -17,7 +17,7 @@ summary = "Chef Infra Server release notes"
 <!-- cSpell:disable  -->
 <!-- vale off -->
 
-## Chef Infra Server 15.10.119
+## Chef Infra Server 15.10.125
 
 Release date: August 27, 2026
 
@@ -36,11 +36,11 @@ Release date: August 27, 2026
 
 This release uses:
 
-- OpenResty 1.29.2.5
+- OpenResty 1.31.1.1
 - OpenJRE 17.0.9+9
 - PostgreSQL 13.23.tuxcare.1.0.0
 - OpenSearch 1.3.20-tuxcare-1.0.3
-- Rack 3.2.6
+- Rack 3.2.5
 - Valkey 7.2.11
 
 ## Chef Infra Server 15.10.114


### PR DESCRIPTION
## Summary

Adds release notes for Chef Infra Server 15.10.119 (released August 25, 2026).

### Changes documented

**Security**
- `chef-server-ctl reconfigure` now removes stale Rack and rexml gem directories left on disk by the package manager during upgrades, resolving CVE-2025-61772, CVE-2026-22860, and CVE-2026-25500 (omnibus-config [#23](https://github.com/chef/chef-server-omnibus-config/pull/23))
- Added minimum version floors for `net-imap`, `rack`, and `rexml` in the `oc-id`, `chef-server-ctl`, and `oc-chef-pedant` Gemfiles sourced from a shared `safe_versions.rb` constant (CHEF-35182, chef/chef-server[#4227](https://github.com/chef/chef-server/pull/4227))

**Improvements**
- External PostgreSQL 14 databases are now accepted in preflight validation; the CSPG014 preflight failure no longer fires for external PG14 users (CHEF-37239, chef/chef-server[#4225](https://github.com/chef/chef-server/pull/4225))

### Sources reviewed
- `chef/chef-server` local repo (git log since 15.10.114)
- `chef/chef-server-omnibus-config` local repo (omnibus submodule diff)