### PR TITLE
Fix broken Chef Automate download URL (m=x86_64 -> m=amd64)

### DIFF
--- a/content/automate/airgapped_installation.md
+++ b/content/automate/airgapped_installation.md
@@ -29,7 +29,7 @@ To get a trial license for an airgapped host [contact Chef](https://www.chef.io/
 Download the Chef Automate command-line tool from the `current` [release channel]({{< relref "install.md#release-channels" >}}).
 
 ```shell
-curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
 ```
 
 Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.

--- a/content/automate/get_started.md
+++ b/content/automate/get_started.md
@@ -50,7 +50,8 @@ Installing Chef Automate with the Vagrantfile below means you're consenting to C
     sysctl -w vm.max_map_count=262144
     sysctl -w vm.dirty_expire_centisecs=20000
     echo "${CFG_IP} ${CFG_HOSTNAME}" | tee -a /etc/hosts
-    curl -fsSL "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o /usr/local/bin/chef-automate
+    curl -fsSL "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o /usr/local/bin/chef-automate.zip
+    unzip -o /usr/local/bin/chef-automate.zip -d /usr/local/bin
     chmod +x /usr/local/bin/chef-automate
     chef-automate deploy --accept-terms-and-mlsa
     echo "Server is up and running. Please log in at https://${CFG_HOSTNAME}/"

--- a/content/automate/ha_aws_deploy_steps.md
+++ b/content/automate/ha_aws_deploy_steps.md
@@ -42,8 +42,8 @@ Run the following steps on Bastion Host Machine:
     #Run commands as sudo.
     sudo -- sh -c "
     #Download Chef Automate CLI.
-    curl \"https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>\" \
-    -o /usr/bin/chef-automate && chmod +x /usr/bin/chef-automate
+    curl -L \"https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>\" \
+    -o /usr/bin/chef-automate.zip && unzip -o /usr/bin/chef-automate.zip -d /usr/bin && chmod +x /usr/bin/chef-automate
     #Download the latest Airgapped Bundle.
     #To download specific version bundle, example version: 4.2.59 then replace latest.aib with 4.2.59.aib
     curl \"https://packages.chef.io/airgap_bundle/current/automate/latest.aib\" -o automate.aib

--- a/content/automate/ha_aws_managed_deploy_steps.md
+++ b/content/automate/ha_aws_managed_deploy_steps.md
@@ -31,8 +31,8 @@ Follow these steps to deploy Chef Automate High Availability (HA) on AWS (Amazon
     ```bash
     sudo -- sh -c "
     # Download Chef Automate CLI.
-    curl \"https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>\" \
-    -o /usr/bin/chef-automate && chmod +x /usr/bin/chef-automate
+    curl -L \"https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>\" \
+    -o /usr/bin/chef-automate.zip && unzip -o /usr/bin/chef-automate.zip -d /usr/bin && chmod +x /usr/bin/chef-automate
 
     # Download the air-gapped bundle.
     curl \"https://packages.chef.io/airgap_bundle/current/automate/<VERSION>.aib\" -o automate.aib

--- a/content/automate/ha_chef_backend_to_automate_ha.md
+++ b/content/automate/ha_chef_backend_to_automate_ha.md
@@ -203,7 +203,7 @@ Where:
 5. SSH to the bastion host and download the Chef Automate CLI:
 
     ```bash
-    curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o /usr/bin/chef-automate && chmod +x /usr/bin/chef-automate
+    curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o /usr/bin/chef-automate.zip && unzip -o /usr/bin/chef-automate.zip -d /usr/bin && chmod +x /usr/bin/chef-automate
     ```
 
     Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.

--- a/content/automate/ha_on_premises_deployment_procedure.md
+++ b/content/automate/ha_on_premises_deployment_procedure.md
@@ -48,8 +48,8 @@ Ensure all resources are on existing or cloud infrastructure (`AWS`/`Azure`/`Goo
 
     ```bash
     sudo -- sh -c "
-    curl \"https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>\" \
-    -o /usr/bin/chef-automate && chmod +x /usr/bin/chef-automate
+    curl -L \"https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>\" \
+    -o /usr/bin/chef-automate.zip && unzip -o /usr/bin/chef-automate.zip -d /usr/bin && chmod +x /usr/bin/chef-automate
     curl \"https://packages.chef.io/airgap_bundle/current/automate/latest.aib\" -o automate.aib
     "
     ```

--- a/content/automate/ha_upgrade_introduction.md
+++ b/content/automate/ha_upgrade_introduction.md
@@ -16,7 +16,7 @@ To upgrade Chef Automate HA, follow these steps:
 1. Download the latest CLI:
 
     ```bash
-    curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate && sudo mv chef-automate /usr/bin/chef-automate
+    curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate && sudo mv chef-automate /usr/bin/chef-automate
     ```
 
     Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.

--- a/content/automate/infra_server.md
+++ b/content/automate/infra_server.md
@@ -44,7 +44,7 @@ Before beginning your installation, check the [System Requirements]({{< relref "
 To download the `chef-automate` command line tool, run the following command in your command line interface:
 
 ```shell
-curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
 ```
 
 Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.

--- a/content/automate/install.md
+++ b/content/automate/install.md
@@ -23,7 +23,7 @@ See [Airgapped Installation]({{< relref "airgapped_installation.md" >}}) for ins
 Download the Chef Automate command-line tool:
 
 ```shell
-curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
 ```
 
 Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.

--- a/content/automate/major_upgrade.md
+++ b/content/automate/major_upgrade.md
@@ -51,7 +51,7 @@ Please upgrade to latest date pattern version number.
 1. On an internet-connected machine, download the latest Chef Automate CLI.
 
     ```sh
-    curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+    curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
     ```
 
     Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.
@@ -186,7 +186,7 @@ To upgrade to 3.0.x, follow the steps below:
 1. Download latest CLI of Chef Automate
 
     ```sh
-    curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+    curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
     ```
 
     Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.
@@ -260,7 +260,7 @@ To upgrade to 3.0.x, follow the steps below:
 1. Download latest CLI of Chef Automate
 
     ```sh
-    curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+    curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
     ```
 
     Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.

--- a/content/automate/major_upgrade_4.x.md
+++ b/content/automate/major_upgrade_4.x.md
@@ -49,7 +49,7 @@ For example, if today you are on version _2021201164433_, your upgrade journey s
 - **Download latest chef-automate cli:**
 
     ```sh
-    curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+    curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
     ```
 
     Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.
@@ -98,7 +98,7 @@ To upgrade Chef Automate from version 3.0.49 to 4.x with embedded Elasticsearch,
 1. Download latest chef-automate cli.
 
     ```sh
-    curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+    curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
     ```
 
     Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.
@@ -245,7 +245,7 @@ To upgrade Chef Automate with external Elasticsearch from version 3.0.49 to 4.x,
 1. Download latest chef-automate cli.
 
     ```sh
-    curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+    curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
     ```
 
     Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.
@@ -349,7 +349,7 @@ To upgrade from version 3.0.49 to 4.x, follow the steps below:
 1. Download latest CLI of Chef Automate.
 
     ```sh
-    curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+    curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
     ```
 
     Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.
@@ -524,7 +524,7 @@ To upgrade to version 3.0.49 to 4.x, follow the steps below:
 1. Download latest CLI of Chef Automate
 
     ```sh
-    curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+    curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
     ```
 
     Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.
@@ -696,7 +696,7 @@ DeploymentServiceCallError: A request to the deployment-service failed: Request 
 To move ahead with the upgrade you can download the latest CLI and air-gapped bundle using the curl command with proxy settings:
 
 ```sh
-curl -x http://proxy_server:proxy_port --proxy-user username:password -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+curl -x http://proxy_server:proxy_port --proxy-user username:password -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
 ```
 
 Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.

--- a/content/automate/managed_services.md
+++ b/content/automate/managed_services.md
@@ -453,7 +453,7 @@ If you are planning to set Chef Automate with External AWS PostgreSQL/OpenSearch
 Download the Chef Automate command-line tool:
 
 ```shell
-curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
 ```
 
 Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.

--- a/content/automate/migrate.md
+++ b/content/automate/migrate.md
@@ -50,7 +50,8 @@ You will need the `chef-automate` command line tool to initiate your upgrade.
 1. Download the latest version of the Chef Automate CLI:
 
     ```shell
-    wget "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -O chef-automate
+    wget "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -O chef-automate.zip
+    unzip chef-automate.zip
     chmod +x chef-automate
     ```
 

--- a/content/automate/on_prem_builder.md
+++ b/content/automate/on_prem_builder.md
@@ -74,7 +74,7 @@ Chef Automate and Chef Habitat Builder require:
 Download the installer:
 
 ```shell
-curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
 ```
 
 Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.

--- a/content/automate/restore.md
+++ b/content/automate/restore.md
@@ -21,7 +21,7 @@ Before restoring a Chef Automate installation, see how to [configure your backup
 1. On the restore host, download the Chef Automate command-line tool:
 
     ```shell
-    curl "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=x86_64&license_id=<LICENSE_ID>" -o chef-automate && chmod +x chef-automate
+    curl -L "https://chefdownload-commercial.chef.io/stable/automate/download?p=linux&m=amd64&license_id=<LICENSE_ID>" -o chef-automate.zip && unzip chef-automate.zip && chmod +x chef-automate
     ```
 
     Replace `<LICENSE_ID>` with your Progress Chef commercial license ID.


### PR DESCRIPTION
## Summary

Fixes a broken Chef Automate CLI download command that has been reported by multiple customers (Tesco, Barclays) as failing this week.

## Root cause

The download command used throughout the Chef Automate docs was broken in three compounding ways:

1. **Wrong architecture parameter** — the URL used `m=x86_64`, which the download API doesn't recognize. Instead of returning a clear error, the API silently returns `HTTP 200` with an empty JSON body (`{"code":0,"status_text":"","message":""}`), which gets saved as if it were the real binary.
2. **Missing `-L` flag on `curl`** — the correct parameter (`m=amd64`) returns an `HTTP 302` redirect to the actual file. Without `-L`, `curl` doesn't follow the redirect and saves an empty file.
3. **Wrong output handling** — the API always returns a `.zip` archive, not a raw executable, but the docs treated the download as if it were already the finished `chef-automate` binary (`chmod +x` with no `unzip` step).

## Fix

- Changed `m=x86_64` → `m=amd64` in all Chef Automate download URLs.
- Added `-L` to `curl` commands that were missing it, so the redirect is followed.
- Changed output filename to `chef-automate.zip` and added an `unzip` step before `chmod +x`, so the extracted `chef-automate` binary is what actually gets marked executable.

## Verification

Tested live against the production download API using a valid trial license:

- Confirmed `m=x86_64` returns `HTTP 200` with a fake/empty JSON body (the broken behavior our customers hit).
- Confirmed `m=amd64` returns `HTTP 302` to a real `chef-automate_linux_amd64.zip`.
- Ran the exact fixed command as written in the docs end-to-end: downloaded the zip (matches reported file size), unzipped it, `chmod +x`'d it, and confirmed via `file` that the result is a valid `ELF 64-bit x86-64` executable.

## Files changed

- `content/automate/install.md`
- `content/automate/airgapped_installation.md`
- `content/automate/get_started.md`
- `content/automate/infra_server.md`
- `content/automate/ha_upgrade_introduction.md`
- `content/automate/migrate.md`
- `content/automate/restore.md`
- `content/automate/on_prem_builder.md`
- `content/automate/managed_services.md`
- `content/automate/major_upgrade.md`
- `content/automate/major_upgrade_4.x.md`
- `content/automate/ha_aws_deploy_steps.md`
- `content/automate/ha_aws_managed_deploy_steps.md`
- `content/automate/ha_on_premises_deployment_procedure.md`
- `content/automate/ha_chef_backend_to_automate_ha.md`
