### PR TITLE
Add Marketplace documentation (V1)

### DIFF
--- a/config/_default/caches.toml
+++ b/config/_default/caches.toml
@@ -1,12 +1,12 @@
-[getjson]
-dir = ":resourceDir/_get"
-maxAge = -1
-[getresource]
-dir = ":resourceDir/_get"
-maxAge = -1
-[getcsv]
-dir = ":resourceDir/_get"
-maxAge = -1
+# [getjson]
+# dir = ":resourceDir/_get"
+# maxAge = -1
+# [getresource]
+# dir = ":resourceDir/_get"
+# maxAge = -1
+# [getcsv]
+# dir = ":resourceDir/_get"
+# maxAge = -1
 [images]
 dir = ":resourceDir/_gen"
 maxAge = -1

--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -1179,6 +1179,33 @@ identifier = "chef_cloud"
 ####
 
 ####
+# Infra Marketplace Menu
+####
+
+[[infra_marketplace]]
+title = "Infra Marketplace"
+identifier = "infra_marketplace"
+url = "/infra_marketplace/"
+
+  [[infra_marketplace]]
+  title = "Overview"
+  identifier = "infra_marketplace/overview"
+  parent = "infra_marketplace"
+  url = "/infra_marketplace/"
+  weight = 10
+
+  [[infra_marketplace]]
+  title = "Compatibility reference"
+  identifier = "infra_marketplace/compatibility_reference"
+  parent = "infra_marketplace"
+  url = "/infra_marketplace/compatibility_reference/"
+  weight = 20
+
+####
+# End Infra Marketplace Menu
+####
+
+####
 # Chef Workstation Menu
 ####
 

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -13,6 +13,7 @@ menu_order = [
   "workstation",
   "effortless",
   "supermarket",
+  "infra_marketplace",
   "release_notes",
   "legacy",
   "extra"

--- a/content/infra_marketplace/_index.md
+++ b/content/infra_marketplace/_index.md
@@ -1,20 +1,21 @@
 +++
-title = "Marketplace initial release overview"
+title = "Infra Marketplace overview"
 draft = false
+
 [menu]
-  [menu.cloud]
-    title = "Marketplace overview"
-    identifier = "chef_cloud/saas/Marketplace initial release overview"
-    parent = "chef_cloud/saas"
-    weight = 30
+  [menu.infra_marketplace]
+    title = "Overview"
+    identifier = "infra_marketplace/overview"
+    parent = "infra_marketplace"
+    weight = 10
 +++
 
-Marketplace is a content destination planned as part of the broader Infra 360 ecosystem.
-This page describes only the confirmed initial-release scope.
+Infra Marketplace provides backward-compatible public cookbook consumption for Chef Supermarket workflows.
+This page describes the confirmed initial-release scope.
 
 ## Intended audience
 
-This page is for DevOps engineers and platform teams that currently consume cookbooks from the public Chef Supermarket and need to understand initial Marketplace compatibility.
+This page is for DevOps engineers and platform teams that currently consume cookbooks from the public Chef Supermarket.
 
 ## Initial-release scope
 
@@ -26,7 +27,7 @@ The confirmed scope includes:
 - Backward compatibility for Berkshelf cookbook consumption workflows.
 - Backward compatibility for Policyfile cookbook consumption workflows.
 - Compatibility only for cookbooks from the public Chef Supermarket.
-- Parallel support for public Chef Supermarket and Marketplace cookbook sources.
+- Parallel support for public Chef Supermarket and Infra Marketplace cookbook sources.
 
 ## Out-of-scope for initial release
 
@@ -38,16 +39,6 @@ The following items are outside the initial-release scope:
 - Migration workflows for private Chef Supermarket.
 - New content types beyond cookbooks from the public Chef Supermarket.
 
-## Supported compatibility scenarios
-
-Marketplace initial-release documentation currently covers:
-
-- Supported read-only `knife supermarket` backward compatibility.
-- Berkshelf backward compatibility.
-- Policyfile backward compatibility.
-
-Use the Marketplace compatibility reference for command and configuration details.
-
 ## Limitations
 
 Compatibility applies only to cookbooks from the public Chef Supermarket.
@@ -57,7 +48,7 @@ Write and administrative commands are outside the initial-release scope.
 
 ## Related information
 
-- [Marketplace compatibility reference](/saas/marketplace_compatibility_reference/)
+- [Infra Marketplace compatibility reference](/infra_marketplace/compatibility_reference/)
 - [knife supermarket](/workstation/latest/tools/knife/knife_supermarket/)
 - [Berkshelf](/workstation/latest/tools/berkshelf/)
 - [About Policyfiles](/client/latest/policy/policyfile/)

--- a/content/infra_marketplace/compatibility_reference.md
+++ b/content/infra_marketplace/compatibility_reference.md
@@ -1,27 +1,28 @@
 +++
-title = "Marketplace compatibility reference"
+title = "Infra Marketplace compatibility reference"
 draft = false
+
 [menu]
-  [menu.cloud]
-    title = "Marketplace compatibility"
-    identifier = "chef_cloud/saas/Marketplace compatibility reference"
-    parent = "chef_cloud/saas"
-    weight = 40
+  [menu.infra_marketplace]
+    title = "Compatibility reference"
+    identifier = "infra_marketplace/compatibility_reference"
+    parent = "infra_marketplace"
+    weight = 20
 +++
 
 This reference documents the initial-release backward compatibility scope for cookbook consumption.
 It applies only to cookbooks from the public Chef Supermarket.
 It does not apply to private Chef Supermarket content.
-Marketplace is available at `https://marketplace.chef.io`.
-You can continue to use `https://supermarket.chef.io` or configure Marketplace as your public cookbook source.
+Infra Marketplace is available at `https://marketplace.chef.io`.
+You can continue to use `https://supermarket.chef.io` or configure Infra Marketplace as your public cookbook source.
 
 ## `knife supermarket` compatibility
 
-Marketplace supports all unauthenticated, read-only `knife supermarket` commands.
+Infra Marketplace supports all unauthenticated, read-only `knife supermarket` commands.
 The command syntax is the same as it is for Chef Supermarket.
-No Marketplace credentials are required.
+No Infra Marketplace credentials are required.
 
-Configure Marketplace for all `knife supermarket` commands by adding the following setting to your `knife.rb` file:
+Configure Infra Marketplace for all `knife supermarket` commands by adding the following setting to your `knife.rb` file:
 
 ```ruby
 knife[:supermarket_site] = "https://marketplace.chef.io"
@@ -29,7 +30,7 @@ knife[:supermarket_site] = "https://marketplace.chef.io"
 
 You can also use the `--supermarket-site https://marketplace.chef.io` option with an individual command.
 
-| Command | Marketplace example | Purpose |
+| Command | Infra Marketplace example | Purpose |
 |---|---|---|
 | `knife supermarket download <cookbook-name>` | `knife supermarket download <cookbook-name> --supermarket-site https://marketplace.chef.io` | Download a cookbook archive. |
 | `knife supermarket install <cookbook-name>` | `knife supermarket install <cookbook-name> --supermarket-site https://marketplace.chef.io` | Install a cookbook into a local Git workflow. |
@@ -37,12 +38,12 @@ You can also use the `--supermarket-site https://marketplace.chef.io` option wit
 | `knife supermarket search <search-query>` | `knife supermarket search <search-query> --supermarket-site https://marketplace.chef.io` | Search available cookbooks. |
 | `knife supermarket show <cookbook-name>` | `knife supermarket show <cookbook-name> --supermarket-site https://marketplace.chef.io` | Show cookbook details. |
 
-The examples use Marketplace for a single command.
+The examples use Infra Marketplace for a single command.
 After you configure `knife[:supermarket_site]`, use the same commands without the `--supermarket-site` option.
 
-## Berkshelf compatibility comparison
+## Berkshelf compatibility
 
-To use Marketplace with Berkshelf, replace the public Chef Supermarket source in your `Berksfile`:
+To use Infra Marketplace with Berkshelf, replace the public Chef Supermarket source in your `Berksfile`:
 
 ```ruby
 source "https://marketplace.chef.io"
@@ -50,24 +51,24 @@ metadata
 ```
 
 Use your existing Berkshelf commands, such as `berks install`.
-No Marketplace credentials are required.
+No Infra Marketplace credentials are required.
 
-| Public cookbook source | Marketplace source | Configuration change | Limitation |
+| Public cookbook source | Infra Marketplace source | Configuration change | Limitation |
 |---|---|---|---|
 | `source "https://supermarket.chef.io"` | `source "https://marketplace.chef.io"` | Replace the source URL. | Private Chef Supermarket content is out of scope. |
 
-## Policyfile compatibility comparison
+## Policyfile compatibility
 
-To use Marketplace with a Policyfile, configure Marketplace as the Supermarket source:
+To use Infra Marketplace with a Policyfile, configure Infra Marketplace as the Supermarket source:
 
 ```ruby
 default_source :supermarket, "https://marketplace.chef.io"
 ```
 
 Use your existing Policyfile commands after you change the source URL.
-No Marketplace credentials are required.
+No Infra Marketplace credentials are required.
 
-| Public cookbook source | Marketplace source | Configuration change | Limitation |
+| Public cookbook source | Infra Marketplace source | Configuration change | Limitation |
 |---|---|---|---|
 | `default_source :supermarket` | `default_source :supermarket, "https://marketplace.chef.io"` | Add the Marketplace URL to `default_source`. | Private Chef Supermarket content is out of scope. |
 
@@ -75,5 +76,5 @@ No Marketplace credentials are required.
 
 - Compatibility applies only to cookbooks from the public Chef Supermarket.
 - Private Chef Supermarket content is not supported.
-- Marketplace supports unauthenticated, read-only `knife supermarket` commands.
+- Infra Marketplace supports unauthenticated, read-only `knife supermarket` commands.
 - Write and administrative commands are outside the initial-release scope.

--- a/content/release_notes/marketplace.md
+++ b/content/release_notes/marketplace.md
@@ -1,35 +1,35 @@
 +++
-title = "Marketplace release notes"
+title = "Infra Marketplace release notes"
 draft = false
-linkTitle = "Marketplace"
-summary = "Marketplace release notes"
+linkTitle = "Infra Marketplace"
+summary = "Infra Marketplace release notes"
 
 [menu]
   [menu.release_notes]
-    title = "Marketplace"
-    identifier = "release_notes/Marketplace"
+    title = "Infra Marketplace"
+    identifier = "release_notes/Infra Marketplace"
     parent = "release_notes"
     weight = 130
 +++
 
-## Marketplace 1.0.0
+## Infra Marketplace 1.0.0
 
 Release date: September 2, 2026
 
-Marketplace 1.0.0 provides backward-compatible public cookbook consumption for Chef Supermarket workflows.
+Infra Marketplace 1.0.0 provides backward-compatible public cookbook consumption for Chef Supermarket workflows.
 
 ### New features requiring configuration updates
 
-- **Marketplace public cookbook source**: You can use Marketplace as the public cookbook source for Berkshelf, Policyfiles, and `knife supermarket` commands.
+- **Infra Marketplace public cookbook source**: You can use Infra Marketplace as the public cookbook source for Berkshelf, Policyfiles, and `knife supermarket` commands.
   Update your source URL to `https://marketplace.chef.io`.
-  See [Marketplace compatibility reference](/saas/marketplace_compatibility_reference/) for configuration steps.
+  See [Infra Marketplace compatibility reference](/infra_marketplace/compatibility_reference/) for configuration steps.
 
 ### New features
 
-- **Unauthenticated read-only Knife commands**: Marketplace supports unauthenticated, read-only `knife supermarket` commands, including `download`, `install`, `list`, `search`, and `show`.
-- **Parallel public-source support**: You can continue to use the public Chef Supermarket source or configure Marketplace as your public cookbook source.
+- **Unauthenticated read-only Knife commands**: Infra Marketplace supports unauthenticated, read-only `knife supermarket` commands, including `download`, `install`, `list`, `search`, and `show`.
+- **Parallel public-source support**: You can continue to use the public Chef Supermarket source or configure Infra Marketplace as your public cookbook source.
 
 ### Limitations
 
-- Marketplace 1.0.0 supports cookbooks from the public Chef Supermarket only.
+- Infra Marketplace 1.0.0 supports cookbooks from the public Chef Supermarket only.
 - Private Chef Supermarket content, write operations, and administrative workflows aren't supported.

--- a/content/release_notes/marketplace.md
+++ b/content/release_notes/marketplace.md
@@ -1,0 +1,35 @@
++++
+title = "Marketplace release notes"
+draft = false
+linkTitle = "Marketplace"
+summary = "Marketplace release notes"
+
+[menu]
+  [menu.release_notes]
+    title = "Marketplace"
+    identifier = "release_notes/Marketplace"
+    parent = "release_notes"
+    weight = 130
++++
+
+## Marketplace 1.0.0
+
+Release date: September 2, 2026
+
+Marketplace 1.0.0 provides backward-compatible public cookbook consumption for Chef Supermarket workflows.
+
+### New features requiring configuration updates
+
+- **Marketplace public cookbook source**: You can use Marketplace as the public cookbook source for Berkshelf, Policyfiles, and `knife supermarket` commands.
+  Update your source URL to `https://marketplace.chef.io`.
+  See [Marketplace compatibility reference](/saas/marketplace_compatibility_reference/) for configuration steps.
+
+### New features
+
+- **Unauthenticated read-only Knife commands**: Marketplace supports unauthenticated, read-only `knife supermarket` commands, including `download`, `install`, `list`, `search`, and `show`.
+- **Parallel public-source support**: You can continue to use the public Chef Supermarket source or configure Marketplace as your public cookbook source.
+
+### Limitations
+
+- Marketplace 1.0.0 supports cookbooks from the public Chef Supermarket only.
+- Private Chef Supermarket content, write operations, and administrative workflows aren't supported.

--- a/content/saas/_index.md
+++ b/content/saas/_index.md
@@ -32,8 +32,3 @@ Maintain compliance and prevent security incidents across heterogeneous estates 
 Empowering IT resource managers through automation to improve efficiency while reducing risk across IT resources.
 
 To find out more about the configuration for Chef SaaS, refer to the [Get Started with Chef SaaS](/saas/get_started/) page.
-
-For Marketplace initial-release documentation, refer to:
-
-- [Marketplace initial release overview](/saas/marketplace_initial_release_overview/)
-- [Marketplace compatibility reference](/saas/marketplace_compatibility_reference/)

--- a/content/saas/_index.md
+++ b/content/saas/_index.md
@@ -32,3 +32,8 @@ Maintain compliance and prevent security incidents across heterogeneous estates 
 Empowering IT resource managers through automation to improve efficiency while reducing risk across IT resources.
 
 To find out more about the configuration for Chef SaaS, refer to the [Get Started with Chef SaaS](/saas/get_started/) page.
+
+For Marketplace initial-release documentation, refer to:
+
+- [Marketplace initial release overview](/saas/marketplace_initial_release_overview/)
+- [Marketplace compatibility reference](/saas/marketplace_compatibility_reference/)

--- a/content/saas/marketplace_compatibility_reference.md
+++ b/content/saas/marketplace_compatibility_reference.md
@@ -1,0 +1,75 @@
++++
+title = "Marketplace compatibility reference"
+draft = false
+[menu]
+  [menu.cloud]
+    title = "Marketplace compatibility"
+    identifier = "chef_cloud/saas/Marketplace compatibility reference"
+    parent = "chef_cloud/saas"
+    weight = 40
++++
+
+This reference documents the initial-release backward compatibility scope for cookbook consumption.
+It applies only to cookbooks from the public Chef Supermarket.
+It does not apply to private Chef Supermarket content.
+
+## Verified baseline behavior in existing docs
+
+The current `knife supermarket` documentation identifies these arguments as not requiring a user account: `download`, `search`, `install`, and `list`.
+The same documentation defines `-m`, `--supermarket-site` as the option for setting the Supermarket URL, with a default of `https://supermarket.chef.io`.
+
+## `knife supermarket` command comparison
+
+The following table covers each verified read-only command listed in existing docs as not requiring a user account.
+
+| Existing public Chef Supermarket command | Marketplace equivalent | Purpose | Notes or differences |
+|---|---|---|---|
+| `knife supermarket download COOKBOOK_NAME [COOKBOOK_VERSION] (options)` | [AUTHOR NOTE: Exact Marketplace command syntax requires engineering validation.] | Download a cookbook archive. | Existing docs verify `-m`, `--supermarket-site` and default `https://supermarket.chef.io`. Marketplace endpoint value and exact option placement are not yet confirmed in this repository. |
+| `knife supermarket install COOKBOOK_NAME [COOKBOOK_VERSION] (options)` | [AUTHOR NOTE: Exact Marketplace command syntax requires engineering validation.] | Install a cookbook from Supermarket into a local git workflow. | Existing docs verify `-m`, `--supermarket-site` and default `https://supermarket.chef.io`. Marketplace endpoint value and exact option placement are not yet confirmed in this repository. |
+| `knife supermarket list (options)` | [AUTHOR NOTE: Exact Marketplace command syntax requires engineering validation.] | List available cookbooks. | Existing docs verify `-m`, `--supermarket-site` and default `https://supermarket.chef.io`. Marketplace endpoint value and exact option placement are not yet confirmed in this repository. |
+| `knife supermarket search SEARCH_QUERY (options)` | [AUTHOR NOTE: Exact Marketplace command syntax requires engineering validation.] | Search available cookbooks. | Existing docs verify `-m`, `--supermarket-site` and default `https://supermarket.chef.io`. Marketplace endpoint value and exact option placement are not yet confirmed in this repository. |
+
+[AUTHOR NOTE: Validate whether any additional read-only `knife supermarket` commands are in initial-release scope. Existing docs also include `show`, but this repository does not confirm initial-release Marketplace support for it.]
+
+## Berkshelf compatibility comparison
+
+Current Berkshelf documentation verifies the default source pattern:
+
+```ruby
+source "https://supermarket.chef.io"
+metadata
+```
+
+Current Berkshelf documentation also verifies support for custom source URLs by adding additional `source` entries.
+
+| Existing public Chef Supermarket behavior | Marketplace equivalent | Verified configuration change | Verified limitation |
+|---|---|---|---|
+| Berkshelf resolves cookbooks from `source "https://supermarket.chef.io"`. | [AUTHOR NOTE: Marketplace Berkshelf source URL requires engineering validation.] | [AUTHOR NOTE: Confirm whether the only change is replacing the source URL with the Marketplace endpoint.] | Initial-release scope is limited to cookbooks from the public Chef Supermarket. Private Chef Supermarket content is out of scope. |
+
+## Policyfile compatibility comparison
+
+Current Policyfile documentation verifies that `default_source :supermarket` pulls from the public Chef Supermarket by default.
+It also verifies a custom URL form:
+
+```ruby
+default_source :supermarket, "https://supermarket-name.example"
+```
+
+| Existing public Chef Supermarket behavior | Marketplace equivalent | Verified configuration change | Verified limitation |
+|---|---|---|---|
+| `default_source :supermarket` uses the public Chef Supermarket by default. | [AUTHOR NOTE: Marketplace Policyfile source endpoint and exact syntax require engineering validation.] | [AUTHOR NOTE: Confirm whether `default_source :supermarket, "<marketplace-endpoint>"` is the supported Marketplace pattern.] | Initial-release scope is limited to cookbooks from the public Chef Supermarket. Private Chef Supermarket content is out of scope. |
+
+## Initial-release limitations
+
+- Compatibility applies only to cookbooks from the public Chef Supermarket.
+- Private Chef Supermarket content is not supported.
+- Only verified supported read-only `knife supermarket` commands are supported.
+- Write and administrative commands are outside the initial-release scope.
+
+## Author validation required
+
+- Confirm the exact Marketplace endpoint.
+- Confirm whether the URL scheme is required.
+- Confirm exact `knife supermarket` Marketplace syntax, including flag placement and required options.
+- Confirm whether `show` is supported in the initial release.
+- Confirm any Marketplace-specific authentication or configuration requirements for CLI, Berkshelf, and Policyfile.

--- a/content/saas/marketplace_compatibility_reference.md
+++ b/content/saas/marketplace_compatibility_reference.md
@@ -12,64 +12,68 @@ draft = false
 This reference documents the initial-release backward compatibility scope for cookbook consumption.
 It applies only to cookbooks from the public Chef Supermarket.
 It does not apply to private Chef Supermarket content.
+Marketplace is available at `https://marketplace.chef.io`.
+You can continue to use `https://supermarket.chef.io` or configure Marketplace as your public cookbook source.
 
-## Verified baseline behavior in existing docs
+## `knife supermarket` compatibility
 
-The current `knife supermarket` documentation identifies these arguments as not requiring a user account: `download`, `search`, `install`, and `list`.
-The same documentation defines `-m`, `--supermarket-site` as the option for setting the Supermarket URL, with a default of `https://supermarket.chef.io`.
+Marketplace supports all unauthenticated, read-only `knife supermarket` commands.
+The command syntax is the same as it is for Chef Supermarket.
+No Marketplace credentials are required.
 
-## `knife supermarket` command comparison
+Configure Marketplace for all `knife supermarket` commands by adding the following setting to your `knife.rb` file:
 
-The following table covers each verified read-only command listed in existing docs as not requiring a user account.
+```ruby
+knife[:supermarket_site] = "https://marketplace.chef.io"
+```
 
-| Existing public Chef Supermarket command | Marketplace equivalent | Purpose | Notes or differences |
-|---|---|---|---|
-| `knife supermarket download COOKBOOK_NAME [COOKBOOK_VERSION] (options)` | [AUTHOR NOTE: Exact Marketplace command syntax requires engineering validation.] | Download a cookbook archive. | Existing docs verify `-m`, `--supermarket-site` and default `https://supermarket.chef.io`. Marketplace endpoint value and exact option placement are not yet confirmed in this repository. |
-| `knife supermarket install COOKBOOK_NAME [COOKBOOK_VERSION] (options)` | [AUTHOR NOTE: Exact Marketplace command syntax requires engineering validation.] | Install a cookbook from Supermarket into a local git workflow. | Existing docs verify `-m`, `--supermarket-site` and default `https://supermarket.chef.io`. Marketplace endpoint value and exact option placement are not yet confirmed in this repository. |
-| `knife supermarket list (options)` | [AUTHOR NOTE: Exact Marketplace command syntax requires engineering validation.] | List available cookbooks. | Existing docs verify `-m`, `--supermarket-site` and default `https://supermarket.chef.io`. Marketplace endpoint value and exact option placement are not yet confirmed in this repository. |
-| `knife supermarket search SEARCH_QUERY (options)` | [AUTHOR NOTE: Exact Marketplace command syntax requires engineering validation.] | Search available cookbooks. | Existing docs verify `-m`, `--supermarket-site` and default `https://supermarket.chef.io`. Marketplace endpoint value and exact option placement are not yet confirmed in this repository. |
+You can also use the `--supermarket-site https://marketplace.chef.io` option with an individual command.
 
-[AUTHOR NOTE: Validate whether any additional read-only `knife supermarket` commands are in initial-release scope. Existing docs also include `show`, but this repository does not confirm initial-release Marketplace support for it.]
+| Command | Marketplace example | Purpose |
+|---|---|---|
+| `knife supermarket download <cookbook-name>` | `knife supermarket download <cookbook-name> --supermarket-site https://marketplace.chef.io` | Download a cookbook archive. |
+| `knife supermarket install <cookbook-name>` | `knife supermarket install <cookbook-name> --supermarket-site https://marketplace.chef.io` | Install a cookbook into a local Git workflow. |
+| `knife supermarket list` | `knife supermarket list --supermarket-site https://marketplace.chef.io` | List available cookbooks. |
+| `knife supermarket search <search-query>` | `knife supermarket search <search-query> --supermarket-site https://marketplace.chef.io` | Search available cookbooks. |
+| `knife supermarket show <cookbook-name>` | `knife supermarket show <cookbook-name> --supermarket-site https://marketplace.chef.io` | Show cookbook details. |
+
+The examples use Marketplace for a single command.
+After you configure `knife[:supermarket_site]`, use the same commands without the `--supermarket-site` option.
 
 ## Berkshelf compatibility comparison
 
-Current Berkshelf documentation verifies the default source pattern:
+To use Marketplace with Berkshelf, replace the public Chef Supermarket source in your `Berksfile`:
 
 ```ruby
-source "https://supermarket.chef.io"
+source "https://marketplace.chef.io"
 metadata
 ```
 
-Current Berkshelf documentation also verifies support for custom source URLs by adding additional `source` entries.
+Use your existing Berkshelf commands, such as `berks install`.
+No Marketplace credentials are required.
 
-| Existing public Chef Supermarket behavior | Marketplace equivalent | Verified configuration change | Verified limitation |
+| Public cookbook source | Marketplace source | Configuration change | Limitation |
 |---|---|---|---|
-| Berkshelf resolves cookbooks from `source "https://supermarket.chef.io"`. | [AUTHOR NOTE: Marketplace Berkshelf source URL requires engineering validation.] | [AUTHOR NOTE: Confirm whether the only change is replacing the source URL with the Marketplace endpoint.] | Initial-release scope is limited to cookbooks from the public Chef Supermarket. Private Chef Supermarket content is out of scope. |
+| `source "https://supermarket.chef.io"` | `source "https://marketplace.chef.io"` | Replace the source URL. | Private Chef Supermarket content is out of scope. |
 
 ## Policyfile compatibility comparison
 
-Current Policyfile documentation verifies that `default_source :supermarket` pulls from the public Chef Supermarket by default.
-It also verifies a custom URL form:
+To use Marketplace with a Policyfile, configure Marketplace as the Supermarket source:
 
 ```ruby
-default_source :supermarket, "https://supermarket-name.example"
+default_source :supermarket, "https://marketplace.chef.io"
 ```
 
-| Existing public Chef Supermarket behavior | Marketplace equivalent | Verified configuration change | Verified limitation |
+Use your existing Policyfile commands after you change the source URL.
+No Marketplace credentials are required.
+
+| Public cookbook source | Marketplace source | Configuration change | Limitation |
 |---|---|---|---|
-| `default_source :supermarket` uses the public Chef Supermarket by default. | [AUTHOR NOTE: Marketplace Policyfile source endpoint and exact syntax require engineering validation.] | [AUTHOR NOTE: Confirm whether `default_source :supermarket, "<marketplace-endpoint>"` is the supported Marketplace pattern.] | Initial-release scope is limited to cookbooks from the public Chef Supermarket. Private Chef Supermarket content is out of scope. |
+| `default_source :supermarket` | `default_source :supermarket, "https://marketplace.chef.io"` | Add the Marketplace URL to `default_source`. | Private Chef Supermarket content is out of scope. |
 
 ## Initial-release limitations
 
 - Compatibility applies only to cookbooks from the public Chef Supermarket.
 - Private Chef Supermarket content is not supported.
-- Only verified supported read-only `knife supermarket` commands are supported.
+- Marketplace supports unauthenticated, read-only `knife supermarket` commands.
 - Write and administrative commands are outside the initial-release scope.
-
-## Author validation required
-
-- Confirm the exact Marketplace endpoint.
-- Confirm whether the URL scheme is required.
-- Confirm exact `knife supermarket` Marketplace syntax, including flag placement and required options.
-- Confirm whether `show` is supported in the initial release.
-- Confirm any Marketplace-specific authentication or configuration requirements for CLI, Berkshelf, and Policyfile.

--- a/content/saas/marketplace_initial_release_overview.md
+++ b/content/saas/marketplace_initial_release_overview.md
@@ -22,10 +22,11 @@ The initial release is limited to backward compatibility for cookbook-consumptio
 
 The confirmed scope includes:
 
-- Backward compatibility for supported read-only `knife supermarket` commands.
+- Backward compatibility for unauthenticated, read-only `knife supermarket` commands, including `download`, `install`, `list`, `search`, and `show`.
 - Backward compatibility for Berkshelf cookbook consumption workflows.
 - Backward compatibility for Policyfile cookbook consumption workflows.
 - Compatibility only for cookbooks from the public Chef Supermarket.
+- Parallel support for public Chef Supermarket and Marketplace cookbook sources.
 
 ## Out-of-scope for initial release
 
@@ -51,7 +52,7 @@ Use the Marketplace compatibility reference for command and configuration detail
 
 Compatibility applies only to cookbooks from the public Chef Supermarket.
 Private Chef Supermarket content is not supported in this initial release.
-Only verified supported read-only `knife supermarket` commands are in scope.
+Unauthenticated, read-only `knife supermarket` commands are in scope.
 Write and administrative commands are outside the initial-release scope.
 
 ## Related information

--- a/content/saas/marketplace_initial_release_overview.md
+++ b/content/saas/marketplace_initial_release_overview.md
@@ -1,0 +1,62 @@
++++
+title = "Marketplace initial release overview"
+draft = false
+[menu]
+  [menu.cloud]
+    title = "Marketplace overview"
+    identifier = "chef_cloud/saas/Marketplace initial release overview"
+    parent = "chef_cloud/saas"
+    weight = 30
++++
+
+Marketplace is a content destination planned as part of the broader Infra 360 ecosystem.
+This page describes only the confirmed initial-release scope.
+
+## Intended audience
+
+This page is for DevOps engineers and platform teams that currently consume cookbooks from the public Chef Supermarket and need to understand initial Marketplace compatibility.
+
+## Initial-release scope
+
+The initial release is limited to backward compatibility for cookbook-consumption workflows that currently use the public Chef Supermarket.
+
+The confirmed scope includes:
+
+- Backward compatibility for supported read-only `knife supermarket` commands.
+- Backward compatibility for Berkshelf cookbook consumption workflows.
+- Backward compatibility for Policyfile cookbook consumption workflows.
+- Compatibility only for cookbooks from the public Chef Supermarket.
+
+## Out-of-scope for initial release
+
+The following items are outside the initial-release scope:
+
+- Private Chef Supermarket content.
+- `knife supermarket` write or administrative workflows.
+- Publishing, sharing, unsharing, deprecating, deleting, and administrative content operations.
+- Migration workflows for private Chef Supermarket.
+- New content types beyond cookbooks from the public Chef Supermarket.
+
+## Supported compatibility scenarios
+
+Marketplace initial-release documentation currently covers:
+
+- Supported read-only `knife supermarket` backward compatibility.
+- Berkshelf backward compatibility.
+- Policyfile backward compatibility.
+
+Use the Marketplace compatibility reference for command and configuration details.
+
+## Limitations
+
+Compatibility applies only to cookbooks from the public Chef Supermarket.
+Private Chef Supermarket content is not supported in this initial release.
+Only verified supported read-only `knife supermarket` commands are in scope.
+Write and administrative commands are outside the initial-release scope.
+
+## Related information
+
+- [Marketplace compatibility reference](/saas/marketplace_compatibility_reference/)
+- [knife supermarket](/workstation/latest/tools/knife/knife_supermarket/)
+- [Berkshelf](/workstation/latest/tools/berkshelf/)
+- [About Policyfiles](/client/latest/policy/policyfile/)

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -87,11 +87,11 @@
     "desc"     "The community cookbook sharing platform for discovering, publishing, and reusing Chef content."
   )
   (dict
-    "name"     "Chef Marketplace"
-    "url"      "/saas/marketplace_initial_release_overview/"
+    "name"     "Infra Marketplace"
+    "url"      "/infra_marketplace/"
     "icon"     ""
     "icon_mat" "store"
-    "desc"     "Initial-release guidance for Marketplace cookbook-consumption compatibility with the public Chef Supermarket."
+    "desc"     "Initial-release guidance for cookbook-consumption compatibility with the public Chef Supermarket."
   )
   (dict
     "name"     "Chef Workstation"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -87,6 +87,13 @@
     "desc"     "The community cookbook sharing platform for discovering, publishing, and reusing Chef content."
   )
   (dict
+    "name"     "Chef Marketplace"
+    "url"      "/saas/marketplace_initial_release_overview/"
+    "icon"     ""
+    "icon_mat" "store"
+    "desc"     "Initial-release guidance for Marketplace cookbook-consumption compatibility with the public Chef Supermarket."
+  )
+  (dict
     "name"     "Chef Workstation"
     "url"      "/workstation/latest/"
     "icon"     ""


### PR DESCRIPTION
## Summary

Adds initial-release documentation for the Infra Marketplace, covering compatibility guidance for cookbook consumption from the public Chef Supermarket, along with supporting site changes.

## Changes

- Add the Infra Marketplace documentation section (`content/infra_marketplace/_index.md`, `content/infra_marketplace/compatibility_reference.md`)
- Add Infra Marketplace release notes (`content/release_notes/marketplace.md`)
- Add an Infra Marketplace card to the homepage (`layouts/index.html`) and update menu/params config
- Disable remote data caches (`config/_default/caches.toml`) to avoid stale content during local builds
