### PR TITLE
Fix Compliance Phase reports panels

### DIFF
--- a/content/client/18/features/chef_compliance_phase.md
+++ b/content/client/18/features/chef_compliance_phase.md
@@ -229,7 +229,7 @@ The following examples:
   ```
 
   {{< /foundation_tabs_panel >}}
-    {{< foundation_tabs_panel panel-id="local-reporter" >}}
+  {{< foundation_tabs_panel panel-id="local-reporter" >}}
   ```ruby
   # Invoke the Compliance Phase
   default['audit']['compliance_phase'] = true

--- a/content/client/19/features/chef_compliance_phase.md
+++ b/content/client/19/features/chef_compliance_phase.md
@@ -229,7 +229,7 @@ The following examples:
   ```
 
   {{< /foundation_tabs_panel >}}
-    {{< foundation_tabs_panel panel-id="local-reporter" >}}
+  {{< foundation_tabs_panel panel-id="local-reporter" >}}
   ```ruby
   # Invoke the Compliance Phase
   default['audit']['compliance_phase'] = true


### PR DESCRIPTION
## Description

Fix compliance phase reports panel indent issue.

The content isn't rendering correctly because the panel code block is indented two spaces too far.

## Definition of Done

## Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

## Related PRs

## Check List

- [ ] Spell Check
- [ ] Local build
- [ ] Examine the local build
- [ ] All tests pass
