### PR TITLE
Add server deprecation warning to landing page

### DIFF
--- a/data/announcements.yml
+++ b/data/announcements.yml
@@ -1,0 +1,14 @@
+# Product announcements shown on the docs landing page (layouts/index.html).
+# Set `active: true` (or delete the entry) to retire an announcement.
+# `severity` maps to an existing admonition style: note, important, warning, or danger.
+# `message` supports Markdown; layouts/index.html renders it with `RenderString`.
+- id: chef-infra-server-eol
+  active: true
+  severity: warning
+  product: Chef Infra Server
+  title: Chef Infra Server is deprecated
+  message: >-
+    Chef Infra Server is deprecated and will reach end-of-life status on November 30, 2026.
+    Migrate to [Chef 360 Platform](/360/latest/) as a replacement.
+    See [supported versions](/versions/#deprecated-products-and-versions) for details,
+    and contact your Chef account representative for help with migration planning.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,6 +5,29 @@
   existing product SVGs from /static/images/ where available.
 */}}
 
+<style>
+  /* Keeps the product icon and heading text on one line within each card. */
+  .product-card-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+  .product-card-heading .product-card-name {
+    margin: 0;
+  }
+  /* Reuses .admonition-warning-title's color/background; only overrides layout so it reads as an inline pill badge. */
+  .product-card-badge {
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: 0.5rem;
+    padding: 0.15rem 0.5rem;
+    border-bottom: none;
+    border-radius: 999px;
+    font-size: 0.7rem;
+  }
+</style>
+
 {{ $products := slice
   (dict
     "name"     "Chef 360 Platform"
@@ -47,6 +70,7 @@
     "icon"     ""
     "icon_mat" "storage"
     "desc"     "A central hub for storing and distributing infrastructure configuration data, policies, and cookbooks."
+    "badge"    "Deprecated"
   )
   (dict
     "name"     "Chef InSpec"
@@ -90,6 +114,23 @@
   </div>
   {{- end }}
 
+  {{- $announcements := where .Site.Data.announcements "active" true }}
+  {{- with $announcements }}
+  <div class="product-announcements">
+    <h2>Product announcements</h2>
+    {{- range . }}
+    <div class="admonition-{{ .severity }}">
+      <p class="admonition-{{ .severity }}-title">{{ .title }}</p>
+      <div class="admonition-{{ .severity }}-text">
+        {{ $.RenderString .message }}
+      </div>
+    </div>
+    {{- end }}
+  </div>
+  {{- end }}
+
+  <h2>Browse by product</h2>
+
   <p class="lead">Select a product to browse its documentation.</p>
 
   <div class="grid-x grid-padding-x small-up-1 medium-up-2 large-up-3 product-card-grid">
@@ -98,16 +139,21 @@
       <div class="card product-card">
 
         <div class="card-section">
-          <div class="product-card-icon" aria-hidden="true">
-            {{ if .icon }}
-              <img src="{{ .icon }}" alt="">
-            {{ else }}
-              <span class="material-symbols-outlined" translate="no">{{ .icon_mat }}</span>
-            {{ end }}
+          <div class="product-card-heading">
+            <div class="product-card-icon" aria-hidden="true">
+              {{ if .icon }}
+                <img src="{{ .icon }}" alt="">
+              {{ else }}
+                <span class="material-symbols-outlined" translate="no">{{ .icon_mat }}</span>
+              {{ end }}
+            </div>
+            <h3 class="product-card-name">
+              <a href="{{ .url }}">{{ .name }}</a>
+              {{- with .badge }}
+              <span class="admonition-warning-title product-card-badge">{{ . }}</span>
+              {{- end }}
+            </h3>
           </div>
-          <h2 class="product-card-name">
-            <a href="{{ .url }}">{{ .name }}</a>
-          </h2>
           <p>{{ .desc }}</p>
         </div>
 


### PR DESCRIPTION
## Description

This adds a "Product announcements" section to the main landing page with a warning that Infra Server is deprecated and will be EOL by the end of November.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

- https://github.com/chef/chef-web-docs/pull/4741

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
