### PR TITLE
retired the support terms: Commercial support, Community support, Derived platforms support

### DIFF
--- a/content/platforms.md
+++ b/content/platforms.md
@@ -32,19 +32,6 @@ Refer to the following sections for definitions of the certification tiers, inst
 **User-reported**
 : These platforms are validated by users. Support is provided on a best-effort basis.
 
-**Commercial support**
-: Commercial support for platforms is part of paid maintenance contracts with Progress Chef Software. Support contracts allow you to open tickets and receive service level agreement (SLA) assistance from our support desk. Commercially supported platforms are extensively tested as part of Chef's development and release process. Commercial support follows the lifecycle of the underlying operating system vendor.
-
-  Commercial support is limited to the platforms listed in the "Commercial Support" tables--platforms not listed in these tables are unsupported.
-
-**Community support**
-: Community support for platforms means that members of the Chef community have contributed to these platforms and Chef doesn't actively work to maintain this functionality. Chef doesn't explicitly test community supported platforms as part of the development and release process.
-
-  Many of these platforms are forks, clones, or otherwise derivative of platforms that Chef commercially supports. Continued functionality for these platforms is likely, but not guaranteed. Unsupported platforms may have missing or non-operative functionality. As always, we welcome community contributions from anyone looking to expand community support for platforms in Chef products.
-
-**Derived platforms support**
-: Chef doesn't explicitly test or provide builds for derived distributions other than those in our supported platform list. However, if the derived distribution is a direct rebuild of the originating distribution and hasn't diverged in functionality or packaged dependencies, Chef will support our customers through our normal channels.
-
 ### Installer types
 
 **Native**

--- a/content/reusable/md/supported_platforms/chef_infra_client_18.md
+++ b/content/reusable/md/supported_platforms/chef_infra_client_18.md
@@ -1,9 +1,9 @@
 
 <!-- markdownlint-disable MD036 -->
 
-**Commercially-supported platforms**
+**Validated and supported platforms**
 
-The following table lists the commercially supported platforms and versions for Chef Infra Client 18.
+The following table lists the validated and supported platforms and versions for Chef Infra Client 18.
 
 | Platform | Architecture | Version |
 | --- | --- | --- |
@@ -21,7 +21,7 @@ The following table lists the commercially supported platforms and versions for 
 | Ubuntu (LTS releases) | `x86_64`,`aarch64` (18.x and above) | `18.04`, `20.04`, `22.04`, `24.04`, `26.04` |
 | Windows | `x86_64` | `2016`, `10` (all channels except "insider" builds), `2019` (Long-term servicing channel (LTSC), both Desktop Experience and Server Core), `11`, `2022`, `2025` |
 
-**Derived platforms**
+**Supported (untested) platforms**
 
 The following table lists supported derived platforms and versions for Chef Infra Client 18.
 
@@ -29,9 +29,9 @@ The following table lists supported derived platforms and versions for Chef Infr
 | --- | --- | --- | --- |
 | AlmaLinux | `x86_64`, `aarch64` | `8.x`, `9.x`, `10.x` | CentOS |
 
-**Community-supported platforms**
+**User-reported platforms**
 
-The following are community-supported platforms for Chef Infra Client 18.
+The following are user-reported platforms for Chef Infra Client 18.
 
 | Platform | Architecture | Version |
 | --- | --- | --- |

--- a/content/reusable/md/supported_platforms/chef_inspec_5_23.md
+++ b/content/reusable/md/supported_platforms/chef_inspec_5_23.md
@@ -1,9 +1,9 @@
 
 <!-- markdownlint-disable MD036 -->
 
-**Commercially-supported platforms**
+**Validated and supported platforms**
 
-The following table lists the commercially-supported platforms and versions for Chef InSpec.
+The following table lists the validated and supported platforms and versions for Chef InSpec.
 
 | Platform                     | Architecture                                   | Version                                                                   |
 | ---------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------- |
@@ -16,7 +16,7 @@ The following table lists the commercially-supported platforms and versions for 
 | Ubuntu                       | `x86_64`, `aarch64` (only `18.04` and `20.04`) | `16.04`, `18.04`, `20.04`                                                 |
 | Windows                      | `x86_64`                                       | `2016`, `10` (all channels except "insider" builds), `2019`, `11`, `2022` |
 
-**Derived platforms**
+**Supported (untested) platforms**
 
 The following table lists supported derived platforms and versions for Chef InSpec.
 

--- a/content/reusable/md/supported_platforms/chef_inspec_5_24.md
+++ b/content/reusable/md/supported_platforms/chef_inspec_5_24.md
@@ -1,9 +1,9 @@
 
 <!-- markdownlint-disable MD036 -->
 
-**Commercially-supported platforms**
+**Validated and supported platforms**
 
-The following table lists the commercially-supported platforms and versions for Chef InSpec.
+The following table lists the validated and supported platforms and versions for Chef InSpec.
 
 | Platform                     | Architecture                                   | Version                                                                           |
 | ---------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------- |
@@ -16,7 +16,7 @@ The following table lists the commercially-supported platforms and versions for 
 | Ubuntu                       | `x86_64`, `aarch64` (only `18.04` and `20.04`) | `16.04`, `18.04`, `20.04`                                                         |
 | Windows                      | `x86_64`                                       | `2016`, `10` (all channels except "insider" builds), `2019`, `11`, `2022`, `2025` |
 
-**Derived platforms**
+**Supported (untested) platforms**
 
 The following table lists supported derived platforms and versions for Chef InSpec.
 

--- a/content/reusable/md/supported_platforms/chef_inspec_7_1.md
+++ b/content/reusable/md/supported_platforms/chef_inspec_7_1.md
@@ -1,5 +1,5 @@
 | Platform                         | Architecture | Platform-native Package | Habitat Package |
 | -------------------------------- | ------------ | ----------------------- | --------------- |
-| Windows                          | x86-64       | Yes                     | No              |
-| Debian-based Linux distributions | x86-64       | Yes                     | No              |
-| RPM-based Linux distributions    | x86-64       | Yes                     | No              |
+| Windows                          | x86-64       | Yes                     | Yes             |
+| Debian-based Linux distributions | x86-64       | Yes                     | Yes             |
+| RPM-based Linux distributions    | x86-64       | Yes                     | Yes             |


### PR DESCRIPTION
Consolidates the 6 platform certification tiers down to 3 by retiring the extra tiers:

- Commercial support → merged into **Validated and supported**
- Derived platforms support → merged into **Supported (untested)**
- Community support → merged into **User-reported**

Updates `content/platforms.md` (removes the 3 retired tier definitions) and renames the corresponding table section headers in `chef_infra_client_18.md`, `chef_inspec_5_23.md`, and `chef_inspec_5_24.md` to match the surviving tier names.

Targets branch `im/platform-support` (PR #4738).